### PR TITLE
Predicate wrap

### DIFF
--- a/ramda.js
+++ b/ramda.js
@@ -1131,16 +1131,19 @@
 
 
         // Create a predicate wrapper which will call a pick function (all/any) for each predicate
-        var predicateWrap = function(method) {
+        var predicateWrap = function(predPicker) {
             return function(preds /* , args */) {
-                var args = _slice(arguments, 1);
-                var iterator = function() {
+                var predIterator = function() {
                     var args = arguments;
-                    return method(function(predicate) {
+                    return predPicker(function(predicate) {
                         return predicate.apply(null, args);
                     }, preds);
                 };
-                return args.length ? iterator.apply(null, args) : arity(max(pluck("length", preds)), iterator);
+                return arguments.length > 1 ?
+                        // Call function imediately if given arguments
+                        predIterator.apply(null, _slice(arguments, 1)) :
+                        // Return a function which will call the predicates with the provided arguments
+                        arity(max(pluck("length", preds)), predIterator);
             };
         };
 


### PR DESCRIPTION
Playing around with reimplementing ramda in lodash as a weekend project :).

The curry change is for an alternative solution I was playing with if we don't care about arity. Below is how I'm writing these methods currently in my implementation

```
function predicateWrap(method) {
    return lodash.curry(function(preds /* , args */) {
        var args = lodash.slice(arguments, 1);
        return method(preds, function(func) {
            return func.apply(null, args);
        });
    }, 2);
}

ramda.allPredicates = predicateWrap(lodash.all);
ramda.anyPredicates = predicateWrap(lodash.any);
```
