### PR TITLE
Allow flatten to handle ridiculously large lists

### DIFF
--- a/ramda.js
+++ b/ramda.js
@@ -995,12 +995,22 @@
         //     flatten([1, 2, [3, 4], 5, [6, [7, 8, [9, [10, 11], 12]]]]);
         //     // => [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
         var flatten = R.flatten = function(list) {
-            var idx = -1, len = list ? list.length : 0, result = [], push = result.push, val;
-            while (++idx < len) {
-                val = list[idx];
-                push.apply(result, isArray(val) ? flatten(val) : [val]);
+            var output = [], idx = 0, value;
+            for (var i = 0, length = list.length; i < length; i++) {
+              value = list[i];
+              if (isArray(value)) {
+                //flatten current level of array or arguments object
+                value = flatten(value);
+                var j = 0, len = value.length;
+                output.length += len;
+                while (j < len) {
+                  output[idx++] = value[j++];
+                }
+              } else {
+                output[idx++] = value;
+              }
             }
-            return result;
+            return output;
         };
 
 

--- a/test/test.flatten.js
+++ b/test/test.flatten.js
@@ -6,8 +6,18 @@ describe('flatten', function() {
 
     it("turns a nested list into one flat list", function() {
         var nest = [1, [2], [3, [4, 5], 6, [[[7], 8]]], 9, 10];
-        assert.deepEqual(flatten(nest), [1,2,3,4,5,6,7,8,9,10]);
+        assert.deepEqual(flatten(nest), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
         nest = [[[[3]], 2, 1], 0, [[-1, -2], -3]];
         assert.deepEqual(flatten(nest), [3, 2, 1, 0, -1, -2, -3]);
+        assert.deepEqual(flatten([1, 2, 3, 4, 5]), [1, 2, 3, 4, 5]);
+    });
+
+    it("is not destructive", function() {
+        var nest = [1, [2], [3, [4, 5], 6, [[[7], 8]]], 9, 10];
+        assert.notEqual(flatten(nest), nest);
+    });
+
+    it("handles ridiculously large inputs", function() {
+        assert.equal(flatten([new Array(1000000), Lib.range(0, 56000), 5, 1, 3]).length, 1056003);
     });
 });


### PR DESCRIPTION
Instead of praying to the gods `.apply` can handle an arguments object as large as the list. Oh this is also faster :)
