### PR TITLE
Better String Representation of Composite Functions [CORRECTED]

### DIFF
--- a/ext/types/Maybe.js
+++ b/ext/types/Maybe.js
@@ -1,41 +1,96 @@
 var isNil = require('./util').isNil;
 
-function Maybe(x) {
-  if (!(this instanceof Maybe)) {
-    return new Maybe(x);
-  }
-  this.value = x;
+/**
+ * @constructor
+ * @param {*} x
+ * @returns {Maybe}
+ */
+function Maybe (x) {
+    return isNil (x) ? new Nothing() : new Just (x);
 }
 
-Maybe.of = function(x) {
-  return new Maybe(x);
+/**
+ * @class
+ * @extends Maybe
+ * @property {*} value
+ * @param {*} x
+ */
+function Just (x) {
+    this.value = x;
+}
+/**
+ * @class
+ * @extends Maybe
+ */
+function Nothing () {
+
+}
+// applicative
+/**
+ * @param x
+ * @returns {Maybe}
+ */
+Nothing.prototype.of = Just.prototype.of = function of (x) {
+    return Maybe (x);
 };
 
 // functor
-Maybe.prototype.map = function(f) {
-  return isNil(this.value) ? this : new Maybe(f(this.value));
+/**
+ * @param {Function} f
+ * @returns {Just}
+ */
+Just.prototype.map = function map (f) {
+    return new Just (f (this.value));
+};
+
+/**
+ * @param f
+ * @returns {Nothing}
+ */
+Nothing.prototype.map = function map (f) {
+    return this;
 };
 
 // apply
 // takes a Maybe that wraps a function (`app`) and applies its `map`
 // method to this Maybe's value, which must be a function.
-Maybe.prototype.ap = function(m) {
-  if (typeof this.value !== 'function') {
-    throw new TypeError("Calling ap on a Maybe requires that the Maybe is wrapping a function");
-  }
-  return m.map(this.value);
+/**
+ * @param {Just} m
+ * @returns {Just}
+ */
+Just.prototype.ap = function ap (m) {
+    if (typeof this.value !== 'function') {
+        throw new TypeError("Calling ap on a Maybe requires that the Maybe is wrapping a function");
+    }
+    return m.map (this.value);
 };
 
-// applicative
-Maybe.prototype.of = Maybe.of;
+/**
+ * @param {Just} m
+ * @returns {Nothing}
+ */
+Nothing.prototype.ap = function ap (m) {
+    return this;
+};
 
 // chain
 //  f must be a function which returns a value
 //  f must return a value of the same Chain
 //  chain must return a value of the same Chain
 //
-Maybe.prototype.chain = function(f) {
-   return this.value ? f(this.value) : this;
+/**
+ * @param f {Function}
+ * @returns {Just}
+ */
+Just.prototype.chain = function chain (f) {
+    return f (this.value);
+};
+/**
+ * @param f {Function}
+ * @returns {Nothing}
+ */
+Nothing.prototype.chain = function chain (f) {
+    return this;
 };
 
 // monad
@@ -43,10 +98,23 @@ Maybe.prototype.chain = function(f) {
 // see above.
 
 // equality method to enable testing
-Maybe.prototype.equals = function(that) {
-  return this.value === that.value;
+/**
+ * @param {Maybe} m
+ * @returns {bool}
+ */
+Just.prototype.equals = Nothing.prototype.equals = function (m) {
+    return this.value === m.value;
 };
 
+Object.defineProperty (Just.prototype, "isNothing", {
+    get : function () {
+        return false;
+    }
+});
+Object.defineProperty (Nothing.prototype, "isNothing", {
+    get : function () {
+        return true;
+    }
+});
+
 module.exports = Maybe;
-
-


### PR DESCRIPTION
Similar to `setSource` but for 2 functions, `setCompositeRepr` creates a
string representation for the composed function in this style

```
function f (...)  {
//stuff
}

OF

function g (...)  {
//stuff
}
```

More specifically, its the string represetnation of `f` + new
lines + `"OF"` + new lines + the string representation of `g`, for the
function `compose(f, g)`.
