### PR TITLE
remove setSource from default, start debug extension

### DIFF
--- a/ext/debug/debug.js
+++ b/ext/debug/debug.js
@@ -1,0 +1,59 @@
+var R = require('./ramda');
+var arity = R.arity;
+
+// Internal function to set the source attributes on a curried functions
+// useful for debugging purposes
+function setSource(curried, source) {
+  curried.toString = function() {
+    return source.toString();
+  };
+  curried.source = source;
+  return curried;
+}
+
+var NO_ARGS_EXCEPTION = new TypeError('Function called with no arguments');
+
+var curry = R.curry = function (fn, fnArity) {
+  fnArity = typeof fnArity === "number" ? fnArity : fn.length;
+  function recurry(args) {
+    return setSource(arity(Math.max(fnArity - (args && args.length || 0), 0), function () { 
+      if (arguments.length === 0) { throw NO_ARGS_EXCEPTION; }
+      var newArgs = concat(args, arguments);
+      if (newArgs.length >= fnArity) {
+        return fn.apply(this, newArgs);
+      }
+      else {
+        return recurry(newArgs);
+      }
+    }), fn); 
+  }
+  return recurry([]);
+};
+
+function curry2(fn) {
+  return setSource(function(a, b) {
+    switch (arguments.length) {
+      case 0: throw NO_ARGS_EXCEPTION;
+      case 1: return setSource(function(b) {
+        return fn(a, b);
+      }, fn);
+    }
+    return fn(a, b);
+  }, fn);
+}
+
+function curry3(fn) {
+  return setSource(function(a, b, c) {
+    switch (arguments.length) {
+      case 0: throw NO_ARGS_EXCEPTION;
+      case 1: return curry2(function(b, c) {
+        return fn(a, b, c);
+      });
+      case 2: return setSource(function(c) {
+        return fn(a, b, c);
+      });
+    }
+    return fn(a, b, c);
+  }, fn);
+}
+

--- a/ext/debug/test/debug.test.js
+++ b/ext/debug/test/debug.test.js
@@ -1,0 +1,29 @@
+var assert = require('assert');
+var Lib = require('./../../../ramda');
+var curry = Lib.curry;
+
+describe('curry', function() {
+    function source(a, b, c) {
+        return a * b * c;
+    }
+    var curried = curry(source);
+/* TODO: restore these for debug build
+    it('curry should set the toString value to the original', function() {
+        assert.equal(String(source), String(curried));
+        assert.equal(String(source), String(curried));
+    });
+
+});
+
+describe('internal curry', function() {
+    var map = Lib.map, filter = Lib.filter;
+    it('curry should set the toString value to the original', function() {
+        assert.notEqual(String(map), String(filter));
+        assert.equal(String(map), String(map.source));
+    });
+    it('curried function != source', function() {
+        assert.notEqual(map, map.source);
+    });
+*/
+});
+

--- a/ramda.js
+++ b/ramda.js
@@ -88,7 +88,7 @@
         var curry = R.curry = function (fn, fnArity) {
             fnArity = typeof fnArity === "number" ? fnArity : fn.length;
             function recurry(args) {
-                return setSource(arity(Math.max(fnArity - (args && args.length || 0), 0), function () {
+                return arity(Math.max(fnArity - (args && args.length || 0), 0), function () {
                     if (arguments.length === 0) { throw NO_ARGS_EXCEPTION; }
                     var newArgs = concat(args, arguments);
                     if (newArgs.length >= fnArity) {
@@ -97,7 +97,7 @@
                     else {
                         return recurry(newArgs);
                     }
-                }), fn);
+                });
             }
 
             return recurry([]);
@@ -105,41 +105,31 @@
 
         var NO_ARGS_EXCEPTION = new TypeError('Function called with no arguments');
 
-        // Internal function to set the source attributes on a curried functions
-        // useful for debugging purposes
-        function setSource(curried, source) {
-            curried.toString = function() {
-                return source.toString();
-            };
-            curried.source = source;
-            return curried;
-        }
-
         // Optimized internal curriers
         function curry2(fn) {
-            return setSource(function(a, b) {
+            return function(a, b) {
                 switch (arguments.length) {
                     case 0: throw NO_ARGS_EXCEPTION;
-                    case 1: return setSource(function(b) {
+                    case 1: return function(b) {
                         return fn(a, b);
-                    }, fn);
+                    };
                 }
                 return fn(a, b);
-            }, fn);
+            };
         }
         function curry3(fn) {
-            return setSource(function(a, b, c) {
+            return function(a, b, c) {
                 switch (arguments.length) {
                     case 0: throw NO_ARGS_EXCEPTION;
                     case 1: return curry2(function(b, c) {
                         return fn(a, b, c);
                     });
-                    case 2: return setSource(function(c) {
+                    case 2: return function(c) {
                         return fn(a, b, c);
-                    });
+                    };
                 }
                 return fn(a, b, c);
-            }, fn);
+            };
         }
 
         // (private) for dynamically dispatching Ramda method to non-Array objects

--- a/test/test.curry.js
+++ b/test/test.curry.js
@@ -15,11 +15,6 @@ describe('curry', function() {
         assert.notEqual(curried, source);
     });
 
-    it('curry should set the toString value to the original', function() {
-        assert.equal(String(source), String(curried));
-        assert.equal(String(source), String(curried));
-    });
-
     it('curry should accept an arity', function() {
         var curried = curry(function(a, b, c, d) {
             return a * b * c;
@@ -38,13 +33,6 @@ describe('curry', function() {
 
 describe('internal curry', function() {
     var map = Lib.map, filter = Lib.filter;
-    it('curry should set the toString value to the original', function() {
-        assert.notEqual(String(map), String(filter));
-        assert.equal(String(map), String(map.source));
-    });
-    it('curried function != source', function() {
-        assert.notEqual(map, map.source);
-    });
 
     it('should throw an expcetion given no arguments', function() {
         assert.throws(map);


### PR DESCRIPTION
Signed-off-by: buzzdecafe m_hur@yahoo.com

please review--i think it makes sense to use setSource only in debug mode, but i don't wanna merge without discussion/confirmation.

Also, this overriding thing may be a bit complex when we have `R` functions pointing at local variables e.g. `curry`; the build has to be able to override those internal functions somehow, or we have to change how they are used.
