### PR TITLE
Add ramda.times

### DIFF
--- a/ramda.js
+++ b/ramda.js
@@ -404,14 +404,18 @@
         };
         aliasFor("identity").is("I");
 
-        // Returns a fixed list (of size `n`) of identical values.
-        R.repeatN = curry2(function (value, n) {
+        R.times = curry2(function (fn, n) {
             var arr = new Array(n);
             var i = -1;
             while (++i < n) {
-                arr[i] = value;
+                arr[i] = fn(i);
             }
             return arr;
+        });
+
+        // Returns a fixed list (of size `n`) of identical values.
+        R.repeatN = curry2(function (value, n) {
+            return R.times(R.always(value), n);
         });
 
 

--- a/test/test.list.js
+++ b/test/test.list.js
@@ -116,6 +116,22 @@ describe('nth', function () {
     });
 });
 
+describe('times', function() {
+    var times = Lib.times;
+
+    it('takes a map func', function() {
+        assert.deepEqual(times(Lib.identity, 5), [0, 1, 2, 3, 4]);
+        assert.deepEqual(times(function(x) {
+            return x * 2;
+        }, 5), [0, 2, 4, 6, 8]);
+    });
+
+    it('is curried', function() {
+        var mapid = times(Lib.identity);
+        assert.deepEqual(mapid(5), [0, 1, 2, 3, 4]);
+    });
+});
+
 describe('repeatN', function () {
     var repeatN = Lib.repeatN;
 


### PR DESCRIPTION
Probably more useful than `repeatN` -- might be best to just drop `repeatN` as its just `R.times(R.always(value), n);`?
