### PR TITLE
concat

### DIFF
--- a/ramda.js
+++ b/ramda.js
@@ -79,9 +79,7 @@
             }
 
             var a = arguments[0];
-            return isString (a)                                             ?
-                String.prototype.concat.apply (a, _slice (arguments, 1))    :
-                Array. prototype.concat.apply (a, _slice (arguments, 1));
+            return (isString (a) ? String : Array).prototype.concat.apply (a, _slice (arguments, 1));
         };
 
         // (private)


### PR DESCRIPTION
`concat :: [a] -> [a] -> ... -> [a]`

`concat (s1, s2, ... , sn) = concat (s1) (s2, s3, ... , sn)` is a variadic function that takes lists or strings and returns a single list or string containing of the elements or characters of the arguments in order from left to right. `concat` is curried with respect to the first argument.

This `concat` now works as expected for `strings`
