### PR TITLE
Docs/documentation revamp

### DIFF
--- a/ramda.js
+++ b/ramda.js
@@ -952,7 +952,7 @@
          *   return elt;
          * };
          *
-         * map(squareEnds, [8, 6, 7, 5, 3, 0, 9];
+         * ramda.map.idx(squareEnds, [8, 6, 7, 5, 3, 0, 9];
          * //=> [64, 6, 7, 5, 3, 0, 81]
          */
         R.map.idx = curry2(function(fn, list) {


### PR DESCRIPTION
Prompted by / further discussion on this in https://github.com/CrossEye/ramda/issues/37.

I rough drafted some JSDoc documentation for Ramda today, very much so modeled after Lodash's documentation (which I generally find to be a lot more searchable/browsable than the documentation Docco produces). My current thinking is to finish this style documentation across all of Ramda's functions, with the ultimate goal of producing a more comprehensive set of docs.

Those docs could potentially resemble something like [Lodash's documentation](http://lodash.com/docs), but I'm not attached to any visual representation in particular.

I've only finished (read: drafted) JSDoc-style documentation for a subset of the library (starting at line 708 in this PR), but I'm curious if this is in line with what y'all had in mind for the project's documentation. If so, let me know--I'm willing to keep documenting until I finish (or until my brain numbs over from documentation overload, whichever comes first).
