### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+# editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_style = space
+indent_size = 4
+max_line_length = 100
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+# Two trailing spaces => newline in GitHub-flavored markdown
+trim_trailing_whitespace = false


### PR DESCRIPTION
I generally use [EditorConfig](http://editorconfig.org/) in projects to be sure I'm respecting the project's style. This looks like the style Ramda is using.
