### PR TITLE
remove aliases

### DIFF
--- a/bench/filter-where.bench.js
+++ b/bench/filter-where.bench.js
@@ -1,16 +1,13 @@
 var _ = require('lodash');
 var R = require('..');
-var filter = R.filter;
-var where = R.where;
-var isEmpty = R.isEmpty;
 
 var objs = [
   {x: [1,2], y: true}, {x: [1,3], y: true}, {x: [], y: false}, {x: [2], y: false},
   {x: [3], y: true}, {x: [1], y: true}, {x: [1,2,3], y: true}, {x: [], y: true},
   {x: [1,2], y: false}, {x: [1,3], y: true}
 ];
-var filterEmptyX = filter(where({x: R.isEmpty}));
-var filterFalseY = filter(where({y: false}));
+var filterEmptyX = R.filter(R.where({x: R.isEmpty}));
+var filterFalseY = R.filter(R.where({y: false}));
 
 module.exports = {
   name: "filter where",
@@ -19,10 +16,10 @@ module.exports = {
       _.filter(objs, {x: []});
     },
     'filter(where({x: isEmpty}), objs)': function() {
-      filter(where({x: isEmpty}), objs);
+      R.filter(R.where({x: R.isEmpty}), objs);
     },
     'filter(where({x: isEmpty}))(objs)': function() {
-      filter(where({x: isEmpty}))(objs);
+      R.filter(R.where({x: R.isEmpty}))(objs);
     },
     'filterEmptyX(objs)': function() {
       filterEmptyX(objs);
@@ -31,10 +28,10 @@ module.exports = {
       _.filter(objs, {y: false});
     },
     'filter(where({y: false}), objs)': function() {
-      filter(where({y: false}), objs);
+      R.filter(R.where({y: false}), objs);
     },
     'filter(where({y: false}))(objs)': function() {
-      filter(where({y: false}))(objs);
+      R.filter(R.where({y: false}))(objs);
     },
     'filterFalseY(objs)': function() {
       filterFalseY(objs);

--- a/bench/find-where.bench.js
+++ b/bench/find-where.bench.js
@@ -1,16 +1,13 @@
 var _ = require('lodash');
 var R = require('..');
-var find = R.find;
-var where = R.where;
-var isEmpty = R.isEmpty;
 
 var objs = [
   {x: [1,2], y: true}, {x: [1,3], y: true}, {x: [], y: false}, {x: [2], y: false},
   {x: [3], y: true}, {x: [1], y: true}, {x: [1,2,3], y: true}, {x: [], y: true},
   {x: [1,2], y: false}, {x: [1,3], y: true}
 ];
-var findEmptyX = find(where({x: R.isEmpty}));
-var findFalseY = find(where({y: false}));
+var findEmptyX = R.find(R.where({x: R.isEmpty}));
+var findFalseY = R.find(R.where({y: false}));
 
 module.exports = {
   name: "find where",
@@ -19,10 +16,10 @@ module.exports = {
       _.find(objs, {x: []});
     },
     'find(where({x: isEmpty}), objs)': function() {
-      find(where({x: isEmpty}), objs);
+      R.find(R.where({x: R.isEmpty}), objs);
     },
     'find(where({x: isEmpty}))(objs)': function() {
-      find(where({x: isEmpty}))(objs);
+      R.find(R.where({x: R.isEmpty}))(objs);
     },
     'findEmptyX(objs)': function() {
       findEmptyX(objs);
@@ -31,10 +28,10 @@ module.exports = {
       _.find(objs, {y: false});
     },
     'find(where({y: false}), objs)': function() {
-      find(where({y: false}), objs);
+      R.find(R.where({y: false}), objs);
     },
     'find(where({y: false}))(objs)': function() {
-      find(where({y: false}))(objs);
+      R.find(R.where({y: false}))(objs);
     },
     'findFalseY(objs)': function() {
       findFalseY(objs);

--- a/bench/findIndex-where.bench.js
+++ b/bench/findIndex-where.bench.js
@@ -1,16 +1,13 @@
 var _ = require('lodash');
 var R = require('..');
-var findIndex = R.findIndex;
-var where = R.where;
-var isEmpty = R.isEmpty;
 
 var objs = [
   {x: [1,2], y: true}, {x: [1,3], y: true}, {x: [], y: false}, {x: [2], y: false},
   {x: [3], y: true}, {x: [1], y: true}, {x: [1,2,3], y: true}, {x: [], y: true},
   {x: [1,2], y: false}, {x: [1,3], y: true}
 ];
-var findIndexEmptyX = findIndex(where({x: R.isEmpty}));
-var findIndexFalseY = findIndex(where({y: false}));
+var findIndexEmptyX = R.findIndex(R.where({x: R.isEmpty}));
+var findIndexFalseY = R.findIndex(R.where({y: false}));
 
 module.exports = {
   name: "findIndex where",
@@ -19,10 +16,10 @@ module.exports = {
       _.findIndex(objs, {x: []});
     },
     'findIndex(where({x: isEmpty}), objs)': function() {
-      findIndex(where({x: isEmpty}), objs);
+      R.findIndex(R.where({x: R.isEmpty}), objs);
     },
     'findIndex(where({x: isEmpty}))(objs)': function() {
-      findIndex(where({x: isEmpty}))(objs);
+      R.findIndex(R.where({x: R.isEmpty}))(objs);
     },
     'findIndexEmptyX(objs)': function() {
       findIndexEmptyX(objs);
@@ -31,10 +28,10 @@ module.exports = {
       _.findIndex(objs, {y: false});
     },
     'findIndex(where({y: false}), objs)': function() {
-      findIndex(where({y: false}), objs);
+      R.findIndex(R.where({y: false}), objs);
     },
     'findIndex(where({y: false}))(objs)': function() {
-      findIndex(where({y: false}))(objs);
+      R.findIndex(R.where({y: false}))(objs);
     },
     'findIndexFalseY(objs)': function() {
       findIndexFalseY(objs);

--- a/ext/debug/debug.js
+++ b/ext/debug/debug.js
@@ -1,5 +1,4 @@
 var R = require('./ramda');
-var arity = R.arity;
 
 // Internal function to set the source attributes on a curried functions
 // useful for debugging purposes
@@ -13,10 +12,10 @@ function setSource(curried, source) {
 
 var NO_ARGS_EXCEPTION = new TypeError('Function called with no arguments');
 
-var curry = R.curry = function (fn, fnArity) {
+R.curry = function (fn, fnArity) {
   fnArity = typeof fnArity === "number" ? fnArity : fn.length;
   function recurry(args) {
-    return setSource(arity(Math.max(fnArity - (args && args.length || 0), 0), function () {
+    return setSource(R.arity(Math.max(fnArity - (args && args.length || 0), 0), function () {
       if (arguments.length === 0) { throw NO_ARGS_EXCEPTION; }
       var newArgs = concat(args, arguments);
       if (newArgs.length >= fnArity) {

--- a/ext/debug/test/debug.test.js
+++ b/ext/debug/test/debug.test.js
@@ -1,12 +1,11 @@
 var assert = require('assert');
 var R = require('../../..');
-var curry = R.curry;
 
 describe('curry', function() {
     function source(a, b, c) {
         return a * b * c;
     }
-    var curried = curry(source);
+    var curried = R.curry(source);
 /* TODO: restore these for debug build
     it('curry should set the toString value to the original', function() {
         assert.equal(String(source), String(curried));
@@ -16,13 +15,12 @@ describe('curry', function() {
 });
 
 describe('internal curry', function() {
-    var map = R.map, filter = R.filter;
     it('curry should set the toString value to the original', function() {
-        assert.notEqual(String(map), String(filter));
-        assert.equal(String(map), String(map.source));
+        assert.notEqual(String(R.map), String(R.filter));
+        assert.equal(String(R.map), String(R.map.source));
     });
     it('curried function != source', function() {
-        assert.notEqual(map, map.source);
+        assert.notEqual(R.map, R.map.source);
     });
 */
 });

--- a/ext/impure/test/impure.test.js
+++ b/ext/impure/test/impure.test.js
@@ -7,12 +7,10 @@ describe('impure', function() {
 
   describe('setProp', function() {
 
-    var setProp = R.setProp;
-
     it('sets a property to a value on the input object', function() {
       var obj = {};
       assert.isUndefined(obj.x);
-      var post = setProp('x', 'XXX', obj);
+      var post = R.setProp('x', 'XXX', obj);
       assert.equal(post.x, 'XXX');
       assert.equal(obj.x, 'XXX');
       assert.equal(obj, post);

--- a/ext/lazylist/test/test.lazy.js
+++ b/ext/lazylist/test/test.lazy.js
@@ -20,42 +20,38 @@ describe('lazylist', function() {
 });
 
 describe('take for a lazylist', function() {
-    var take = R.take;
     var lz;
     function I(x) { return x; }
     function inc(n) { return n + 1; }
 
     lz = lazylist(0, I, inc);
     it("takes the first n elements of an infinite sequence", function() {
-        assert.deepEqual(take(5, lz), [0, 1, 2, 3, 4]);
+        assert.deepEqual(R.take(5, lz), [0, 1, 2, 3, 4]);
     });
 });
 
 describe('takeWhile for a lazylist', function() {
-    var takeWhile = R.takeWhile, identity = R.identity;
     var inc = function (n) {return n + 1;};
     var pred = function(n) {return n < 5;};
 
-    var lz = lazylist(0, identity, inc);
+    var lz = lazylist(0, R.identity, inc);
     it("takes the elements of an infinite sequence while the supplied predicate is true", function() {
-        assert.deepEqual(takeWhile(pred, lz), [0, 1, 2, 3, 4]);
+        assert.deepEqual(R.takeWhile(pred, lz), [0, 1, 2, 3, 4]);
     });
 });
 
 describe('skip for a lazylist', function() {
-    var take = R.take, skip = R.skip;
     var lz;
     function I(x) { return x; }
     function inc(n) { return n + 1; }
     lz = lazylist(0, I, inc);
 
     it("skips the first n elements of an infinite sequence", function() {
-        assert.deepEqual(take(5, skip(10, lz)), [10, 11, 12, 13, 14]);
+        assert.deepEqual(R.take(5, R.skip(10, lz)), [10, 11, 12, 13, 14]);
     });
 });
 
 describe('map for a lazylist', function() {
-    var take = R.take, map = R.map;
     var lz;
     function I(x) { return x; }
     function inc(n) { return n + 1; }
@@ -64,12 +60,11 @@ describe('map for a lazylist', function() {
     lz = lazylist(0, I, inc);
 
     it("maps a function over the elements of even an infinite sequence", function() {
-        assert.deepEqual(take(5, map(square, lz)), [0, 1, 4, 9, 16]);
+        assert.deepEqual(R.take(5, R.map(square, lz)), [0, 1, 4, 9, 16]);
     });
 });
 
 describe('filter for a lazylist', function() {
-    var take = R.take, filter = R.filter;
     var even = function(n) {return n % 2 === 0;};
 
     var fibonacci = lazylist(
@@ -79,26 +74,24 @@ describe('filter for a lazylist', function() {
     );
 
     it("filters the elements of even an infinite sequence according to a function", function() {
-        assert.deepEqual(take(5, filter(even, fibonacci)), [0, 2, 8, 34, 144]);
+        assert.deepEqual(R.take(5, R.filter(even, fibonacci)), [0, 2, 8, 34, 144]);
     });
 });
 
 describe('repeat', function() {
-    var take = R.take, repeat = R.repeat;
-
     it("returns a lazy list of identical values", function() {
-        assert.deepEqual(take(5, repeat(0)), [0, 0, 0, 0, 0]);
+        assert.deepEqual(R.take(5, R.repeat(0)), [0, 0, 0, 0, 0]);
     });
 
     it("can accept any value, including `null`", function() {
-        assert.deepEqual(take(3, repeat(null)), [null, null, null]);
+        assert.deepEqual(R.take(3, R.repeat(null)), [null, null, null]);
     });
 
     it("can accept any value, including `undefined`", function() {
-        assert.deepEqual(take(4, repeat(undefined)), [undefined, undefined, undefined, undefined]);
+        assert.deepEqual(R.take(4, R.repeat(undefined)), [undefined, undefined, undefined, undefined]);
     });
 
     it("can accept any value, including an arbitrary object", function() {
-        assert.deepEqual(take(2, repeat({a: 10, b: {c: 20}})), [{a: 10, b: {c: 20}}, {a: 10, b: {c: 20}}]);
+        assert.deepEqual(R.take(2, R.repeat({a: 10, b: {c: 20}})), [{a: 10, b: {c: 20}}, {a: 10, b: {c: 20}}]);
     });
 });

--- a/ext/random/random.js
+++ b/ext/random/random.js
@@ -100,7 +100,7 @@
 
     // Returns a shuffled version of a list, using the
     // [Fisher-Yates shuffle](http://en.wikipedia.org/wiki/Fisher–Yates_shuffle).
-    var shuffle = R.shuffle = function(random, list) {
+    R.shuffle = function(random, list) {
         var idx = -1;
         var len = list.length;
         var position;

--- a/ext/random/test/test.random.js
+++ b/ext/random/test/test.random.js
@@ -27,7 +27,6 @@ describe('Random', function() {
 });
 
 describe('shuffle', function() {
-    var shuffle = R.shuffle;
     var random;
 
     beforeEach(function() {
@@ -36,7 +35,7 @@ describe('shuffle', function() {
 
     it('returns a shuffled copy of a list', function() {
         var list = [1, 2, 3,4, 5, 6, 7, 8, 9, 10];
-        assert.deepEqual(shuffle(random, list), [6, 3, 4, 8, 5, 1, 7, 10, 2, 9]);
+        assert.deepEqual(R.shuffle(random, list), [6, 3, 4, 8, 5, 1, 7, 10, 2, 9]);
     });
 
 });

--- a/ext/types/test/types.js
+++ b/ext/types/test/types.js
@@ -1,7 +1,5 @@
 var R = require('../../..');
 
-var I = R.identity;
-
 var interfaces = { functor: ['map'] };
 interfaces.apply = interfaces.functor.concat(['ap']);
 interfaces.applicative = interfaces.apply.concat(['of']);
@@ -22,7 +20,7 @@ module.exports = {
   functor: {
     iface: correctInterface('functor'),
     id: function(obj) {
-      return obj.equals(obj.map(I));
+      return obj.equals(obj.map(R.identity));
     },
     compose: function(obj, f, g) {
       return obj.map(function(x) { return f(g(x)); })
@@ -47,7 +45,7 @@ module.exports = {
   applicative: {
     iface: correctInterface('applicative'),
     id: function(obj, obj2) {
-      return obj.of(I).ap(obj2).equals(obj2);
+      return obj.of(R.identity).ap(obj2).equals(obj2);
     },
     homomorphic: function(obj, f, x) {
       return obj.of(f).ap(obj.of(x)).equals(obj.of(f(x)));

--- a/test/test.allany.js
+++ b/test/test.allany.js
@@ -2,26 +2,25 @@ var assert = require("assert");
 var R = require("..");
 
 describe('all', function() {
-    var all = R.all;
     var even = function(n) {return n % 2 === 0;};
     var T = function() {return true;};
 
     it('returns true if all elements satisfy the predicate', function() {
-        assert.equal(all(even, [2, 4, 6, 8, 10, 12]), true);
+        assert.equal(R.all(even, [2, 4, 6, 8, 10, 12]), true);
     });
 
     it('returns false if any element fails to satisfy the predicate', function() {
-        assert.equal(all(even, [2, 4, 6, 8, 9, 10]), false);
+        assert.equal(R.all(even, [2, 4, 6, 8, 9, 10]), false);
     });
 
     it('returns true for an empty list', function() {
-        assert.equal(all(T, []), true);
+        assert.equal(R.all(T, []), true);
     });
 
     it('should short-circuit on first false value', function() {
         var count = 0;
         var test = function(n) {count++; return even(n);};
-        var result = all(test, [2, 4, 6, 7, 8, 10]);
+        var result = R.all(test, [2, 4, 6, 7, 8, 10]);
         assert(!result);
         assert.equal(count, 4);
     });
@@ -29,51 +28,50 @@ describe('all', function() {
     it('is automatically curried', function () {
         var count = 0;
         var test = function(n) {count++; return even(n);};
-        assert(all(test)([2, 4, 6, 7, 8, 10]) === false);
+        assert(R.all(test)([2, 4, 6, 7, 8, 10]) === false);
     });
 
     it('should be aliased by `every`', function() {
         assert.equal(R.every(even, [2, 4, 6, 8, 10]), true);
-        assert.strictEqual(R.every, all);
+        assert.strictEqual(R.every, R.all);
     });
 });
 
 describe("any", function() {
-    var any = R.any;
     var odd = function(n) {return n % 2 === 1;};
     var T = function() {return true;};
 
     it('returns true if any element satisfies the predicate', function() {
-        assert.equal(any(odd, [2, 4, 6, 8, 10, 11, 12]), true);
+        assert.equal(R.any(odd, [2, 4, 6, 8, 10, 11, 12]), true);
     });
 
     it('returns false if all elements fails to satisfy the predicate', function() {
-        assert.equal(any(odd, [2, 4, 6, 8, 10, 12]), false);
+        assert.equal(R.any(odd, [2, 4, 6, 8, 10, 12]), false);
     });
 
     it('works with more complex objects', function() {
         var people = [{first: 'Paul', last: 'Grenier'}, {first:'Mike', last: 'Hurley'}, {first: 'Will', last: 'Klein'}];
         var alliterative = function(person) {return person.first.charAt(0) === person.last.charAt(0);};
-        assert.equal(any(alliterative, people), false);
+        assert.equal(R.any(alliterative, people), false);
         people.push({first: 'Scott', last: 'Sauyet'});
-        assert.equal(any(alliterative, people), true);
+        assert.equal(R.any(alliterative, people), true);
     });
 
     it('can use a configurable function', function() {
         var teens = [{name: 'Alice', age: 14}, {name: 'Betty', age: 18}, {name: 'Cindy', age: 17}];
         var atLeast = function(age) {return function(person) {return person.age >= age;};};
-        assert.equal(any(atLeast(16), teens), true, 'Some can legally drive');
-        assert.equal(any(atLeast(21), teens), false, 'None can legally drink');
+        assert.equal(R.any(atLeast(16), teens), true, 'Some can legally drive');
+        assert.equal(R.any(atLeast(21), teens), false, 'None can legally drink');
     });
 
     it('returns false for an empty list', function() {
-        assert.equal(any(T, []), false);
+        assert.equal(R.any(T, []), false);
     });
 
     it('should short-circuit on first true value', function() {
         var count = 0;
         var test = function(n) {count++; return odd(n);};
-        var result = any(test, [2, 4, 6, 7, 8, 10]);
+        var result = R.any(test, [2, 4, 6, 7, 8, 10]);
         assert(result);
         assert.equal(count, 4);
     });
@@ -81,11 +79,11 @@ describe("any", function() {
     it('is automatically curried', function () {
         var count = 0;
         var test = function(n) {count++; return odd(n);};
-        assert(any(test)([2, 4, 6, 7, 8, 10]) === true);
+        assert(R.any(test)([2, 4, 6, 7, 8, 10]) === true);
     });
 
     it('should be aliased by `some`', function() {
         assert.equal(R.some(odd, [2, 4, 6, 8, 10, 11, 12]), true);
-        assert.strictEqual(R.some, any);
+        assert.strictEqual(R.some, R.any);
     });
 });

--- a/test/test.always.js
+++ b/test/test.always.js
@@ -2,52 +2,48 @@ var assert = require('assert');
 var R = require('..');
 
 describe('always', function() {
-    var always = R.always;
     it('should return a function that returns the object initially supplied', function() {
-        var theMeaning = always(42);
+        var theMeaning = R.always(42);
         assert.equal(theMeaning(), 42);
         assert.equal(theMeaning(10), 42);
         assert.equal(theMeaning(false), 42);
     });
 
     it('should work with various types', function() {
-        assert.equal(always(false)(), false);
-        assert.equal(always('abc')(), 'abc');
-        assert.deepEqual(always({a: 1, b: 2})(), {a: 1, b: 2});
+        assert.equal(R.always(false)(), false);
+        assert.equal(R.always('abc')(), 'abc');
+        assert.deepEqual(R.always({a: 1, b: 2})(), {a: 1, b: 2});
         var obj = {a: 1, b: 2};
-        assert.strictEqual(always(obj)(), obj);
+        assert.strictEqual(R.always(obj)(), obj);
         var now = new Date(1776, 6, 4);
-        assert.deepEqual(always(now)(), new Date(1776, 6, 4));
+        assert.deepEqual(R.always(now)(), new Date(1776, 6, 4));
     });
 
     it('should be aliased by `constant`', function() {
-        assert.strictEqual(R.constant, always);
+        assert.strictEqual(R.constant, R.always);
     });
 });
 
 describe ('alwaysZero', function() {
-    var alwaysZero = R.alwaysZero;
     it('should always return zero', function() {
-        assert.equal(alwaysZero(), 0);
-        assert.equal(alwaysZero(10), 0);
-        assert.equal(alwaysZero(false), 0);
+        assert.equal(R.alwaysZero(), 0);
+        assert.equal(R.alwaysZero(10), 0);
+        assert.equal(R.alwaysZero(false), 0);
     });
 });
 
 describe ('alwaysFalse', function() {
-    var alwaysFalse = R.alwaysFalse;
     it('should always return false', function() {
-        assert.equal(alwaysFalse(), false);
-        assert.equal(alwaysFalse(10), false);
-        assert.equal(alwaysFalse(true), false);
+        assert.equal(R.alwaysFalse(), false);
+        assert.equal(R.alwaysFalse(10), false);
+        assert.equal(R.alwaysFalse(true), false);
     });
 });
 
 describe ('alwaysTrue', function() {
-    var alwaysTrue = R.alwaysTrue;
     it('should always return true', function() {
-        assert.equal(alwaysTrue(), true);
-        assert.equal(alwaysTrue(10), true);
-        assert.equal(alwaysTrue(true), true);
+        assert.equal(R.alwaysTrue(), true);
+        assert.equal(R.alwaysTrue(10), true);
+        assert.equal(R.alwaysTrue(true), true);
     });
 });

--- a/test/test.booleans.js
+++ b/test/test.booleans.js
@@ -2,12 +2,10 @@ var assert = require("assert");
 var R = require("..");
 
 describe('or', function() {
-    var or = R.or;
-
     it('should combine two boolean-returning functions into one', function() {
         var even = function(x) {return x % 2 === 0;};
         var gt10 = function(x) {return x > 10;};
-        var f = or(even, gt10);
+        var f = R.or(even, gt10);
         assert.equal(f(8), true);
         assert.equal(f(13), true);
         assert.equal(f(7), false);
@@ -16,7 +14,7 @@ describe('or', function() {
     it('should accept functions that take multiple parameters', function() {
         var between = function(a, b, c) {return a < b && b < c;};
         var total20 = function(a, b, c) {return a + b + c === 20;};
-        var f = or(between, total20);
+        var f = R.or(between, total20);
         assert.equal(f(4, 5, 8), true);
         assert.equal(f(12, 2, 6), true);
         assert.equal(f(7, 5, 1), false);
@@ -26,18 +24,16 @@ describe('or', function() {
         var T = function() { return true; };
         var Z = function() { effect = "Z got evaluated"; };
         var effect = "not evaluated";
-        or(T, Z);
+        R.or(T, Z);
         assert.equal(effect, "not evaluated");
     });
 });
 
 describe('and', function() {
-    var and = R.and;
-
     it('should combine two boolean-returning functions into one', function() {
         var even = function(x) {return x % 2 === 0;};
         var gt10 = function(x) {return x > 10;};
-        var f = and(even, gt10);
+        var f = R.and(even, gt10);
         assert.equal(f(8), false);
         assert.equal(f(13), false);
         assert.equal(f(14), true);
@@ -46,7 +42,7 @@ describe('and', function() {
     it('should accept functions that take multiple parameters', function() {
         var between = function(a, b, c) {return a < b && b < c;};
         var total20 = function(a, b, c) {return a + b + c === 20;};
-        var f = and(between, total20);
+        var f = R.and(between, total20);
         assert.equal(f(4, 5, 11), true);
         assert.equal(f(12, 2, 6), false);
         assert.equal(f(5, 6, 15), false);
@@ -56,38 +52,35 @@ describe('and', function() {
         var F = function() { return false; };
         var Z = function() { effect = "Z got evaluated"; };
         var effect = "not evaluated";
-        and(F, Z);
+        R.and(F, Z);
         assert.equal(effect, "not evaluated");
     });
 });
 
 describe('not', function() {
-    var not = R.not;
-
     it('should create boolean-returning function that reverses another', function() {
         var even = function(x) {return x % 2 === 0;};
-        var f = not(even);
+        var f = R.not(even);
         assert.equal(f(8), false);
         assert.equal(f(13), true);
     });
 
     it('should accept a function that take multiple parameters', function() {
         var between = function(a, b, c) {return a < b && b < c;};
-        var f = not(between);
+        var f = R.not(between);
         assert.equal(f(4, 5, 11), false);
         assert.equal(f(12, 2, 6), true);
     });
 });
 
 describe('allPredicates', function() {
-    var allPredicates = R.allPredicates;
     var odd = function(n) {return n % 2 !== 0;};
     var lt20 = function(n) {return n < 20;};
     var gt5 = function(n) {return n > 5;};
     var plusEq = function(w, x, y, z) { return w + x  === y + z; };
 
     it('should report whether all predicates are satisfied by a given value', function() {
-        var ok = allPredicates([odd, lt20, gt5]);
+        var ok = R.allPredicates([odd, lt20, gt5]);
         assert.equal(ok(7), true);
         assert.equal(ok(9), true);
         assert.equal(ok(10), false);
@@ -96,24 +89,23 @@ describe('allPredicates', function() {
     });
 
     it('does not have to be curried', function() {
-        assert.equal(allPredicates([odd, gt5], 3), false);
-        assert.equal(allPredicates([odd, gt5], 7), true);
+        assert.equal(R.allPredicates([odd, gt5], 3), false);
+        assert.equal(R.allPredicates([odd, gt5], 7), true);
     });
 
     it('reports its arity as the longest predicate length', function() {
-        assert.equal(allPredicates([odd, gt5, plusEq]).length, 4);
+        assert.equal(R.allPredicates([odd, gt5, plusEq]).length, 4);
     });
 });
 
 describe('anyPredicates', function() {
-    var anyPredicates = R.anyPredicates;
     var odd = function(n) {return n % 2 !== 0;};
     var gt20 = function(n) {return n > 20;};
     var lt5 = function(n) {return n < 5;};
     var plusEq = function(w, x, y, z) { return w + x  === y + z; };
 
     it('should report whether any predicates are satisfied by a given value', function() {
-        var ok = anyPredicates([odd, gt20, lt5]);
+        var ok = R.anyPredicates([odd, gt20, lt5]);
         assert.equal(ok(7), true);
         assert.equal(ok(9), true);
         assert.equal(ok(10), false);
@@ -123,11 +115,11 @@ describe('anyPredicates', function() {
     });
 
     it('does not have to be curried', function() {
-        assert.equal(anyPredicates([odd, lt5], 3), true);
-        assert.equal(anyPredicates([odd, lt5], 22), false);
+        assert.equal(R.anyPredicates([odd, lt5], 3), true);
+        assert.equal(R.anyPredicates([odd, lt5], 22), false);
     });
 
     it('reports its arity as the longest predicate length', function() {
-      assert.equal(anyPredicates([odd, lt5, plusEq]).length, 4);
+      assert.equal(R.anyPredicates([odd, lt5, plusEq]).length, 4);
     });
 });

--- a/test/test.clone.js
+++ b/test/test.clone.js
@@ -2,17 +2,15 @@ var assert = require("assert");
 var R = require("..");
 
 describe('clone', function() {
-    var clone = R.clone;
-
     it('returns a copy of an array', function() {
-      assert.deepEqual(clone([1,2,3,4,5]), [1,2,3,4,5]);
+      assert.deepEqual(R.clone([1,2,3,4,5]), [1,2,3,4,5]);
     });
 
     it('copies objects in the array by reference', function() {
       var o1 = {x: 1};
       var o2 = {x: 2};
       var o3 = {x: 3};
-      var c = clone([o1, o2, o3]);
+      var c = R.clone([o1, o2, o3]);
       assert.equal(c[0], o1);
     });
 });

--- a/test/test.compose.js
+++ b/test/test.compose.js
@@ -2,21 +2,20 @@ var assert = require("assert");
 var R = require("..");
 
 describe('compose', function() {
-    var compose = R.compose;
     function a(x) {return x + "A";}
     function b(x) {return x + "B";}
     function c(x) {return x + "C";}
     function d(x) {return x + "D";}
 
     it('executes its passed in functions in order from right to left', function() {
-        assert.equal(compose(a, b, c, d)(""), "DCBA");
+        assert.equal(R.compose(a, b, c, d)(""), "DCBA");
     });
 
     it('first function is passed multiple args', function() {
         function e(a, b, c) {
             return c + "E";
         }
-        assert.equal(compose(a, b, c, e)(1, 2, 3), "3ECBA");
+        assert.equal(R.compose(a, b, c, e)(1, 2, 3), "3ECBA");
     });
 
     it('passes context to functions', function() {
@@ -30,7 +29,7 @@ describe('compose', function() {
             return this.z * val;
         }
         var context = {
-            a: compose(x, y, z),
+            a: R.compose(x, y, z),
             x: 4,
             y: 2,
             z: 1
@@ -43,43 +42,42 @@ describe('compose', function() {
        function a3(x, y) { return 'A2'; }
        function a4(x, y) { return 'A2'; }
 
-       var f1 = compose(b, a);
+       var f1 = R.compose(b, a);
        assert.equal(f1.length, a.length);
-       var f2 = compose(b, a2);
+       var f2 = R.compose(b, a2);
        assert.equal(f2.length, a2.length);
-       var f3 = compose(b, a3);
+       var f3 = R.compose(b, a3);
        assert.equal(f3.length, a3.length);
-       var f4 = compose(b, a4);
+       var f4 = R.compose(b, a4);
        assert.equal(f4.length, a4.length);
     });
 
     it('throws if given no arguments', function() {
-        assert.throws(function() { compose(); });
+        assert.throws(function() { R.compose(); });
     });
 
     it('returns argument if given exactly one argument', function() {
         function f() {}
-        assert.strictEqual(compose(f), f);
+        assert.strictEqual(R.compose(f), f);
     });
 
 });
 
 describe('pipe', function() {
-    var pipe = R.pipe;
     function a(x) {return x + "A";}
     function b(x) {return x + "B";}
     function c(x) {return x + "C";}
     function d(x) {return x + "D";}
 
     it('executes its passed in functions in order from left to right', function() {
-        assert.equal(pipe(a, b, c, d)(""), "ABCD");
+        assert.equal(R.pipe(a, b, c, d)(""), "ABCD");
     });
 
     it('first function is passed multiple args', function() {
         function e(a, b, c) {
             return c + "E";
         }
-        assert.equal(pipe(e, a, b, c)(1, 2, 3), "3EABC");
+        assert.equal(R.pipe(e, a, b, c)(1, 2, 3), "3EABC");
     });
 
     it('passes context to functions', function() {
@@ -93,7 +91,7 @@ describe('pipe', function() {
             return this.z * val;
         }
         var context = {
-            a: pipe(x, y, z),
+            a: R.pipe(x, y, z),
             x: 4,
             y: 2,
             z: 1
@@ -103,18 +101,16 @@ describe('pipe', function() {
 });
 
 describe('useWith', function() {
-    var useWith = R.useWith;
-
     function max() { return Math.max.apply(Math, arguments); }
     function add1(x) { return x + 1; }
     function mult2(x) { return x * 2; }
     function div3(x) { return x/3; }
-    var f = useWith(max, add1, mult2, div3);
+    var f = R.useWith(max, add1, mult2, div3);
 
     it('takes a arbitrary number of function arguments and returns a function', function() {
-        assert.equal(typeof useWith(max), 'function');
-        assert.equal(typeof useWith(max, add1), 'function');
-        assert.equal(typeof useWith(max, add1, mult2, div3), 'function');
+        assert.equal(typeof R.useWith(max), 'function');
+        assert.equal(typeof R.useWith(max, add1), 'function');
+        assert.equal(typeof R.useWith(max, add1, mult2, div3), 'function');
     });
 
     it('passes the arguments received to their respective functions', function() {
@@ -133,10 +129,9 @@ describe('useWith', function() {
 });
 
 describe('fork', function() {
-    var fork = R.fork, add = R.add;
     var mult = function(a, b) {return a * b;};
 
     it('passes the results of applying the arguments individually to two separate functions into a single one', function() {
-        assert.equal(fork(mult, add(1), add(3))(2), 15); // mult(add1(2), add3(2)) = mult(3, 5) = 3 * 15;
+        assert.equal(R.fork(mult, R.add(1), R.add(3))(2), 15); // mult(add1(2), add3(2)) = mult(3, 5) = 3 * 15;
     });
 });

--- a/test/test.containsuniq.js
+++ b/test/test.containsuniq.js
@@ -3,39 +3,35 @@ var R = require("..");
 
 
 describe("contains", function() {
-    var contains = R.contains;
     it("returns true if an element is in a list", function() {
-        assert.equal(contains(7, [1,2,3,9,8,7,100,200,300]), true);
+        assert.equal(R.contains(7, [1,2,3,9,8,7,100,200,300]), true);
     });
 
     it("returns false if an element is not in a list", function() {
-        assert.equal(contains(99, [1,2,3,9,8,7,100,200,300]), false);
+        assert.equal(R.contains(99, [1,2,3,9,8,7,100,200,300]), false);
     });
 
     it("returns false for the empty list", function() {
-        assert.equal(contains(1, []), false);
+        assert.equal(R.contains(1, []), false);
     });
 });
 
 describe('uniq', function() {
-    var uniq = R.uniq;
-
     it('returns a set from any array (i.e. purges duplicate elements)', function() {
         var arr = [1,2,3,1,2,3,1,2,3];
-        assert.deepEqual(uniq(arr), [1,2,3]);
+        assert.deepEqual(R.uniq(arr), [1,2,3]);
     });
 
     it('keeps elements from the left', function() {
-      assert.deepEqual(uniq([1, 2, 3, 4, 1]), [1,2,3,4]);
+      assert.deepEqual(R.uniq([1, 2, 3, 4, 1]), [1,2,3,4]);
     });
 
     it('returns an empty array for an empty array', function() {
-        assert.deepEqual(uniq([]), []);
+        assert.deepEqual(R.uniq([]), []);
     });
 });
 
 describe('uniqWith', function() {
-    var uniqWith = R.uniqWith;
     var T = R.alwaysTrue;
     var F = R.alwaysFalse;
     function eqI(x, accX) { return x.i === accX.i; }
@@ -43,30 +39,28 @@ describe('uniqWith', function() {
     it('returns a set from any array (i.e. purges duplicate elements) based on predicate', function() {
         var objs = [{x: T, i: 0}, {x: F, i: 1},{x: T, i: 2}, {x: T, i: 3},{x: F, i: 4}, {x: F, i: 5},{x: T, i: 6}, {x: F, i: 7}];
         var objs2 = [{x: T, i: 0}, {x: F, i: 1},{x: T, i: 2}, {x: T, i: 3},{x: F, i: 0}, {x: T, i: 1},{x: F, i: 2}, {x: F, i: 3}];
-        assert.deepEqual(uniqWith(eqI, objs), objs);
-        assert.deepEqual(uniqWith(eqI, objs2), [{x: T, i: 0}, {x: F, i: 1},{x: T, i: 2}, {x: T, i: 3}]);
+        assert.deepEqual(R.uniqWith(eqI, objs), objs);
+        assert.deepEqual(R.uniqWith(eqI, objs2), [{x: T, i: 0}, {x: F, i: 1},{x: T, i: 2}, {x: T, i: 3}]);
     });
 
     it('keeps elements from the left', function() {
-      assert.deepEqual(uniqWith(eqI, [{i: 1}, {i: 2}, {i: 3}, {i: 4}, {i: 1}]), [{i: 1}, {i: 2}, {i: 3}, {i: 4}]);
+      assert.deepEqual(R.uniqWith(eqI, [{i: 1}, {i: 2}, {i: 3}, {i: 4}, {i: 1}]), [{i: 1}, {i: 2}, {i: 3}, {i: 4}]);
     });
 
     it('returns an empty array for an empty array', function() {
-        assert.deepEqual(uniqWith(eqI, []), []);
+        assert.deepEqual(R.uniqWith(eqI, []), []);
     });
 });
 
 describe('isSet', function() {
-    var isSet = R.isSet;
-
     it('returns true if a list is composed of unique elements', function() {
         var arr = [1,2,3,1,2,3,1,2,3];
-        assert.equal(isSet(arr), false);
-        assert.equal(isSet([3,1,4,2,5,7,9]), true);
+        assert.equal(R.isSet(arr), false);
+        assert.equal(R.isSet([3,1,4,2,5,7,9]), true);
     });
 
     it('returns true for an empty array', function() {
-        assert.equal(isSet([]), true);
+        assert.equal(R.isSet([]), true);
     });
 
 });

--- a/test/test.core.js
+++ b/test/test.core.js
@@ -2,61 +2,52 @@ var assert = require('assert');
 var R = require('..');
 
 describe('isEmpty', function() {
-    var isEmpty = R.isEmpty;
-
     it('returns true if the list is empty', function() {
-        assert.equal(isEmpty([]), true);
+        assert.equal(R.isEmpty([]), true);
     });
 
     it('returns false if the list is not empty', function() {
-        assert.equal(isEmpty(['']), false);
+        assert.equal(R.isEmpty(['']), false);
     });
 });
 
 describe('isAtom', function() {
-    var isAtom = R.isAtom;
     it('is false for Arrays', function() {
-        assert.equal(isAtom([]), false);
-        assert.equal(isAtom([1, 2, 3, 4]), false);
+        assert.equal(R.isAtom([]), false);
+        assert.equal(R.isAtom([1, 2, 3, 4]), false);
     });
     it('is false for undefined and null', function() {
-        assert.equal(isAtom(), false);
-        assert.equal(isAtom(null), false);
+        assert.equal(R.isAtom(), false);
+        assert.equal(R.isAtom(null), false);
     });
 
     it('is true for primitive values', function() {
-        assert.equal(isAtom(1), true);
-        assert.equal(isAtom('a'), true);
-        assert.equal(isAtom({}), true);
-        assert.equal(isAtom(true), true);
-        assert.equal(isAtom(false), true);
+        assert.equal(R.isAtom(1), true);
+        assert.equal(R.isAtom('a'), true);
+        assert.equal(R.isAtom({}), true);
+        assert.equal(R.isAtom(true), true);
+        assert.equal(R.isAtom(false), true);
     });
 });
 
 describe('prepend', function() {
-    var prepend = R.prepend;
-
     it('adds the element to the beginning of the list', function() {
-        assert.deepEqual(prepend('x', ['y', 'z']), ['x', 'y', 'z']);
-        assert.deepEqual(prepend(['a', 'z'], ['x', 'y']), [['a', 'z'], 'x', 'y']);
+        assert.deepEqual(R.prepend('x', ['y', 'z']), ['x', 'y', 'z']);
+        assert.deepEqual(R.prepend(['a', 'z'], ['x', 'y']), [['a', 'z'], 'x', 'y']);
     });
 });
 
 describe('append', function() {
-    var append = R.append;
-
     it('adds the element to the end of the list', function() {
-        assert.deepEqual(append('z', ['x', 'y']), ['x', 'y', 'z']);
-        assert.deepEqual(append(['a', 'z'], ['x', 'y']), ['x', 'y', ['a', 'z']]);
+        assert.deepEqual(R.append('z', ['x', 'y']), ['x', 'y', 'z']);
+        assert.deepEqual(R.append(['a', 'z'], ['x', 'y']), ['x', 'y', ['a', 'z']]);
     });
 });
 
 describe('concat', function() {
-    var concat = R.concat;
-
     it('adds combines the elements of the two lists', function() {
-        assert.deepEqual(concat(['a', 'b'], ['c', 'd']), ['a', 'b', 'c', 'd']);
-        assert.deepEqual(concat([], ['c', 'd']), ['c', 'd']);
+        assert.deepEqual(R.concat(['a', 'b'], ['c', 'd']), ['a', 'b', 'c', 'd']);
+        assert.deepEqual(R.concat([], ['c', 'd']), ['c', 'd']);
     });
 
     var z1 = {
@@ -66,94 +57,83 @@ describe('concat', function() {
     var z2 = { x: 'z2' };
 
     it('adds combines the elements of the two lists', function() {
-        assert.deepEqual(concat(['a', 'b'], ['c', 'd']), ['a', 'b', 'c', 'd']);
-        assert.deepEqual(concat([], ['c', 'd']), ['c', 'd']);
+        assert.deepEqual(R.concat(['a', 'b'], ['c', 'd']), ['a', 'b', 'c', 'd']);
+        assert.deepEqual(R.concat([], ['c', 'd']), ['c', 'd']);
     });
     it('works for objects with a concat method', function() {
-      assert.equal(concat('foo', 'bar'), 'foobar');
-      assert.equal(concat(z1, z2), 'z1 z2');
+      assert.equal(R.concat('foo', 'bar'), 'foobar');
+      assert.equal(R.concat(z1, z2), 'z1 z2');
     });
 });
 
 describe('head', function() {
-    var head = R.head;
-
     it('returns undefined for an empty list', function() {
-        assert.equal(typeof(head([])),  "undefined");
+        assert.equal(typeof(R.head([])),  "undefined");
     });
     it('returns undefined for no arguments', function() {
-        assert.equal(typeof(head()), "undefined");
+        assert.equal(typeof(R.head()), "undefined");
     });
     it('returns the first element of a list', function() {
-        assert.equal(head(['a', 'b', 'c', 'd']), 'a');
+        assert.equal(R.head(['a', 'b', 'c', 'd']), 'a');
     });
 });
 
 describe('last', function() {
-    var last = R.last;
-
     it('returns undefined for an empty list', function() {
-        assert.equal(typeof(last([])),  "undefined");
+        assert.equal(typeof(R.last([])),  "undefined");
     });
     it('returns undefined for no arguments', function() {
-        assert.equal(typeof(last()), "undefined");
+        assert.equal(typeof(R.last()), "undefined");
     });
     it('returns the first element of a list', function() {
-        assert.equal(last(['a', 'b', 'c', 'd']), 'd');
+        assert.equal(R.last(['a', 'b', 'c', 'd']), 'd');
     });
 });
 
 describe('tail', function() {
-    var tail = R.tail;
-
     it('returns an empty list for an empty list', function() {
-        assert.deepEqual(tail([]), []);
+        assert.deepEqual(R.tail([]), []);
     });
     it('returns an empty list for no arguments', function() {
-        assert.deepEqual(tail(), []);
+        assert.deepEqual(R.tail(), []);
     });
     it('returns a new list containing all the elements after the first element of a list', function() {
-        assert.deepEqual(['b', 'c', 'd'], tail(['a', 'b', 'c', 'd']));
+        assert.deepEqual(['b', 'c', 'd'], R.tail(['a', 'b', 'c', 'd']));
     });
 });
 
 describe('size', function() {
-    var size = R.size;
-
     it('counts the elements of a list', function() {
-        assert.equal(size(['a', 'b', 'c', 'd']), 4);
+        assert.equal(R.size(['a', 'b', 'c', 'd']), 4);
     });
 
     it('should be aliased by `length`', function() {
         assert.equal(R.length([2, 4, 6, 8, 10]), 5);
-        assert.strictEqual(R.length, size);
+        assert.strictEqual(R.length, R.size);
     });
 
 });
 
 describe('sort', function() {
-    var sort = R.sort;
-
     it('sorts the elements of a list', function() {
-        assert.deepEqual(sort(function(a, b) {return a - b;}, [3, 1, 8, 1, 2, 5]), [1, 1, 2, 3, 5, 8]);
+        assert.deepEqual(R.sort(function(a, b) {return a - b;}, [3, 1, 8, 1, 2, 5]), [1, 1, 2, 3, 5, 8]);
     });
 
     it('does not affect the list passed supplied', function() {
         var list = [3, 1, 8, 1, 2, 5];
-        assert.deepEqual(sort(function(a, b) {return a - b;}, list), [1, 1, 2, 3, 5, 8]);
+        assert.deepEqual(R.sort(function(a, b) {return a - b;}, list), [1, 1, 2, 3, 5, 8]);
         assert.deepEqual(list, [3, 1, 8, 1, 2, 5]);
     });
 
     it('is automatically curried', function() {
-        var sortByLength = sort(function(a, b) {return a.length - b.length;});
+        var sortByLength = R.sort(function(a, b) {return a.length - b.length;});
         assert.deepEqual(sortByLength(["one", "two", "three", "four", "five", "six"]),
                                       ["one", "two", "six", "four", "five", "three"]);
     });
 });
 
 describe('comparator', function() {
-    var comparator = R.comparator;
     it('builds a comparator function for sorting out of a simple predicate that reports whether the first param is smaller', function() {
-        assert.deepEqual([3, 1, 8, 1, 2, 5].sort(comparator(function(a, b) {return a < b;})), [1, 1, 2, 3, 5, 8]);
+        assert.deepEqual([3, 1, 8, 1, 2, 5].sort(R.comparator(function(a, b) {return a < b;})), [1, 1, 2, 3, 5, 8]);
     });
 });

--- a/test/test.curry.js
+++ b/test/test.curry.js
@@ -1,12 +1,11 @@
 var assert = require('assert');
 var R = require('..');
-var curry = R.curry;
 
 describe('curry', function() {
     function source(a, b, c) {
         return a * b * c;
     }
-    var curried = curry(source);
+    var curried = R.curry(source);
     it('curry should curry', function() {
         assert.equal(curried(1)(2)(3), 6);
         assert.equal(curried(1, 2)(3), 6);
@@ -16,7 +15,7 @@ describe('curry', function() {
     });
 
     it('curry should accept an arity', function() {
-        var curried = curry(function(a, b, c, d) {
+        var curried = R.curry(function(a, b, c, d) {
             return a * b * c;
         }, 3);
         assert.equal(curried(1)(2)(3), 6);
@@ -32,11 +31,9 @@ describe('curry', function() {
 });
 
 describe('internal curry', function() {
-    var map = R.map, filter = R.filter;
-
     it('should throw an expcetion given no arguments', function() {
-        assert.throws(map);
-        assert.throws(map(R.I));
+        assert.throws(R.map);
+        assert.throws(R.map(R.I));
         //doesnt throw an exception
         R.concat([]);
     });

--- a/test/test.each.js
+++ b/test/test.each.js
@@ -1,19 +1,18 @@
 var assert = require('assert');
 var R = require('..');
-var each = R.each;
 
 describe('each', function() {
     var list = [{x: 1, y: 2}, {x: 100, y: 200}, {x: 300, y: 400}, {x: 234, y: 345}];
 
     it('performs the passed in function on each element of the list', function() {
         var sideEffect = {};
-        each(function(elem) { sideEffect[elem.x] = elem.y; }, list);
+        R.each(function(elem) { sideEffect[elem.x] = elem.y; }, list);
         assert.deepEqual(sideEffect, {1: 2, 100: 200, 300: 400, 234: 345});
     });
 
     it('returns the original list', function() {
         var s = '';
-        assert.deepEqual(each(function(obj) { s += obj.x; }, list), list);
+        assert.deepEqual(R.each(function(obj) { s += obj.x; }, list), list);
         assert.equal('1100300234', s);
     });
 });
@@ -23,13 +22,13 @@ describe('each.idx', function() {
 
     it('performs the passed in function on each element of the list and passes in the index and list as well', function() {
         var sideEffect = {};
-        each.idx(function(elem, idx) { sideEffect[elem.x] = idx; }, list);
+        R.each.idx(function(elem, idx) { sideEffect[elem.x] = idx; }, list);
         assert.deepEqual(sideEffect, {1: 0, 100: 1, 300: 2, 234: 3});
     });
 
     it('returns the original list', function() {
         var s = '';
-        assert.deepEqual(each.idx(function(obj, idx, ls) { s += obj.x; }, list), list);
+        assert.deepEqual(R.each.idx(function(obj, idx, ls) { s += obj.x; }, list), list);
         assert.equal('1100300234', s);
     });
 });

--- a/test/test.filter.js
+++ b/test/test.filter.js
@@ -2,149 +2,137 @@ var assert = require("assert");
 var R = require("..");
 
 describe('filter', function() {
-    var filter = R.filter;
     var even = function(x) {return x % 2 === 0;};
 
     it('reduces an array to those matching a filter', function() {
-        assert.deepEqual(filter(even, [1, 2, 3, 4, 5]), [2, 4]);
+        assert.deepEqual(R.filter(even, [1, 2, 3, 4, 5]), [2, 4]);
     });
 
     it('should be automatically curried', function() {
-        var onlyEven = filter(even);
+        var onlyEven = R.filter(even);
         assert.deepEqual(onlyEven([1, 2, 3, 4, 5, 6, 7]), [2, 4, 6]);
     });
 });
 
 describe('filter.idx', function() {
-    var filter = R.filter;
     var even = function(x) {return x % 2 === 0;};
     var everyOther = function(val, idx) {return idx % 2 === 0;};
     var lastTwo = function(val, idx, list) {return list.length - idx < 3;};
 
     it('works just like a normal filter', function() {
-        assert.deepEqual(filter.idx(even, [1, 2, 3, 4, 5]), [2, 4]);
+        assert.deepEqual(R.filter.idx(even, [1, 2, 3, 4, 5]), [2, 4]);
     });
 
     it('passes the index as a second parameter to the predicate', function() {
-        assert.deepEqual(filter.idx(everyOther, [8, 6, 7, 5, 3, 0, 9]), [8, 7, 3, 9]);
+        assert.deepEqual(R.filter.idx(everyOther, [8, 6, 7, 5, 3, 0, 9]), [8, 7, 3, 9]);
     });
 
     it('passes the entire list as a third parameter to the predicate', function() {
-        assert.deepEqual(filter.idx(lastTwo, [8, 6, 7, 5, 3, 0, 9]), [0, 9]);
+        assert.deepEqual(R.filter.idx(lastTwo, [8, 6, 7, 5, 3, 0, 9]), [0, 9]);
     });
 
     it('should be automatically curried', function() {
-        var everyOtherPosition = filter.idx(everyOther);
+        var everyOtherPosition = R.filter.idx(everyOther);
         assert.deepEqual(everyOtherPosition([8, 6, 7, 5, 3, 0, 9]), [8, 7, 3, 9]);
     });
 });
 
 describe('reject', function() {
-    var reject = R.reject;
     var even = function(x) {return x % 2 === 0;};
 
     it('reduces an array to those not matching a filter', function() {
-        assert.deepEqual(reject(even, [1, 2, 3, 4, 5]), [1, 3, 5]);
+        assert.deepEqual(R.reject(even, [1, 2, 3, 4, 5]), [1, 3, 5]);
     });
 
     it('should be automatically curried', function() {
-        var odd = reject(even);
+        var odd = R.reject(even);
         assert.deepEqual(odd([1, 2, 3,4, 5, 6, 7]), [1, 3, 5, 7]);
     });
 });
 
 describe('reject.idx', function() {
-    var reject = R.reject;
     var even = function(x) {return x % 2 === 0;};
     var everyOther = function(val, idx) {return idx % 2 === 0;};
     var lastTwo = function(val, idx, list) {return list.length - idx < 3;};
 
     it('works just like a normal reject', function() {
-        assert.deepEqual(reject.idx(even, [1, 2, 3, 4, 5]), [1, 3, 5]);
+        assert.deepEqual(R.reject.idx(even, [1, 2, 3, 4, 5]), [1, 3, 5]);
     });
 
     it('passes the index as a second parameter to the predicate', function() {
-        assert.deepEqual(reject.idx(everyOther, [8, 6, 7, 5, 3, 0, 9]), [6, 5, 0]);
+        assert.deepEqual(R.reject.idx(everyOther, [8, 6, 7, 5, 3, 0, 9]), [6, 5, 0]);
     });
 
     it('passes the entire list as a third parameter to the predicate', function() {
-        assert.deepEqual(reject.idx(lastTwo, [8, 6, 7, 5, 3, 0, 9]), [8, 6, 7, 5, 3]);
+        assert.deepEqual(R.reject.idx(lastTwo, [8, 6, 7, 5, 3, 0, 9]), [8, 6, 7, 5, 3]);
     });
 
     it('should be automatically curried', function() {
-        var everyOtherPosition = reject.idx(everyOther);
+        var everyOtherPosition = R.reject.idx(everyOther);
         assert.deepEqual(everyOtherPosition([8, 6, 7, 5, 3, 0, 9]), [6, 5, 0]);
     });
 });
 
 describe('take', function() {
-    var take = R.take;
-
     it('should take only the first `n` elements from a list', function() {
-        assert.deepEqual(take(3, ['a', 'b', 'c', 'd', 'e', 'f', 'g']), ['a', 'b', 'c']);
+        assert.deepEqual(R.take(3, ['a', 'b', 'c', 'd', 'e', 'f', 'g']), ['a', 'b', 'c']);
     });
 
     it('should be automatically curried', function() {
-        var take3 = take(3);
+        var take3 = R.take(3);
         assert.deepEqual(take3(['a', 'b', 'c', 'd', 'e', 'f', 'g']), ['a', 'b', 'c']);
         assert.deepEqual(take3(['w', 'x', 'y', 'z']), ['w', 'x', 'y']);
     });
 });
 
 describe('takeWhile', function() {
-    var takeWhile = R.takeWhile;
-
     it('should continue taking elements while the function reports `true`', function() {
-        assert.deepEqual(takeWhile(function(x) {return x != 5;}, [1, 3, 5, 7, 9]), [1, 3]);
+        assert.deepEqual(R.takeWhile(function(x) {return x != 5;}, [1, 3, 5, 7, 9]), [1, 3]);
     });
 
     it('should start at the right arg and acknowledges undefined', function() {
-        assert.deepEqual(takeWhile(function(x) { assert.ok(false); }, []), []);
-        assert.deepEqual(takeWhile(function(x) {return x !== void 0;}, [1, 3, void 0, 5, 7]), [1, 3]);
+        assert.deepEqual(R.takeWhile(function(x) { assert.ok(false); }, []), []);
+        assert.deepEqual(R.takeWhile(function(x) {return x !== void 0;}, [1, 3, void 0, 5, 7]), [1, 3]);
     });
 
     it('should be automatically curried', function() {
-        var takeUntil7 = takeWhile(function(x) {return x != 7;});
+        var takeUntil7 = R.takeWhile(function(x) {return x != 7;});
         assert.deepEqual(takeUntil7([1, 3, 5, 7, 9]), [1, 3, 5]);
         assert.deepEqual(takeUntil7([2, 4, 6, 8, 10]), [2, 4, 6, 8, 10]);
     });
 });
 
 describe('skip', function() {
-    var skip = R.skip;
-
     it('should skip the first `n` elements from a list, returning the remainder', function() {
-        assert.deepEqual(skip(3, ['a', 'b', 'c', 'd', 'e', 'f', 'g']), ['d', 'e', 'f', 'g']);
+        assert.deepEqual(R.skip(3, ['a', 'b', 'c', 'd', 'e', 'f', 'g']), ['d', 'e', 'f', 'g']);
     });
 
     it('should be automatically curried', function() {
-        var skip2 = skip(2);
+        var skip2 = R.skip(2);
         assert.deepEqual(skip2(['a', 'b', 'c', 'd', 'e']), ['c', 'd', 'e']);
         assert.deepEqual(skip2(['x', 'y', 'z']), ['z']);
     });
 
     it('should be aliased by `drop`', function() {
         assert.deepEqual(R.drop(1, ['a', 'b', 'c']), ['b', 'c']);
-        assert.strictEqual(R.drop, skip);
+        assert.strictEqual(R.drop, R.skip);
     });
 });
 
 describe('skipUntil', function() {
-    var skipUntil = R.skipUntil;
-
     it('should continue taking elements while the function reports `true`', function() {
-        assert.deepEqual(skipUntil(function(x) {return x === 5;}, [1, 3, 5, 7, 9]), [5, 7, 9]);
+        assert.deepEqual(R.skipUntil(function(x) {return x === 5;}, [1, 3, 5, 7, 9]), [5, 7, 9]);
     });
 
     it('should start at the right arg and acknowledges undefined', function() {
-        assert.deepEqual(skipUntil(function(x) {
+        assert.deepEqual(R.skipUntil(function(x) {
            assert.ok(false);
         }, []), []);
-        assert.deepEqual(skipUntil(function(x) {return x === void 0;}, [1, 3, void 0, 5, 7]), [void 0, 5, 7]);
+        assert.deepEqual(R.skipUntil(function(x) {return x === void 0;}, [1, 3, void 0, 5, 7]), [void 0, 5, 7]);
     });
 
     it('should be automatically curried', function() {
-        var skipUntil7 = skipUntil(function(x) {return x === 7;});
+        var skipUntil7 = R.skipUntil(function(x) {return x === 7;});
         assert.deepEqual(skipUntil7([1, 3, 5, 7, 9]), [7, 9]);
         assert.deepEqual(skipUntil7([2, 4, 6, 8, 10]), []);
     });

--- a/test/test.find.js
+++ b/test/test.find.js
@@ -2,7 +2,6 @@ var assert = require("assert");
 var R = require("..");
 
 describe('find', function() {
-    var find = R.find;
     var obj1 = {x: 100};
     var obj2 = {x: 200};
     var a = [11, 10, 9, 'cow', obj1, 8, 7, 100, 200, 300, obj2, 4, 3, 2, 1, 0];
@@ -12,19 +11,18 @@ describe('find', function() {
     var xGt100 = function(o) { return o && o.x > 100; };
 
     it("returns the first element that satisfies the predicate", function() {
-        assert.equal(find(even, a), 10);
-        assert.equal(find(gt100, a), 200);
-        assert.equal(find(isStr, a), 'cow');
-        assert.equal(find(xGt100, a), obj2);
+        assert.equal(R.find(even, a), 10);
+        assert.equal(R.find(gt100, a), 200);
+        assert.equal(R.find(isStr, a), 'cow');
+        assert.equal(R.find(xGt100, a), obj2);
     });
 
     it("returns `undefined` when no element satisfies the predicate", function() {
-        assert.equal(find(even, 'zing'), undefined);
+        assert.equal(R.find(even, 'zing'), undefined);
     });
 });
 
 describe('findIndex', function() {
-    var findIndex = R.findIndex;
     var obj1 = {x: 100};
     var obj2 = {x: 200};
     var a = [11, 10, 9, 'cow', obj1, 8, 7, 100, 200, 300, obj2, 4, 3, 2, 1, 0];
@@ -34,19 +32,18 @@ describe('findIndex', function() {
     var xGt100 = function(o) { return o && o.x > 100; };
 
     it("returns the index of the first element that satisfies the predicate", function() {
-        assert.equal(findIndex(even, a), 1);
-        assert.equal(findIndex(gt100, a), 8);
-        assert.equal(findIndex(isStr, a), 3);
-        assert.equal(findIndex(xGt100, a), 10);
+        assert.equal(R.findIndex(even, a), 1);
+        assert.equal(R.findIndex(gt100, a), 8);
+        assert.equal(R.findIndex(isStr, a), 3);
+        assert.equal(R.findIndex(xGt100, a), 10);
     });
 
     it("returns -1 when no element satisfies the predicate", function() {
-        assert.equal(findIndex(even, 'zing'), -1);
+        assert.equal(R.findIndex(even, 'zing'), -1);
     });
 });
 
 describe('findLast', function() {
-    var findLast = R.findLast;
     var obj1 = {x: 100};
     var obj2 = {x: 200};
     var a = [11, 10, 9, 'cow', obj1, 8, 7, 100, 200, 300, obj2, 4, 3, 2, 1, 0];
@@ -56,19 +53,18 @@ describe('findLast', function() {
     var xGt100 = function(o) { return o && o.x > 100; };
 
     it("returns the index of the last element that satisfies the predicate", function() {
-        assert.equal(findLast(even, a), 0);
-        assert.equal(findLast(gt100, a), 300);
-        assert.equal(findLast(isStr, a), 'cow');
-        assert.equal(findLast(xGt100, a), obj2);
+        assert.equal(R.findLast(even, a), 0);
+        assert.equal(R.findLast(gt100, a), 300);
+        assert.equal(R.findLast(isStr, a), 'cow');
+        assert.equal(R.findLast(xGt100, a), obj2);
     });
 
     it("returns `undefined` when no element satisfies the predicate", function() {
-        assert.equal(findLast(even, 'zing'), undefined);
+        assert.equal(R.findLast(even, 'zing'), undefined);
     });
 });
 
 describe('findLastIndex', function() {
-    var findLastIndex = R.findLastIndex;
     var obj1 = {x: 100};
     var obj2 = {x: 200};
     var a = [11, 10, 9, 'cow', obj1, 8, 7, 100, 200, 300, obj2, 4, 3, 2, 1, 0];
@@ -78,13 +74,13 @@ describe('findLastIndex', function() {
     var xGt100 = function(o) { return o && o.x > 100; };
 
     it("returns the index of the last element that satisfies the predicate", function() {
-        assert.equal(findLastIndex(even, a), 15);
-        assert.equal(findLastIndex(gt100, a), 9);
-        assert.equal(findLastIndex(isStr, a), 3);
-        assert.equal(findLastIndex(xGt100, a), 10);
+        assert.equal(R.findLastIndex(even, a), 15);
+        assert.equal(R.findLastIndex(gt100, a), 9);
+        assert.equal(R.findLastIndex(isStr, a), 3);
+        assert.equal(R.findLastIndex(xGt100, a), 10);
     });
 
     it("returns -1 when no element satisfies the predicate", function() {
-        assert.equal(findLastIndex(even, 'zing'), -1);
+        assert.equal(R.findLastIndex(even, 'zing'), -1);
     });
 });

--- a/test/test.flatten.js
+++ b/test/test.flatten.js
@@ -2,49 +2,45 @@ var assert = require("assert");
 var R = require("..");
 
 describe('flatten', function() {
-    var flatten = R.flatten;
-
     it("turns a nested list into one flat list", function() {
         var nest = [1, [2], [3, [4, 5], 6, [[[7], 8]]], 9, 10];
-        assert.deepEqual(flatten(nest), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+        assert.deepEqual(R.flatten(nest), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
         nest = [[[[3]], 2, 1], 0, [[-1, -2], -3]];
-        assert.deepEqual(flatten(nest), [3, 2, 1, 0, -1, -2, -3]);
-        assert.deepEqual(flatten([1, 2, 3, 4, 5]), [1, 2, 3, 4, 5]);
+        assert.deepEqual(R.flatten(nest), [3, 2, 1, 0, -1, -2, -3]);
+        assert.deepEqual(R.flatten([1, 2, 3, 4, 5]), [1, 2, 3, 4, 5]);
     });
 
     it("is not destructive", function() {
         var nest = [1, [2], [3, [4, 5], 6, [[[7], 8]]], 9, 10];
-        assert.notEqual(flatten(nest), nest);
+        assert.notEqual(R.flatten(nest), nest);
     });
 
     it("handles ridiculously large inputs", function() {
-        assert.equal(flatten([new Array(1000000), R.range(0, 56000), 5, 1, 3]).length, 1056003);
+        assert.equal(R.flatten([new Array(1000000), R.range(0, 56000), 5, 1, 3]).length, 1056003);
     });
 
     it("handles array-like objects", function() {
       var o = { length: 3, "0": [1, 2, [3]], "1": [], "2": ["a", "b", "c", ["d", "e"]] };
-      assert.deepEqual(flatten(o), [1, 2, 3, "a", "b", "c", "d", "e"]);
+      assert.deepEqual(R.flatten(o), [1, 2, 3, "a", "b", "c", "d", "e"]);
     });
 });
 
 describe('unnest', function() {
-    var unnest = R.unnest;
-
     it("only flattens one layer deep of a nested list", function() {
         var nest = [1, [2], [3, [4, 5], 6, [[[7], 8]]], 9, 10];
-        assert.deepEqual(unnest(nest), [1, 2, 3, [4, 5], 6, [[[7], 8]], 9, 10]);
+        assert.deepEqual(R.unnest(nest), [1, 2, 3, [4, 5], 6, [[[7], 8]], 9, 10]);
         nest = [[[[3]], 2, 1], 0, [[-1, -2], -3]];
-        assert.deepEqual(unnest(nest), [[[3]],2,1,0,[-1,-2],-3]);
-        assert.deepEqual(unnest([1, 2, 3, 4, 5]), [1, 2, 3, 4, 5]);
+        assert.deepEqual(R.unnest(nest), [[[3]],2,1,0,[-1,-2],-3]);
+        assert.deepEqual(R.unnest([1, 2, 3, 4, 5]), [1, 2, 3, 4, 5]);
     });
 
     it("is not destructive", function() {
         var nest = [1, [2], [3, [4, 5], 6, [[[7], 8]]], 9, 10];
-        assert.notEqual(unnest(nest), nest);
+        assert.notEqual(R.unnest(nest), nest);
     });
 
     it("handles array-like objects", function() {
       var o = { length: 3, "0": [1, 2, [3]], "1": [], "2": ["a", "b", "c", ["d", "e"]]};
-      assert.deepEqual(unnest(o), [1, 2, [3], "a", "b", "c", ["d", "e"]]);
+      assert.deepEqual(R.unnest(o), [1, 2, [3], "a", "b", "c", ["d", "e"]]);
     });
 });

--- a/test/test.fold.js
+++ b/test/test.fold.js
@@ -2,70 +2,67 @@ var assert = require("assert");
 var R = require("..");
 
 describe('foldl', function() {
-    var foldl = R.foldl;
     var add = function(a, b) {return a + b;};
     var mult = function(a, b) {return a * b;};
 
     it('should fold simple functions over arrays with the supplied accumulator', function() {
-        assert.equal(foldl(add, 0, [1, 2, 3, 4]), 10);
-        assert.equal(foldl(mult, 1, [1, 2, 3, 4]), 24);
+        assert.equal(R.foldl(add, 0, [1, 2, 3, 4]), 10);
+        assert.equal(R.foldl(mult, 1, [1, 2, 3, 4]), 24);
     });
 
     it('should return the accumulator for an empty array', function() {
-        assert.equal(foldl(add, 0, []), 0);
-        assert.equal(foldl(mult, 1, []), 1);
+        assert.equal(R.foldl(add, 0, []), 0);
+        assert.equal(R.foldl(mult, 1, []), 1);
     });
 
     it('should be automatically curried', function() {
-        var sum = foldl(add, 0);
+        var sum = R.foldl(add, 0);
         assert.equal(sum([1, 2, 3, 4]), 10);
     });
 
     it('should be aliased by `reduce`', function() {
         assert.equal(R.reduce(add, 0, [1, 2, 3, 4]), 10);
-        assert.strictEqual(R.reduce, foldl);
+        assert.strictEqual(R.reduce, R.foldl);
     });
 
     it('should correctly report the arity of curried versions', function() {
-        var sum = foldl(add, 0);
+        var sum = R.foldl(add, 0);
         assert.equal(sum.length, 1);
     });
 });
 
 describe('foldr', function() {
-    var foldr = R.foldr;
     var avg = function(a, b) {return (a + b) / 2;};
 
     it('should fold lists in the right order', function() {
-        assert.equal(foldr(function(a, b) {return a + b;}, '', ['a', 'b', 'c', 'd']), 'dcba');
+        assert.equal(R.foldr(function(a, b) {return a + b;}, '', ['a', 'b', 'c', 'd']), 'dcba');
     });
 
     it('should fold simple functions over arrays with the supplied accumulator', function() {
-        assert.equal(foldr(avg, 54, [12, 4, 10, 6]), 12);
+        assert.equal(R.foldr(avg, 54, [12, 4, 10, 6]), 12);
     });
 
     it('should return the accumulator for an empty array', function() {
-        assert.equal(foldr(avg, 0, []), 0);
+        assert.equal(R.foldr(avg, 0, []), 0);
     });
 
     it('should be automatically curried', function() {
-        var something = foldr(avg, 54);
+        var something = R.foldr(avg, 54);
         assert.equal(something([12, 4, 10, 6]), 12);
     });
 
     it('should be aliased by `reduceRight`', function() {
         assert.equal(R.reduceRight(avg, 54, [12, 4, 10, 6]), 12);
-        assert.strictEqual(R.reduceRight, foldr);
+        assert.strictEqual(R.reduceRight, R.foldr);
     });
 
     it('should correctly report the arity of curried versions', function() {
-        var something = foldr(avg, 0);
+        var something = R.foldr(avg, 0);
         assert.equal(something.length, 1);
     });
 });
 
 describe('foldl.idx', function() {
-    var foldl = R.foldl;
     var timesIdx = function(tot, num, idx, ls) {return tot + (num * idx);};
     var objectify = function(acc, elem, idx, ls) { acc[elem] = idx; return acc;};
 
@@ -73,8 +70,8 @@ describe('foldl.idx', function() {
     });
 
     it('passes the index as a third parameter to the predicate', function() {
-        assert.equal(foldl.idx(timesIdx, 0, [1, 2, 3, 4, 5]), 40);
-        assert.deepEqual(foldl.idx(objectify, {}, ['a', 'b', 'c', 'd', 'e']), {a: 0, b: 1, c: 2, d: 3, e: 4});
+        assert.equal(R.foldl.idx(timesIdx, 0, [1, 2, 3, 4, 5]), 40);
+        assert.deepEqual(R.foldl.idx(objectify, {}, ['a', 'b', 'c', 'd', 'e']), {a: 0, b: 1, c: 2, d: 3, e: 4});
     });
 
     it('passes the entire list as a fourth parameter to the predicate', function() {
@@ -83,32 +80,30 @@ describe('foldl.idx', function() {
 });
 
 describe('foldr.idx', function() {
-    var foldr = R.foldr;
-
     it('folds lists in the right order', function() {
-        assert.equal(foldr.idx(function(a, b, idx, list) {return a + idx + b;}, '', ['a', 'b', 'c', 'd']), '3d2c1b0a');
+        assert.equal(R.foldr.idx(function(a, b, idx, list) {return a + idx + b;}, '', ['a', 'b', 'c', 'd']), '3d2c1b0a');
     });
 
     it('folds simple functions over arrays with the supplied accumulator', function() {
-        assert.deepEqual(foldr.idx(function(acc, n, i) { return acc.concat([i, n]); }, [], [12, 4, 10, 6]), [3, 6, 2, 10, 1, 4, 0, 12]);
+        assert.deepEqual(R.foldr.idx(function(acc, n, i) { return acc.concat([i, n]); }, [], [12, 4, 10, 6]), [3, 6, 2, 10, 1, 4, 0, 12]);
     });
 
     it('returns the accumulator for an empty array', function() {
         var memo = [];
-        assert.equal(foldr.idx(function(a, n, i, ls) { return a.concat(i); }, memo, []), memo);
+        assert.equal(R.foldr.idx(function(a, n, i, ls) { return a.concat(i); }, memo, []), memo);
     });
 
     it('should be automatically curried', function() {
-        var something = foldr.idx(function(acc, b, i) { return acc += i + b; }, 54);
+        var something = R.foldr.idx(function(acc, b, i) { return acc += i + b; }, 54);
         assert.equal(something([12, 4, 10, 6]), 92);
     });
 
     it('should be aliased by `reduceRight`', function() {
-        assert.strictEqual(R.reduceRight.idx, foldr.idx);
+        assert.strictEqual(R.reduceRight.idx, R.foldr.idx);
     });
 
     it('should correctly report the arity of curried versions', function() {
-        var something = foldr.idx(function(acc, b, i) { return acc += i + b; }, 0);
+        var something = R.foldr.idx(function(acc, b, i) { return acc += i + b; }, 0);
         assert.equal(something.length, 1);
     });
 });

--- a/test/test.functionBasics.js
+++ b/test/test.functionBasics.js
@@ -2,27 +2,24 @@ var assert = require('assert');
 var R = require('..');
 
 describe('flip', function() {
-    var flip = R.flip;
     it('should return a function which inverts the first two arguments to the supplied function', function() {
         var f = function(a, b, c) {return a + ' ' + b + ' ' + c;};
-        var g = flip(f);
+        var g = R.flip(f);
         assert.equal(f('a', 'b', 'c'), 'a b c');
         assert.equal(g('a', 'b', 'c'), 'b a c');
     });
 
     it('should return a curried function', function() {
         var f = function(a, b, c) {return a + ' ' + b + ' ' + c;};
-        var g = flip(f)('a');
+        var g = R.flip(f)('a');
         assert.equal(g('b', 'c'), 'b a c');
     });
 });
 
 describe('once', function() {
-    var once = R.once;
-
     it('should return a function that calls the supplied function only the first time called', function() {
         var ctr = 0;
-        var fn = once(function() {ctr++;});
+        var fn = R.once(function() {ctr++;});
         fn();
         assert.equal(ctr, 1);
         fn();
@@ -32,14 +29,14 @@ describe('once', function() {
     });
 
     it('should pass along arguments supplied', function() {
-        var fn = once(function(a, b) {return a + b;});
+        var fn = R.once(function(a, b) {return a + b;});
         var result = fn(5, 10);
         assert.equal(result, 15);
     });
 
     it('should retain and return the first value calculated, even if different arguments are passed later', function() {
         var ctr = 0;
-        var fn = once(function(a, b) {ctr++; return a + b;});
+        var fn = R.once(function(a, b) {ctr++; return a + b;});
         var result = fn(5, 10);
         assert.equal(result, 15);
         assert.equal(ctr, 1);
@@ -50,18 +47,16 @@ describe('once', function() {
 });
 
 describe('memoize', function() {
-    var memoize = R.memoize;
-
     it('should calculate the value for a given input only once', function() {
         var ctr = 0;
-        var fib = memoize(function (n) {ctr++; return n < 2 ? n : fib(n - 2) + fib(n - 1);});
+        var fib = R.memoize(function (n) {ctr++; return n < 2 ? n : fib(n - 2) + fib(n - 1);});
         var result = fib(10);
         assert.equal(result, 55);
         assert.equal(ctr, 11); // fib(0), fib(1), ... fib(10), no memoization would take 177 iterations.
     });
 
     it('should handle multiple parameters', function() {
-        var f = memoize(function(a, b, c) {return a + ', ' + b + c;});
+        var f = R.memoize(function(a, b, c) {return a + ', ' + b + c;});
         assert.equal(f('Hello', 'World' , '!'), 'Hello, World!');
         assert.equal(f('Goodbye', 'Cruel World' , '!!!'), 'Goodbye, Cruel World!!!');
         assert.equal(f('Hello', 'how are you' , '?'), 'Hello, how are you?');
@@ -70,12 +65,11 @@ describe('memoize', function() {
 });
 
 describe('construct', function() {
-    var construct = R.construct;
     var Rectangle = function(w, h) {this.width = w; this.height = h;};
     Rectangle.prototype.area = function() {return this.width * this.height;};
 
     it('should turn a constructor function into one that can be called without `new`', function() {
-        var rect = construct(Rectangle);
+        var rect = R.construct(Rectangle);
         var r1 = rect(3, 4);
         assert(r1 instanceof Rectangle);
         assert.equal(r1.width, 3);
@@ -83,7 +77,7 @@ describe('construct', function() {
     });
 
     it('should return a curried function', function() {
-        var rect = construct(Rectangle);
+        var rect = R.construct(Rectangle);
         var rect3 = rect(3);
         var r1 = rect3(4);
         assert(r1 instanceof Rectangle);
@@ -94,10 +88,8 @@ describe('construct', function() {
 });
 
 describe('unary', function() {
-    var unary = R.unary;
-
     it('should turn multiple-argument function into unary one', function() {
-        unary(function(x, y, z) {
+        R.unary(function(x, y, z) {
             assert.equal(arguments.length, 1);
             assert.equal(typeof y, "undefined");
             assert.equal(typeof z, "undefined");
@@ -105,24 +97,22 @@ describe('unary', function() {
     });
 
     it('initial argument is passed through normally', function() {
-        unary(function(x, y, z) {
+        R.unary(function(x, y, z) {
             assert.equal(x, 10);
         })(10, 20, 30);
     });
 });
 
 describe('binary', function() {
-    var binary = R.binary;
-
     it('should turn multiple-argument function into binary one', function() {
-        binary(function(x, y, z) {
+        R.binary(function(x, y, z) {
             assert.equal(arguments.length, 2);
             assert.equal(typeof z, "undefined");
         })(10, 20, 30);
     });
 
     it('initial arguments are passed through normally', function() {
-        binary(function(x, y, z) {
+        R.binary(function(x, y, z) {
             assert.equal(x, 10);
             assert.equal(y, 20);
         })(10, 20, 30);
@@ -130,22 +120,21 @@ describe('binary', function() {
 });
 
 describe('ap', function() {
-    var ap = R.ap;
     function inc(x) { return x + 1; }
     function mult2(x) { return x * 2; }
     function plus3(x) { return x + 3; }
 
     it('applies a list of functions to a list of values', function() {
-      assert.deepEqual(ap([mult2, plus3], [1, 2, 3]), [2,4,6,4,5,6]);
+      assert.deepEqual(R.ap([mult2, plus3], [1, 2, 3]), [2,4,6,4,5,6]);
     });
 
     it('dispatches to the passed object\'s ap method when values is a non-Array object', function() {
       var obj = { ap: function(fs) { return { x: fs[0](1) }; } };
-      assert.deepEqual(ap([R.add(1)], obj), obj.ap([R.add(1)]));
+      assert.deepEqual(R.ap([R.add(1)], obj), obj.ap([R.add(1)]));
     });
 
     it('is curried', function() {
-      var val = ap([mult2, plus3]);
+      var val = R.ap([mult2, plus3]);
       assert.equal(typeof val, 'function');
       assert.deepEqual(val([1,2,3]), [2,4,6,4,5,6]);
     });

--- a/test/test.groupBy.js
+++ b/test/test.groupBy.js
@@ -2,8 +2,6 @@ var assert = require('assert');
 var R = require('..');
 
 describe('groupBy', function() {
-    var groupBy = R.groupBy, prop = R.prop;
-
     it('should split the list into groups according to the grouping function', function() {
         var grade = function(score) {
             return (score < 65) ? 'F' : (score < 70) ? 'D' : (score < 80) ? 'C' : (score < 90) ? 'B' : 'A';
@@ -21,7 +19,7 @@ describe('groupBy', function() {
             {name: 'Jack', score: 69}
         ];
         var byGrade = function(student) {return grade(student.score || 0);};
-        assert.deepEqual(groupBy(byGrade, students), {
+        assert.deepEqual(R.groupBy(byGrade, students), {
             'A': [{name: 'Dianne', score: 99}, {name: 'Gillian', score: 91}],
             'B': [{name: 'Abby', score: 84}, {name: 'Chris', score: 89}, {name: 'Irene', score: 85}],
             'C': [{name: 'Brad', score: 73}, {name: 'Hannah', score: 78}],
@@ -31,7 +29,7 @@ describe('groupBy', function() {
     });
 
     it('should be automatically curried', function() {
-        var splitByType = groupBy(prop("type"));
+        var splitByType = R.groupBy(R.prop("type"));
         assert.deepEqual(splitByType([
             {type: 'A', val: 10},
             {type: 'B', val: 20},

--- a/test/test.is.js
+++ b/test/test.is.js
@@ -4,17 +4,15 @@ var assert = require('assert');
 var R = require('..');
 
 describe('is', function() {
-    var is = R.is;
-
     it('works with built-in types', function() {
-        assert.strictEqual(is(Array, []), true);
-        assert.strictEqual(is(Boolean, new Boolean(false)), true);
-        assert.strictEqual(is(Date, new Date()), true);
-        assert.strictEqual(is(Function, function() {}), true);
-        assert.strictEqual(is(Number, new Number(0)), true);
-        assert.strictEqual(is(Object, {}), true);
-        assert.strictEqual(is(RegExp, /(?:)/), true);
-        assert.strictEqual(is(String, new String('')), true);
+        assert.strictEqual(R.is(Array, []), true);
+        assert.strictEqual(R.is(Boolean, new Boolean(false)), true);
+        assert.strictEqual(R.is(Date, new Date()), true);
+        assert.strictEqual(R.is(Function, function() {}), true);
+        assert.strictEqual(R.is(Number, new Number(0)), true);
+        assert.strictEqual(R.is(Object, {}), true);
+        assert.strictEqual(R.is(RegExp, /(?:)/), true);
+        assert.strictEqual(R.is(String, new String('')), true);
     });
 
     it('works with user-defined types', function() {
@@ -25,14 +23,14 @@ describe('is', function() {
         var foo = new Foo();
         var bar = new Bar();
 
-        assert.strictEqual(is(Foo, foo), true);
-        assert.strictEqual(is(Bar, bar), true);
-        assert.strictEqual(is(Foo, bar), true);
-        assert.strictEqual(is(Bar, foo), false);
+        assert.strictEqual(R.is(Foo, foo), true);
+        assert.strictEqual(R.is(Bar, bar), true);
+        assert.strictEqual(R.is(Foo, bar), true);
+        assert.strictEqual(R.is(Bar, foo), false);
     });
 
     it('is curried', function() {
-        var isArray = is(Array);
+        var isArray = R.is(Array);
         assert.strictEqual(isArray([]), true);
         assert.strictEqual(isArray({}), false);
     });
@@ -40,7 +38,7 @@ describe('is', function() {
     it('considers almost everything an object', function() {
         function Foo() {}
         var foo = new Foo();
-        var isObject = is(Object);
+        var isObject = R.is(Object);
 
         assert.strictEqual(isObject(foo), true);
         assert.strictEqual(isObject(function() { return arguments; }()), true);
@@ -57,8 +55,8 @@ describe('is', function() {
     });
 
     it('treats primitives like object equivalents', function() {
-        assert.strictEqual(is(Boolean, false), true);
-        assert.strictEqual(is(Number, 0), true);
-        assert.strictEqual(is(String, ''), true);
+        assert.strictEqual(R.is(Boolean, false), true);
+        assert.strictEqual(R.is(Number, 0), true);
+        assert.strictEqual(R.is(String, ''), true);
     });
 });

--- a/test/test.keysvals.js
+++ b/test/test.keysvals.js
@@ -3,7 +3,6 @@ var R = require("..");
 
 
 describe("keys", function() {
-    var keys = R.keys;
     var obj = {a: 100, b: [1,2,3], c: { x: 200, y: 300}, d: "D", e: null, f: (function(){}())};
     function C() { this.a = 100; this.b = 200; }
     C.prototype.x = function() { return "x"; };
@@ -11,11 +10,11 @@ describe("keys", function() {
     var cobj = new C();
 
     it("returns an array of the given object's own keys", function() {
-        assert.deepEqual(keys(obj), ['a','b','c','d','e','f']);
+        assert.deepEqual(R.keys(obj), ['a','b','c','d','e','f']);
     });
 
     it("should work with hasOwnProperty override", function() {
-        assert.deepEqual(keys({
+        assert.deepEqual(R.keys({
             /* jshint -W001 */
             "hasOwnProperty": false
             /* jshint +W001 */
@@ -30,12 +29,11 @@ describe("keys", function() {
     });
 
     it("does not include the given object's prototype properties", function() {
-        assert.deepEqual(keys(cobj), ['a', 'b']);
+        assert.deepEqual(R.keys(cobj), ['a', 'b']);
     });
 });
 
 describe("keysIn", function() {
-    var keysIn = R.keysIn;
     var obj = {a: 100, b: [1,2,3], c: { x: 200, y: 300}, d: "D", e: null, f: (function(){}())};
     function C() { this.a = 100; this.b = 200; }
     C.prototype.x = function() { return "x"; };
@@ -43,11 +41,11 @@ describe("keysIn", function() {
     var cobj = new C();
 
     it("returns an array of the given object's keys", function() {
-        assert.deepEqual(keysIn(obj), ['a','b','c','d','e','f']);
+        assert.deepEqual(R.keysIn(obj), ['a','b','c','d','e','f']);
     });
 
     it("includes the given object's prototype properties", function() {
-        assert.deepEqual(keysIn(cobj), ['a', 'b', 'x', 'y']);
+        assert.deepEqual(R.keysIn(cobj), ['a', 'b', 'x', 'y']);
     });
 
     it("should work for primitives", function() {
@@ -60,7 +58,6 @@ describe("keysIn", function() {
 
 
 describe("values", function() {
-    var values = R.values;
     var obj = {a: 100, b: [1,2,3], c: { x: 200, y: 300}, d: "D", e: null, f: (function(){}())};
     function C() { this.a = 100; this.b = 200; }
     C.prototype.x = function() { return "x"; };
@@ -68,8 +65,8 @@ describe("values", function() {
     var cobj = new C();
 
     it("returns an array of the given object's values", function() {
-        assert.deepEqual(values(obj), [100,[1,2,3],{x: 200, y: 300},'D',null,undefined]);
-        assert.deepEqual(values({
+        assert.deepEqual(R.values(obj), [100,[1,2,3],{x: 200, y: 300},'D',null,undefined]);
+        assert.deepEqual(R.values({
             /* jshint -W001 */
             hasOwnProperty: false
             /* jshint +W001 */
@@ -77,7 +74,7 @@ describe("values", function() {
     });
 
     it("does not include the given object's prototype properties", function() {
-        assert.deepEqual(values(cobj), [100, 200]);
+        assert.deepEqual(R.values(cobj), [100, 200]);
     });
 
     it("should work for primitives", function() {
@@ -89,7 +86,6 @@ describe("values", function() {
 });
 
 describe("valuesIn", function() {
-    var valuesIn = R.valuesIn;
     var obj = {a: 100, b: [1,2,3], c: { x: 200, y: 300}, d: "D", e: null, f: (function(){}())};
     function C() { this.a = 100; this.b = 200; }
     C.prototype.x = function() { return "x"; };
@@ -97,11 +93,11 @@ describe("valuesIn", function() {
     var cobj = new C();
 
     it("returns an array of the given object's values", function() {
-        assert.deepEqual(valuesIn(obj), [100,[1,2,3],{x: 200, y: 300},'D',null,undefined]);
+        assert.deepEqual(R.valuesIn(obj), [100,[1,2,3],{x: 200, y: 300},'D',null,undefined]);
     });
 
     it("includes the given object's prototype properties", function() {
-        assert.deepEqual(valuesIn(cobj), [100, 200, C.prototype.x, 'y']);
+        assert.deepEqual(R.valuesIn(cobj), [100, 200, C.prototype.x, 'y']);
     });
 
     it("should work for primitives", function() {

--- a/test/test.list.js
+++ b/test/test.list.js
@@ -9,77 +9,73 @@ describe('join', function () {
 });
 
 describe('remove', function () {
-    var remove = R.remove;
-
     it('splices out a sub-list of the given list', function() {
         var list = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j'];
-        assert.deepEqual(remove(2, 5, list), ['a', 'b', 'h', 'i', 'j']);
+        assert.deepEqual(R.remove(2, 5, list), ['a', 'b', 'h', 'i', 'j']);
     });
 
     it('returns the appropriate sublist when start == 0', function() {
         var list = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j'];
-        assert.deepEqual(remove(0, 5, list), ['f', 'g', 'h', 'i', 'j']);
-        assert.deepEqual(remove(0, 1, list), ['b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j']);
-        assert.deepEqual(remove(0, list.length, list), []);
+        assert.deepEqual(R.remove(0, 5, list), ['f', 'g', 'h', 'i', 'j']);
+        assert.deepEqual(R.remove(0, 1, list), ['b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j']);
+        assert.deepEqual(R.remove(0, list.length, list), []);
     });
 
     it('removes the end of the list if the count is too large', function() {
         var list = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j'];
-        assert.deepEqual(remove(2, 20, list), ['a', 'b']);
+        assert.deepEqual(R.remove(2, 20, list), ['a', 'b']);
     });
 
     it('retains the entire list if the start is too large', function() {
         var list = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j'];
-        assert.deepEqual(remove(13, 3, list), ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j']);
+        assert.deepEqual(R.remove(13, 3, list), ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j']);
     });
 
     it('should be curried', function() {
         var list = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j'];
-        assert.deepEqual(remove(13)(3)(list), ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j']);
-        assert.deepEqual(remove(13, 3)(list), ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j']);
+        assert.deepEqual(R.remove(13)(3)(list), ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j']);
+        assert.deepEqual(R.remove(13, 3)(list), ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j']);
     });
 });
 
 describe('insert', function () {
-    var insert = R.insert;
     it('inserts an element into the given list', function() {
         var list = ['a', 'b', 'c', 'd', 'e'];
-        assert.deepEqual(insert(2, 'x', list), ['a', 'b', 'x', 'c', 'd', 'e']);
+        assert.deepEqual(R.insert(2, 'x', list), ['a', 'b', 'x', 'c', 'd', 'e']);
     });
 
     it('inserts another list as an element', function() {
         var list = ['a', 'b', 'c', 'd', 'e'];
-        assert.deepEqual(insert(2, ['s', 't'], list), ['a', 'b', ['s', 't'], 'c', 'd', 'e']);
+        assert.deepEqual(R.insert(2, ['s', 't'], list), ['a', 'b', ['s', 't'], 'c', 'd', 'e']);
     });
 
     it('appends to the end of the list if the index is too large', function() {
         var list = ['a', 'b', 'c', 'd', 'e'];
-        assert.deepEqual(insert(8, 'z', list), ['a', 'b', 'c', 'd', 'e', 'z']);
+        assert.deepEqual(R.insert(8, 'z', list), ['a', 'b', 'c', 'd', 'e', 'z']);
     });
 
     it('should be curried', function() {
         var list = ['a', 'b', 'c', 'd', 'e'];
-        assert.deepEqual(insert(8)('z')(list), ['a', 'b', 'c', 'd', 'e', 'z']);
-        assert.deepEqual(insert(8, 'z')(list), ['a', 'b', 'c', 'd', 'e', 'z']);
+        assert.deepEqual(R.insert(8)('z')(list), ['a', 'b', 'c', 'd', 'e', 'z']);
+        assert.deepEqual(R.insert(8, 'z')(list), ['a', 'b', 'c', 'd', 'e', 'z']);
     });
 });
 
 
 describe('insert.all', function () {
-    var insert = R.insert;
     it('inserts a list of elements into the given list', function() {
         var list = ['a', 'b', 'c', 'd', 'e'];
-        assert.deepEqual(insert.all(2, ['x', 'y', 'z'], list), ['a', 'b', 'x', 'y', 'z', 'c', 'd', 'e']);
+        assert.deepEqual(R.insert.all(2, ['x', 'y', 'z'], list), ['a', 'b', 'x', 'y', 'z', 'c', 'd', 'e']);
     });
 
     it('appends to the end of the list if the index is too large', function() {
         var list = ['a', 'b', 'c', 'd', 'e'];
-        assert.deepEqual(insert.all(8, ['p', 'q', 'r'], list), ['a', 'b', 'c', 'd', 'e', 'p', 'q', 'r']);
+        assert.deepEqual(R.insert.all(8, ['p', 'q', 'r'], list), ['a', 'b', 'c', 'd', 'e', 'p', 'q', 'r']);
     });
 
     it('should be curried', function() {
         var list = ['a', 'b', 'c', 'd', 'e'];
-        assert.deepEqual(insert.all(8)(['p', 'q', 'r'], list), ['a', 'b', 'c', 'd', 'e', 'p', 'q', 'r']);
+        assert.deepEqual(R.insert.all(8)(['p', 'q', 'r'], list), ['a', 'b', 'c', 'd', 'e', 'p', 'q', 'r']);
     });
 });
 
@@ -125,63 +121,55 @@ describe('nth', function () {
 });
 
 describe('times', function() {
-    var times = R.times;
-
     it('takes a map func', function() {
-        assert.deepEqual(times(R.identity, 5), [0, 1, 2, 3, 4]);
-        assert.deepEqual(times(function(x) {
+        assert.deepEqual(R.times(R.identity, 5), [0, 1, 2, 3, 4]);
+        assert.deepEqual(R.times(function(x) {
             return x * 2;
         }, 5), [0, 2, 4, 6, 8]);
     });
 
     it('is curried', function() {
-        var mapid = times(R.identity);
+        var mapid = R.times(R.identity);
         assert.deepEqual(mapid(5), [0, 1, 2, 3, 4]);
     });
 });
 
 describe('repeatN', function () {
-    var repeatN = R.repeatN;
-
     it('returns a lazy list of identical values', function () {
-        assert.deepEqual(repeatN(0, 5), [0, 0, 0, 0, 0]);
+        assert.deepEqual(R.repeatN(0, 5), [0, 0, 0, 0, 0]);
     });
 
     it('can accept any value, including `null`', function () {
-        assert.deepEqual(repeatN(null, 3), [null, null, null]);
+        assert.deepEqual(R.repeatN(null, 3), [null, null, null]);
     });
 
     it('is automatically curried', function () {
-        var nTrues = repeatN(true);
+        var nTrues = R.repeatN(true);
         assert.deepEqual(nTrues(4), [true, true, true, true]);
     });
 });
 
 describe('of', function() {
-    var of = R.of;
-
     it('returns its argument as an Array', function() {
-        assert.deepEqual(of(100), [100]);
-        assert.deepEqual(of([100]), [[100]]);
-        assert.deepEqual(of(null), [null]);
-        assert.deepEqual(of(undefined), [undefined]);
-        assert.deepEqual(of([]), [[]]);
+        assert.deepEqual(R.of(100), [100]);
+        assert.deepEqual(R.of([100]), [[100]]);
+        assert.deepEqual(R.of(null), [null]);
+        assert.deepEqual(R.of(undefined), [undefined]);
+        assert.deepEqual(R.of([]), [[]]);
     });
 });
 
 describe('empty', function() {
-    var empty = R.empty;
     it('returns an empty list', function() {
-        assert.deepEqual(empty([1,2,3]), []);
+        assert.deepEqual(R.empty([1,2,3]), []);
     });
 
 });
 
 describe('chain', function() {
-    var chain = R.chain;
     var dbl = R.map(R.multiply(2));
     it('maps a function over a nested list and returns the (shallow) flattened result', function() {
-        assert.deepEqual(chain(dbl, [[1,2,3], [1], [0, 10, -3, 5, 7]]), [2, 4, 6, 2, 0, 20, -6, 10, 14]);
-        assert.deepEqual(chain(dbl, [[1,2,3], []]), [2, 4, 6]);
+        assert.deepEqual(R.chain(dbl, [[1,2,3], [1], [0, 10, -3, 5, 7]]), [2, 4, 6, 2, 0, 20, -6, 10, 14]);
+        assert.deepEqual(R.chain(dbl, [[1,2,3], []]), [2, 4, 6]);
     });
 });

--- a/test/test.map.js
+++ b/test/test.map.js
@@ -2,28 +2,26 @@ var assert = require("assert");
 var R = require("..");
 
 describe('map', function() {
-    var map = R.map;
     var times2 = function(x) {return x * 2;};
     var add1 = function(x) {return x + 1;};
 
     it('maps simple functions over arrays', function() {
-        assert.deepEqual(map(times2, [1, 2, 3, 4]), [2, 4, 6, 8]);
+        assert.deepEqual(R.map(times2, [1, 2, 3, 4]), [2, 4, 6, 8]);
     });
 
     it('is automatically curried', function() {
-        var inc = map(add1);
+        var inc = R.map(add1);
         assert.deepEqual(inc([1, 2, 3]), [2, 3, 4]);
     });
 
     it('correctly reports the arity of curried versions', function() {
-        var inc = map(add1);
+        var inc = R.map(add1);
         assert.equal(inc.length, 1);
     });
 
 });
 
 describe('map.idx', function() {
-    var map = R.map;
     var times2 = function(x) {return x * 2;};
     var addIdx = function(x, idx) {return x + idx;};
     var squareEnds = function(x, idx, list) {
@@ -31,35 +29,33 @@ describe('map.idx', function() {
     };
 
     it('works just like a normal map', function() {
-        assert.deepEqual(map.idx(times2, [1, 2, 3, 4]), [2, 4, 6, 8]);
+        assert.deepEqual(R.map.idx(times2, [1, 2, 3, 4]), [2, 4, 6, 8]);
     });
 
     it('passes the index as a second parameter to the callback', function() {
-        assert.deepEqual(map.idx(addIdx, [8, 6, 7, 5, 3, 0, 9]), [8 + 0, 6 + 1, 7 + 2, 5 + 3, 3 + 4, 0 + 5, 9 + 6]);
+        assert.deepEqual(R.map.idx(addIdx, [8, 6, 7, 5, 3, 0, 9]), [8 + 0, 6 + 1, 7 + 2, 5 + 3, 3 + 4, 0 + 5, 9 + 6]);
     });
 
     it('passes the entire list as a third parameter to the callback', function() {
-        assert.deepEqual(map.idx(squareEnds, [8, 6, 7, 5, 3, 0, 9]), [64, 6, 7, 5, 3, 0, 81]);
+        assert.deepEqual(R.map.idx(squareEnds, [8, 6, 7, 5, 3, 0, 9]), [64, 6, 7, 5, 3, 0, 81]);
     });
 
     it('is automatically curried', function() {
-        var makeSquareEnds = map.idx(squareEnds);
+        var makeSquareEnds = R.map.idx(squareEnds);
         assert.deepEqual(makeSquareEnds([8, 6, 7, 5, 3, 0, 9]), [64, 6, 7, 5, 3, 0, 81]);
     });
 });
 
 describe('mapObj', function() {
-    var mapObj = R.mapObj;
     var square = function(n) {return n * n;};
 
     it('runs the given function over each of the object properties', function() {
         var obj = {a: 1, b: 2, c: 3};
-        assert.deepEqual(mapObj(square, obj), {a: 1, b: 4, c: 9});
+        assert.deepEqual(R.mapObj(square, obj), {a: 1, b: 4, c: 9});
     });
 });
 
 describe('mapObj.idx', function() {
-    var mapObj = R.mapObj;
     var times2 = function(x) {return x * 2;};
     var addIdx = function(x, key) {return x + key;};
     var squareVowels = function(x, key, obj) {
@@ -68,21 +64,21 @@ describe('mapObj.idx', function() {
     };
 
     it('works just like a normal mapObj', function() {
-        assert.deepEqual(mapObj.idx(times2, {a: 1, b: 2, c: 3, d: 4}), {a: 2, b: 4, c: 6, d: 8});
+        assert.deepEqual(R.mapObj.idx(times2, {a: 1, b: 2, c: 3, d: 4}), {a: 2, b: 4, c: 6, d: 8});
     });
 
     it('passes the index as a second parameter to the callback', function() {
-        assert.deepEqual(mapObj.idx(addIdx, {a: 8, b: 6, c: 7, d: 5, e: 3, f: 0, g: 9}),
+        assert.deepEqual(R.mapObj.idx(addIdx, {a: 8, b: 6, c: 7, d: 5, e: 3, f: 0, g: 9}),
           {a: '8a', b: '6b', c: '7c', d: '5d', e: '3e', f: '0f', g: '9g'});
     });
 
     it('passes the entire list as a third parameter to the callback', function() {
-        assert.deepEqual(mapObj.idx(squareVowels, {a: 8, b: 6, c: 7, d: 5, e: 3, f: 0, g: 9}),
+        assert.deepEqual(R.mapObj.idx(squareVowels, {a: 8, b: 6, c: 7, d: 5, e: 3, f: 0, g: 9}),
           {a: 64, b: 6, c: 7, d: 5, e: 9, f: 0, g: 9});
     });
 
     it('is automatically curried', function() {
-        var makeSquareVowels = mapObj.idx(squareVowels);
+        var makeSquareVowels = R.mapObj.idx(squareVowels);
         assert.deepEqual(makeSquareVowels({a: 8, b: 6, c: 7, d: 5, e: 3, f: 0, g: 9}),
           {a: 64, b: 6, c: 7, d: 5, e: 9, f: 0, g: 9});
     });

--- a/test/test.math.js
+++ b/test/test.math.js
@@ -2,182 +2,160 @@ var assert = require("assert");
 var R = require("..");
 
 describe('add', function() {
-    var add = R.add;
-
     it('should add together two numbers', function() {
-        assert.equal(10, add(3, 7));
+        assert.equal(10, R.add(3, 7));
     });
 
     it('should be automatically curried', function() {
-        var incr = add(1);
+        var incr = R.add(1);
         assert.equal(43, incr(42));
     });
 });
 
 describe('multiply', function() {
-    var multiply = R.multiply;
-
     it('should add together two numbers', function() {
-        assert.equal(42, multiply(6, 7));
+        assert.equal(42, R.multiply(6, 7));
     });
 
     it('should be automatically curried', function() {
-        var dbl = multiply(2);
+        var dbl = R.multiply(2);
         assert.equal(30, dbl(15));
     });
 });
 
 describe('subtract', function() {
-    var subtract = R.subtract;
-
     it('should subtract two numbers', function() {
-        assert.equal(15, subtract(22, 7));
+        assert.equal(15, R.subtract(22, 7));
     });
 
     it('should be automatically curried', function() {
-        var ninesCompl = subtract(9);
+        var ninesCompl = R.subtract(9);
         assert.equal(3, ninesCompl(6));
     });
 });
 
 describe('subtractN', function() {
-    var subtractN = R.subtractN;
-
     it('should subtract two numbers', function() {
-        assert.equal(15, subtractN(7,22));
+        assert.equal(15, R.subtractN(7,22));
     });
 
     it('should be automatically curried', function() {
-        var minus6 = subtractN(6);
+        var minus6 = R.subtractN(6);
         assert.equal(3, minus6(9));
     });
 });
 
 describe('divide', function() {
-    var divide = R.divide;
-
     it('should divide two numbers', function() {
-        assert.equal(4, divide(28, 7));
+        assert.equal(4, R.divide(28, 7));
     });
 
     it('should be automatically curried', function() {
-        var divideInto120 = divide(120);
+        var divideInto120 = R.divide(120);
         assert.equal(3, divideInto120(40));
     });
 });
 
 describe('divideBy', function() {
-    var divideBy = R.divideBy;
-
     it('should divide two numbers', function() {
-        assert.equal(4, divideBy(7, 28));
+        assert.equal(4, R.divideBy(7, 28));
     });
 
     it('should be automatically curried', function() {
-        var half = divideBy(2);
+        var half = R.divideBy(2);
         assert.equal(20, half(40));
 
     });
 });
 
 describe('modulo', function() {
-  var modulo = R.modulo;
   it('divides the first param by the second and returns the remainder', function() {
-    assert.equal(modulo(100, 2), 0);
-    assert.equal(modulo(100, 3), 1);
-    assert.equal(modulo(100, 17), 15);
+    assert.equal(R.modulo(100, 2), 0);
+    assert.equal(R.modulo(100, 3), 1);
+    assert.equal(R.modulo(100, 17), 15);
   });
 
   it('is automatically curried', function() {
-    var modOf120by = modulo(120);
+    var modOf120by = R.modulo(120);
     assert.equal(typeof modOf120by, 'function');
     assert.equal(modOf120by(3), 0);
     assert.equal(modOf120by(19), 6);
   });
 
   it('preserves javascript-style modulo evaluation for negative numbers', function() {
-    assert.equal(modulo(-5, 4), -1);
+    assert.equal(R.modulo(-5, 4), -1);
   });
 });
 
 describe('moduloBy', function() {
-  var moduloBy = R.moduloBy;
   it('divides the second param by the first and returns the remainder', function() {
-    assert.equal(moduloBy(2, 100), 0);
-    assert.equal(moduloBy(3, 100), 1);
-    assert.equal(moduloBy(17, 100), 15);
+    assert.equal(R.moduloBy(2, 100), 0);
+    assert.equal(R.moduloBy(3, 100), 1);
+    assert.equal(R.moduloBy(17, 100), 15);
   });
 
   it('is automatically curried', function() {
-    var isOdd = moduloBy(2);
+    var isOdd = R.moduloBy(2);
     assert.equal(typeof isOdd, 'function');
     assert.equal(isOdd(3), 1);
     assert.equal(isOdd(198), 0);
   });
 
   it('preserves javascript-style modulo evaluation for negative numbers', function() {
-    assert.equal(moduloBy(4, -5), -1);
+    assert.equal(R.moduloBy(4, -5), -1);
   });
 });
 
 describe('mathMod', function() {
-  var mathMod = R.mathMod;
-
   it('requires integer arguments', function() {
-    assert.notEqual(mathMod('s', 3), mathMod('s', 3));
-    assert.notEqual(mathMod(3, 's'), mathMod(3, 's'));
-    assert.notEqual(mathMod(12.2, 3), mathMod(12.2, 3));
-    assert.notEqual(mathMod(3, 12.2), mathMod(3, 12.2));
+    assert.notEqual(R.mathMod('s', 3), R.mathMod('s', 3));
+    assert.notEqual(R.mathMod(3, 's'), R.mathMod(3, 's'));
+    assert.notEqual(R.mathMod(12.2, 3), R.mathMod(12.2, 3));
+    assert.notEqual(R.mathMod(3, 12.2), R.mathMod(3, 12.2));
   });
 
   it('behaves differently than JS modulo', function() {
-    assert.notEqual(mathMod(-17, 5), -17 % 5);
-    assert.notEqual(mathMod(17.2, 5), 17.2 % 5);
-    assert.notEqual(mathMod(17, -5), 17 % -5);
+    assert.notEqual(R.mathMod(-17, 5), -17 % 5);
+    assert.notEqual(R.mathMod(17.2, 5), 17.2 % 5);
+    assert.notEqual(R.mathMod(17, -5), 17 % -5);
   });
 
   it('is curried', function() {
-    var f = mathMod(29);
+    var f = R.mathMod(29);
     assert.equal(f(6), 5);
   });
 
 });
 
 describe('sum', function() {
-    var sum = R.sum;
-
     it('should add together the array of numbers supplied', function() {
-        assert.equal(10, sum([1, 2, 3, 4]));
+        assert.equal(10, R.sum([1, 2, 3, 4]));
     });
 
     it('does not save the state of the accumulator', function() {
-        assert.equal(10, sum([1,2,3,4]));
-        assert.equal(1, sum([1]));
-        assert.equal(25, sum([5,5,5,5,5]));
+        assert.equal(10, R.sum([1,2,3,4]));
+        assert.equal(1, R.sum([1]));
+        assert.equal(25, R.sum([5,5,5,5,5]));
     });
 });
 
 describe('product', function() {
-    var product = R.product;
-
     it('should multiply together the array of numbers supplied', function() {
-        assert.equal(24, product([1, 2, 3, 4]));
+        assert.equal(24, R.product([1, 2, 3, 4]));
     });
 });
 
 describe('lt', function() {
-    var lt = R.lt;
-
     it('should report whether one item is less than another', function() {
-        assert(lt(3, 5));
-        assert(!lt(6, 4));
-        assert(!lt(7.0, 7.0));
-        assert(lt('abc', 'xyz'));
-        assert(!lt('abcd', 'abc'));
+        assert(R.lt(3, 5));
+        assert(!R.lt(6, 4));
+        assert(!R.lt(7.0, 7.0));
+        assert(R.lt('abc', 'xyz'));
+        assert(!R.lt('abcd', 'abc'));
     });
 
     it('should be automatically curried', function() {
-        var atLeast20 = lt(20);
+        var atLeast20 = R.lt(20);
         assert(!atLeast20(10));
         assert(!atLeast20(20));
         assert(atLeast20(25));
@@ -185,18 +163,16 @@ describe('lt', function() {
 });
 
 describe('lte', function() {
-    var lte = R.lte;
-
     it('should report whether one item is less than another', function() {
-        assert(lte(3, 5));
-        assert(!lte(6, 4));
-        assert(lte(7.0, 7.0));
-        assert(lte('abc', 'xyz'));
-        assert(!lte('abcd', 'abc'));
+        assert(R.lte(3, 5));
+        assert(!R.lte(6, 4));
+        assert(R.lte(7.0, 7.0));
+        assert(R.lte('abc', 'xyz'));
+        assert(!R.lte('abcd', 'abc'));
     });
 
     it('should be automatically curried', function() {
-        var greaterThan20 = lte(20);
+        var greaterThan20 = R.lte(20);
         assert(!greaterThan20(10));
         assert(greaterThan20(20));
         assert(greaterThan20(25));
@@ -204,18 +180,16 @@ describe('lte', function() {
 });
 
 describe('gt', function() {
-    var gt = R.gt;
-
     it('should report whether one item is less than another', function() {
-        assert(!gt(3, 5));
-        assert(gt(6, 4));
-        assert(!gt(7.0, 7.0));
-        assert(!gt('abc', 'xyz'));
-        assert(gt('abcd', 'abc'));
+        assert(!R.gt(3, 5));
+        assert(R.gt(6, 4));
+        assert(!R.gt(7.0, 7.0));
+        assert(!R.gt('abc', 'xyz'));
+        assert(R.gt('abcd', 'abc'));
     });
 
     it('should be automatically curried', function() {
-        var lessThan20 = gt(20);
+        var lessThan20 = R.gt(20);
         assert(lessThan20(10));
         assert(!lessThan20(20));
         assert(!lessThan20(25));
@@ -223,18 +197,16 @@ describe('gt', function() {
 });
 
 describe('gte', function() {
-    var gte = R.gte;
-
     it('should report whether one item is less than another', function() {
-        assert(!gte(3, 5));
-        assert(gte(6, 4));
-        assert(gte(7.0, 7.0));
-        assert(!gte('abc', 'xyz'));
-        assert(gte('abcd', 'abc'));
+        assert(!R.gte(3, 5));
+        assert(R.gte(6, 4));
+        assert(R.gte(7.0, 7.0));
+        assert(!R.gte('abc', 'xyz'));
+        assert(R.gte('abcd', 'abc'));
     });
 
     it('should be automatically curried', function() {
-        var upTo20 = gte(20);
+        var upTo20 = R.gte(20);
         assert(upTo20(10));
         assert(upTo20(20));
         assert(!upTo20(25));
@@ -242,63 +214,55 @@ describe('gte', function() {
 });
 
 describe('max', function() {
-    var max = R.max;
-
     it('calculates the largest value of a list', function() {
-        assert.equal(max([2, 1, 2, 8, 6, 7, 5, 3, 0, 9]), 9);
-        assert.equal(max([7, 22, 11, 34, 17, 52, 26, 13, 40, 20, 10, 5, 16, 8, 4, 2, 1]), 52);
+        assert.equal(R.max([2, 1, 2, 8, 6, 7, 5, 3, 0, 9]), 9);
+        assert.equal(R.max([7, 22, 11, 34, 17, 52, 26, 13, 40, 20, 10, 5, 16, 8, 4, 2, 1]), 52);
     });
 
     it('accepts negative numbers, decimals, and even strings', function() {
-        assert.equal(max([-6, -2, -4.3, -1.1, -5]), -1.1);
-        assert.equal(max([7, "22", 11, 34, 17, "52", 26, 13, 40, 20, "10", 5, 16, 8, 4, "2", "1"]), 52);
+        assert.equal(R.max([-6, -2, -4.3, -1.1, -5]), -1.1);
+        assert.equal(R.max([7, "22", 11, 34, 17, "52", 26, 13, 40, 20, "10", 5, 16, 8, 4, "2", "1"]), 52);
     });
 });
 
 describe('min', function() {
-    var min = R.min;
-
     it('calculates the smallest value of a list', function() {
-        assert.equal(min([2, 1, 2, 8, 6, 7, 5, 3, 0, 9]), 0);
-        assert.equal(min([7, 22, 11, 34, 17, 52, 26, 13, 40, 20, 10, 5, 16, 8, 4, 2, 1]), 1);
+        assert.equal(R.min([2, 1, 2, 8, 6, 7, 5, 3, 0, 9]), 0);
+        assert.equal(R.min([7, 22, 11, 34, 17, 52, 26, 13, 40, 20, 10, 5, 16, 8, 4, 2, 1]), 1);
     });
 
     it('accepts negative numbers, decimals, and even strings', function() {
-        assert.equal(min([-6, -2, -4.3, -1.1, -5]), -6);
-        assert.equal(min([7, "22", 11, 34, 17, "52", 26, 13, 40, 20, "10", 5, 16, 8, 4, "2", "1"]), 1);
+        assert.equal(R.min([-6, -2, -4.3, -1.1, -5]), -6);
+        assert.equal(R.min([7, "22", 11, 34, 17, "52", 26, 13, 40, 20, "10", 5, 16, 8, 4, "2", "1"]), 1);
     });
 });
 
 describe('maxWith', function() {
-    var maxWith = R.maxWith, prop = R.prop;
-
     it('calculates the largest value of a list using the supplied comparator', function() {
-        assert.deepEqual(maxWith(prop('x'), [{x: 3, y: 1}, {x: 5, y: 10}, {x: -2, y: 0}]), {x: 5, y: 10});
+        assert.deepEqual(R.maxWith(R.prop('x'), [{x: 3, y: 1}, {x: 5, y: 10}, {x: -2, y: 0}]), {x: 5, y: 10});
     });
 
     it('returns undefined for the empty list', function() {
-        assert.equal(maxWith(prop('x'), []), undefined);
+        assert.equal(R.maxWith(R.prop('x'), []), undefined);
     });
 
     it('is properly curried', function() {
-        var highestX = maxWith(prop('x'));
+        var highestX = R.maxWith(R.prop('x'));
         assert.deepEqual(highestX([{x: 3, y: 1}, {x: 5, y: 10}, {x: -2, y: 0}]), {x: 5, y: 10});
     });
 });
 
 describe('minWith', function() {
-    var minWith = R.minWith, prop = R.prop;
-
     it('calculates the smallest value of a list using the supplied comparator', function() {
-        assert.deepEqual(minWith(prop('x'), [{x: 3, y: 1}, {x: 5, y: 10}, {x: -2, y: 0}]), {x: -2, y: 0});
+        assert.deepEqual(R.minWith(R.prop('x'), [{x: 3, y: 1}, {x: 5, y: 10}, {x: -2, y: 0}]), {x: -2, y: 0});
     });
 
     it('returns null for the empty list', function() {
-        assert.equal(typeof(minWith(prop('x'), [])), "undefined");
+        assert.equal(typeof(R.minWith(R.prop('x'), [])), "undefined");
     });
 
     it('is properly curried', function() {
-        var lowestX = minWith(prop('x'));
+        var lowestX = R.minWith(R.prop('x'));
         assert.deepEqual(lowestX([{x: 3, y: 1}, {x: 5, y: 10}, {x: -2, y: 0}]), {x: -2, y: 0});
     });
 });

--- a/test/test.objectBasics.js
+++ b/test/test.objectBasics.js
@@ -2,24 +2,21 @@ var assert = require('assert');
 var R = require('..');
 
 describe('prop', function () {
-    var prop = R.prop;
     var fred = {name: 'Fred', age: 23};
 
     it('should return a function that fetches the appropriate property', function () {
-        var nm = prop('name');
+        var nm = R.prop('name');
         assert.equal(typeof nm, 'function');
         assert.equal(nm(fred), 'Fred');
     });
 
     it('should be aliased by `get`', function () { // TODO: should it?
         assert.equal(R.get('age')(fred), 23);
-        assert.strictEqual(R.get, prop);
+        assert.strictEqual(R.get, R.prop);
     });
 });
 
 describe('func', function () {
-    var func = R.func;
-
     it('should return a function that applies the appropriate function to the supplied object', function () {
         var fred = {first: 'Fred', last: 'Flintstone', getName: function () {
             return this.first + ' ' + this.last;
@@ -27,7 +24,7 @@ describe('func', function () {
         var barney = {first: 'Barney', last: 'Rubble', getName: function () {
             return this.first + ' ' + this.last;
         }};
-        var gName = func('getName');
+        var gName = R.func('getName');
         assert.equal(typeof gName, 'function');
         assert.equal(gName(fred), 'Fred Flintstone');
         assert.equal(gName(barney), 'Barney Rubble');
@@ -43,7 +40,7 @@ describe('func', function () {
             this.y += dy;
         };
         var p1 = new Point(10, 20);
-        var moveBy = func('moveBy');
+        var moveBy = R.func('moveBy');
         moveBy(p1, 5, 7);
         assert.equal(p1.x, 15);
         assert.equal(p1.y, 27);
@@ -52,7 +49,6 @@ describe('func', function () {
 
 // TODO: This needs a better home than objectBasics
 describe('pluck', function () {
-    var pluck = R.pluck;
     var people = [
         {name: 'Fred', age: 23},
         {name: 'Wilma', age: 21} ,
@@ -60,18 +56,17 @@ describe('pluck', function () {
     ];
 
     it('should return a function that maps the appropriate property over an array', function () {
-        var nm = pluck('name');
+        var nm = R.pluck('name');
         assert.equal(typeof nm, 'function');
         assert.deepEqual(nm(people), ['Fred', 'Wilma', 'Pebbles']);
     });
 });
 
 describe('props', function () {
-    var props = R.props;
     var fred = {name: 'Fred', age: 23, feet: 'large'};
 
     it('should return a function that fetches the appropriate properties from the initially supplied object', function () {
-        var p = props(fred);
+        var p = R.props(fred);
         assert.equal(p('name'), 'Fred');
         assert.equal(p('age'), 23);
         assert.equal(p('feet'), 'large');
@@ -79,94 +74,88 @@ describe('props', function () {
 });
 
 describe('pick', function () {
-    var pick = R.pick;
     var obj = {a: 1, b: 2, c: 3, d: 4, e: 5, f: 6};
 
     it('should copy the named properties of an object to the new object', function () {
-        assert.deepEqual(pick(['a', 'c', 'f'], obj), {a: 1, c: 3, f: 6});
+        assert.deepEqual(R.pick(['a', 'c', 'f'], obj), {a: 1, c: 3, f: 6});
     });
     it('should ignore properties not included', function () {
-        assert.deepEqual(pick(['a', 'c', 'g'], obj), {a: 1, c: 3});
+        assert.deepEqual(R.pick(['a', 'c', 'g'], obj), {a: 1, c: 3});
     });
     it('should be automatically curried', function () {
-        var copyAB = pick(['a', 'b']);
+        var copyAB = R.pick(['a', 'b']);
         assert.deepEqual(copyAB(obj), {a: 1, b: 2});
     });
 });
 
 describe('omit', function () {
-    var omit = R.omit;
     var obj = {a: 1, b: 2, c: 3, d: 4, e: 5, f: 6};
 
     it('should copy an object omitting the listed properties', function () {
-        assert.deepEqual(omit(['a', 'c', 'f'], obj), {b: 2, d: 4, e: 5});
+        assert.deepEqual(R.omit(['a', 'c', 'f'], obj), {b: 2, d: 4, e: 5});
     });
 
     it('should be automatically curried', function () {
-        var skipAB = omit(['a', 'b']);
+        var skipAB = R.omit(['a', 'b']);
         assert.deepEqual(skipAB(obj), {c: 3, d: 4, e: 5, f: 6});
     });
 });
 
 describe('pickWith', function() {
-    var pickWith = R.pickWith;
     var obj = {a: 1, b: 2, c: 3, d: 4, e: 5, f: 6};
 
     it('should create a copy of the object', function() {
-        assert.notEqual(pickWith(R.always(true), obj), obj);
+        assert.notEqual(R.pickWith(R.always(true), obj), obj);
     });
     it('returning truthy keeps the key', function() {
-        assert.deepEqual(pickWith(R.alwaysTrue, obj), obj);
-        assert.deepEqual(pickWith(R.always({}), obj), obj);
-        assert.deepEqual(pickWith(R.always(1), obj), obj);
+        assert.deepEqual(R.pickWith(R.alwaysTrue, obj), obj);
+        assert.deepEqual(R.pickWith(R.always({}), obj), obj);
+        assert.deepEqual(R.pickWith(R.always(1), obj), obj);
     });
     it('returning falsy keeps the key', function() {
-        assert.deepEqual(pickWith(R.always(false), obj), {});
-        assert.deepEqual(pickWith(R.always(0), obj), {});
-        assert.deepEqual(pickWith(R.always(null), obj), {});
+        assert.deepEqual(R.pickWith(R.always(false), obj), {});
+        assert.deepEqual(R.pickWith(R.always(0), obj), {});
+        assert.deepEqual(R.pickWith(R.always(null), obj), {});
     });
     it('should be called with (val,key,obj)', function() {
-        assert.deepEqual(pickWith(function(val, key, _obj) {
+        assert.deepEqual(R.pickWith(function(val, key, _obj) {
             assert.equal(_obj, obj);
             return key === 'd' && val === 4;
         }, obj), {d: 4});
     });
     it('should be automatically curried', function () {
-        var copier = pickWith(R.alwaysTrue);
+        var copier = R.pickWith(R.alwaysTrue);
         assert.deepEqual(copier(obj), obj);
     });
 });
 
 
 describe('pickAll', function () {
-    var pickAll = R.pickAll;
     var obj = {a: 1, b: 2, c: 3, d: 4, e: 5, f: 6};
     it('should copy the named properties of an object to the new object', function () {
-        assert.deepEqual(pickAll(['a', 'c', 'f'], obj), {a: 1, c: 3, f: 6});
+        assert.deepEqual(R.pickAll(['a', 'c', 'f'], obj), {a: 1, c: 3, f: 6});
     });
     it('should include properties not present on the input object', function () {
-        assert.deepEqual(pickAll(['a', 'c', 'g'], obj), {a: 1, c: 3, g: undefined});
+        assert.deepEqual(R.pickAll(['a', 'c', 'g'], obj), {a: 1, c: 3, g: undefined});
     });
     it('should be automatically curried', function () {
-        var copyAB = pickAll(['a', 'b']);
+        var copyAB = R.pickAll(['a', 'b']);
         assert.deepEqual(copyAB(obj), {a: 1, b: 2});
     });
 });
 
 describe('eqProps', function () {
-    var eqProps = R.eqProps;
     it('reports whether two objects have the same value for a given property', function () {
-        assert.equal(eqProps('name', {name: 'fred', age: 10}, {name: 'fred', age: 12}), true);
-        assert.equal(eqProps('name', {name: 'fred', age: 10}, {name: 'franny', age: 10}), false);
+        assert.equal(R.eqProps('name', {name: 'fred', age: 10}, {name: 'fred', age: 12}), true);
+        assert.equal(R.eqProps('name', {name: 'fred', age: 10}, {name: 'franny', age: 10}), false);
     });
     it('should be automatically curried', function () {
-        var sameName = eqProps('name');
+        var sameName = R.eqProps('name');
         assert.equal(sameName({name: 'fred', age: 10}, {name: 'fred', age: 12}), true);
     });
 });
 
 describe('where', function () {
-    var where = R.where;
     it('takes a spec and a test object and returns true if the test object satisfies the spec', function () {
 
         var spec = {x: 1, y: 2};
@@ -174,10 +163,10 @@ describe('where', function () {
         var test2 = {x: 0, y: 10};
         var test3 = {x: 1, y: 101};
         var test4 = {x: 1, y: 2};
-        assert.equal(where(spec, test1), false);
-        assert.equal(where(spec, test2), false);
-        assert.equal(where(spec, test3), false);
-        assert.equal(where(spec, test4), true);
+        assert.equal(R.where(spec, test1), false);
+        assert.equal(R.where(spec, test2), false);
+        assert.equal(R.where(spec, test3), false);
+        assert.equal(R.where(spec, test4), true);
     });
 
     it('calls any functions in the spec against the test object value for that property', function () {
@@ -197,10 +186,10 @@ describe('where', function () {
         var test3 = {a: 2, b: 8, c: 12};
         var test4 = {a: 3, b: 11, c: 5};
 
-        assert.equal(where(spec, test1), true);
-        assert.equal(where(spec, test2), true);
-        assert.equal(where(spec, test3), false);
-        assert.equal(where(spec, test4), false);
+        assert.equal(R.where(spec, test1), true);
+        assert.equal(R.where(spec, test2), true);
+        assert.equal(R.where(spec, test3), false);
+        assert.equal(R.where(spec, test4), false);
     });
 
     it('does not need the spec and the test object to have the same interface (the test object will have a superset of the specs properties)', function () {
@@ -208,8 +197,8 @@ describe('where', function () {
         var test1 = {x: 20, y: 100, z: 100};
         var test2 = {w: 1, x: 100, y: 100, z: 100};
 
-        assert.equal(where(spec, test1), false);
-        assert.equal(where(spec, test2), true);
+        assert.equal(R.where(spec, test1), false);
+        assert.equal(R.where(spec, test2), true);
     });
 
     it('is false if the test object is null-ish', function () {
@@ -217,9 +206,9 @@ describe('where', function () {
         var testN = null;
         var testU;
         var testF = false;
-        assert.equal(where(spec, testN), false);
-        assert.equal(where(spec, testU), false);
-        assert.equal(where(spec, testF), false);
+        assert.equal(R.where(spec, testN), false);
+        assert.equal(R.where(spec, testU), false);
+        assert.equal(R.where(spec, testF), false);
     });
 
     it('matches specs that have undefined properties', function () {
@@ -228,25 +217,25 @@ describe('where', function () {
         var test2 = {x: null};
         var test3 = {x: undefined};
         var test4 = {x: 1};
-        //assert.equal(where(spec, test1), false);    // TODO: discuss Scott's objections
-        assert.equal(where(spec, test2), false);
-        assert.equal(where(spec, test3), true);
-        assert.equal(where(spec, test4), false);
+        //assert.equal(R.where(spec, test1), false);    // TODO: discuss Scott's objections
+        assert.equal(R.where(spec, test2), false);
+        assert.equal(R.where(spec, test3), true);
+        assert.equal(R.where(spec, test4), false);
     });
 
     it('is automatically curried', function () {
-        var predicate = where({x: 1, y: 2});
+        var predicate = R.where({x: 1, y: 2});
         assert.equal(predicate({x: 1, y: 2, z: 3}), true);
         assert.equal(predicate({x: 3, y: 2, z: 1}), false);
     });
 
     it('empty spec is true', function() {
-        assert.equal(where({}, {a: 1}), true);
-        assert.equal(where(null, {a: 1}), true);
+        assert.equal(R.where({}, {a: 1}), true);
+        assert.equal(R.where(null, {a: 1}), true);
     });
 
     it('equal objects are true', function() {
-        assert.equal(where(R, R), true);
+        assert.equal(R.where(R, R), true);
     });
 
     function Parent() {
@@ -260,44 +249,42 @@ describe('where', function () {
         var spec = {
             toString: R.alwaysTrue
         };
-        assert.equal(where(spec, {}), true);
-        assert.equal(where(spec, {a: 1}), true);
-        assert.equal(where(spec, {toString: 1}), true);
-        assert.equal(where({a: R.alwaysTrue}, {x: 1}), false);
+        assert.equal(R.where(spec, {}), true);
+        assert.equal(R.where(spec, {a: 1}), true);
+        assert.equal(R.where(spec, {toString: 1}), true);
+        assert.equal(R.where({a: R.alwaysTrue}, {x: 1}), false);
     });
 
     it('matches inherited props', function () {
-        assert.equal(where({y: 6}, parent), true);
-        assert.equal(where({x: 5}, parent), true);
-        assert.equal(where({x: 5, y: 6}, parent), true);
-        assert.equal(where({x: 4, y: 6}, parent), false);
+        assert.equal(R.where({y: 6}, parent), true);
+        assert.equal(R.where({x: 5}, parent), true);
+        assert.equal(R.where({x: 5, y: 6}, parent), true);
+        assert.equal(R.where({x: 4, y: 6}, parent), false);
     });
 
     it('doesnt match inherited spec', function() {
-        assert.equal(where(parent, {y: 6}), true);
-        assert.equal(where(parent, {x: 5}), false);
+        assert.equal(R.where(parent, {y: 6}), true);
+        assert.equal(R.where(parent, {x: 5}), false);
     });
 
 });
 
 describe('mixin', function () {
-    var mixin = R.mixin;
-
     it('takes two objects, merges their own properties and returns a new object', function () {
         var a = {w: 1, x: 2};
         var b = {y: 3, z: 4};
-        assert.deepEqual(mixin(a, b), {w: 1, x: 2, y: 3, z: 4});
+        assert.deepEqual(R.mixin(a, b), {w: 1, x: 2, y: 3, z: 4});
     });
 
     it('overrides properties in the first object with properties in the second object', function () {
         var a = {w: 1, x: 2};
         var b = {w: 100, y: 3, z: 4};
-        assert.deepEqual(mixin(a, b), {w: 100, x: 2, y: 3, z: 4});
+        assert.deepEqual(R.mixin(a, b), {w: 100, x: 2, y: 3, z: 4});
     });
 
     it('should not be destructive', function() {
         var a = {w: 1, x: 2};
-        var res = mixin(a, {x: 5});
+        var res = R.mixin(a, {x: 5});
         assert.notEqual(a, res);
         assert.deepEqual(res, {w: 1, x: 5});
     });
@@ -306,12 +293,12 @@ describe('mixin', function () {
         var a = {w: 1, x: 2};
         function Cla() {}
         Cla.prototype.x = 5;
-        assert.deepEqual(mixin(new Cla(), a), {w: 1, x: 2});
-        assert.deepEqual(mixin(a, new Cla()), {w: 1, x: 2});
+        assert.deepEqual(R.mixin(new Cla(), a), {w: 1, x: 2});
+        assert.deepEqual(R.mixin(a, new Cla()), {w: 1, x: 2});
     });
 
     it('outta be curried', function () {
-        var curried = mixin({w: 1, x: 2});
+        var curried = R.mixin({w: 1, x: 2});
         var b = {y: 3, z: 4};
         assert.deepEqual(curried(b), {w: 1, x: 2, y: 3, z: 4});
     });

--- a/test/test.partial.js
+++ b/test/test.partial.js
@@ -2,66 +2,62 @@ var assert = require("assert");
 var R = require("..");
 
 describe('lPartial', function() {
-    var lPartial = R.lPartial;
     var disc = function(a, b, c) { // note disc(3, 7, 4) => 1
         return b * b - 4 * a * c;
     };
 
     it('should cache the initially supplied left-most parameters in the generated function', function() {
-        var f = lPartial(disc, 3);
+        var f = R.lPartial(disc, 3);
         assert.equal(f(7, 4), 1);
-        var g = lPartial(disc, 3, 7);
+        var g = R.lPartial(disc, 3, 7);
         assert.equal(g(4), 1);
     });
 
     it('should be aliased by `applyLeft`', function() {
-        assert.strictEqual(R.applyLeft, lPartial);
+        assert.strictEqual(R.applyLeft, R.lPartial);
     });
 
     it('should correctly report the arity of the new function', function() {
-        var f = lPartial(disc, 3);
+        var f = R.lPartial(disc, 3);
         assert.equal(f.length, 2);
-        var g = lPartial(disc, 3, 7);
+        var g = R.lPartial(disc, 3, 7);
         assert.equal(g.length, 1);
     });
 });
 
 describe('rPartial', function() {
-    var rPartial = R.rPartial;
     var disc = function(a, b, c) { // note disc(3, 7, 4) => 1
         return b * b - 4 * a * c;
     };
 
     it('should cache the initially supplied right-most parameters in the generated function', function() {
-        var f = rPartial(disc, 4);
+        var f = R.rPartial(disc, 4);
         assert.equal(f(3, 7), 1);
-        var g = rPartial(disc, 7, 4);
+        var g = R.rPartial(disc, 7, 4);
         assert.equal(g(3), 1);
     });
 
     it('should be aliased by `applyRight`', function() {
-        assert.strictEqual(R.applyRight, rPartial);
+        assert.strictEqual(R.applyRight, R.rPartial);
     });
 
     it('should correctly report the arity of the new function', function() {
-        var f = rPartial(disc, 4);
+        var f = R.rPartial(disc, 4);
         assert.equal(f.length, 2);
-        var g = rPartial(disc, 7, 4);
+        var g = R.rPartial(disc, 7, 4);
         assert.equal(g.length, 1);
     });
 });
 
 describe('curry', function() {
-    var curry = R.curry;
-
     it('should curry a single value', function() {
-        var f = curry(function(a, b, c, d) {return (a + b * c) / d;}); // f(12, 3, 6, 2) == 15
+        var f = R.curry(function(a, b, c, d) {return (a + b * c) / d;}); // f(12, 3, 6, 2) == 15
         var g = f(12);
         assert.equal(g(3, 6, 2), 15);
     });
 
     it('should curry multiple values', function() {
-        var f = curry(function(a, b, c, d) {return (a + b * c) / d;}); // f(12, 3, 6, 2) == 15
+        var f = R.curry(function(a, b, c, d) {return (a + b * c) / d;}); // f(12, 3, 6, 2) == 15
         var g = f(12, 3);
         assert.equal(g(6, 2), 15);
         var h = f(12, 3, 6);
@@ -69,7 +65,7 @@ describe('curry', function() {
     });
 
     it('should allow further currying of a curried function', function() {
-        var f = curry(function(a, b, c, d) {return (a + b * c) / d;}); // f(12, 3, 6, 2) == 15
+        var f = R.curry(function(a, b, c, d) {return (a + b * c) / d;}); // f(12, 3, 6, 2) == 15
         var g = f(12);
         assert.equal(g(3, 6, 2), 15);
         var h = g(3);
@@ -79,7 +75,7 @@ describe('curry', function() {
     });
 
     it('should properly report the length of the curried function', function() {
-        var f = curry(function(a, b, c, d) {return (a + b * c) / d;});
+        var f = R.curry(function(a, b, c, d) {return (a + b * c) / d;});
         assert.equal(f.length, 4);
         var g = f(12);
         assert.equal(g.length, 3);

--- a/test/test.partition.js
+++ b/test/test.partition.js
@@ -2,18 +2,16 @@ var assert = require('assert');
 var R = require('..');
 
 describe('partition', function() {
-    var partition = R.partition;
-
     it('splits a list into two lists according to a predicate', function() {
         var pred = function(n) { return n % 2; };
-        assert.deepEqual(partition(pred, []), [[], []]);
-        assert.deepEqual(partition(pred, [0, 2, 4, 6]), [[], [0, 2, 4, 6]]);
-        assert.deepEqual(partition(pred, [1, 3, 5, 7]), [[1, 3, 5, 7], []]);
-        assert.deepEqual(partition(pred, [0, 1, 2, 3]), [[1, 3], [0, 2]]);
+        assert.deepEqual(R.partition(pred, []), [[], []]);
+        assert.deepEqual(R.partition(pred, [0, 2, 4, 6]), [[], [0, 2, 4, 6]]);
+        assert.deepEqual(R.partition(pred, [1, 3, 5, 7]), [[1, 3, 5, 7], []]);
+        assert.deepEqual(R.partition(pred, [0, 1, 2, 3]), [[1, 3], [0, 2]]);
     });
 
     it('is curried', function() {
-        var polarize = partition(Boolean);
+        var polarize = R.partition(Boolean);
         assert.deepEqual(polarize([true, 0, 1, null]), [[true, 1], [0, null]]);
     });
 });

--- a/test/test.path.js
+++ b/test/test.path.js
@@ -3,7 +3,6 @@ var R = require("..");
 
 describe("path", function() {
     var deepObject = { a: { b: { c: "c" } }, falseVal: false, nullVal: null, undefinedVal: undefined, arrayVal: ["arr"] };
-    var path = R.path;
     it("takes a dot-delimited path and an object and returns the value at the path or undefined", function() {
         var obj = {
           a: {
@@ -20,12 +19,12 @@ describe("path", function() {
           i: "I",
           j: ["J"]
         };
-        assert.equal(path("a.b.c", obj), 100);
-        assert.equal(path("", obj), undefined);
-        assert.equal(path("a.e.f.1", obj), 101);
-        assert.equal(path("j.0", obj), "J");
-        assert.equal(path("j.1", obj), undefined);
-        assert.equal(path("a.b.c", null), undefined);
+        assert.equal(R.path("a.b.c", obj), 100);
+        assert.equal(R.path("", obj), undefined);
+        assert.equal(R.path("a.e.f.1", obj), 101);
+        assert.equal(R.path("j.0", obj), "J");
+        assert.equal(R.path("j.1", obj), undefined);
+        assert.equal(R.path("a.b.c", null), undefined);
     });
 
     it("should get a deep property's value from objects", function() {
@@ -54,7 +53,6 @@ describe("path", function() {
 
 describe("pathOn", function() {
     var deepObject = { a: { b: { c: "c" } }, falseVal: false, nullVal: null, undefinedVal: undefined, arrayVal: ["arr"] };
-    var pathOn = R.pathOn;
     it("takes a string separator, string path, and an object and returns the value at the path or undefined", function() {
         var obj = {
           a: {
@@ -71,12 +69,12 @@ describe("pathOn", function() {
           i: "I",
           j: ["J"]
         };
-        assert.equal(pathOn("|", "a|b|c", obj), 100);
-        assert.equal(pathOn(" ", "", obj), undefined);
-        assert.equal(pathOn(" ", "a e f 1", obj), 101);
-        assert.equal(pathOn("_", "j_0", obj), "J");
-        assert.equal(pathOn("~", "j~1", obj), undefined);
-        assert.equal(pathOn("Z", "aZbZc", null), undefined);
+        assert.equal(R.pathOn("|", "a|b|c", obj), 100);
+        assert.equal(R.pathOn(" ", "", obj), undefined);
+        assert.equal(R.pathOn(" ", "a e f 1", obj), 101);
+        assert.equal(R.pathOn("_", "j_0", obj), "J");
+        assert.equal(R.pathOn("~", "j~1", obj), undefined);
+        assert.equal(R.pathOn("Z", "aZbZc", null), undefined);
     });
 
     it("should get a deep property's value from objects", function() {
@@ -102,7 +100,6 @@ describe("pathWith", function() {
       i: "I",
       j: ["J"]
     };
-    var pathWith = R.pathWith;
     it("takes a function, a string path, and an object, and returns the value at that path or undefined.", function() {
 
         var everyThirdChar = function(str) {
@@ -117,12 +114,12 @@ describe("pathWith", function() {
         };
         var path = "axxbyyc";
 
-        assert.equal(pathWith(everyThirdChar, "azsbt5c", obj), 100);
-        assert.equal(pathWith(everyThirdChar, "", obj), undefined);
-        assert.equal(pathWith(everyThirdChar, "axxeaafaa1", obj), 101);
-        assert.equal(pathWith(everyThirdChar, "j__0", obj), "J");
-        assert.equal(pathWith(everyThirdChar, "j__1", obj), undefined);
-        assert.equal(pathWith(everyThirdChar, "azsbt5c", null), undefined);
+        assert.equal(R.pathWith(everyThirdChar, "azsbt5c", obj), 100);
+        assert.equal(R.pathWith(everyThirdChar, "", obj), undefined);
+        assert.equal(R.pathWith(everyThirdChar, "axxeaafaa1", obj), 101);
+        assert.equal(R.pathWith(everyThirdChar, "j__0", obj), "J");
+        assert.equal(R.pathWith(everyThirdChar, "j__1", obj), undefined);
+        assert.equal(R.pathWith(everyThirdChar, "azsbt5c", null), undefined);
     });
 
     function squareBrackets(path) {
@@ -132,7 +129,7 @@ describe("pathWith", function() {
     }
 
     it("takes a function accepting a string returnign an array for path", function() {
-        assert.equal(pathWith(squareBrackets, "a['b']['c']", obj), 100);
+        assert.equal(R.pathWith(squareBrackets, "a['b']['c']", obj), 100);
     });
 });
 */

--- a/test/test.product.js
+++ b/test/test.product.js
@@ -2,52 +2,50 @@ var assert = require("assert");
 var R = require("..");
 
 describe('xprod', function() {
-    var xprod = R.xprod;
     var a = [1, 2], b = ['a', 'b', 'c'];
 
     it('returns an empty list if either input list is empty', function() {
-        assert.deepEqual(xprod([], [1,2,3]), []);
-        assert.deepEqual(xprod([1,2,3], []), []);
+        assert.deepEqual(R.xprod([], [1,2,3]), []);
+        assert.deepEqual(R.xprod([1,2,3], []), []);
     });
 
     it('should create the collection of all cross-product pairs of its parameters', function() {
-        assert.deepEqual(xprod(a, b), [[1, 'a'], [1, 'b'], [1, 'c'], [2, 'a'], [2, 'b'], [2, 'c']]);
+        assert.deepEqual(R.xprod(a, b), [[1, 'a'], [1, 'b'], [1, 'c'], [2, 'a'], [2, 'b'], [2, 'c']]);
     });
 
     it('should be automatically curried', function() {
-        var something = xprod(b);
+        var something = R.xprod(b);
         assert.deepEqual(something(a), [['a', 1], ['a', 2], ['b', 1], ['b', 2], ['c', 1], ['c', 2]]);
     });
 
     it('should correctly report the arity of curried versions', function() {
-        var something = xprod(a);
+        var something = R.xprod(a);
         assert.equal(something.length, 1);
     });
 });
 
 describe('xprodWith', function() {
-    var xprodWith = R.xprodWith;
     var concat = function(x, y) {return '' + x + y;};
     var a = [1, 2], b = ['a', 'b', 'c'];
 
     it('returns an empty list if either input list is empty', function() {
-        assert.deepEqual(xprodWith(concat, [], [1,2,3]), []);
-        assert.deepEqual(xprodWith(concat, [1,2,3], []), []);
+        assert.deepEqual(R.xprodWith(concat, [], [1,2,3]), []);
+        assert.deepEqual(R.xprodWith(concat, [1,2,3], []), []);
     });
 
     it('should create the collection of all cross-product pairs of its parameters', function() {
-        assert.deepEqual(xprodWith(concat, a, b), ['1a', '1b', '1c', '2a', '2b', '2c']);
+        assert.deepEqual(R.xprodWith(concat, a, b), ['1a', '1b', '1c', '2a', '2b', '2c']);
     });
 
     it('should be automatically curried', function() {
-        var f1 = xprodWith(concat);
+        var f1 = R.xprodWith(concat);
         assert.deepEqual(f1(b, a), ['a1', 'a2', 'b1', 'b2', 'c1', 'c2']);
         var f2 = f1(a);
         assert.deepEqual(f2(b), ['1a', '1b', '1c', '2a', '2b', '2c']);
     });
 
     it('should correctly report the arity of curried versions', function() {
-        var something = xprodWith(a);
+        var something = R.xprodWith(a);
         assert.equal(something.length, 2);
     });
 });

--- a/test/test.range.js
+++ b/test/test.range.js
@@ -2,27 +2,25 @@ var assert = require("assert");
 var R = require("..");
 
 describe('range', function() {
-    var range = R.range;
-
     it('should return list of numbers', function() {
-        assert.deepEqual(range(0, 5), [0, 1, 2, 3, 4]);
-        assert.deepEqual(range(4, 7), [4, 5, 6]);
+        assert.deepEqual(R.range(0, 5), [0, 1, 2, 3, 4]);
+        assert.deepEqual(R.range(4, 7), [4, 5, 6]);
     });
 
     it('should return the empty list if the first parameter is not larger than the second', function() {
-        assert.deepEqual(range(7, 3), []);
-        assert.deepEqual(range(5, 5), []);
+        assert.deepEqual(R.range(7, 3), []);
+        assert.deepEqual(R.range(5, 5), []);
     });
 
     it('should be automatically curried', function() {
-        var from10 = range(10);
+        var from10 = R.range(10);
         assert.deepEqual(from10(15), [10, 11, 12, 13, 14]);
     });
 
     it('should return an empty array if from > to', function() {
-         var result = range(10, 5);
+         var result = R.range(10, 5);
          assert.deepEqual(result, []);
          result.push(5);
-         assert.deepEqual(range(10, 5), []);
+         assert.deepEqual(R.range(10, 5), []);
     });
 });

--- a/test/test.reverse.js
+++ b/test/test.reverse.js
@@ -2,14 +2,12 @@ var assert = require("assert");
 var R = require("..");
 
 describe('reverse', function() {
-    var reverse = R.reverse;
-
     it('should reverse arrays', function() {
-        assert.deepEqual(reverse([1, 2, 3, 4]), [4, 3, 2, 1]);
+        assert.deepEqual(R.reverse([1, 2, 3, 4]), [4, 3, 2, 1]);
     });
 
     it('should return the empty list to itself', function() {
-        assert.deepEqual(reverse([]), []);
+        assert.deepEqual(R.reverse([]), []);
     });
 
 });

--- a/test/test.sql.js
+++ b/test/test.sql.js
@@ -2,7 +2,6 @@ var assert = require("assert");
 var R = require("..");
 
 describe('project', function() {
-    var project = R.project;
     var kids = [
         {name: 'Abby', age: 7, hair: 'blond'},
         {name: 'Fred', age: 12, hair: 'brown'},
@@ -11,7 +10,7 @@ describe('project', function() {
     ];
 
     it('should select the chosen properties from each element in a list', function() {
-        assert.deepEqual(project(['name', 'age'], kids), [
+        assert.deepEqual(R.project(['name', 'age'], kids), [
             {name: 'Abby', age: 7},
             {name: 'Fred', age: 12},
             {name: 'Rusty', age: 10},
@@ -20,7 +19,7 @@ describe('project', function() {
     });
 
     it('should have an undefined property on the output tuple for any input tuple that does not have the property', function() {
-        assert.deepEqual(project(["name", "hair"], kids), [
+        assert.deepEqual(R.project(["name", "hair"], kids), [
             {name: 'Abby', hair: 'blond'},
             {name: 'Fred', hair: 'brown'},
             {name: 'Rusty', hair: 'brown'},
@@ -29,7 +28,7 @@ describe('project', function() {
     });
 
     it('should be automatically curried', function() {
-        var myFields = project(['name', 'age']);
+        var myFields = R.project(['name', 'age']);
         assert.deepEqual(myFields(kids), [
             {name: 'Abby', age: 7},
             {name: 'Fred', age: 12},
@@ -40,57 +39,53 @@ describe('project', function() {
 });
 
 describe('propEq', function() {
-    var propEq = R.propEq, filter = R.filter;
     var obj1 = {name: 'Abby', age: 7, hair: 'blond'};
     var obj2 = {name: 'Fred', age: 12, hair: 'brown'};
     var obj3 = {name: 'Rusty', age: 10, hair: 'brown'};
     var obj4 = {name: 'Alois', age: 15, disposition: 'surly'};
 
     it('should determine whether a particular property matches a given value for a specific object', function() {
-        assert.equal(propEq('name', 'Abby', obj1), true);
-        assert.equal(propEq('hair', 'brown', obj2), true);
-        assert.equal(propEq('hair', 'blond', obj2), false);
+        assert.equal(R.propEq('name', 'Abby', obj1), true);
+        assert.equal(R.propEq('hair', 'brown', obj2), true);
+        assert.equal(R.propEq('hair', 'blond', obj2), false);
     });
 
     it('should be automatically curried', function() {
         var kids = [obj1, obj2, obj3, obj4];
-        var hairMatch = propEq("hair");
+        var hairMatch = R.propEq("hair");
         assert.equal(typeof hairMatch, "function");
         var brunette = hairMatch("brown");
-        assert.deepEqual(filter(brunette, kids), [obj2, obj3]);
+        assert.deepEqual(R.filter(brunette, kids), [obj2, obj3]);
         // more likely usage:
-        assert.deepEqual(filter(propEq("hair", "brown"), kids), [obj2, obj3]);
+        assert.deepEqual(R.filter(R.propEq("hair", "brown"), kids), [obj2, obj3]);
     });
 
 });
 
 describe('union', function() {
-    var union = R.union;
     var M = [1,2,3,4];
     var N = [3,4,5,6];
     var Mo = [{a: 1},{a: 2},{a: 3},{a: 4}];
     var No = [{a: 3},{a: 4},{a: 5},{a: 6}];
     it("combines two lists into the set of all their elements", function() {
-        assert.deepEqual(union(M, N), [1,2,3,4,5,6]);
+        assert.deepEqual(R.union(M, N), [1,2,3,4,5,6]);
     });
 
     it("does not work for non-primitives (use `unionWith`)", function() {
-        assert.equal(union(Mo, No).length, 8);
+        assert.equal(R.union(Mo, No).length, 8);
     });
 });
 
 describe('unionWith', function() {
-    var unionWith = R.unionWith;
     var Ro = [{a: 1},{a: 2},{a: 3},{a: 4}];
     var So = [{a: 3},{a: 4},{a: 5},{a: 6}];
     var eqA = function(r, s) { return r.a === s.a; };
     it("combines two lists into the set of all their elements based on the passed-in equality predicate", function() {
-        assert.deepEqual(unionWith(eqA, Ro, So), [{a: 1},{a: 2},{a: 3},{a: 4},{a: 5},{a: 6}]);
+        assert.deepEqual(R.unionWith(eqA, Ro, So), [{a: 1},{a: 2},{a: 3},{a: 4},{a: 5},{a: 6}]);
     });
 });
 
 describe('intersection', function() {
-    var intersection = R.intersection;
     var M = [1,2,3,4];
     var M2 = [1,2,3,4,1,2,3,4];
     var N = [3,4,5,6];
@@ -98,30 +93,28 @@ describe('intersection', function() {
     var Mo = [{a: 1},{a: 2},{a: 3},{a: 4}];
     var No = [{a: 3},{a: 4},{a: 5},{a: 6}];
     it("combines two lists into the set of common elements", function() {
-        assert.deepEqual(intersection(M, N), [3,4]);
+        assert.deepEqual(R.intersection(M, N), [3,4]);
     });
 
     it("does not allow duplicates in the output even if the input lists had duplicates", function() {
-        assert.deepEqual(intersection(M2, N2), [3,4]);
+        assert.deepEqual(R.intersection(M2, N2), [3,4]);
     });
 
     it("does not work for non-primitives (use `intersectionWith`)", function() {
-        assert.equal(intersection(Mo, No).length, 0);
+        assert.equal(R.intersection(Mo, No).length, 0);
     });
 });
 
 describe('intersectionWith', function() {
-    var intersectionWith = R.intersectionWith;
     var Ro = [{a: 1},{a: 2},{a: 3},{a: 4}];
     var So = [{a: 3},{a: 4},{a: 5},{a: 6}];
     var eqA = function(r, s) { return r.a === s.a; };
     it("combines two lists into the set of all their elements based on the passed-in equality predicate", function() {
-        assert.deepEqual(intersectionWith(eqA, Ro, So), [{a: 3},{a: 4}]);
+        assert.deepEqual(R.intersectionWith(eqA, Ro, So), [{a: 3},{a: 4}]);
     });
 });
 
 describe('difference', function() {
-    var difference = R.difference;
     var M = [1,2,3,4];
     var M2 = [1,2,3,4,1,2,3,4];
     var N = [3,4,5,6];
@@ -129,30 +122,29 @@ describe('difference', function() {
     var Mo = [{a: 1},{a: 2},{a: 3},{a: 4}];
     var No = [{a: 3},{a: 4},{a: 5},{a: 6}];
     it("finds the set of all elements in the first list not contained in the second", function() {
-        assert.deepEqual(difference(M, N), [1,2]);
+        assert.deepEqual(R.difference(M, N), [1,2]);
     });
 
     it("does not allow duplicates in the output even if the input lists had duplicates", function() {
-        assert.deepEqual(difference(M2, N2), [1,2]);
+        assert.deepEqual(R.difference(M2, N2), [1,2]);
     });
 
     it("does not work for non-primitives (use `differenceWith`)", function() {
-        assert.equal(difference(Mo, No).length, 4);
+        assert.equal(R.difference(Mo, No).length, 4);
     });
 });
 
 describe('differenceWith', function() {
-    var differenceWith = R.differenceWith;
     var Ro = [{a: 1},{a: 2},{a: 3},{a: 4}];
     var Ro2 = [{a: 1},{a: 2},{a: 3},{a: 4},{a: 1},{a: 2},{a: 3},{a: 4}];
     var So = [{a: 3},{a: 4},{a: 5},{a: 6}];
     var So2 = [{a: 3},{a: 4},{a: 5},{a: 6},{a: 3},{a: 4},{a: 5},{a: 6}];
     var eqA = function(r, s) { return r.a === s.a; };
     it("combines two lists into the set of all their elements based on the passed-in equality predicate", function() {
-        assert.deepEqual(differenceWith(eqA, Ro, So), [{a: 1},{a: 2}]);
+        assert.deepEqual(R.differenceWith(eqA, Ro, So), [{a: 1},{a: 2}]);
     });
     it("does not allow duplicates in the output even if the input lists had duplicates", function() {
-        assert.deepEqual(differenceWith(eqA, Ro2, So2), [{a: 1},{a: 2}]);
+        assert.deepEqual(R.differenceWith(eqA, Ro2, So2), [{a: 1},{a: 2}]);
     });
 });
 
@@ -171,7 +163,6 @@ describe('differenceWith', function() {
         {title: 'Five Leaves Left', artist: 'Nick Drake', genre: 'Folk'},
         {title: 'The Magic Flute', artist: 'John Eliot Gardiner', genre: 'Classical'}
     ];
-    var prop = R.prop;
     var derivedGenre = (function() {
         var remap = {
             Baroque: 'Classical',
@@ -180,23 +171,21 @@ describe('differenceWith', function() {
             Metal: 'Rock'  /*, etc */
         };
         return function(album) {
-            var genre = prop("genre", album);
+            var genre = R.prop("genre", album);
             return remap[genre] || genre;
         };
     }());
 
     describe('sortBy', function() {
-        var sortBy = R.sortBy;
-
         it('should sort by a simple property of the objects', function() {
-            var sortedAlbums = sortBy(prop("title"), albums);
+            var sortedAlbums = R.sortBy(R.prop("title"), albums);
             assert.equal(sortedAlbums.length, albums.length);
             assert.equal(sortedAlbums[0].title, "A Farewell to Kings");
             assert.equal(sortedAlbums[11].title, "Timeout");
         });
 
         it('should be automatically curried', function() {
-            var sorter = sortBy(prop("title"));
+            var sorter = R.sortBy(R.prop("title"));
             var sortedAlbums = sorter(albums);
             assert.equal(sortedAlbums.length, albums.length);
             assert.equal(sortedAlbums[0].title, "A Farewell to Kings");
@@ -205,22 +194,20 @@ describe('differenceWith', function() {
     });
 
     describe('countBy', function() {
-        var countBy = R.countBy;
-
         it('should count by a simple property of the objects', function() {
-            assert.deepEqual(countBy(prop("genre"), albums), {
+            assert.deepEqual(R.countBy(R.prop("genre"), albums), {
                 Baroque: 2, Rock: 2, Jazz: 2, Romantic: 1, Metal: 1, Modern: 1, Broadway: 1, Folk: 1, Classical: 1
             });
         });
 
         it('should count by a more complex function on the objects', function() {
-            assert.deepEqual(countBy(derivedGenre, albums), {
+            assert.deepEqual(R.countBy(derivedGenre, albums), {
                 Classical: 5, Rock: 3, Jazz: 2, Broadway: 1, Folk: 1
             });
         });
 
         it('should be automatically curried', function() {
-            var counter = countBy(prop("genre"));
+            var counter = R.countBy(R.prop("genre"));
             assert.deepEqual(counter(albums), {
                 Baroque: 2, Rock: 2, Jazz: 2, Romantic: 1, Metal: 1, Modern: 1, Broadway: 1, Folk: 1, Classical: 1
             });
@@ -228,9 +215,8 @@ describe('differenceWith', function() {
     });
 
     describe('groupBy', function() {
-        var groupBy = R.groupBy;
         it('should group by a simple property of the objects', function() {
-            assert.deepEqual(groupBy(prop("genre"), albums), {
+            assert.deepEqual(R.groupBy(R.prop("genre"), albums), {
                 Baroque: [{title: 'Art of the Fugue', artist: 'Glenn Gould', genre: 'Baroque'}, {title: 'Goldberg Variations', artist: 'Daniel Barenboim', genre: 'Baroque'}],
                 Rock: [{title: 'A Farewell to Kings', artist: 'Rush', genre: 'Rock'}, {title: 'Fly By Night', artist: 'Rush', genre: 'Rock'}],
                 Jazz: [{title: 'Timeout', artist: 'Dave Brubeck Quartet', genre: 'Jazz'}, {title: 'Romance with the Unseen', artist: 'Don Byron', genre: 'Jazz'}],
@@ -244,7 +230,7 @@ describe('differenceWith', function() {
         });
 
         it('should group by a more complex function on the objects', function() {
-            assert.deepEqual(groupBy(derivedGenre, albums), {
+            assert.deepEqual(R.groupBy(derivedGenre, albums), {
                 Classical: [
                     {title: 'Art of the Fugue', artist: 'Glenn Gould', genre: 'Baroque'},
                     {title: 'Goldberg Variations', artist: 'Daniel Barenboim', genre: 'Baroque'},
@@ -264,7 +250,7 @@ describe('differenceWith', function() {
         });
 
         it('should be automatically curried', function() {
-            var grouper = groupBy(prop("genre"));
+            var grouper = R.groupBy(R.prop("genre"));
             assert.deepEqual(grouper(albums), {
                 Baroque: [{title: 'Art of the Fugue', artist: 'Glenn Gould', genre: 'Baroque'}, {title: 'Goldberg Variations', artist: 'Daniel Barenboim', genre: 'Baroque'}],
                 Rock: [{title: 'A Farewell to Kings', artist: 'Rush', genre: 'Rock'}, {title: 'Fly By Night', artist: 'Rush', genre: 'Rock'}],

--- a/test/test.stringBasics.js
+++ b/test/test.stringBasics.js
@@ -2,146 +2,125 @@ var assert = require('assert');
 var R = require('..');
 
 describe('substring', function() {
-    var substring = R.substring;
-
     it('should return the substring of a string', function() {
-        assert.equal(substring(2, 5, 'abcdefghijklm'), 'cde');
+        assert.equal(R.substring(2, 5, 'abcdefghijklm'), 'cde');
     });
 
     it('should be automatically curried', function() {
-        var from2 = substring(2);
+        var from2 = R.substring(2);
         assert.equal(from2(5, 'abcdefghijklm'), 'cde');
-        var from2to5 = substring(2, 5);
+        var from2to5 = R.substring(2, 5);
         assert.equal(from2to5('abcdefghijklm'), 'cde');
     });
 });
 
 describe('substringFrom', function() {
-    var substringFrom = R.substringFrom;
-
     it('should return the trailing substring of a string', function() {
-        assert.equal(substringFrom(8, 'abcdefghijklm'), 'ijklm');
+        assert.equal(R.substringFrom(8, 'abcdefghijklm'), 'ijklm');
     });
 
     it('should be automatically curried', function() {
-        var after8 = substringFrom(8);
+        var after8 = R.substringFrom(8);
         assert.equal(after8('abcdefghijklm'), 'ijklm');
     });
 });
 
 describe('substringTo', function() {
-    var substringTo = R.substringTo;
-
     it('should return the trailing substring of a string', function() {
-        assert.equal(substringTo(8, 'abcdefghijklm'), 'abcdefgh');
+        assert.equal(R.substringTo(8, 'abcdefghijklm'), 'abcdefgh');
     });
 
     it('should be automatically curried', function() {
-        var through8 = substringTo(8);
+        var through8 = R.substringTo(8);
         assert.equal(through8('abcdefghijklm'), 'abcdefgh');
     });
 });
 
 describe('charAt', function() {
-    var charAt = R.charAt;
-
     it('should return the character at the nth position of a string', function() {
-        assert.equal(charAt(8, 'abcdefghijklm'), 'i');
+        assert.equal(R.charAt(8, 'abcdefghijklm'), 'i');
     });
 
     it('should be automatically curried', function() {
-        var at8 = charAt(8);
+        var at8 = R.charAt(8);
         assert.equal(at8('abcdefghijklm'), 'i');
     });
 });
 
 describe('charCodeAt', function() {
-    var charCodeAt = R.charCodeAt;
-
     it('should return the ascii character at the nth position of a string', function() {
-        assert.equal(charCodeAt(8, 'abcdefghijklm'), 105);  // 'a' ~ 97, 'b' ~ 98, ... 'i' ~ 105
+        assert.equal(R.charCodeAt(8, 'abcdefghijklm'), 105);  // 'a' ~ 97, 'b' ~ 98, ... 'i' ~ 105
     });
 
     it('should be automatically curried', function() {
-        var at8 = charCodeAt(8);
+        var at8 = R.charCodeAt(8);
         assert.equal(at8('abcdefghijklm'), 105);
     });
 });
 
 describe('match', function() {
-    var match = R.match;
     var re = /[A-Z]\d\d\-[a-zA-Z]+/;
 
     it('should determine whether a string matches a regex', function() {
-        assert.equal(match(re, 'B17-afn').length, 1);
-        assert.equal(match(re, 'B1-afn'), null);
+        assert.equal(R.match(re, 'B17-afn').length, 1);
+        assert.equal(R.match(re, 'B1-afn'), null);
     });
 
     it('should be automatically curried', function() {
-        var format = match(re);
+        var format = R.match(re);
         assert.equal(format('B17-afn').length, 1);
         assert.equal(format('B1-afn'), null);
     });
 });
 
 describe('strIndexOf', function() {
-    var strIndexOf = R.strIndexOf;
-
     it('should find the index of a substring inside a string', function() {
-        assert.equal(strIndexOf('c', 'abcdefg'), 2);
+        assert.equal(R.strIndexOf('c', 'abcdefg'), 2);
     });
 
     it('should return -1 if the value is not found', function() {
-        assert.equal(strIndexOf('x', 'abcdefg'), -1);
+        assert.equal(R.strIndexOf('x', 'abcdefg'), -1);
     });
 
     it('should be automatically curried', function() {
-        var findD = strIndexOf('d');
+        var findD = R.strIndexOf('d');
         assert.equal(findD('abcdefg'), 3);
     });
 });
 
 describe('strLastIndexOf', function() {
-    var strLastIndexOf = R.strLastIndexOf;
-
     it('should find the index of a substring inside a string', function() {
-        assert.equal(strLastIndexOf('a', 'bananas'), 5);
+        assert.equal(R.strLastIndexOf('a', 'bananas'), 5);
     });
 
     it('should return -1 if the value is not found', function() {
-        assert.equal(strLastIndexOf('x', 'abcdefg'), -1);
+        assert.equal(R.strLastIndexOf('x', 'abcdefg'), -1);
     });
 
     it('should be automatically curried', function() {
-        var findA = strLastIndexOf('a');
+        var findA = R.strLastIndexOf('a');
         assert.equal(findA('banana split'), 5);
     });
 });
 
 describe('toUpperCase', function() {
-    var toUpperCase = R.toUpperCase;
-
     it('should uppercase a string', function() {
-        assert.equal(toUpperCase('abc'), 'ABC');
+        assert.equal(R.toUpperCase('abc'), 'ABC');
     });
 });
 
 describe('toLowerCase', function() {
-    var toLowerCase = R.toLowerCase;
-
     it('should lowercase a string', function() {
-        assert.equal(toLowerCase('XYZ'), 'xyz');
+        assert.equal(R.toLowerCase('XYZ'), 'xyz');
     });
 });
 
 describe('split', function() {
-    var split = R.split;
-
     it('should split a string into an array', function() {
-        assert.deepEqual(split('.', 'a.b.c.xyz.d'), ['a', 'b', 'c', 'xyz', 'd']);
+        assert.deepEqual(R.split('.', 'a.b.c.xyz.d'), ['a', 'b', 'c', 'xyz', 'd']);
     });
 
     it('the split string can be arbitrary', function() {
-        assert.deepEqual(split('at', 'The Cat in the Hat sat on the mat'), ['The C', ' in the H', ' s', ' on the m', '']);
+        assert.deepEqual(R.split('at', 'The Cat in the Hat sat on the mat'), ['The C', ' in the H', ' s', ' on the m', '']);
     });
 });

--- a/test/test.tapeq.js
+++ b/test/test.tapeq.js
@@ -2,9 +2,8 @@ var assert = require("assert");
 var R = require("..");
 
 describe('tap', function() {
-    var tap = R.tap;
     it("returns a function that returns tap's argument", function() {
-        var f = tap(100);
+        var f = R.tap(100);
         assert.equal(typeof f, "function");
         assert.equal(f(null), 100);
     });
@@ -12,29 +11,28 @@ describe('tap', function() {
     it("may take a function for a second argument that executes with tap's argument", function() {
         var sideEffect = 0;
         assert.equal(sideEffect, 0);
-        var rv = tap(200, function(x) { sideEffect = "string " + x; });
+        var rv = R.tap(200, function(x) { sideEffect = "string " + x; });
         assert.equal(rv, 200);
         assert.equal(sideEffect, "string 200");
     });
 
     it("ignores the scond argument if it's not a function", function() {
-        assert(tap(300, 400), 300);
-        assert(tap(300, [400]), 300);
-        assert(tap(300, {x: 400}), 300);
-        assert(tap(300, '400'), 300);
-        assert(tap(300, false), 300);
-        assert(tap(300, null), 300);
+        assert(R.tap(300, 400), 300);
+        assert(R.tap(300, [400]), 300);
+        assert(R.tap(300, {x: 400}), 300);
+        assert(R.tap(300, '400'), 300);
+        assert(R.tap(300, false), 300);
+        assert(R.tap(300, null), 300);
     });
 });
 
 describe('eq', function() {
-    var eq = R.eq;
     var a = [];
     var b = a;
     it("tests for strict equality of its operands", function() {
-        assert.equal(eq(100, 100), true);
-        assert.equal(eq(100, '100'), false);
-        assert.equal(eq([], []), false);
-        assert.equal(eq(a, b), true);
+        assert.equal(R.eq(100, 100), true);
+        assert.equal(R.eq(100, '100'), false);
+        assert.equal(R.eq([], []), false);
+        assert.equal(R.eq(a, b), true);
     });
 });

--- a/test/test.unfold.js
+++ b/test/test.unfold.js
@@ -2,15 +2,13 @@ var assert = require("assert");
 var R = require("..");
 
 describe('unfoldr', function() {
-    var unfoldr = R.unfoldr;
-
     it('should unfold simple functions with a starting point to create a list', function() {
-        assert.deepEqual(unfoldr(function(n) {if (n > 0) {return [n, n - 1];}}, 10), [10, 9, 8, 7, 6, 5, 4, 3, 2, 1]);
+        assert.deepEqual(R.unfoldr(function(n) {if (n > 0) {return [n, n - 1];}}, 10), [10, 9, 8, 7, 6, 5, 4, 3, 2, 1]);
     });
 
     it('should just be cool!', function() {
         var fib = function(n) {var count = 0; return function(pair) {if (count++ < n) {return [pair[0], [pair[1], pair[0] + pair[1]]];}};};
-        assert.deepEqual(unfoldr(fib(10), [0, 1]), [0, 1, 1, 2, 3, 5, 8, 13, 21, 34]);
+        assert.deepEqual(R.unfoldr(fib(10), [0, 1]), [0, 1, 1, 2, 3, 5, 8, 13, 21, 34]);
     });
 
 });

--- a/test/test.wrap.js
+++ b/test/test.wrap.js
@@ -2,11 +2,9 @@ var assert = require('assert');
 var R = require('..');
 
 describe('wrap', function() {
-    var wrap = R.wrap;
-
     it('surrounds the invocation of one function with another', function() {
         var greet = function(name) {return 'Hello ' + name;};
-        var extendedGreet = wrap(greet, function(gr, name) {
+        var extendedGreet = R.wrap(greet, function(gr, name) {
             return gr('my dear ' + name) + ', how are you?';
         });
         assert.equal(greet('joe'), 'Hello joe');

--- a/test/test.zip.js
+++ b/test/test.zip.js
@@ -2,59 +2,55 @@ var assert = require("assert");
 var R = require("..");
 
 describe('zipWith', function() {
-    var zipWith = R.zipWith;
     var a = [1,2,3], b = [100, 200, 300], c = [10, 20, 30, 40, 50, 60];
     var add = function(a, b) { return a + b; };
     var x = function(a, b) { return a * b; };
     var s = function(a, b) { return a + ' cow ' + b; };
     it("returns an array created by applying its passed-in function pair-wise on its passed in arrays", function() {
-        assert.deepEqual(zipWith(add, a, b), [101, 202, 303]);
-        assert.deepEqual(zipWith(x, a, b), [100, 400, 900]);
-        assert.deepEqual(zipWith(s, a, b), ['1 cow 100', '2 cow 200', '3 cow 300']);
+        assert.deepEqual(R.zipWith(add, a, b), [101, 202, 303]);
+        assert.deepEqual(R.zipWith(x, a, b), [100, 400, 900]);
+        assert.deepEqual(R.zipWith(s, a, b), ['1 cow 100', '2 cow 200', '3 cow 300']);
     });
 
     it("returns an array whose length is equal to the shorter of its input arrays", function() {
-        assert.equal(zipWith(add, a, c).length, a.length);
+        assert.equal(R.zipWith(add, a, c).length, a.length);
     });
 });
 
 describe('zip', function() {
-    var zip = R.zip;
     it("returns an array of 'tuples'", function() {
         var a = [1,2,3], b = [100, 200, 300];
-        assert.deepEqual(zip(a, b), [[1, 100], [2, 200], [3, 300]]);
+        assert.deepEqual(R.zip(a, b), [[1, 100], [2, 200], [3, 300]]);
     });
 
     it("returns a list as long as the shorter of the lists input", function() {
         var a = [1,2,3], b = [100, 200, 300, 400], c = [10, 20];
-        assert.deepEqual(zip(a, b), [[1, 100], [2, 200], [3, 300]]);
-        assert.deepEqual(zip(a, c), [[1, 10], [2, 20]]);
+        assert.deepEqual(R.zip(a, b), [[1, 100], [2, 200], [3, 300]]);
+        assert.deepEqual(R.zip(a, c), [[1, 10], [2, 20]]);
     });
 });
 
 describe('zipObj', function() {
-    var zipObj = R.zipObj;
     it("combines an array of keys with an arrau of values into a single object", function() {
-        assert.deepEqual(zipObj(['a', 'b', 'c'], [1, 2, 3]), {a: 1, b: 2, c: 3});
+        assert.deepEqual(R.zipObj(['a', 'b', 'c'], [1, 2, 3]), {a: 1, b: 2, c: 3});
     });
     it("ignores extra values", function() {
-        assert.deepEqual(zipObj(['a', 'b', 'c'], [1, 2, 3, 4, 5, 6, 7]), {a: 1, b: 2, c: 3});
+        assert.deepEqual(R.zipObj(['a', 'b', 'c'], [1, 2, 3, 4, 5, 6, 7]), {a: 1, b: 2, c: 3});
     });
     it("extra keys are undefined", function() {
-        assert.deepEqual(zipObj(['a', 'b', 'c', 'd', 'e', 'f'], [1, 2, 3]),
+        assert.deepEqual(R.zipObj(['a', 'b', 'c', 'd', 'e', 'f'], [1, 2, 3]),
           {a: 1, b: 2, c: 3, d: undefined, e: undefined, f: undefined});
     });
     it('last one in wins when there are duplicate keys', function() {
-        assert.deepEqual(zipObj(['a', 'b', 'c', 'a'], [1, 2, 3, 'LAST']), {a: 'LAST', b: 2, c: 3});
+        assert.deepEqual(R.zipObj(['a', 'b', 'c', 'a'], [1, 2, 3, 'LAST']), {a: 'LAST', b: 2, c: 3});
     });
 });
 
 describe('fromPairs', function() {
-    var fromPairs = R.fromPairs;
     it("combines an array of two-element arrays into an object", function() {
-        assert.deepEqual(fromPairs([['a', 1], ['b', 2], ['c', 3]]), {a: 1, b: 2, c: 3});
+        assert.deepEqual(R.fromPairs([['a', 1], ['b', 2], ['c', 3]]), {a: 1, b: 2, c: 3});
     });
     it("skips empty Arrays and non-Array elements", function() {
-        assert.deepEqual(fromPairs([['a', 1], 'x', [], ['b', 2], {}, ['c', 3]]), {a: 1, b: 2, c: 3});
+        assert.deepEqual(R.fromPairs([['a', 1], 'x', [], ['b', 2], {}, ['c', 3]]), {a: 1, b: 2, c: 3});
     });
 });


### PR DESCRIPTION
Not only does this change remove ≅200 lines of code, it makes it easy to differentiate functions defined in the test suite from Ramda functions.

I would go further and remove the aliases in **ramda.js**, but that's a controversial change.
