### PR TITLE
replace typeof check in isArrayLike

### DIFF
--- a/ramda.js
+++ b/ramda.js
@@ -146,7 +146,7 @@
          * isArrayLike({length: 10}); //=> true
          */
         var isArrayLike = function(x) {
-            return isArray(x) || (typeof x !== "string" && x != null && x.length >= 0);
+            return x != null && x.length >= 0 && (isArray(x) || !R.is(String, x));
         };
 
         /**


### PR DESCRIPTION
Before:

``` javascript
> isArrayLike(new String('foo'))
true
```

After:

``` javascript
> isArrayLike(new String('foo'))
false
```
