### PR TITLE
update README urls

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -80,7 +80,7 @@ module.exports = function(grunt) {
 
     push: {
       options: {
-        files: ['package.json', 'bower.json'],
+        files: ['package.json', 'bower.json', 'ramda.js'],
         add: false,
         commit: false,
         createTag: false,

--- a/README.md
+++ b/README.md
@@ -68,14 +68,14 @@ or the minified version:
 or from a CDN, either cdnjs:
 
 ```html
-<script src="//cdnjs.cloudflare.com/ajax/libs/ramda/0.2.3/ramda.min.js"></script>
+<script src="//cdnjs.cloudflare.com/ajax/libs/ramda/0.3.0/ramda.min.js"></script>
 ```
 
 or one of the below links from [jsDelivr](http://jsdelivr.net):
 
 ```html
-<script src="//cdn.jsdelivr.net/ramda/0.2.3/ramda.min.js"></script>
-<script src="//cdn.jsdelivr.net/ramda/0.2/ramda.min.js"></script>
+<script src="//cdn.jsdelivr.net/ramda/0.3.0/ramda.min.js"></script>
+<script src="//cdn.jsdelivr.net/ramda/0.3/ramda.min.js"></script>
 <script src="//cdn.jsdelivr.net/ramda/latest/ramda.min.js"></script>
 ```
 

--- a/ramda.js
+++ b/ramda.js
@@ -1,4 +1,5 @@
-//     ramda.js 0.3.0
+//     ramda.js 
+//     "version": "0.3.0"
 //     https://github.com/CrossEye/ramda
 //     (c) 2013-2014 Scott Sauyet and Michael Hurley
 //     Ramda may be freely distributed under the MIT license.


### PR DESCRIPTION
in future run "grunt push:$LEVEL:bump-only" to update package.json. bower.json, & ramda.js before publish. gotta work in updating README urls with latest version as well.
