### PR TITLE
Make foldl work on plain objects

### DIFF
--- a/ramda.js
+++ b/ramda.js
@@ -149,7 +149,7 @@
         var isArrayLike = function isArrayLike(x) {
             return isArray(x) || (
                 !!x &&
-                typeof x === "object" && 
+                typeof x === "object" &&
                 ! (x instanceof String) &&
                 (
                     !!(x.nodeType === 1 && x.length) ||
@@ -1390,14 +1390,54 @@
         // --------
 
         /**
+         * An internal version of foldl. Works on array-like objects.
+         *
+         * @private
+         * @param {Function} fn The iterator function. Receives two values, the accumulator and the
+         * current element from the array.
+         * @param {*} acc The accumulator value.
+         * @param {Array} list The list to iterate over.
+         * @return {*} The final, accumulated value.
+         */
+        var arrayFoldl = function arrayFoldl(fn, acc, array) {
+            var idx = -1,
+                len = array.length;
+            while (++idx < len) {
+                acc = fn(acc, array[idx]);
+            }
+            return acc;
+        };
+
+        /**
+         * An internal version of foldl. Works on plain objects.
+         *
+         * @private
+         * @param {Function} fn The iterator function. Receives two values, the accumulator and the
+         * current element from the array.
+         * @param {*} acc The accumulator value.
+         * @param {Object} list The list to iterate over.
+         * @return {*} The final, accumulated value.
+         */
+        var objFoldl = function objFoldl(fn, acc, list) {
+            var ks = keys(list),
+                idx = -1,
+                len = ks.length;
+            while (++idx < len) {
+                acc = fn(acc, list[ks[idx]]);
+            }
+            return acc;
+        };
+
+        /**
          * Returns a single item by iterating through the list, successively calling the iterator
-         * function and passing it an accumulator value and the current value from the array, and
+         * function and passing it an accumulator value and the current value from the list, and
          * then passing the result to the next call.
          *
          * The iterator function receives two values: *(acc, value)*
          *
-         * Note: `ramda.foldl` does not skip deleted or unassigned indices (sparse arrays), unlike
-         * the native `Array.prototype.reduce` method. For more details on this behavior, see:
+         * Note: When operating on arrays, `ramda.foldl` does not skip deleted or unassigned indices
+         * (sparse arrays), unlike the native `Array.prototype.reduce` method. For more details on
+         * this behavior, see:
          * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/reduce#Description
          *
          * @static
@@ -1407,7 +1447,7 @@
          * @param {Function} fn The iterator function. Receives two values, the accumulator and the
          * current element from the array.
          * @param {*} acc The accumulator value.
-         * @param {Array} list The list to iterate over.
+         * @param {Array,Object} list The list to iterate over.
          * @return {*} The final, accumulated value.
          * @example
          *
@@ -1419,11 +1459,7 @@
          * foldl(numbers, add, 10); //=> 16
          */
         var foldl = R.foldl =  curry3(checkForMethod('foldl', function(fn, acc, list) {
-            var idx = -1, len = list.length;
-            while (++idx < len) {
-                acc = fn(acc, list[idx]);
-            }
-            return acc;
+            return (isArray(list) ? arrayFoldl : objFoldl)(fn, acc, list);
         }));
         aliasFor("foldl").is("reduce");
 

--- a/test/test.fold.js
+++ b/test/test.fold.js
@@ -15,6 +15,24 @@ describe('foldl', function() {
         assert.equal(R.foldl(mult, 1, []), 1);
     });
 
+    it('should fold simple functions over objects with the supplied accumulator', function() {
+        assert.equal(R.foldl(add, 0, { a: 1, b: 2, c: 3, d: 4 }), 10);
+        assert.equal(R.foldl(mult, 1, { a: 1, b: 2, c: 3, d: 4 }), 24);
+    });
+
+    it('should ignore prototypally inherited properties on objects', function() {
+        var parent = { parent: 1 };
+        var child = Object.create(parent);
+        child.child = 100;
+        assert.equal(child.parent, 1);
+        assert.equal(R.foldl(add, 0, child), 100);
+    });
+
+    it('should return the accumulator for an empty object', function() {
+        assert.equal(R.foldl(add, 0, {}), 0);
+        assert.equal(R.foldl(mult, 1, {}), 1);
+    });
+
     it('should be automatically curried', function() {
         var sum = R.foldl(add, 0);
         assert.equal(sum([1, 2, 3, 4]), 10);


### PR DESCRIPTION
Like a lot of other folks (especially those coming from Lodash/Underscore), I frequently find myself reaching for `foldl` when dealing with plain objects. Converting the object to an array before passing it to `foldl`-like functions is both verbose and has some significant disadvantages. Currently, most Ramda functions only work on arrays, but I'd like to change that, starting with `fold`-family functions.

I see this as more of a conversation starter than anything, since work to be done here before this PR is ready. I'm not satisfied with the current implementation of this for a few reasons:
- Currently, because `foldl` is decorated by `checkForMethod`, this wastefully checks whether or not the target is an array twice--once in the `checkForMethod` call, and again in the body of the function when checking which function to dispatch. I can conceive of a few ways to get around this, but not without fairly significant refactoring (e.g. I think the `checkForMethod` decoration pattern is a little inflexible as is; I'd pull the check back into each function body, and maybe refactor the dispatching code into a separate function `dispatchMethod`).
- I'd want to amend this PR before merge to include a patch to all fold-like functions (`foldl.idx`,  `foldr`, etc.) to keep the assorted interfaces consistent.

A broader topic of conversation is to extend this kind of polymorphic functionality to functions other than `foldl` (e.g. `map` `any`, etc.)--many list-oriented functions are useful whether the input list is an array or an object.
