### PR TITLE
Added utility function to get list of all function names in a object

### DIFF
--- a/ramda.js
+++ b/ramda.js
@@ -4975,6 +4975,51 @@
     });
 
 
+    /**
+     * @private
+     * @param {Function} fn The strategy for extracting function names from an object
+     * @return {Function} A function that takes an object and returns an array of function names
+     *
+     */
+    var functionsWith = function(fn) {
+        return function(obj) {
+            return R.filter(function(key) { return typeof obj[key] === 'function'; }, fn(obj));
+        };
+    };
+
+
+    /**
+     * Returns a list of function names of object's own functions
+     *
+     * @static .
+     * @memberOf R
+     * @category Object
+     * @param {Object} obj The objects with functions in it
+     * @return {Array} returns list of object's own function names
+     * @example .
+     *
+     *      R.functions(R) // => returns list of ramda's own function names
+     *      R.functions(this) // => returns list of function names in global scope's own function names
+     */
+    R.functions = functionsWith(R.keys);
+
+
+    /**
+     * Returns a list of function names of object's own and prototype functions
+     *
+     * @static .
+     * @memberOf R
+     * @category Object
+     * @param {Object} obj The objects with functions in it
+     * @return {Array} returns list of object's own and prototype function names
+     * @example .
+     *
+     *      R.functionsIn(R) // => returns list of ramda's own and prototype function names
+     *      R.functionsIn(this) // => returns list of function names in global scope's own and prototype function names
+     */
+    R.functionsIn = functionsWith(R.keysIn);
+
+
     // All the functional goodness, wrapped in a nice little package, just for you!
     return R;
 }));

--- a/test/index.html
+++ b/test/index.html
@@ -56,6 +56,8 @@
   <script src="test.wrap.js"></script>
   <script src="test.keysvals.js"></script>
   <script src="test.functionBasics.js"></script>
+  <script src="test.functions.js"></script>
+  <script src="test.functionsIn.js"></script>
   <script src="test.expose.js"></script>
   <script src="test.list.js"></script>
   <script src="test.indexof.js"></script>

--- a/test/test.functions.js
+++ b/test/test.functions.js
@@ -1,0 +1,24 @@
+var assert = require('assert');
+var R = require('..');
+
+describe('functions', function() {
+
+    function F() {
+        this.sort = function () {};
+        this.map = function () {};
+        this.obj = {};
+        this.num = 4;
+    }
+
+    F.prototype.x = function() {};
+    F.prototype.y = function() {};
+    F.prototype.z = {};
+
+    var f = new F();
+
+    it('should return list of functions without prototype functions', function() {
+        assert.deepEqual(R.functions(f).sort(), ['map', 'sort']);
+        assert.equal(R.functions(f).length, 2);
+    });
+
+});

--- a/test/test.functionsIn.js
+++ b/test/test.functionsIn.js
@@ -1,0 +1,24 @@
+var assert = require('assert');
+var R = require('..');
+
+describe('functionsIn', function() {
+
+    function F() {
+        this.sort = function () {};
+        this.map = function () {};
+        this.obj = {};
+        this.num = 4;
+    }
+
+    F.prototype.x = function() {};
+    F.prototype.y = function() {};
+    F.prototype.z = {};
+
+    var f = new F();
+
+    it('should return list of functions with prototype functions', function() {
+        assert.deepEqual(R.functionsIn(f).sort(), ['map', 'sort', 'x', 'y']);
+        assert.equal(R.functionsIn(f).length, 4);
+    });
+
+});


### PR DESCRIPTION
Added utility method to get the list of function names in the object just like underscore of lodash _.functions or _.methods

Useful to create the Ramda plugins for example ramdangular

Its easy to get the list of utility functions Ramda has and make them available to the $rootScope in Angular

R.functions(R)  --> will return all the function names Ramda supports
