### PR TITLE
style: normalize formatting

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,187 +1,192 @@
 var desireds = require('./sauce/desireds');
 
 module.exports = function(grunt) {
-  grunt.initConfig({
+    grunt.initConfig({
 
-    pkg: grunt.file.readJSON('package.json'),
+        pkg: grunt.file.readJSON('package.json'),
 
-    orchestrate_token: process.env.ORCHESTRATE_API_KEY,
+        orchestrate_token: process.env.ORCHESTRATE_API_KEY,
 
-    uglify: {
-      options: {
-        banner: '/*! <%= pkg.name %> <%= grunt.template.today("yyyy-mm-dd") %> */\n'
-      },
-      dist: {
-        files: {
-          'dist/<%= pkg.name %>.min.js': ['<%= pkg.name %>.js']
-        }
-      }
-    },
-
-    mocha: {
-      browser: ['test/**/*.html'],
-      options: {
-        run: true
-      }
-    },
-
-    mochaTest: {
-      test: {
-        options: {
-          // reporter: 'progress'
-          // reporter: 'list'
-          reporter: 'spec'
+        uglify: {
+            options: {
+                banner: '/*! <%= pkg.name %> <%= grunt.template.today("yyyy-mm-dd") %> */\n'
+            },
+            dist: {
+                files: {
+                    'dist/<%= pkg.name %>.min.js': ['<%= pkg.name %>.js']
+                }
+            }
         },
-        src: ['test/**/*.js', 'ext/**/test/*.js']
-        //src: ['test/**/*.js']
-      }
-    },
 
-    jscs: {
-      files: ['*.js', 'ext/**/*.js', 'test/*.js'],
-      options: {
-        disallowMixedSpacesAndTabs: true,
-        disallowMultipleLineStrings: true,
-        disallowSpaceAfterObjectKeys: true,
-        disallowSpaceAfterPrefixUnaryOperators: ['++', '--', '+', '-', '~', '!'],
-        disallowSpaceBeforePostfixUnaryOperators: ['++', '--'],
-        disallowSpacesInsideArrayBrackets: true,
-        disallowSpacesInsideObjectBrackets: true,
-        disallowSpacesInsideParentheses: true,
-        disallowTrailingWhitespace: true,
-        disallowYodaConditions: true,
-        requireCapitalizedConstructors: true,
-        requireCommaBeforeLineBreak: true,
-        requireDotNotation: true,
-        requireLineFeedAtFileEnd: true,
-        requireParenthesesAroundIIFE: true,
-        requireSpaceAfterBinaryOperators: ['+', '-', '/', '*', '=', '==', '===', '!=', '!==', '>', '>=', '<', '<=', ',', ':'],
-        requireSpaceAfterKeywords: ['if', 'else', 'for', 'while', 'do', 'switch', 'return', 'try', 'catch', 'finally'],
-        requireSpaceBeforeBinaryOperators: ['+', '-', '/', '*', '=', '==', '===', '!=', '!==', '>', '>=', '<', '<='],
-        requireSpaceBeforeBlockStatements: true,
-        requireSpacesInConditionalExpression: true,
-        requireSpacesInFunctionExpression: {beforeOpeningCurlyBrace: true},
-        validateLineBreaks: 'LF',
-        validateQuoteMarks: {escape: true, mark: "'"}
-      }
-    },
+        mocha: {
+            browser: ['test/**/*.html'],
+            options: {
+                run: true
+            }
+        },
 
-    jshint: {
-      files: ['ramda.js', 'ext/**/*.js', 'test/*.js'],
-      options: {
-        evil: true,
-        eqnull: true
-      }
-    },
+        mochaTest: {
+            test: {
+                options: {
+                    // reporter: 'progress'
+                    // reporter: 'list'
+                    reporter: 'spec'
+                },
+                src: ['test/**/*.js', 'ext/**/test/*.js']
+            }
+        },
 
-    docco: {
-      doc: {
-        src: ['<%= pkg.name %>.js'],
-        options: {
-          template: 'docs/tpl/ramda.jst',
-          css: 'docs/tpl/ramda.css',
-          output: 'docs/'
+        jscs: {
+            files: ['*.js', 'ext/**/*.js', 'test/*.js'],
+            options: {
+                disallowKeywordsOnNewLine: ['else', 'catch', 'finally'],
+                disallowMixedSpacesAndTabs: true,
+                disallowMultipleLineStrings: true,
+                disallowQuotedKeysInObjects: 'allButReserved',
+                disallowSpaceAfterObjectKeys: true,
+                disallowSpaceAfterPrefixUnaryOperators: ['++', '--', '+', '-', '~', '!'],
+                disallowSpaceBeforePostfixUnaryOperators: ['++', '--'],
+                disallowSpacesInFunction: {beforeOpeningRoundBrace: true},
+                disallowSpacesInsideArrayBrackets: true,
+                disallowSpacesInsideObjectBrackets: true,
+                disallowSpacesInsideParentheses: true,
+                disallowTrailingWhitespace: true,
+                disallowYodaConditions: true,
+                requireCapitalizedConstructors: true,
+                requireCommaBeforeLineBreak: true,
+                requireCurlyBraces: ['if', 'else', 'for', 'while', 'do', 'try', 'catch', 'finally'],
+                requireDotNotation: true,
+                requireLineFeedAtFileEnd: true,
+                requireParenthesesAroundIIFE: true,
+                requireSpaceAfterBinaryOperators: ['+', '-', '/', '*', '=', '==', '===', '!=', '!==', '>', '>=', '<', '<=', ',', ':'],
+                requireSpaceAfterKeywords: ['if', 'else', 'for', 'while', 'do', 'switch', 'return', 'try', 'catch', 'finally'],
+                requireSpaceAfterLineComment: true,
+                requireSpaceBeforeBinaryOperators: ['+', '-', '/', '*', '=', '==', '===', '!=', '!==', '>', '>=', '<', '<='],
+                requireSpaceBeforeBlockStatements: true,
+                requireSpacesInConditionalExpression: true,
+                requireSpacesInFunction: {beforeOpeningCurlyBrace: true},
+                validateIndentation: 4,
+                validateLineBreaks: 'LF',
+                validateQuoteMarks: {escape: true, mark: "'"}
+            }
+        },
+
+        jshint: {
+            files: ['ramda.js', 'ext/**/*.js', 'test/*.js'],
+            options: {
+                evil: true,
+                eqnull: true
+            }
+        },
+
+        docco: {
+            doc: {
+                src: ['<%= pkg.name %>.js'],
+                options: {
+                    template: 'docs/tpl/ramda.jst',
+                    css: 'docs/tpl/ramda.css',
+                    output: 'docs/'
+                }
+            }
+        },
+
+        benchmark: {
+            all: {
+                src: ['bench/*.bench.js'],
+                dest: 'bench/report/bench.<%= (new Date()).getTime() %>.json',
+            }
+        },
+
+        clean: {
+            dist: {
+                src: ['dist']
+            }
+        },
+
+        copy: {
+            dist: {
+                files: [
+                    {expand: true, src: ['docs/*'], dest: 'dist/docs'},
+                    {expand: true, src: ['ramda.js', 'package.json', 'bower.json', 'LICENSE.txt', 'README.md'], dest: 'dist'}
+                ]
+            }
+        },
+
+        push: {
+            options: {
+                files: ['package.json', 'bower.json', 'ramda.js'],
+                add: false,
+                commit: false,
+                createTag: false,
+                push: false
+            }
+        },
+
+        jsdoc: {
+            dist: {
+                src: ['*.js'],
+                options: {
+                    destination: 'jsdoc-out'
+                }
+            }
         }
-      }
-    },
 
-    benchmark: {
-      all: {
-        src: ['bench/*.bench.js'],
-        dest: 'bench/report/bench.<%= (new Date()).getTime() %>.json',
-      }
-    },
-
-    clean: {
-      dist: {
-        src: ['dist']
-      }
-    },
-
-    copy: {
-      dist: {
-        files: [
-            {expand: true, src: ['docs/*'], dest: 'dist/docs'},
-            {expand: true, src: ['ramda.js', 'package.json', 'bower.json', 'LICENSE.txt', 'README.md'], dest: 'dist'}
-        ]
-      }
-    },
-
-    push: {
-      options: {
-        files: ['package.json', 'bower.json', 'ramda.js'],
-        add: false,
-        commit: false,
-        createTag: false,
-        push: false
-      }
-    },
-
-    jsdoc: {
-      dist: {
-        src: ['*.js'],
-        options: {
-          destination: 'jsdoc-out'
-        }
-      }
-    }
-
-  });
-
-  grunt.loadNpmTasks('grunt-contrib-uglify');
-  grunt.loadNpmTasks('grunt-contrib-jshint');
-  grunt.loadNpmTasks('grunt-contrib-clean');
-  grunt.loadNpmTasks('grunt-contrib-copy');
-  grunt.loadNpmTasks('grunt-jscs');
-  grunt.loadNpmTasks('grunt-mocha');
-  grunt.loadNpmTasks('grunt-mocha-test');
-  grunt.loadNpmTasks('grunt-docco');
-  grunt.loadNpmTasks('grunt-push-release');
-  grunt.loadNpmTasks('grunt-benchmark');
-  grunt.loadNpmTasks('grunt-readme');
-  grunt.loadNpmTasks('grunt-jsdoc');
-
-  grunt.registerTask('uploadBenchmarks', 'upload benchmark report to orchestrate', function() {
-    // upload files in report dir to orchestrate
-    var done = this.async();
-    var reportDir = 'bench/report/';
-    var token = grunt.config.get('orchestrate_token');
-    var db = require('orchestrate')(token);
-
-    grunt.file.recurse(reportDir, function(abspath, rootdir, subdir, filename) {
-      var json = {};
-      var timestamp = filename.split('.')[1];
-      if (timestamp) {
-        json.timestamp = timestamp;
-        json.datestamp = (new Date(+timestamp)).toISOString();
-        json.platform = {
-          branch: process.env.TRAVIS_BRANCH,
-          buildId: process.env.TRAVIS_BUILD_ID,
-          commit: process.env.TRAVIS_COMMIT,
-          commitRange: process.env.TRAVIS_COMMIT_RANGE,
-          tag: process.env.TRAVIS_TAG,
-          node: process.env.TRAVIS_NODE_VERSION || process.versions.node
-        };
-        json.report = grunt.file.readJSON(abspath);
-        db.put('benchmarks', json.timestamp, json)
-          .then(function() {
-            console.log('SUCCESS');
-            grunt.file.delete(abspath);
-            done();
-          })
-          .fail(function(err) {
-            console.log('FAIL', err.body.message);
-            done();
-          });
-      }
     });
-  });
 
-  grunt.registerTask('dist', ['uglify', 'copy:dist']);
+    grunt.loadNpmTasks('grunt-contrib-uglify');
+    grunt.loadNpmTasks('grunt-contrib-jshint');
+    grunt.loadNpmTasks('grunt-contrib-clean');
+    grunt.loadNpmTasks('grunt-contrib-copy');
+    grunt.loadNpmTasks('grunt-jscs');
+    grunt.loadNpmTasks('grunt-mocha');
+    grunt.loadNpmTasks('grunt-mocha-test');
+    grunt.loadNpmTasks('grunt-docco');
+    grunt.loadNpmTasks('grunt-push-release');
+    grunt.loadNpmTasks('grunt-benchmark');
+    grunt.loadNpmTasks('grunt-readme');
+    grunt.loadNpmTasks('grunt-jsdoc');
 
-  grunt.registerTask('test', ['jshint', 'jscs', 'mochaTest:test']);
-  grunt.registerTask('min', ['jshint', 'mochaTest:test', /* 'docco:doc', */ 'uglify']);
-  grunt.registerTask('version', ['clean:dist', 'jshint', /*'docco:doc',*/ 'uglify', 'copy:dist']);
-  grunt.registerTask('publish', ['push', 'version']);
-  grunt.registerTask('bench', ['benchmark', 'uploadBenchmarks']);
+    grunt.registerTask('uploadBenchmarks', 'upload benchmark report to orchestrate', function() {
+        // upload files in report dir to orchestrate
+        var done = this.async();
+        var reportDir = 'bench/report/';
+        var token = grunt.config.get('orchestrate_token');
+        var db = require('orchestrate')(token);
+
+        grunt.file.recurse(reportDir, function(abspath, rootdir, subdir, filename) {
+            var json = {};
+            var timestamp = filename.split('.')[1];
+            if (timestamp) {
+                json.timestamp = timestamp;
+                json.datestamp = (new Date(+timestamp)).toISOString();
+                json.platform = {
+                    branch: process.env.TRAVIS_BRANCH,
+                    buildId: process.env.TRAVIS_BUILD_ID,
+                    commit: process.env.TRAVIS_COMMIT,
+                    commitRange: process.env.TRAVIS_COMMIT_RANGE,
+                    tag: process.env.TRAVIS_TAG,
+                    node: process.env.TRAVIS_NODE_VERSION || process.versions.node
+                };
+                json.report = grunt.file.readJSON(abspath);
+                db.put('benchmarks', json.timestamp, json)
+                    .then(function() {
+                        console.log('SUCCESS');
+                        grunt.file.delete(abspath);
+                        done();
+                    })
+                    .fail(function(err) {
+                        console.log('FAIL', err.body.message);
+                        done();
+                    });
+            }
+        });
+    });
+
+    grunt.registerTask('dist', ['uglify', 'copy:dist']);
+
+    grunt.registerTask('test', ['jshint', 'jscs', 'mochaTest:test']);
+    grunt.registerTask('min', ['jshint', 'mochaTest:test', /* 'docco:doc', */ 'uglify']);
+    grunt.registerTask('version', ['clean:dist', 'jshint', /*'docco:doc',*/ 'uglify', 'copy:dist']);
+    grunt.registerTask('publish', ['push', 'version']);
+    grunt.registerTask('bench', ['benchmark', 'uploadBenchmarks']);
 };

--- a/ext/debug/debug.js
+++ b/ext/debug/debug.js
@@ -3,55 +3,59 @@ var R = require('./ramda');
 // Internal function to set the source attributes on a curried functions
 // useful for debugging purposes
 function setSource(curried, source) {
-  curried.toString = function() {
-    return source.toString();
-  };
-  curried.source = source;
-  return curried;
+    curried.toString = function() {
+        return source.toString();
+    };
+    curried.source = source;
+    return curried;
 }
 
 var NO_ARGS_EXCEPTION = new TypeError('Function called with no arguments');
 
-R.curry = function (fn, fnArity) {
-  fnArity = typeof fnArity === 'number' ? fnArity : fn.length;
-  function recurry(args) {
-    return setSource(R.arity(Math.max(fnArity - (args && args.length || 0), 0), function () {
-      if (arguments.length === 0) { throw NO_ARGS_EXCEPTION; }
-      var newArgs = concat(args, arguments);
-      if (newArgs.length >= fnArity) {
-        return fn.apply(this, newArgs);
-      }
-      else {
-        return recurry(newArgs);
-      }
-    }), fn);
-  }
-  return recurry([]);
+R.curry = function(fn, fnArity) {
+    fnArity = typeof fnArity === 'number' ? fnArity : fn.length;
+    function recurry(args) {
+        return setSource(R.arity(Math.max(fnArity - (args && args.length || 0), 0), function() {
+            if (arguments.length === 0) { throw NO_ARGS_EXCEPTION; }
+            var newArgs = concat(args, arguments);
+            if (newArgs.length >= fnArity) {
+                return fn.apply(this, newArgs);
+            } else {
+                return recurry(newArgs);
+            }
+        }), fn);
+    }
+    return recurry([]);
 };
 
 function curry2(fn) {
-  return setSource(function(a, b) {
-    switch (arguments.length) {
-      case 0: throw NO_ARGS_EXCEPTION;
-      case 1: return setSource(function(b) {
+    return setSource(function(a, b) {
+        switch (arguments.length) {
+            case 0:
+                throw NO_ARGS_EXCEPTION;
+            case 1:
+                return setSource(function(b) {
+                    return fn(a, b);
+                }, fn);
+        }
         return fn(a, b);
-      }, fn);
-    }
-    return fn(a, b);
-  }, fn);
+    }, fn);
 }
 
 function curry3(fn) {
-  return setSource(function(a, b, c) {
-    switch (arguments.length) {
-      case 0: throw NO_ARGS_EXCEPTION;
-      case 1: return curry2(function(b, c) {
+    return setSource(function(a, b, c) {
+        switch (arguments.length) {
+            case 0:
+                throw NO_ARGS_EXCEPTION;
+            case 1:
+                return curry2(function(b, c) {
+                    return fn(a, b, c);
+                });
+            case 2:
+                return setSource(function(c) {
+                    return fn(a, b, c);
+                });
+        }
         return fn(a, b, c);
-      });
-      case 2: return setSource(function(c) {
-        return fn(a, b, c);
-      });
-    }
-    return fn(a, b, c);
-  }, fn);
+    }, fn);
 }

--- a/ext/impure/setProp.js
+++ b/ext/impure/setProp.js
@@ -1,6 +1,6 @@
 var R = require('../..');
 
-var setProp = R.curry (function (prop, value, obj) {
+var setProp = R.curry (function(prop, value, obj) {
     obj[prop] = value;
     return obj;
 });

--- a/ext/lazylist/lazylist.js
+++ b/ext/lazylist/lazylist.js
@@ -1,134 +1,134 @@
-(function (factory) {
-  if (typeof define === 'function' && define.amd) {
-    define(['ramda'], factory);
-  } else if (typeof exports === 'object') {
-    module.exports = factory(require('../..'));
-  } else {
-    this.lazylist = factory(this.ramda);
-  }
-}(function (R) {
+(function(factory) {
+    if (typeof define === 'function' && define.amd) {
+        define(['ramda'], factory);
+    } else if (typeof exports === 'object') {
+        module.exports = factory(require('../..'));
+    } else {
+        this.lazylist = factory(this.ramda);
+    }
+}(function(R) {
 
-  // Lazy lists
-  // ----------
-  //
+    // Lazy lists
+    // ----------
+    //
 
-  // Support for infinite lists, using an initial seed, a function that calculates the head from the seed and
-  // a function that creates a new seed from the current seed.  Lazy list objects have this structure:
-  //
-  //     {
-  //        '0': someValue,
-  //        tail: someFunction() {},
-  //        length: Infinity
-  //     }
-  //
-  // Lazy list objects also have such functions as `take`, `skip`, `map`, and `filter`, but the equivalent
-  // functions from Ramda will work with them as well.
-  //
-  // ### Example ###
-  //
-  //     var fibonacci = lazylist(
-  //         [0, 1],
-  //         function(pair) {return pair[0];},
-  //         function(pair) {return [pair[1], pair[0] + pair[1]];}
-  //     );
-  //     var even = function(n) {return (n % 2) === 0;};
-  //
-  //     take(5, filter(even, fibonacci)) //=> [0, 2, 8, 34, 144]
-  //
-  // Note that the `take(5)` call is necessary to get a finite list out of this.  Otherwise, this would still
-  // be an infinite list.
+    // Support for infinite lists, using an initial seed, a function that calculates the head from the seed and
+    // a function that creates a new seed from the current seed.  Lazy list objects have this structure:
+    //
+    //     {
+    //        '0': someValue,
+    //        tail: someFunction() {},
+    //        length: Infinity
+    //     }
+    //
+    // Lazy list objects also have such functions as `take`, `skip`, `map`, and `filter`, but the equivalent
+    // functions from Ramda will work with them as well.
+    //
+    // ### Example ###
+    //
+    //     var fibonacci = lazylist(
+    //         [0, 1],
+    //         function(pair) {return pair[0];},
+    //         function(pair) {return [pair[1], pair[0] + pair[1]];}
+    //     );
+    //     var even = function(n) {return (n % 2) === 0;};
+    //
+    //     take(5, filter(even, fibonacci)) //=> [0, 2, 8, 34, 144]
+    //
+    // Note that the `take(5)` call is necessary to get a finite list out of this.  Otherwise, this would still
+    // be an infinite list.
 
-  var lazylist = (function() {
-    // partial shim for Object.create
-    var create = (function() {
-      var F = function() {};
-      return function(src) {
-        F.prototype = src;
-        return new F();
-      };
+    var lazylist = (function() {
+        // partial shim for Object.create
+        var create = (function() {
+            var F = function() {};
+            return function(src) {
+                F.prototype = src;
+                return new F();
+            };
+        }());
+
+        // Trampolining to support recursion in Lazy lists
+        var trampoline = function(fn) {
+            var result = fn.apply(this, R.tail(arguments));
+            while (typeof result === 'function') {
+                result = result();
+            }
+            return result;
+        };
+        // Internal Lazy list constructor
+        var  LZ = function(seed, current, step) {
+            this['0'] = current(seed);
+            this.tail = function() {
+                return new LZ(step(seed), current, step);
+            };
+        };
+
+        // Lazy lists can be used with OO techniques as well as our standard functional calls.  These are the
+        // implementations of those methods and other properties.
+        LZ.prototype = {
+            constructor: LZ,
+            // All lazylists are infinite.
+            length: Infinity,
+            // `take` implementation for lazylists.
+            take: function(n) {
+                var take = function(ctr, lz, ret) {
+                    return (ctr === 0) ? ret : take(ctr - 1, lz.tail(), ret.concat([lz[0]]));
+                };
+                return trampoline(take, n, this, []);
+            },
+            takeWhile: function(pred) {
+                var results = [], current = this;
+                while (pred(current[0])) {
+                    results.push(current[0]);
+                    current = current.tail();
+                }
+                return results;
+            },
+            // `skip` implementation for lazylists.
+            skip: function(n) {
+                var skip = function(ctr, lz) {
+                    return (ctr <= 0) ? lz : skip(ctr - 1, lz.tail());
+                };
+                return trampoline(skip, n, this);
+            },
+            // `map` implementation for lazylists.
+            map: function(fn) {
+                var ls = this;
+                var lz = create(LZ.prototype);
+                lz[0] = fn(ls[0]);
+                lz.tail = function() {
+                    return ls.tail().map(fn);
+                };
+                return lz;
+            },
+            // `filter` implementation for lazylists.
+            filter: function(fn) {
+                var ls = this, head = ls[0];
+                while (!fn(head)) {
+                    ls = ls.tail();
+                    head = ls[0];
+                }
+                var lz = create(LZ.prototype);
+                lz[0] = head;
+                lz.tail = function() {return R.filter(fn, ls.tail());};
+                return lz;
+            }
+        };
+
+        // The actual public `lazylist` function.
+        return function(seed, current, step) {
+            return new LZ(seed, current, step);
+        };
     }());
 
-    // Trampolining to support recursion in Lazy lists
-    var trampoline = function(fn) {
-      var result = fn.apply(this, R.tail(arguments));
-      while (typeof result === 'function') {
-        result = result();
-      }
-      return result;
-    };
-    // Internal Lazy list constructor
-    var  LZ = function(seed, current, step) {
-      this['0'] = current(seed);
-      this.tail = function() {
-        return new LZ(step(seed), current, step);
-      };
+    R.lazylist = lazylist;
+
+    // Returns a lazy list of identical values, probably most useful with `take` for initializing a list.
+    R.repeat = function(value) {
+        var fn = R.always(value);
+        return lazylist(null, fn, fn);
     };
 
-    // Lazy lists can be used with OO techniques as well as our standard functional calls.  These are the
-    // implementations of those methods and other properties.
-    LZ.prototype = {
-      constructor: LZ,
-      // All lazylists are infinite.
-      length: Infinity,
-      // `take` implementation for lazylists.
-      take: function(n) {
-        var take = function(ctr, lz, ret) {
-          return (ctr === 0) ? ret : take(ctr - 1, lz.tail(), ret.concat([lz[0]]));
-        };
-        return trampoline(take, n, this, []);
-      },
-      takeWhile: function(pred) {
-        var results = [], current = this;
-        while (pred(current[0])) {
-          results.push(current[0]);
-          current = current.tail();
-        }
-        return results;
-      },
-      // `skip` implementation for lazylists.
-      skip: function(n) {
-        var skip = function(ctr, lz) {
-          return (ctr <= 0) ? lz : skip(ctr - 1, lz.tail());
-        };
-        return trampoline(skip, n, this);
-      },
-      // `map` implementation for lazylists.
-      map: function(fn) {
-        var ls = this;
-        var lz = create(LZ.prototype);
-        lz[0] = fn(ls[0]);
-        lz.tail = function() {
-          return ls.tail().map(fn);
-        };
-        return lz;
-      },
-      // `filter` implementation for lazylists.
-      filter: function(fn) {
-        var ls = this, head = ls[0];
-        while (!fn(head)) {
-          ls = ls.tail();
-          head = ls[0];
-        }
-        var lz = create(LZ.prototype);
-        lz[0] = head;
-        lz.tail = function() {return R.filter(fn, ls.tail());};
-        return lz;
-      }
-    };
-
-    // The actual public `lazylist` function.
-    return function(seed, current, step) {
-      return new LZ(seed, current, step);
-    };
-  }());
-
-  R.lazylist = lazylist;
-
-  // Returns a lazy list of identical values, probably most useful with `take` for initializing a list.
-  R.repeat = function(value) {
-     var fn = R.always(value);
-     return lazylist(null, fn, fn);
-  };
-
-  return lazylist;
+    return lazylist;
 }));

--- a/ext/lazylist/test/test.lazy.js
+++ b/ext/lazylist/test/test.lazy.js
@@ -31,7 +31,7 @@ describe('take for a lazylist', function() {
 });
 
 describe('takeWhile for a lazylist', function() {
-    var inc = function (n) {return n + 1;};
+    var inc = function(n) {return n + 1;};
     var pred = function(n) {return n < 5;};
 
     var lz = lazylist(0, R.identity, inc);

--- a/ext/random/random.js
+++ b/ext/random/random.js
@@ -1,4 +1,4 @@
-(function (factory) {
+(function(factory) {
     if (typeof define === 'function' && define.amd) {
         define(['ramda'], factory);
     } else if (typeof exports === 'object') {
@@ -6,7 +6,7 @@
     } else {
         this.Random = factory(this.ramda);
     }
-}(function (R) {
+}(function(R) {
 
     // Random
     // ----------
@@ -24,7 +24,7 @@
     var Mash = function Mash() {
         var n = 0xefc8249d;
 
-        var mash = function (data) {
+        var mash = function(data) {
             data = data.toString();
             for (var i = 0; i < data.length; i++) {
                 n += data.charCodeAt(i);
@@ -47,7 +47,7 @@
     // mirrored at https://github.com/nquinlan/better-random-numbers-for-javascript-mirror
     // Johannes Baagøe <baagoe@baagoe.com>, 2010
     var Random = function Random() {
-        return (function (args) {
+        return (function(args) {
             var s0 = 0;
             var s1 = 0;
             var s2 = 0;
@@ -77,17 +77,17 @@
             }
             mash = null;
 
-            var random = function () {
+            var random = function() {
                 var t = 2091639 * s0 + c * 2.3283064365386963e-10; // 2^-32
                 s0 = s1;
                 s1 = s2;
                 s2 = t - (c = t | 0);
                 return s2;
             };
-            random.uint32 = function () {
+            random.uint32 = function() {
                 return random() * 0x100000000; // 2^32
             };
-            random.fract53 = function () {
+            random.fract53 = function() {
                 return random() +
                     (random() * 0x200000 | 0) * 1.1102230246251565e-16; // 2^-53
             };

--- a/ext/types/Either.js
+++ b/ext/types/Either.js
@@ -1,37 +1,37 @@
 
 function Either(left, right) {
-  if (!(this instanceof Either)) {
-    return new Either(left, right);
-  }
-  this.left = left;
-  this.right = right;
+    if (!(this instanceof Either)) {
+        return new Either(left, right);
+    }
+    this.left = left;
+    this.right = right;
 }
 
 Either.of = function(value, err) {
-  return new Either(err, value);
+    return new Either(err, value);
 };
 
 Either.prototype.map = function(f) {
-  return this.right == null ? this : new Either(this.left, f(this.right));
+    return this.right == null ? this : new Either(this.left, f(this.right));
 };
 
 Either.prototype.ap = function(app) {
-  return this.right == null ? this : app.map(this.right);
+    return this.right == null ? this : app.map(this.right);
 };
 
 // `f` must return a new Either; not sure if this impl is sufficient
 Either.prototype.chain = function(f) {
-  return this.right == null ? this : f(this.right);
+    return this.right == null ? this : f(this.right);
 };
 
 Either.prototype.of = Either.of;
 
 Either.prototype.equals = function(that) {
-  return this.right === that.right;
+    return this.right === that.right;
 };
 
 Either.equals = function(e1, e2) {
-  return e1.equals(e2);
+    return e1.equals(e2);
 };
 
 module.exports = Either;

--- a/ext/types/Future.js
+++ b/ext/types/Future.js
@@ -1,25 +1,25 @@
 // `f` is a function that takes two function arguments: `reject` (failure) and `resolve` (success)
 function Future(f) {
-  if (!(this instanceof Future)) {
-    return new Future(f);
-  }
-  this.fork = f;
+    if (!(this instanceof Future)) {
+        return new Future(f);
+    }
+    this.fork = f;
 }
 
 // functor
 Future.prototype.map = function(f) {
-  return this.chain(function(a) { return Future.of(f(a)); });
+    return this.chain(function(a) { return Future.of(f(a)); });
 };
 
 // apply
 Future.prototype.ap = function(m) {
-  return this.chain(function(f) { return m.map(f); });
+    return this.chain(function(f) { return m.map(f); });
 };
 
 // applicative
 Future.of = function(x) {
-  // should include a default rejection?
-  return new Future(function(_, resolve) { return resolve(x); });
+    // should include a default rejection?
+    return new Future(function(_, resolve) { return resolve(x); });
 };
 
 Future.prototype.of = Future.of;
@@ -29,10 +29,10 @@ Future.prototype.of = Future.of;
 //  f must return a value of the same Chain
 //  chain must return a value of the same Chain
 Future.prototype.chain = function(f) {  // Sorella's:
-  return new Future(function(reject, resolve) {
-    return this.fork(function(a) { return reject(a); },
-                     function(b) { return f(b).fork(reject, resolve); });
-  }.bind(this));
+    return new Future(function(reject, resolve) {
+        return this.fork(function(a) { return reject(a); },
+                         function(b) { return f(b).fork(reject, resolve); });
+    }.bind(this));
 };
 
 // monad
@@ -41,8 +41,8 @@ Future.prototype.chain = function(f) {  // Sorella's:
 
 // equality method to enable testing
 Future.prototype.equals = function(that) {
-  // TODO: how do you define equality for two Futures?
-  return true;
+    // TODO: how do you define equality for two Futures?
+    return true;
 };
 
 module.exports = Future;

--- a/ext/types/IO.js
+++ b/ext/types/IO.js
@@ -1,52 +1,52 @@
 var compose = require('../..').compose;
 
 function IO(fn) {
-  if (!(this instanceof IO)) {
-    return new IO(fn);
-  }
-  this.fn = fn;
+    if (!(this instanceof IO)) {
+        return new IO(fn);
+    }
+    this.fn = fn;
 }
 
 // `f` must return an IO
 IO.prototype.chain = function(f) {
-  var io = this;
-  return new IO(function() {
-    return f(io.fn()).fn();
-  });
+    var io = this;
+    return new IO(function() {
+        return f(io.fn()).fn();
+    });
 };
 
 IO.prototype.map = function(f) {
-  var io = this;
-  return new IO(compose(f, io.fn));
+    var io = this;
+    return new IO(compose(f, io.fn));
 };
 
 // `this` IO must wrap a function `f` that takes an IO (`thatIo`) as input
 // `f` must return an IO
 IO.prototype.ap = function(thatIo) {
-  return this.chain(function(f) {
-    return thatIo.map(f);
-  });
+    return this.chain(function(f) {
+        return thatIo.map(f);
+    });
 };
 
 IO.runIO = function(io) {
-  return io.runIO.apply(io, [].slice.call(arguments, 1));
+    return io.runIO.apply(io, [].slice.call(arguments, 1));
 };
 
 IO.prototype.runIO = function() {
-  return this.fn.apply(this, arguments);
+    return this.fn.apply(this, arguments);
 };
 
 IO.prototype.of = function(x) {
-  return new IO(function() { return x; });
+    return new IO(function() { return x; });
 };
 
 IO.of = IO.prototype.of;
 
 // this is really only to accommodate testing ....
 IO.prototype.equals = function(that) {
-  return this === that ||
-         this.fn === that.fn ||
-         IO.runIO(this) === IO.runIO(that);
+    return this === that ||
+           this.fn === that.fn ||
+           IO.runIO(this) === IO.runIO(that);
 };
 
 module.exports = IO;

--- a/ext/types/Maybe.js
+++ b/ext/types/Maybe.js
@@ -1,31 +1,31 @@
 
 function Maybe(x) {
-  if (!(this instanceof Maybe)) {
-    return new Maybe(x);
-  }
-  this.value = x;
+    if (!(this instanceof Maybe)) {
+        return new Maybe(x);
+    }
+    this.value = x;
 }
 
 Maybe.of = function(x) {
-  return new Maybe(x);
+    return new Maybe(x);
 };
 
 // functor
 Maybe.prototype.map = function(f) {
-  return this.value == null ? this : new Maybe(f(this.value));
+    return this.value == null ? this : new Maybe(f(this.value));
 };
 
 // apply
 // takes a Maybe that wraps a function (`app`) and applies its `map`
 // method to this Maybe's value, which must be a function.
 Maybe.prototype.ap = function(m) {
-  if (this.value == null) {
-    return m;  // ???
-  }
-  if (typeof this.value !== 'function') {
-    throw new TypeError('Calling ap on a Maybe requires that the Maybe is wrapping a function');
-  }
-  return m.map(this.value);
+    if (this.value == null) {
+        return m;  // ???
+    }
+    if (typeof this.value !== 'function') {
+        throw new TypeError('Calling ap on a Maybe requires that the Maybe is wrapping a function');
+    }
+    return m.map(this.value);
 };
 
 // applicative
@@ -37,7 +37,7 @@ Maybe.prototype.of = Maybe.of;
 //  chain must return a value of the same Chain
 //
 Maybe.prototype.chain = function(f) {
-   return this.value == null ? this : f(this.value);
+    return this.value == null ? this : f(this.value);
 };
 
 // monad
@@ -46,7 +46,7 @@ Maybe.prototype.chain = function(f) {
 
 // equality method to enable testing
 Maybe.prototype.equals = function(that) {
-  return this.value === that.value;
+    return this.value === that.value;
 };
 
 module.exports = Maybe;

--- a/ext/types/test/either.test.js
+++ b/ext/types/test/either.test.js
@@ -5,48 +5,48 @@ var R = require('../../..');
 var Either = require('../Either');
 
 describe('Either', function() {
-  var e = Either('original left', 1);
+    var e = Either('original left', 1);
 
-  it('is a Functor', function() {
-    var fTest = types.functor;
-    assert.equal(true, fTest.iface(e));
-    assert.equal(true, fTest.id(e));
-    assert.equal(true, fTest.compose(e, R.multiply(2), R.add(3)));
-  });
+    it('is a Functor', function() {
+        var fTest = types.functor;
+        assert.equal(true, fTest.iface(e));
+        assert.equal(true, fTest.id(e));
+        assert.equal(true, fTest.compose(e, R.multiply(2), R.add(3)));
+    });
 
-  it('is an Apply', function() {
-    var aTest = types.apply;
-    var appA = Either('apply test fn a', R.multiply(10));
-    var appU = Either('apply test fn u', R.add(5));
-    var appV = Either('apply test value v', 10);
+    it('is an Apply', function() {
+        var aTest = types.apply;
+        var appA = Either('apply test fn a', R.multiply(10));
+        var appU = Either('apply test fn u', R.add(5));
+        var appV = Either('apply test value v', 10);
 
-    assert.equal(true, aTest.iface(appA));
-    assert.equal(true, aTest.compose(appA, appU, appV));
-  });
+        assert.equal(true, aTest.iface(appA));
+        assert.equal(true, aTest.compose(appA, appU, appV));
+    });
 
-  it('is an Applicative', function() {
-    var aTest = types.applicative;
-    var app1 = Either('app1', 101);
-    var app2 = Either('app2', -123);
-    var appF = Either('appF', R.multiply(3));
+    it('is an Applicative', function() {
+        var aTest = types.applicative;
+        var app1 = Either('app1', 101);
+        var app2 = Either('app2', -123);
+        var appF = Either('appF', R.multiply(3));
 
-    assert.equal(true, aTest.iface(app1));
-    assert.equal(true, aTest.id(app1, app2));
-    assert.equal(true, aTest.homomorphic(app1, R.add(3), 46));
-    assert.equal(true, aTest.interchange(app1, appF, 17));
-  });
+        assert.equal(true, aTest.iface(app1));
+        assert.equal(true, aTest.id(app1, app2));
+        assert.equal(true, aTest.homomorphic(app1, R.add(3), 46));
+        assert.equal(true, aTest.interchange(app1, appF, 17));
+    });
 
-  it('is a Chain', function() {
-    var cTest = types.chain;
-    var f1 = function(x) {return Either('f1', (3 * x));};
-    var f2 = function(x) {return Either('f2', (5 + x));};
+    it('is a Chain', function() {
+        var cTest = types.chain;
+        var f1 = function(x) {return Either('f1', (3 * x));};
+        var f2 = function(x) {return Either('f2', (5 + x));};
 
-    assert.equal(true, cTest.iface(e));
-    assert.equal(true, cTest.associative(e, f1, f2));
-  });
+        assert.equal(true, cTest.iface(e));
+        assert.equal(true, cTest.associative(e, f1, f2));
+    });
 
-  it('is a Monad', function() {
-    var mTest = types.monad;
-    assert.equal(true, mTest.iface(e));
-  });
+    it('is a Monad', function() {
+        var mTest = types.monad;
+        assert.equal(true, mTest.iface(e));
+    });
 });

--- a/ext/types/test/future.test.js
+++ b/ext/types/test/future.test.js
@@ -5,7 +5,7 @@ var R = require('../../..');
 var Future = require('../Future');
 
 describe('Future', function() {
-  it('will have tests once I figure out how to determine equality of Futures', function() {
-    assert.equal(true, !!'imagine your ad here');
-  });
+    it('will have tests once I figure out how to determine equality of Futures', function() {
+        assert.equal(true, !!'imagine your ad here');
+    });
 });

--- a/ext/types/test/io.test.js
+++ b/ext/types/test/io.test.js
@@ -5,59 +5,59 @@ var R = require('../../..');
 var IO = require('../IO');
 
 describe('IO', function() {
-  var f1 = function(x) { console.log('IO 1'); return '1 '; };
-  var f2 = function(x) { console.log('IO 2'); return x + '2 '; };
-  var f3 = function(x) { console.log('IO 3'); return x + '3 '; };
-  var i1 = IO(f1);
-  var i2 = IO(f2);
-  var i3 = IO(f3);
+    var f1 = function(x) { console.log('IO 1'); return '1 '; };
+    var f2 = function(x) { console.log('IO 2'); return x + '2 '; };
+    var f3 = function(x) { console.log('IO 3'); return x + '3 '; };
+    var i1 = IO(f1);
+    var i2 = IO(f2);
+    var i3 = IO(f3);
 
-  it('is a Functor', function() {
-    var fTest = types.functor;
-    assert.equal(true, fTest.iface(i1));
-    assert.equal(true, fTest.id(i1));
-    assert.equal(true, fTest.compose(i1, f2, f3));
-  });
-
-  it('is an Apply', function() {
-    var aTest = types.apply;
-    var a = IO(function(n) { return R.add(1); });
-    var b = IO(function() { return R.always(2); });
-    var c = IO(R.always(4));
-
-    assert.equal(true, aTest.iface(i1));
-    assert.equal(true, aTest.compose(a, b, c));
-  });
-
-  it('is an Applicative', function() {
-    var aTest = types.applicative;
-
-    assert.equal(true, aTest.iface(i1));
-    assert.equal(true, aTest.id(IO, i2));
-    assert.equal(true, aTest.homomorphic(i1, R.add(3), 46));
-    assert.equal(true, aTest.interchange(
-        IO(function() { return R.multiply(20); }),
-        IO(function() { return R.multiply(0.5); }),
-       73
-    ));
-  });
-
-  it('is a Chain', function() {
-    var cTest = types.chain;
-    var c = IO(function() {
-      return IO(function() {
-        return IO(function() {
-          return 3;
-        });
-      });
+    it('is a Functor', function() {
+        var fTest = types.functor;
+        assert.equal(true, fTest.iface(i1));
+        assert.equal(true, fTest.id(i1));
+        assert.equal(true, fTest.compose(i1, f2, f3));
     });
-    assert.equal(true, cTest.iface(i1));
-    assert.equal(true, cTest.associative(c, R.I, R.I));
-  });
 
-  it('is a Monad', function() {
-    var mTest = types.monad;
-    assert.equal(true, mTest.iface(i1));
-  });
+    it('is an Apply', function() {
+        var aTest = types.apply;
+        var a = IO(function(n) { return R.add(1); });
+        var b = IO(function() { return R.always(2); });
+        var c = IO(R.always(4));
+
+        assert.equal(true, aTest.iface(i1));
+        assert.equal(true, aTest.compose(a, b, c));
+    });
+
+    it('is an Applicative', function() {
+        var aTest = types.applicative;
+
+        assert.equal(true, aTest.iface(i1));
+        assert.equal(true, aTest.id(IO, i2));
+        assert.equal(true, aTest.homomorphic(i1, R.add(3), 46));
+        assert.equal(true, aTest.interchange(
+            IO(function() { return R.multiply(20); }),
+            IO(function() { return R.multiply(0.5); }),
+            73
+        ));
+    });
+
+    it('is a Chain', function() {
+        var cTest = types.chain;
+        var c = IO(function() {
+            return IO(function() {
+                return IO(function() {
+                    return 3;
+                });
+            });
+        });
+        assert.equal(true, cTest.iface(i1));
+        assert.equal(true, cTest.associative(c, R.I, R.I));
+    });
+
+    it('is a Monad', function() {
+        var mTest = types.monad;
+        assert.equal(true, mTest.iface(i1));
+    });
 
 });

--- a/ext/types/test/maybe.test.js
+++ b/ext/types/test/maybe.test.js
@@ -5,65 +5,65 @@ var R = require('../../..');
 var Maybe = require('../Maybe');
 
 describe('Maybe', function() {
-  var m = Maybe(1);
-  var maybeNull = Maybe(null);
+    var m = Maybe(1);
+    var maybeNull = Maybe(null);
 
-  it('is a Functor', function() {
-    var fTest = types.functor;
-    assert.equal(true, fTest.iface(m));
-    assert.equal(true, fTest.id(m));
-    assert.equal(true, fTest.compose(m, R.multiply(2), R.add(3)));
-    assert.equal(true, fTest.iface(maybeNull));
-    assert.equal(true, fTest.id(maybeNull));
-    assert.equal(true, fTest.compose(maybeNull, R.multiply(2), R.add(3)));
-  });
+    it('is a Functor', function() {
+        var fTest = types.functor;
+        assert.equal(true, fTest.iface(m));
+        assert.equal(true, fTest.id(m));
+        assert.equal(true, fTest.compose(m, R.multiply(2), R.add(3)));
+        assert.equal(true, fTest.iface(maybeNull));
+        assert.equal(true, fTest.id(maybeNull));
+        assert.equal(true, fTest.compose(maybeNull, R.multiply(2), R.add(3)));
+    });
 
-  it('is an Apply', function() {
-    var aTest = types.apply;
-    var appA = Maybe(R.multiply(10));
-    var appU = Maybe(R.add(7));
-    var appV = Maybe(10);
+    it('is an Apply', function() {
+        var aTest = types.apply;
+        var appA = Maybe(R.multiply(10));
+        var appU = Maybe(R.add(7));
+        var appV = Maybe(10);
 
-    assert.equal(true, aTest.iface(appA));
-    assert.equal(true, aTest.compose(appA, appU, appV));
-    assert.equal(true, aTest.iface(maybeNull));
-  });
+        assert.equal(true, aTest.iface(appA));
+        assert.equal(true, aTest.compose(appA, appU, appV));
+        assert.equal(true, aTest.iface(maybeNull));
+    });
 
-  it('is an Applicative', function() {
-    var aTest = types.applicative;
-    var app1 = Maybe(101);
-    var app2 = Maybe(-123);
-    var appF = Maybe(R.multiply(3));
+    it('is an Applicative', function() {
+        var aTest = types.applicative;
+        var app1 = Maybe(101);
+        var app2 = Maybe(-123);
+        var appF = Maybe(R.multiply(3));
 
-    assert.equal(true, aTest.iface(app1));
-    assert.equal(true, aTest.id(app1, app2));
-    assert.equal(true, aTest.id(app1, maybeNull));
-    assert.equal(true, aTest.homomorphic(app1, R.add(3), 46));
-    assert.equal(true, aTest.interchange(app2, appF, 17));
+        assert.equal(true, aTest.iface(app1));
+        assert.equal(true, aTest.id(app1, app2));
+        assert.equal(true, aTest.id(app1, maybeNull));
+        assert.equal(true, aTest.homomorphic(app1, R.add(3), 46));
+        assert.equal(true, aTest.interchange(app2, appF, 17));
 
-    assert.equal(true, aTest.iface(maybeNull));
-    assert.equal(true, aTest.id(maybeNull, Maybe(null)));
-    assert.equal(true, aTest.homomorphic(maybeNull, R.add(3), 46));
-    assert.equal(true, aTest.interchange(maybeNull, appF, 17));
+        assert.equal(true, aTest.iface(maybeNull));
+        assert.equal(true, aTest.id(maybeNull, Maybe(null)));
+        assert.equal(true, aTest.homomorphic(maybeNull, R.add(3), 46));
+        assert.equal(true, aTest.interchange(maybeNull, appF, 17));
 
-  });
+    });
 
-  it('is a Chain', function() {
-    var cTest = types.chain;
-    var f1 = function(x) {return Maybe(3 * x);};
-    var f2 = function(x) {return Maybe(5 + x);};
-    var fNull = function() {return Maybe(null);};
-    assert.equal(true, cTest.iface(m));
-    assert.equal(true, cTest.associative(m, f1, f2));
-    assert.equal(true, cTest.iface(maybeNull));
-    assert.equal(true, cTest.associative(m, fNull, f2));
-    assert.equal(true, cTest.associative(m, f1, fNull));
-    assert.equal(true, cTest.associative(m, fNull, fNull));
-  });
+    it('is a Chain', function() {
+        var cTest = types.chain;
+        var f1 = function(x) {return Maybe(3 * x);};
+        var f2 = function(x) {return Maybe(5 + x);};
+        var fNull = function() {return Maybe(null);};
+        assert.equal(true, cTest.iface(m));
+        assert.equal(true, cTest.associative(m, f1, f2));
+        assert.equal(true, cTest.iface(maybeNull));
+        assert.equal(true, cTest.associative(m, fNull, f2));
+        assert.equal(true, cTest.associative(m, f1, fNull));
+        assert.equal(true, cTest.associative(m, fNull, fNull));
+    });
 
-  it('is a Monad', function() {
-    var mTest = types.monad;
-    assert.equal(true, mTest.iface(m));
-  });
+    it('is a Monad', function() {
+        var mTest = types.monad;
+        assert.equal(true, mTest.iface(m));
+    });
 
 });

--- a/ext/types/test/types.js
+++ b/ext/types/test/types.js
@@ -7,65 +7,68 @@ interfaces.chain = interfaces.apply.concat(['chain']);
 interfaces.monad = R.uniq(interfaces.chain.concat(interfaces.applicative));
 
 function correctInterface(type) {
-  return function(obj) {
-    return R.every(function(method) {
-      return obj[method] && typeof obj[method] === 'function';
-    }, interfaces[type]);
-  };
+    return function(obj) {
+        return R.every(function(method) {
+            return obj[method] && typeof obj[method] === 'function';
+        }, interfaces[type]);
+    };
 }
 
 
 module.exports = {
 
-  functor: {
-    iface: correctInterface('functor'),
-    id: function(obj) {
-      return obj.equals(obj.map(R.identity));
+    functor: {
+        iface: correctInterface('functor'),
+        id: function(obj) {
+            return obj.equals(obj.map(R.identity));
+        },
+        compose: function(obj, f, g) {
+            return obj.map(function(x) { return f(g(x)); }).equals(
+                obj.map(g).map(f)
+            );
+        }
     },
-    compose: function(obj, f, g) {
-      return obj.map(function(x) { return f(g(x)); })
-                .equals(obj.map(g).map(f));
-    }
-  },
 
-  apply: {
-    iface: correctInterface('apply'),
-    compose: function(a, u, v) {
-      return a.ap(u.ap(v)).equals(
-               a.map(function(f) {
-                 return function(g) {
-                   return function(x) {
-                     return f(g(x));
-                   };
-                 };
-               }).ap(u).ap(v));
-    }
-  },
-
-  applicative: {
-    iface: correctInterface('applicative'),
-    id: function(obj, obj2) {
-      return obj.of(R.identity).ap(obj2).equals(obj2);
+    apply: {
+        iface: correctInterface('apply'),
+        compose: function(a, u, v) {
+            return a.ap(u.ap(v)).equals(
+                a.map(function(f) {
+                    return function(g) {
+                        return function(x) {
+                            return f(g(x));
+                        };
+                    };
+                }).ap(u).ap(v)
+            );
+        }
     },
-    homomorphic: function(obj, f, x) {
-      return obj.of(f).ap(obj.of(x)).equals(obj.of(f(x)));
+
+    applicative: {
+        iface: correctInterface('applicative'),
+        id: function(obj, obj2) {
+            return obj.of(R.identity).ap(obj2).equals(obj2);
+        },
+        homomorphic: function(obj, f, x) {
+            return obj.of(f).ap(obj.of(x)).equals(obj.of(f(x)));
+        },
+        interchange: function(obj1, obj2, x) {
+            return obj2.ap(obj1.of(x)).equals(
+                obj1.of(function(f) { return f(x); }).ap(obj2)
+            );
+        }
     },
-    interchange: function(obj1, obj2, x) {
-      return obj2.ap(obj1.of(x)).equals(
-             obj1.of(function(f) { return f(x); }).ap(obj2));
-    }
-  },
 
-  chain: {
-    iface: correctInterface('chain'),
-    associative: function(obj, f, g) {
-      return obj.chain(f).chain(g).equals(
-                    obj.chain(function(x) { return f(x).chain(g); })
-             );
-    }
-  },
+    chain: {
+        iface: correctInterface('chain'),
+        associative: function(obj, f, g) {
+            return obj.chain(f).chain(g).equals(
+                obj.chain(function(x) { return f(x).chain(g); })
+            );
+        }
+    },
 
-  monad: {
-    iface: correctInterface('monad')
-  }
+    monad: {
+        iface: correctInterface('monad')
+    }
 };

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -31,15 +31,15 @@ gulp.task('min', function() {
     var banner = '/*! <%= pkg.name %> <%= pkg.version %>: ' + moment().format('YYYY-MM-DD') + ' */\n';
     gulp.src(lib)
         .pipe(uglify())
-        .pipe(header(banner, {'pkg': pkg}))
+        .pipe(header(banner, {pkg: pkg}))
         .pipe(rename('ramda.min.js'))
         .pipe(gulp.dest('./dist'));
 });
 
-gulp.task('cover', function (cb) {
-  gulp.src(lib)
-      .pipe(istanbul())
-      .on('end', cb);
+gulp.task('cover', function(cb) {
+    gulp.src(lib)
+        .pipe(istanbul())
+        .on('end', cb);
 });
 
 gulp.task('test', function() {
@@ -49,12 +49,12 @@ gulp.task('test', function() {
 });
 
 // Run tests and output reports
-gulp.task('test2', function () {
-  gulp.run('cover', function () {
-    gulp.src('test/*.js')
-        .pipe(mocha({reporter: 'spec'})) // Run any unit test frameworks here
-        .pipe(istanbul.writeReports());
-  });
+gulp.task('test2', function() {
+    gulp.run('cover', function() {
+        gulp.src('test/*.js')
+            .pipe(mocha({reporter: 'spec'})) // Run any unit test frameworks here
+            .pipe(istanbul.writeReports());
+    });
 });
 
 gulp.task('default', function() {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "grunt-contrib-clean": "~0.6.0",
     "grunt-contrib-jshint": "~0.10.0",
     "grunt-contrib-uglify": "~0.5.1",
-    "grunt-jscs": "~0.6.2",
+    "grunt-jscs": "~0.7.0",
     "grunt-mocha-test": "~0.11.0",
     "grunt-readme": "^0.4.5",
     "grunt-benchmark": "https://github.com/buzzdecafe/grunt-benchmark/archive/09999a8c3fbfff04a1695846c1ccd0bd8a0ef5ab.tar.gz",

--- a/ramda.js
+++ b/ramda.js
@@ -16,7 +16,7 @@
 //
 //  [umd]: https://github.com/umdjs/umd/blob/master/returnExports.js
 
-(function (factory) {
+(function(factory) {
     if (typeof exports === 'object') {
         module.exports = factory(this);
     } else if (typeof define === 'function' && define.amd) {
@@ -24,7 +24,7 @@
     } else {
         this.ramda = factory(this);
     }
-}(function (global) {
+}(function(global) {
 
     'use strict';
 
@@ -178,13 +178,12 @@
     var curry = R.curry = function _curry(fn, fnArity) {
         fnArity = typeof fnArity === 'number' ? fnArity : fn.length;
         function recurry(args) {
-            return arity(Math.max(fnArity - (args && args.length || 0), 0), function () {
+            return arity(Math.max(fnArity - (args && args.length || 0), 0), function() {
                 if (arguments.length === 0) { throw NO_ARGS_EXCEPTION; }
                 var newArgs = concat(args, arguments);
                 if (newArgs.length >= fnArity) {
                     return fn.apply(this, newArgs);
-                }
-                else {
+                } else {
                     return recurry(newArgs);
                 }
             });
@@ -215,11 +214,14 @@
     function curry2(fn) {
         return function(a, b) {
             switch (arguments.length) {
-                case 0: throw NO_ARGS_EXCEPTION;
-                case 1: return function(b) {
+                case 0:
+                    throw NO_ARGS_EXCEPTION;
+                case 1:
+                    return function(b) {
+                        return fn(a, b);
+                    };
+                default:
                     return fn(a, b);
-                };
-                default: return fn(a, b);
             }
         };
     }
@@ -243,14 +245,18 @@
     function curry3(fn) {
         return function(a, b, c) {
             switch (arguments.length) {
-                case 0: throw NO_ARGS_EXCEPTION;
-                case 1: return curry2(function(b, c) {
+                case 0:
+                    throw NO_ARGS_EXCEPTION;
+                case 1:
+                    return curry2(function(b, c) {
+                        return fn(a, b, c);
+                    });
+                case 2:
+                    return function(c) {
+                        return fn(a, b, c);
+                    };
+                default:
                     return fn(a, b, c);
-                });
-                case 2: return function(c) {
-                    return fn(a, b, c);
-                };
-                default: return fn(a, b, c);
             }
         };
     }
@@ -352,25 +358,25 @@
      *      // Only `n` arguments are passed to the wrapped function
      *      takesOneArg(1, 2); //=> [1, undefined]
      */
-    var nAry = R.nAry = (function () {
+    var nAry = R.nAry = (function() {
         var cache = {
-            0: function (func) {
-                return function () {
+            0: function(func) {
+                return function() {
                     return func.call(this);
                 };
             },
-            1: function (func) {
-                return function (arg0) {
+            1: function(func) {
+                return function(arg0) {
                     return func.call(this, arg0);
                 };
             },
-            2: function (func) {
-                return function (arg0, arg1) {
+            2: function(func) {
+                return function(arg0, arg1) {
                     return func.call(this, arg0, arg1);
                 };
             },
-            3: function (func) {
-                return function (arg0, arg1, arg2) {
+            3: function(func) {
+                return function(arg0, arg1, arg2) {
                     return func.call(this, arg0, arg1, arg2);
                 };
             }
@@ -384,11 +390,11 @@
         //         }
         //     };
 
-        var makeN = function (n) {
+        var makeN = function(n) {
             var fnArgs = mkArgStr(n);
             var body = [
-                    '    return function(' + fnArgs + ') {',
-                    '        return func.call(this' + (fnArgs ? ', ' + fnArgs : '') + ');',
+                '    return function(' + fnArgs + ') {',
+                '        return func.call(this' + (fnArgs ? ', ' + fnArgs : '') + ');',
                 '    }'
             ].join('\n');
             return new Function('func', body);
@@ -481,25 +487,25 @@
      *      // All arguments are passed through to the wrapped function
      *      takesOneArg(1, 2); //=> [1, 2]
      */
-    var arity = R.arity = (function () {
+    var arity = R.arity = (function() {
         var cache = {
-            0: function (func) {
-                return function () {
+            0: function(func) {
+                return function() {
                     return func.apply(this, arguments);
                 };
             },
-            1: function (func) {
-                return function (arg0) {
+            1: function(func) {
+                return function(arg0) {
                     return func.apply(this, arguments);
                 };
             },
-            2: function (func) {
-                return function (arg0, arg1) {
+            2: function(func) {
+                return function(arg0, arg1) {
                     return func.apply(this, arguments);
                 };
             },
-            3: function (func) {
-                return function (arg0, arg1, arg2) {
+            3: function(func) {
+                return function(arg0, arg1, arg2) {
                     return func.apply(this, arguments);
                 };
             }
@@ -512,10 +518,10 @@
         //         }
         //     };
 
-        var makeN = function (n) {
+        var makeN = function(n) {
             var fnArgs = mkArgStr(n);
             var body = [
-                    '    return function(' + fnArgs + ') {',
+                '    return function(' + fnArgs + ') {',
                 '        return func.apply(this, arguments);',
                 '    }'
             ].join('\n');
@@ -556,7 +562,7 @@
     var invoker = R.invoker = function _invoker(name, obj, len) {
         var method = obj[name];
         var length = len === void 0 ? method.length : len;
-        return method && curry(function () {
+        return method && curry(function() {
             if (arguments.length) {
                 var target = Array.prototype.pop.call(arguments);
                 var targetMethod = target[name];
@@ -623,7 +629,7 @@
     var useWith = R.useWith = function _useWith(fn /*, transformers */) {
         var transformers = _slice(arguments, 1);
         var tlen = transformers.length;
-        return curry(arity(tlen, function () {
+        return curry(arity(tlen, function() {
             var args = [], idx = -1;
             while (++idx < tlen) {
                 args.push(transformers[idx](arguments[idx]));
@@ -915,10 +921,15 @@
      *      ramda.concat('ABC', 'DEF'); // 'ABCDEF'
      */
     R.concat = curry2(function(set1, set2) {
-        if (isArray(set2)) { return concat(set1, set2); }
-        else if (R.is(String, set1)) { return set1.concat(set2); }
-        else if (hasMethod('concat', set2)) { return set2.concat(set1); }
-        else { throw new TypeError("can't concat " + typeof set2); }
+        if (isArray(set2)) {
+            return concat(set1, set2);
+        } else if (R.is(String, set1)) {
+            return set1.concat(set2);
+        } else if (hasMethod('concat', set2)) {
+            return set2.concat(set1);
+        } else {
+            throw new TypeError("can't concat " + typeof set2);
+        }
     });
 
 
@@ -1151,7 +1162,7 @@
      *      ramda.flip([1, 2, 3]); //=> [2, 1, 3]
      */
     var flip = R.flip = function _flip(fn) {
-        return function (a, b) {
+        return function(a, b) {
             switch (arguments.length) {
                 case 0: throw NO_ARGS_EXCEPTION;
                 case 1: return function(b) { return fn.apply(this, [b, a].concat(_slice(arguments, 1))); };
@@ -1188,7 +1199,7 @@
      */
     R.lPartial = function _lPartial(fn /*, args */) {
         var args = _slice(arguments, 1);
-        return arity(Math.max(fn.length - args.length, 0), function () {
+        return arity(Math.max(fn.length - args.length, 0), function() {
             return fn.apply(this, concat(args, arguments));
         });
     };
@@ -1258,8 +1269,8 @@
      */
     R.memoize = function _memoize(fn) {
         var cache = {};
-        return function () {
-            var position = foldl(function (cache, arg) {
+        return function() {
+            var position = foldl(function(cache, arg) {
                     return cache[arg] || (cache[arg] = {});
                 }, cache,
                 _slice(arguments, 0, arguments.length - 1));
@@ -1288,7 +1299,7 @@
      */
     R.once = function _once(fn) {
         var called = false, result;
-        return function () {
+        return function() {
             if (called) {
                 return result;
             }
@@ -1351,7 +1362,7 @@
      *      map(constructN(1, Widget), allConfigs); //=> a list of Widgets
      */
     var constructN = R.constructN = function _constructN(n, Fn) {
-        var f = function () {
+        var f = function() {
             var Temp = function() {}, inst, ret;
             Temp.prototype = Fn.prototype;
             inst = new Temp();
@@ -1423,11 +1434,11 @@
      *      //≅ multiply( add(1, 2), subtract(1, 2) );
      *      //=> -3
      */
-    R.fork = function (after) {
+    R.fork = function(after) {
         var fns = _slice(arguments, 1);
-        return function () {
+        return function() {
             var args = arguments;
-            return after.apply(this, map(function (fn) {
+            return after.apply(this, map(function(fn) {
                 return fn.apply(this, args);
             }, fns));
         };
@@ -1731,7 +1742,7 @@
      */
     // TODO: consider mapObj.key in parallel with mapObj.idx.  Also consider folding together with `map` implementation.
     R.mapObj = curry2(function _mapObject(fn, obj) {
-        return foldl(function (acc, key) {
+        return foldl(function(acc, key) {
             acc[key] = fn(obj[key]);
             return acc;
         }, {}, keys(obj));
@@ -1760,7 +1771,7 @@
      *      ramda.mapObj(double, values); //=> { x: 'x2', y: 'y4', z: 'z6' }
      */
     R.mapObj.idx = curry2(function mapObjectIdx(fn, obj) {
-        return foldl(function (acc, key) {
+        return foldl(function(acc, key) {
             acc[key] = fn(obj[key], key, obj);
             return acc;
         }, {}, keys(obj));
@@ -2263,7 +2274,9 @@
             i = from < 0 ? Math.max(0, length + from) : from;
         }
         for (; i < length; i++) {
-            if (array[i] === item) return i;
+            if (array[i] === item) {
+                return i;
+            }
         }
         return -1;
     };
@@ -2289,7 +2302,9 @@
             idx = from < 0 ? idx + from + 1 : Math.min(idx, from + 1);
         }
         while (--idx >= 0) {
-            if (array[idx] === item) return idx;
+            if (array[idx] === item) {
+                return idx;
+            }
         }
         return -1;
     };
@@ -2421,7 +2436,8 @@
      * @param x the item to find
      * @param {Array} list the list to iterate over
      * @return {Boolean} `true` if `x` is in `list`, else `false`
-     */ //TODO: add an example
+     */
+    // TODO: add an example
     function containsWith(pred, x, list) {
         var idx = -1, len = list.length;
         while (++idx < len) {
@@ -2958,7 +2974,7 @@
      *      sort(cmp, people);
      */
     var comparator = R.comparator = function _comparator(pred) {
-        return function (a, b) {
+        return function(a, b) {
             return pred(a, b) ? -1 : pred(b, a) ? 1 : 0;
         };
     };
@@ -3012,7 +3028,7 @@
      *     // }
      */
     R.groupBy = curry2(function _groupBy(fn, list) {
-        return foldl(function (acc, elt) {
+        return foldl(function(acc, elt) {
             var key = fn(elt);
             acc[key] = append(elt, acc[key] || (acc[key] = []));
             return acc;
@@ -3036,7 +3052,7 @@
      *     // => [ [ 'sss', 'bars' ],  [ 'ttt', 'foo' ] ]
      */
     R.partition = curry2(function _partition(pred, list) {
-        return foldl(function (acc, elt) {
+        return foldl(function(acc, elt) {
             acc[pred(elt) ? 0 : 1].push(elt);
             return acc;
         }, [[], []], list);
@@ -3217,7 +3233,7 @@
      *      t(); // => 'Tee'
      */
     var always = R.always = function _always(val) {
-        return function () {
+        return function() {
             return val;
         };
     };
@@ -3270,7 +3286,9 @@
      *      keys({a: 1, b: 2, c: 3}) // => ['a', 'b', 'c']
      */
     var keys = R.keys = function _keys(obj) {
-        if (nativeKeys) return nativeKeys(Object(obj));
+        if (nativeKeys) {
+            return nativeKeys(Object(obj));
+        }
         var prop, ks = [];
         for (prop in obj) {
             if (hasOwnProperty.call(obj, prop)) {
@@ -3506,7 +3524,7 @@
     // TODO: document, even for internals...
     var pickAll = function _pickAll(names, obj) {
         var copy = {};
-        forEach(function (name) {
+        forEach(function(name) {
             copy[name] = obj[name];
         }, names);
         return copy;
@@ -3667,9 +3685,9 @@
      */
     R.where = function where(spec, testObj) {
         var parsedSpec = R.groupBy(function(key) {
-                return typeof spec[key] === 'function' ? 'fn' : 'obj';
-            }, keys(spec)
-        );
+            return typeof spec[key] === 'function' ? 'fn' : 'obj';
+        }, keys(spec));
+
         switch (arguments.length) {
             case 0: throw NO_ARGS_EXCEPTION;
             case 1:
@@ -4293,7 +4311,7 @@
      */
     R.maxWith = curry2(function _maxWith(keyFn, list) {
         if (!(list && list.length > 0)) {
-           return;
+            return;
         }
         var idx = 0, winner = list[idx], max = keyFn(winner), testKey;
         while (++idx < list.length) {

--- a/test/test.allany.js
+++ b/test/test.allany.js
@@ -25,7 +25,7 @@ describe('every', function() {
         assert.equal(count, 4);
     });
 
-    it('is automatically curried', function () {
+    it('is automatically curried', function() {
         var count = 0;
         var test = function(n) {count++; return even(n);};
         assert(R.every(test)([2, 4, 6, 7, 8, 10]) === false);
@@ -71,7 +71,7 @@ describe('some', function() {
         assert.equal(count, 4);
     });
 
-    it('is automatically curried', function () {
+    it('is automatically curried', function() {
         var count = 0;
         var test = function(n) {count++; return odd(n);};
         assert(R.some(test)([2, 4, 6, 7, 8, 10]) === true);

--- a/test/test.booleans.js
+++ b/test/test.booleans.js
@@ -120,6 +120,6 @@ describe('anyPredicates', function() {
     });
 
     it('reports its arity as the longest predicate length', function() {
-      assert.equal(R.anyPredicates([odd, lt5, plusEq]).length, 4);
+        assert.equal(R.anyPredicates([odd, lt5, plusEq]).length, 4);
     });
 });

--- a/test/test.clone.js
+++ b/test/test.clone.js
@@ -3,17 +3,17 @@ var R = require('..');
 
 describe('clone', function() {
     it('returns a copy of an array', function() {
-      var input = [1, 2, 3, 4, 5];
-      var output = R.clone(input);
-      assert.deepEqual(output, input);
-      assert.notStrictEqual(output, input);
+        var input = [1, 2, 3, 4, 5];
+        var output = R.clone(input);
+        assert.deepEqual(output, input);
+        assert.notStrictEqual(output, input);
     });
 
     it('copies objects in the array by reference', function() {
-      var o1 = {x: 1};
-      var o2 = {x: 2};
-      var o3 = {x: 3};
-      var c = R.clone([o1, o2, o3]);
-      assert.equal(c[0], o1);
+        var o1 = {x: 1};
+        var o2 = {x: 2};
+        var o3 = {x: 3};
+        var c = R.clone([o1, o2, o3]);
+        assert.equal(c[0], o1);
     });
 });

--- a/test/test.compose.js
+++ b/test/test.compose.js
@@ -37,19 +37,19 @@ describe('compose', function() {
         assert.equal(context.a(5), 40);
     });
 
-     it('returns a function with arity == rightmost argument', function() {
-       function a2(x, y) { return 'A2'; }
-       function a3(x, y) { return 'A2'; }
-       function a4(x, y) { return 'A2'; }
+    it('returns a function with arity == rightmost argument', function() {
+        function a2(x, y) { return 'A2'; }
+        function a3(x, y) { return 'A2'; }
+        function a4(x, y) { return 'A2'; }
 
-       var f1 = R.compose(b, a);
-       assert.equal(f1.length, a.length);
-       var f2 = R.compose(b, a2);
-       assert.equal(f2.length, a2.length);
-       var f3 = R.compose(b, a3);
-       assert.equal(f3.length, a3.length);
-       var f4 = R.compose(b, a4);
-       assert.equal(f4.length, a4.length);
+        var f1 = R.compose(b, a);
+        assert.equal(f1.length, a.length);
+        var f2 = R.compose(b, a2);
+        assert.equal(f2.length, a2.length);
+        var f3 = R.compose(b, a3);
+        assert.equal(f3.length, a3.length);
+        var f4 = R.compose(b, a4);
+        assert.equal(f4.length, a4.length);
     });
 
     it('throws if given no arguments', function() {

--- a/test/test.containsuniq.js
+++ b/test/test.containsuniq.js
@@ -23,7 +23,7 @@ describe('uniq', function() {
     });
 
     it('keeps elements from the left', function() {
-      assert.deepEqual(R.uniq([1, 2, 3, 4, 1]), [1, 2, 3, 4]);
+        assert.deepEqual(R.uniq([1, 2, 3, 4, 1]), [1, 2, 3, 4]);
     });
 
     it('returns an empty array for an empty array', function() {
@@ -44,7 +44,7 @@ describe('uniqWith', function() {
     });
 
     it('keeps elements from the left', function() {
-      assert.deepEqual(R.uniqWith(eqI, [{i: 1}, {i: 2}, {i: 3}, {i: 4}, {i: 1}]), [{i: 1}, {i: 2}, {i: 3}, {i: 4}]);
+        assert.deepEqual(R.uniqWith(eqI, [{i: 1}, {i: 2}, {i: 3}, {i: 4}, {i: 1}]), [{i: 1}, {i: 2}, {i: 3}, {i: 4}]);
     });
 
     it('returns an empty array for an empty array', function() {

--- a/test/test.core.js
+++ b/test/test.core.js
@@ -51,11 +51,11 @@ describe('concat', function() {
     });
 
     var z1 = {
-      x: 'z1'
+        x: 'z1'
     };
     var z2 = {
-      x: 'z2',
-      concat: function(that) { return this.x + ' ' + that.x; }
+        x: 'z2',
+        concat: function(that) { return this.x + ' ' + that.x; }
     };
 
     it('adds combines the elements of the two lists', function() {
@@ -63,18 +63,18 @@ describe('concat', function() {
         assert.deepEqual(R.concat([], ['c', 'd']), ['c', 'd']);
     });
     it('works on strings', function() {
-      assert.equal(R.concat('foo', 'bar'), 'foobar');
+        assert.equal(R.concat('foo', 'bar'), 'foobar');
     });
     it('delegates to non-String object with a concat method, as second param', function() {
-      assert.equal(R.concat(z1, z2), 'z2 z1');
+        assert.equal(R.concat(z1, z2), 'z2 z1');
     });
     it('is curried', function() {
-      var conc123 = R.concat([1, 2, 3]);
-      assert.deepEqual(conc123([4, 5, 6]), [1, 2, 3, 4, 5, 6]);
-      assert.deepEqual(conc123(['a', 'b', 'c']), [1, 2, 3, 'a', 'b', 'c']);
+        var conc123 = R.concat([1, 2, 3]);
+        assert.deepEqual(conc123([4, 5, 6]), [1, 2, 3, 4, 5, 6]);
+        assert.deepEqual(conc123(['a', 'b', 'c']), [1, 2, 3, 'a', 'b', 'c']);
     });
     it('throws if not an array, String, or object with a concat method', function() {
-      assert.throws(function() { return R.concat({}, {}); }, TypeError);
+        assert.throws(function() { return R.concat({}, {}); }, TypeError);
     });
 });
 

--- a/test/test.curry.js
+++ b/test/test.curry.js
@@ -34,7 +34,7 @@ describe('internal curry', function() {
     it('should throw an expcetion given no arguments', function() {
         assert.throws(R.map);
         assert.throws(R.map(R.I));
-        //doesnt throw an exception
+        // doesnt throw an exception
         R.concat([]);
     });
 });

--- a/test/test.filter.js
+++ b/test/test.filter.js
@@ -121,7 +121,7 @@ describe('skipUntil', function() {
 
     it('should start at the right arg and acknowledges undefined', function() {
         assert.deepEqual(R.skipUntil(function(x) {
-           assert.ok(false);
+            assert.ok(false);
         }, []), []);
         assert.deepEqual(R.skipUntil(function(x) {return x === void 0;}, [1, 3, void 0, 5, 7]), [void 0, 5, 7]);
     });

--- a/test/test.flatten.js
+++ b/test/test.flatten.js
@@ -20,8 +20,8 @@ describe('flatten', function() {
     });
 
     it('handles array-like objects', function() {
-      var o = {length: 3, '0': [1, 2, [3]], '1': [], '2': ['a', 'b', 'c', ['d', 'e']]};
-      assert.deepEqual(R.flatten(o), [1, 2, 3, 'a', 'b', 'c', 'd', 'e']);
+        var o = {length: 3, 0: [1, 2, [3]], 1: [], 2: ['a', 'b', 'c', ['d', 'e']]};
+        assert.deepEqual(R.flatten(o), [1, 2, 3, 'a', 'b', 'c', 'd', 'e']);
     });
 });
 
@@ -40,7 +40,7 @@ describe('unnest', function() {
     });
 
     it('handles array-like objects', function() {
-      var o = {length: 3, '0': [1, 2, [3]], '1': [], '2': ['a', 'b', 'c', ['d', 'e']]};
-      assert.deepEqual(R.unnest(o), [1, 2, [3], 'a', 'b', 'c', ['d', 'e']]);
+        var o = {length: 3, 0: [1, 2, [3]], 1: [], 2: ['a', 'b', 'c', ['d', 'e']]};
+        assert.deepEqual(R.unnest(o), [1, 2, [3], 'a', 'b', 'c', ['d', 'e']]);
     });
 });

--- a/test/test.functionBasics.js
+++ b/test/test.functionBasics.js
@@ -16,9 +16,9 @@ describe('flip', function() {
     });
 
     it('produces a function that throws if given no arguments', function() {
-      var f = function(x, y) { return x + ' then ' + y; };
-      var g = R.flip(f);
-      assert.throws(g, TypeError);
+        var f = function(x, y) { return x + ' then ' + y; };
+        var g = R.flip(f);
+        assert.throws(g, TypeError);
     });
 });
 
@@ -55,7 +55,7 @@ describe('once', function() {
 describe('memoize', function() {
     it('should calculate the value for a given input only once', function() {
         var ctr = 0;
-        var fib = R.memoize(function (n) {ctr++; return n < 2 ? n : fib(n - 2) + fib(n - 1);});
+        var fib = R.memoize(function(n) {ctr++; return n < 2 ? n : fib(n - 2) + fib(n - 1);});
         var result = fib(10);
         assert.equal(result, 55);
         assert.equal(ctr, 11); // fib(0), fib(1), ... fib(10), no memoization would take 177 iterations.
@@ -166,17 +166,17 @@ describe('ap', function() {
     function plus3(x) { return x + 3; }
 
     it('applies a list of functions to a list of values', function() {
-      assert.deepEqual(R.ap([mult2, plus3], [1, 2, 3]), [2, 4, 6, 4, 5, 6]);
+        assert.deepEqual(R.ap([mult2, plus3], [1, 2, 3]), [2, 4, 6, 4, 5, 6]);
     });
 
     it('dispatches to the passed object\'s ap method when values is a non-Array object', function() {
-      var obj = {ap: function(fs) { return {x: fs[0](1)}; }};
-      assert.deepEqual(R.ap([R.add(1)], obj), obj.ap([R.add(1)]));
+        var obj = {ap: function(fs) { return {x: fs[0](1)}; }};
+        assert.deepEqual(R.ap([R.add(1)], obj), obj.ap([R.add(1)]));
     });
 
     it('is curried', function() {
-      var val = R.ap([mult2, plus3]);
-      assert.equal(typeof val, 'function');
-      assert.deepEqual(val([1, 2, 3]), [2, 4, 6, 4, 5, 6]);
+        var val = R.ap([mult2, plus3]);
+        assert.equal(typeof val, 'function');
+        assert.deepEqual(val([1, 2, 3]), [2, 4, 6, 4, 5, 6]);
     });
 });

--- a/test/test.functions.js
+++ b/test/test.functions.js
@@ -4,8 +4,8 @@ var R = require('..');
 describe('functions', function() {
 
     function F() {
-        this.sort = function () {};
-        this.map = function () {};
+        this.sort = function() {};
+        this.map = function() {};
         this.obj = {};
         this.num = 4;
     }

--- a/test/test.functionsIn.js
+++ b/test/test.functionsIn.js
@@ -4,8 +4,8 @@ var R = require('..');
 describe('functionsIn', function() {
 
     function F() {
-        this.sort = function () {};
-        this.map = function () {};
+        this.sort = function() {};
+        this.map = function() {};
         this.obj = {};
         this.num = 4;
     }

--- a/test/test.groupBy.js
+++ b/test/test.groupBy.js
@@ -20,11 +20,11 @@ describe('groupBy', function() {
         ];
         var byGrade = function(student) {return grade(student.score || 0);};
         assert.deepEqual(R.groupBy(byGrade, students), {
-            'A': [{name: 'Dianne', score: 99}, {name: 'Gillian', score: 91}],
-            'B': [{name: 'Abby', score: 84}, {name: 'Chris', score: 89}, {name: 'Irene', score: 85}],
-            'C': [{name: 'Brad', score: 73}, {name: 'Hannah', score: 78}],
-            'D': [{name: 'Fred', score: 67}, {name: 'Jack', score: 69}],
-            'F': [{name: 'Eddy', score: 58}]
+            A: [{name: 'Dianne', score: 99}, {name: 'Gillian', score: 91}],
+            B: [{name: 'Abby', score: 84}, {name: 'Chris', score: 89}, {name: 'Irene', score: 85}],
+            C: [{name: 'Brad', score: 73}, {name: 'Hannah', score: 78}],
+            D: [{name: 'Fred', score: 67}, {name: 'Jack', score: 69}],
+            F: [{name: 'Eddy', score: 58}]
         });
     });
 
@@ -38,9 +38,9 @@ describe('groupBy', function() {
             {type: 'C', val: 50},
             {type: 'B', val: 60}
         ]), {
-            'A': [{type: 'A', val: 10}, {type: 'A', val: 30}, {type: 'A', val: 40}],
-            'B': [{type: 'B', val: 20}, {type: 'B', val: 60}],
-            'C': [{type: 'C', val: 50}]
+            A: [{type: 'A', val: 10}, {type: 'A', val: 30}, {type: 'A', val: 40}],
+            B: [{type: 'B', val: 20}, {type: 'B', val: 60}],
+            C: [{type: 'C', val: 50}]
         });
 
     });

--- a/test/test.keysvals.js
+++ b/test/test.keysvals.js
@@ -16,7 +16,7 @@ describe('keys', function() {
     it('should work with hasOwnProperty override', function() {
         assert.deepEqual(R.keys({
             /* jshint -W001 */
-            'hasOwnProperty': false
+            hasOwnProperty: false
             /* jshint +W001 */
         }), ['hasOwnProperty']);
     });

--- a/test/test.list.js
+++ b/test/test.list.js
@@ -1,14 +1,14 @@
 var assert = require('assert');
 var R = require('..');
 
-describe('join', function () {
-    it("concatenates a list's elements to a string, with an seperator string between elements", function () {
+describe('join', function() {
+    it("concatenates a list's elements to a string, with an seperator string between elements", function() {
         var list = [1, 2, 3, 4];
         assert.equal(R.join('~', list), '1~2~3~4');
     });
 });
 
-describe('remove', function () {
+describe('remove', function() {
     it('splices out a sub-list of the given list', function() {
         var list = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j'];
         assert.deepEqual(R.remove(2, 5, list), ['a', 'b', 'h', 'i', 'j']);
@@ -38,7 +38,7 @@ describe('remove', function () {
     });
 });
 
-describe('insert', function () {
+describe('insert', function() {
     it('inserts an element into the given list', function() {
         var list = ['a', 'b', 'c', 'd', 'e'];
         assert.deepEqual(R.insert(2, 'x', list), ['a', 'b', 'x', 'c', 'd', 'e']);
@@ -62,7 +62,7 @@ describe('insert', function () {
 });
 
 
-describe('insert.all', function () {
+describe('insert.all', function() {
     it('inserts a list of elements into the given list', function() {
         var list = ['a', 'b', 'c', 'd', 'e'];
         assert.deepEqual(R.insert.all(2, ['x', 'y', 'z'], list), ['a', 'b', 'x', 'y', 'z', 'c', 'd', 'e']);
@@ -80,8 +80,8 @@ describe('insert.all', function () {
 });
 
 
-describe('slice', function () {
-    it('retrieves the proper sublist of a list', function () {
+describe('slice', function() {
+    it('retrieves the proper sublist of a list', function() {
         var list = [8, 6, 7, 5, 3, 0, 9];
         assert.deepEqual(R.slice(2, 5, list), [7, 5, 3]);
     });
@@ -93,8 +93,8 @@ describe('slice', function () {
     // });
 });
 
-describe('slice.from', function () {
-    it('retrieves the proper suffix sublist of a list starting with the desired index', function () {
+describe('slice.from', function() {
+    it('retrieves the proper suffix sublist of a list starting with the desired index', function() {
         var list = [8, 6, 7, 5, 3, 0, 9];
         assert.deepEqual(R.slice.from(2, list), [7, 5, 3, 0, 9]);
     });
@@ -114,16 +114,16 @@ describe('times', function() {
     });
 });
 
-describe('repeatN', function () {
-    it('returns a lazy list of identical values', function () {
+describe('repeatN', function() {
+    it('returns a lazy list of identical values', function() {
         assert.deepEqual(R.repeatN(0, 5), [0, 0, 0, 0, 0]);
     });
 
-    it('can accept any value, including `null`', function () {
+    it('can accept any value, including `null`', function() {
         assert.deepEqual(R.repeatN(null, 3), [null, null, null]);
     });
 
-    it('is automatically curried', function () {
+    it('is automatically curried', function() {
         var nTrues = R.repeatN(true);
         assert.deepEqual(nTrues(4), [true, true, true, true]);
     });

--- a/test/test.math.js
+++ b/test/test.math.js
@@ -92,22 +92,22 @@ describe('divideBy', function() {
 });
 
 describe('modulo', function() {
-  it('divides the first param by the second and returns the remainder', function() {
-    assert.equal(R.modulo(100, 2), 0);
-    assert.equal(R.modulo(100, 3), 1);
-    assert.equal(R.modulo(100, 17), 15);
-  });
+    it('divides the first param by the second and returns the remainder', function() {
+        assert.equal(R.modulo(100, 2), 0);
+        assert.equal(R.modulo(100, 3), 1);
+        assert.equal(R.modulo(100, 17), 15);
+    });
 
-  it('is automatically curried', function() {
-    var modOf120by = R.modulo(120);
-    assert.equal(typeof modOf120by, 'function');
-    assert.equal(modOf120by(3), 0);
-    assert.equal(modOf120by(19), 6);
-  });
+    it('is automatically curried', function() {
+        var modOf120by = R.modulo(120);
+        assert.equal(typeof modOf120by, 'function');
+        assert.equal(modOf120by(3), 0);
+        assert.equal(modOf120by(19), 6);
+    });
 
-  it('preserves javascript-style modulo evaluation for negative numbers', function() {
-    assert.equal(R.modulo(-5, 4), -1);
-  });
+    it('preserves javascript-style modulo evaluation for negative numbers', function() {
+        assert.equal(R.modulo(-5, 4), -1);
+    });
 
     it('throws if given no arguments', function() {
         assert.throws(R.modulo, TypeError);
@@ -115,22 +115,22 @@ describe('modulo', function() {
 });
 
 describe('moduloBy', function() {
-  it('divides the second param by the first and returns the remainder', function() {
-    assert.equal(R.moduloBy(2, 100), 0);
-    assert.equal(R.moduloBy(3, 100), 1);
-    assert.equal(R.moduloBy(17, 100), 15);
-  });
+    it('divides the second param by the first and returns the remainder', function() {
+        assert.equal(R.moduloBy(2, 100), 0);
+        assert.equal(R.moduloBy(3, 100), 1);
+        assert.equal(R.moduloBy(17, 100), 15);
+    });
 
-  it('is automatically curried', function() {
-    var isOdd = R.moduloBy(2);
-    assert.equal(typeof isOdd, 'function');
-    assert.equal(isOdd(3), 1);
-    assert.equal(isOdd(198), 0);
-  });
+    it('is automatically curried', function() {
+        var isOdd = R.moduloBy(2);
+        assert.equal(typeof isOdd, 'function');
+        assert.equal(isOdd(3), 1);
+        assert.equal(isOdd(198), 0);
+    });
 
-  it('preserves javascript-style modulo evaluation for negative numbers', function() {
-    assert.equal(R.moduloBy(4, -5), -1);
-  });
+    it('preserves javascript-style modulo evaluation for negative numbers', function() {
+        assert.equal(R.moduloBy(4, -5), -1);
+    });
 
     it('throws if given no arguments', function() {
         assert.throws(R.moduloBy);
@@ -138,23 +138,23 @@ describe('moduloBy', function() {
 });
 
 describe('mathMod', function() {
-  it('requires integer arguments', function() {
-    assert.notEqual(R.mathMod('s', 3), R.mathMod('s', 3));
-    assert.notEqual(R.mathMod(3, 's'), R.mathMod(3, 's'));
-    assert.notEqual(R.mathMod(12.2, 3), R.mathMod(12.2, 3));
-    assert.notEqual(R.mathMod(3, 12.2), R.mathMod(3, 12.2));
-  });
+    it('requires integer arguments', function() {
+        assert.notEqual(R.mathMod('s', 3), R.mathMod('s', 3));
+        assert.notEqual(R.mathMod(3, 's'), R.mathMod(3, 's'));
+        assert.notEqual(R.mathMod(12.2, 3), R.mathMod(12.2, 3));
+        assert.notEqual(R.mathMod(3, 12.2), R.mathMod(3, 12.2));
+    });
 
-  it('behaves differently than JS modulo', function() {
-    assert.notEqual(R.mathMod(-17, 5), -17 % 5);
-    assert.notEqual(R.mathMod(17.2, 5), 17.2 % 5);
-    assert.notEqual(R.mathMod(17, -5), 17 % -5);
-  });
+    it('behaves differently than JS modulo', function() {
+        assert.notEqual(R.mathMod(-17, 5), -17 % 5);
+        assert.notEqual(R.mathMod(17.2, 5), 17.2 % 5);
+        assert.notEqual(R.mathMod(17, -5), 17 % -5);
+    });
 
-  it('is curried', function() {
-    var f = R.mathMod(29);
-    assert.equal(f(6), 5);
-  });
+    it('is curried', function() {
+        var f = R.mathMod(29);
+        assert.equal(f(6), 5);
+    });
 
 
     it('throws if given no arguments', function() {
@@ -197,7 +197,7 @@ describe('lt', function() {
     });
 
     it('throws when given no arguments', function() {
-      assert.throws(R.lt, TypeError);
+        assert.throws(R.lt, TypeError);
     });
 });
 
@@ -218,7 +218,7 @@ describe('lte', function() {
     });
 
     it('throws when given no arguments', function() {
-      assert.throws(R.lte, TypeError);
+        assert.throws(R.lte, TypeError);
     });
 });
 
@@ -239,7 +239,7 @@ describe('gt', function() {
     });
 
     it('throws when given no arguments', function() {
-      assert.throws(R.gt, TypeError);
+        assert.throws(R.gt, TypeError);
     });
 });
 
@@ -260,7 +260,7 @@ describe('gte', function() {
     });
 
     it('throws when given no arguments', function() {
-      assert.throws(R.gte, TypeError);
+        assert.throws(R.gte, TypeError);
     });
 });
 

--- a/test/test.objectBasics.js
+++ b/test/test.objectBasics.js
@@ -1,16 +1,16 @@
 var assert = require('assert');
 var R = require('..');
 
-describe('prop', function () {
+describe('prop', function() {
     var fred = {name: 'Fred', age: 23};
 
-    it('should return a function that fetches the appropriate property', function () {
+    it('should return a function that fetches the appropriate property', function() {
         var nm = R.prop('name');
         assert.equal(typeof nm, 'function');
         assert.equal(nm(fred), 'Fred');
     });
 
-    it('should be aliased by `get`', function () { // TODO: should it?
+    it('should be aliased by `get`', function() { // TODO: should it?
         assert.equal(R.get('age')(fred), 23);
         assert.strictEqual(R.get, R.prop);
     });
@@ -20,36 +20,36 @@ describe('prop', function () {
     });
 });
 
-describe('propOrDefault', function () {
+describe('propOrDefault', function() {
     var fred = {name: 'Fred', age: 23};
     var anon = {age: 99};
 
     var nm = R.propOrDefault('name', 'Unknown');
 
-    it('should return a function that fetches the appropriate property', function () {
+    it('should return a function that fetches the appropriate property', function() {
         assert.equal(typeof nm, 'function');
         assert.equal(nm(fred), 'Fred');
     });
 
-    it('should return the default value when the property does not exist', function () {
+    it('should return the default value when the property does not exist', function() {
         assert.equal(nm(anon), 'Unknown');
     });
 
-    it('should not return properties from the prototype chain', function () {
-        var Person = function () {};
-        Person.prototype.age = function () {};
+    it('should not return properties from the prototype chain', function() {
+        var Person = function() {};
+        Person.prototype.age = function() {};
 
         var bob = new Person();
         assert.equal(R.propOrDefault('age', 100, bob), 100);
     });
 });
 
-describe('func', function () {
-    it('should return a function that applies the appropriate function to the supplied object', function () {
-        var fred = {first: 'Fred', last: 'Flintstone', getName: function () {
+describe('func', function() {
+    it('should return a function that applies the appropriate function to the supplied object', function() {
+        var fred = {first: 'Fred', last: 'Flintstone', getName: function() {
             return this.first + ' ' + this.last;
         }};
-        var barney = {first: 'Barney', last: 'Rubble', getName: function () {
+        var barney = {first: 'Barney', last: 'Rubble', getName: function() {
             return this.first + ' ' + this.last;
         }};
         var gName = R.func('getName');
@@ -67,12 +67,12 @@ describe('func', function () {
         assert.equal(R.func('f', obj), 'called f');
     });
 
-    it('should apply additional arguments to the function', function () {
-        var Point = function (x, y) {
+    it('should apply additional arguments to the function', function() {
+        var Point = function(x, y) {
             this.x = x;
             this.y = y;
         };
-        Point.prototype.moveBy = function (dx, dy) {
+        Point.prototype.moveBy = function(dx, dy) {
             this.x += dx;
             this.y += dy;
         };
@@ -91,24 +91,24 @@ describe('func', function () {
 });
 
 // TODO: This needs a better home than objectBasics
-describe('pluck', function () {
+describe('pluck', function() {
     var people = [
         {name: 'Fred', age: 23},
         {name: 'Wilma', age: 21} ,
         {name: 'Pebbles', age: 2}
     ];
 
-    it('should return a function that maps the appropriate property over an array', function () {
+    it('should return a function that maps the appropriate property over an array', function() {
         var nm = R.pluck('name');
         assert.equal(typeof nm, 'function');
         assert.deepEqual(nm(people), ['Fred', 'Wilma', 'Pebbles']);
     });
 });
 
-describe('props', function () {
+describe('props', function() {
     var fred = {name: 'Fred', age: 23, feet: 'large'};
 
-    it('should return a function that fetches the appropriate properties from the initially supplied object', function () {
+    it('should return a function that fetches the appropriate properties from the initially supplied object', function() {
         var p = R.props(fred);
         assert.equal(p('name'), 'Fred');
         assert.equal(p('age'), 23);
@@ -116,29 +116,29 @@ describe('props', function () {
     });
 });
 
-describe('pick', function () {
+describe('pick', function() {
     var obj = {a: 1, b: 2, c: 3, d: 4, e: 5, f: 6};
 
-    it('should copy the named properties of an object to the new object', function () {
+    it('should copy the named properties of an object to the new object', function() {
         assert.deepEqual(R.pick(['a', 'c', 'f'], obj), {a: 1, c: 3, f: 6});
     });
-    it('should ignore properties not included', function () {
+    it('should ignore properties not included', function() {
         assert.deepEqual(R.pick(['a', 'c', 'g'], obj), {a: 1, c: 3});
     });
-    it('should be automatically curried', function () {
+    it('should be automatically curried', function() {
         var copyAB = R.pick(['a', 'b']);
         assert.deepEqual(copyAB(obj), {a: 1, b: 2});
     });
 });
 
-describe('omit', function () {
+describe('omit', function() {
     var obj = {a: 1, b: 2, c: 3, d: 4, e: 5, f: 6};
 
-    it('should copy an object omitting the listed properties', function () {
+    it('should copy an object omitting the listed properties', function() {
         assert.deepEqual(R.omit(['a', 'c', 'f'], obj), {b: 2, d: 4, e: 5});
     });
 
-    it('should be automatically curried', function () {
+    it('should be automatically curried', function() {
         var skipAB = R.omit(['a', 'b']);
         assert.deepEqual(skipAB(obj), {c: 3, d: 4, e: 5, f: 6});
     });
@@ -166,40 +166,40 @@ describe('pickWith', function() {
             return key === 'd' && val === 4;
         }, obj), {d: 4});
     });
-    it('should be automatically curried', function () {
+    it('should be automatically curried', function() {
         var copier = R.pickWith(R.alwaysTrue);
         assert.deepEqual(copier(obj), obj);
     });
 });
 
 
-describe('pickAll', function () {
+describe('pickAll', function() {
     var obj = {a: 1, b: 2, c: 3, d: 4, e: 5, f: 6};
-    it('should copy the named properties of an object to the new object', function () {
+    it('should copy the named properties of an object to the new object', function() {
         assert.deepEqual(R.pickAll(['a', 'c', 'f'], obj), {a: 1, c: 3, f: 6});
     });
-    it('should include properties not present on the input object', function () {
+    it('should include properties not present on the input object', function() {
         assert.deepEqual(R.pickAll(['a', 'c', 'g'], obj), {a: 1, c: 3, g: undefined});
     });
-    it('should be automatically curried', function () {
+    it('should be automatically curried', function() {
         var copyAB = R.pickAll(['a', 'b']);
         assert.deepEqual(copyAB(obj), {a: 1, b: 2});
     });
 });
 
-describe('eqProps', function () {
-    it('reports whether two objects have the same value for a given property', function () {
+describe('eqProps', function() {
+    it('reports whether two objects have the same value for a given property', function() {
         assert.equal(R.eqProps('name', {name: 'fred', age: 10}, {name: 'fred', age: 12}), true);
         assert.equal(R.eqProps('name', {name: 'fred', age: 10}, {name: 'franny', age: 10}), false);
     });
-    it('should be automatically curried', function () {
+    it('should be automatically curried', function() {
         var sameName = R.eqProps('name');
         assert.equal(sameName({name: 'fred', age: 10}, {name: 'fred', age: 12}), true);
     });
 });
 
-describe('where', function () {
-    it('takes a spec and a test object and returns true if the test object satisfies the spec', function () {
+describe('where', function() {
+    it('takes a spec and a test object and returns true if the test object satisfies the spec', function() {
 
         var spec = {x: 1, y: 2};
         var test1 = {x: 0, y: 200};
@@ -212,15 +212,15 @@ describe('where', function () {
         assert.equal(R.where(spec, test4), true);
     });
 
-    it('calls any functions in the spec against the test object value for that property', function () {
+    it('calls any functions in the spec against the test object value for that property', function() {
         var spec = {
-            a: function (a, obj) {
+            a: function(a, obj) {
                 return a < obj.b + obj.c;
             },
-            b: function (b, obj) {
+            b: function(b, obj) {
                 return b < obj.a + obj.c;
             },
-            c: function (c, obj) {
+            c: function(c, obj) {
                 return c < obj.a + obj.b;
             }
         };
@@ -235,7 +235,7 @@ describe('where', function () {
         assert.equal(R.where(spec, test4), false);
     });
 
-    it('does not need the spec and the test object to have the same interface (the test object will have a superset of the specs properties)', function () {
+    it('does not need the spec and the test object to have the same interface (the test object will have a superset of the specs properties)', function() {
         var spec = {x: 100};
         var test1 = {x: 20, y: 100, z: 100};
         var test2 = {w: 1, x: 100, y: 100, z: 100};
@@ -244,7 +244,7 @@ describe('where', function () {
         assert.equal(R.where(spec, test2), true);
     });
 
-    it('is false if the test object is null-ish', function () {
+    it('is false if the test object is null-ish', function() {
         var spec = {x: 200};
         var testN = null;
         var testU;
@@ -254,19 +254,19 @@ describe('where', function () {
         assert.equal(R.where(spec, testF), false);
     });
 
-    it('matches specs that have undefined properties', function () {
+    it('matches specs that have undefined properties', function() {
         var spec = {x: undefined};
         var test1 = {};
         var test2 = {x: null};
         var test3 = {x: undefined};
         var test4 = {x: 1};
-        //assert.equal(R.where(spec, test1), false);    // TODO: discuss Scott's objections
+//      assert.equal(R.where(spec, test1), false);    // TODO: discuss Scott's objections
         assert.equal(R.where(spec, test2), false);
         assert.equal(R.where(spec, test3), true);
         assert.equal(R.where(spec, test4), false);
     });
 
-    it('is automatically curried', function () {
+    it('is automatically curried', function() {
         var predicate = R.where({x: 1, y: 2});
         assert.equal(predicate({x: 1, y: 2, z: 3}), true);
         assert.equal(predicate({x: 3, y: 2, z: 1}), false);
@@ -288,7 +288,7 @@ describe('where', function () {
     Parent.prototype.x = 5;
     var parent = new Parent();
 
-    it('matches inherited functions', function () {
+    it('matches inherited functions', function() {
         var spec = {
             toString: R.alwaysTrue
         };
@@ -298,7 +298,7 @@ describe('where', function () {
         assert.equal(R.where({a: R.alwaysTrue}, {x: 1}), false);
     });
 
-    it('matches inherited props', function () {
+    it('matches inherited props', function() {
         assert.equal(R.where({y: 6}, parent), true);
         assert.equal(R.where({x: 5}, parent), true);
         assert.equal(R.where({x: 5, y: 6}, parent), true);
@@ -312,14 +312,14 @@ describe('where', function () {
 
 });
 
-describe('mixin', function () {
-    it('takes two objects, merges their own properties and returns a new object', function () {
+describe('mixin', function() {
+    it('takes two objects, merges their own properties and returns a new object', function() {
         var a = {w: 1, x: 2};
         var b = {y: 3, z: 4};
         assert.deepEqual(R.mixin(a, b), {w: 1, x: 2, y: 3, z: 4});
     });
 
-    it('overrides properties in the first object with properties in the second object', function () {
+    it('overrides properties in the first object with properties in the second object', function() {
         var a = {w: 1, x: 2};
         var b = {w: 100, y: 3, z: 4};
         assert.deepEqual(R.mixin(a, b), {w: 100, x: 2, y: 3, z: 4});
@@ -340,7 +340,7 @@ describe('mixin', function () {
         assert.deepEqual(R.mixin(a, new Cla()), {w: 1, x: 2});
     });
 
-    it('outta be curried', function () {
+    it('outta be curried', function() {
         var curried = R.mixin({w: 1, x: 2});
         var b = {y: 3, z: 4};
         assert.deepEqual(curried(b), {w: 1, x: 2, y: 3, z: 4});

--- a/test/test.path.js
+++ b/test/test.path.js
@@ -5,19 +5,19 @@ describe('path', function() {
     var deepObject = {a: {b: {c: 'c'}}, falseVal: false, nullVal: null, undefinedVal: undefined, arrayVal: ['arr']};
     it('takes a dot-delimited path and an object and returns the value at the path or undefined', function() {
         var obj = {
-          a: {
-            b: {
-              c: 100,
-              d: 200
+            a: {
+                b: {
+                    c: 100,
+                    d: 200
+                },
+                e: {
+                    f: [100, 101, 102],
+                    g: 'G'
+                },
+                h: 'H'
             },
-            e: {
-              f: [100, 101, 102],
-              g: 'G'
-            },
-            h: 'H'
-          },
-          i: 'I',
-          j: ['J']
+            i: 'I',
+            j: ['J']
         };
         assert.equal(R.path('a.b.c', obj), 100);
         assert.equal(R.path('', obj), undefined);
@@ -55,19 +55,19 @@ describe('pathOn', function() {
     var deepObject = {a: {b: {c: 'c'}}, falseVal: false, nullVal: null, undefinedVal: undefined, arrayVal: ['arr']};
     it('takes a string separator, string path, and an object and returns the value at the path or undefined', function() {
         var obj = {
-          a: {
-            b: {
-              c: 100,
-              d: 200
+            a: {
+                b: {
+                    c: 100,
+                    d: 200
+                },
+                e: {
+                    f: [100, 101, 102],
+                    g: 'G'
+                },
+                h: 'H'
             },
-            e: {
-              f: [100, 101, 102],
-              g: 'G'
-            },
-            h: 'H'
-          },
-          i: 'I',
-          j: ['J']
+            i: 'I',
+            j: ['J']
         };
         assert.equal(R.pathOn('|', 'a|b|c', obj), 100);
         assert.equal(R.pathOn(' ', '', obj), undefined);

--- a/test/test.range.js
+++ b/test/test.range.js
@@ -18,9 +18,9 @@ describe('range', function() {
     });
 
     it('should return an empty array if from > to', function() {
-         var result = R.range(10, 5);
-         assert.deepEqual(result, []);
-         result.push(5);
-         assert.deepEqual(R.range(10, 5), []);
+        var result = R.range(10, 5);
+        assert.deepEqual(result, []);
+        result.push(5);
+        assert.deepEqual(R.range(10, 5), []);
     });
 });


### PR DESCRIPTION
**Pro-tip:** Append `?w=` to the URL when viewing these changes to see a meaningful diff.

---

Overview:
- normalize function formatting:
  - function statement: `function f() {}`
  - function expression: `function() {}`
- `disallowQuotedKeysInObjects: true` (e.g. `{foo: 42}` rather than `{'foo': 42}`)
- `requireSpaceAfterLineComment: true` (e.g. `// comment` rather than `//comment`)
- `validateIndentation: 4`

I prefer two spaces for indentation, and this style is currently used in some of the project's files, but **ramda.js** itself uses four spaces so I went with that. If you'd like to switch to two spaces I'll update this pull request. :)

How is **ramda.api.js** used?
