### PR TITLE
Add tests for nAry, eq, where and propOrDefault

### DIFF
--- a/ramda.js
+++ b/ramda.js
@@ -3154,9 +3154,7 @@
      *      eq(1, 1) // => true
      *      eq(1, '1') // => false
      */
-    R.eq = function _eq(a, b) {
-        return arguments.length < 2 ? function _eq(b) { return a === b; } : a === b;
-    };
+    R.eq = curry2(function _eq(a, b) { return a === b; });
 
 
     /**

--- a/test/test.functionBasics.js
+++ b/test/test.functionBasics.js
@@ -160,6 +160,31 @@ describe('binary', function() {
     });
 });
 
+describe('nAry', function() {
+
+    function toArray(args) { return Array.prototype.slice.call(args, 0); }
+
+    it('should turn multiple-argument function into a nullary one', function() {
+        var fn = R.nAry(0, function(x, y, z) { return toArray(arguments); });
+        assert.equal(fn.length, 0);
+        assert.deepEqual(fn(1, 2, 3), []);
+    });
+
+    it('should turn multiple-argument function into a ternary one', function() {
+        var fn = R.nAry(3, function(a, b, c, d) { return toArray(arguments); });
+        assert.equal(fn.length, 3);
+        assert.deepEqual(fn(1, 2, 3, 4), [1, 2, 3]);
+        assert.deepEqual(fn(1), [1, undefined, undefined]);
+    });
+
+    it('should be able to create functions of arbitrary arity', function() {
+        var fn = R.nAry(10, function() { return toArray(arguments); });
+        assert.equal(fn.length, 10);
+        assert.deepEqual(fn.apply(null, R.range(0, 25)), R.range(0, 10));
+        assert.deepEqual(fn(), R.repeatN(undefined, 10));
+    });
+});
+
 describe('ap', function() {
     function inc(x) { return x + 1; }
     function mult2(x) { return x * 2; }

--- a/test/test.objectBasics.js
+++ b/test/test.objectBasics.js
@@ -42,6 +42,10 @@ describe('propOrDefault', function() {
         var bob = new Person();
         assert.equal(R.propOrDefault('age', 100, bob), 100);
     });
+
+    it('throws if given no arguments', function() {
+        assert.throws(R.propOrDefault, TypeError);
+    });
 });
 
 describe('func', function() {
@@ -308,6 +312,10 @@ describe('where', function() {
     it('doesnt match inherited spec', function() {
         assert.equal(R.where(parent, {y: 6}), true);
         assert.equal(R.where(parent, {x: 5}), false);
+    });
+
+    it('throws if given no arguments', function() {
+        assert.throws(R.where, TypeError);
     });
 
 });

--- a/test/test.tapeq.js
+++ b/test/test.tapeq.js
@@ -35,4 +35,13 @@ describe('eq', function() {
         assert.equal(R.eq([], []), false);
         assert.equal(R.eq(a, b), true);
     });
+
+    it('is curried', function() {
+        var isA = R.eq(a);
+        assert.equal(isA([]), false);
+    });
+
+    it('throws if given no arguments', function() {
+        assert.throws(R.eq, TypeError);
+    });
 });


### PR DESCRIPTION
- Add new tests for nAry that didn't have tests before.
- Add test for currying eq.
- Add tests for eq, where and propOrDefault with 0 args.
- Fix eq to throw with 0 args.
