### PR TITLE
Fix two bugs in findLast and findLastIndex

### DIFF
--- a/ramda.js
+++ b/ramda.js
@@ -2255,7 +2255,7 @@
      */
     R.findLast = curry2(function _findLast(fn, list) {
         var idx = list.length;
-        while (--idx) {
+        while (--idx >= 0) {
             if (fn(list[idx])) {
                 return list[idx];
             }
@@ -2283,7 +2283,7 @@
      */
     R.findLastIndex = curry2(function _findLastIndex(fn, list) {
         var idx = list.length;
-        while (--idx) {
+        while (--idx >= 0) {
             if (fn(list[idx])) {
                 return idx;
             }

--- a/test/test.find.js
+++ b/test/test.find.js
@@ -62,6 +62,14 @@ describe('findLast', function() {
     it('returns `undefined` when no element satisfies the predicate', function() {
         assert.equal(R.findLast(even, 'zing'), undefined);
     });
+
+    it('works when the first element matches', function() {
+        assert.equal(R.findLast(even, [2, 3, 5]), 2);
+    });
+
+    it('does not go into an infinite loop on an empty array', function() {
+        assert.equal(R.findLast(even, []), undefined);
+    });
 });
 
 describe('findLastIndex', function() {
@@ -82,5 +90,13 @@ describe('findLastIndex', function() {
 
     it('returns -1 when no element satisfies the predicate', function() {
         assert.equal(R.findLastIndex(even, 'zing'), -1);
+    });
+
+    it('works when the first element matches', function() {
+        assert.equal(R.findLastIndex(even, [2, 3, 5]), 0);
+    });
+
+    it('does not go into an infinite loop on an empty array', function() {
+        assert.equal(R.findLastIndex(even, []), -1);
     });
 });


### PR DESCRIPTION
This fixes two issues:

(1) If only the first element of an array matched the predicate, neither findLast nor findLastIndex
would report is as present.

(2) More critically, if queried with an empty array, both functions would enter into an infinite
loop.
