### PR TITLE
Fix a critical bug in R.mathMod

### DIFF
--- a/ramda.js
+++ b/ramda.js
@@ -4314,8 +4314,8 @@
      *      mathMod(17, 5.3) // NaN
      */
     R.mathMod = curry2(function _mathMod(m, p) {
-        if (!isInteger(m) || m < 1) { return NaN; }
-        if (!isInteger(p)) { return NaN; }
+        if (!isInteger(m)) { return NaN; }
+        if (!isInteger(p) || p < 1) { return NaN; }
         return ((m % p) + p) % p;
     });
 

--- a/test/test.math.js
+++ b/test/test.math.js
@@ -151,6 +151,14 @@ describe('mathMod', function() {
         assert.notEqual(R.mathMod(17, -5), 17 % -5);
     });
 
+    it('computes the true modulo function', function() {
+        assert.equal(R.mathMod(-17, 5), 3);
+        assert.equal(isNaN(R.mathMod(17, -5)), true);
+        assert.equal(isNaN(R.mathMod(17, 0)), true);
+        assert.equal(isNaN(R.mathMod(17.2, 5)), true);
+        assert.equal(isNaN(R.mathMod(17, 5.5)), true);
+    });
+
     it('is curried', function() {
         var f = R.mathMod(29);
         assert.equal(f(6), 5);


### PR DESCRIPTION
The wrong argument of `mathMod` was being checked for being less than 1. As a result, it was not actually computing values as advertised.
