### PR TITLE
Fix a bug in R.skip

### DIFF
--- a/ramda.js
+++ b/ramda.js
@@ -2171,7 +2171,11 @@
      *     skip(3, [1,2,3,4,5,6,7]); // => [4,5,6,7]
      */
     R.skip = curry2(checkForMethod('skip', function _skip(n, list) {
-        return _slice(list, n);
+        if (n < list.length) {
+            return _slice(list, n);
+        } else {
+            return [];
+        }
     }));
 
 

--- a/test/test.filter.js
+++ b/test/test.filter.js
@@ -107,6 +107,10 @@ describe('skip', function() {
         assert.deepEqual(R.skip(3, ['a', 'b', 'c', 'd', 'e', 'f', 'g']), ['d', 'e', 'f', 'g']);
     });
 
+    it('should return an empty array if `n` is too large', function() {
+        assert.deepEqual(R.skip(20, ['a', 'b', 'c', 'd', 'e', 'f', 'g']), []);
+    });
+
     it('should be automatically curried', function() {
         var skip2 = R.skip(2);
         assert.deepEqual(skip2(['a', 'b', 'c', 'd', 'e']), ['c', 'd', 'e']);


### PR DESCRIPTION
Calling `R.skip(n, list)` for `n >= list.length` would result in an error being thrown. Instead,
this commit causes an empty array to be returned.
