### PR TITLE
Add missing test module

### DIFF
--- a/test/index.html
+++ b/test/index.html
@@ -64,6 +64,7 @@
   <script src="test.stringBasics.js"></script>
   <script src="test.path.js"></script>
   <script src="test.sql.js"></script>
+  <script src="test.is.js"></script>
   <script src="../ext/lazylist/test/test.lazy.js"></script>
   <script>
     mocha.checkLeaks();


### PR DESCRIPTION
The `is` test file was not included in test/index.html, and so its tests were not run. This commit adds it.
