### PR TITLE
add missing @func tag

### DIFF
--- a/ramda.js
+++ b/ramda.js
@@ -242,6 +242,7 @@
      * second position, sort of a curry-right.  This allows for more natural
      * processing of functions which are really binary operators.
      *
+     * @func
      * @memberOf R
      * @category Functions
      * @param {function} fn The operation to adjust


### PR DESCRIPTION
I assume the missing tag is the reason `R.op` is treated differently from all the other functions at [ramdajs.com](http://ramdajs.com/R.html).
