### PR TITLE
Define reverse explicitly

### DIFF
--- a/ramda.js
+++ b/ramda.js
@@ -1159,7 +1159,7 @@
      *      squareThenDoubleThenTriple(5); //=> 150
      */
     R.pipe = function _pipe() {
-        return compose.apply(this, _slice(arguments).reverse());
+        return compose.apply(this, R.reverse(arguments));
     };
 
 
@@ -2947,8 +2947,14 @@
      *      R.reverse([1]);        //=> [1]
      *      R.reverse([]);         //=> []
      */
-    R.reverse = function _reverse(list) {
-        return clone(list || []).reverse();
+    R.reverse = function reverse(list) {
+        var idx = -1, length = list.length;
+        var pointer = length;
+        var result = new Array(length);
+        while (++idx < length) {
+            result[--pointer] = list[idx];
+        }
+        return result;
     };
 
 


### PR DESCRIPTION
http://jsperf.com/r-reverse-e

Couple different options
- fb5b242d474296abf23fd0e2e1953c10604c3cd6
- via `map` a91f33bb9c07a0aa424fb9f6541bff0169258ac0
- Refactor `_slice` c2729bbe21c659d596ab178619bd66a81e2038e3

Feel free to punt this. I just hate `[].reverse`
