### PR TITLE
Add R.has and R.hasIn functions and tests

### DIFF
--- a/ramda.js
+++ b/ramda.js
@@ -3404,6 +3404,60 @@
         return hasOwnProperty.call(obj, p) ? obj[p] : val;
     });
 
+    /**
+     * Returns whether or not an object has an own property with
+     * the specified name
+     *
+     * @func
+     * @memberOf R
+     * @category Object
+     * @sig s -> {s: x} -> Boolean
+     * @param {String} prop The name of the property to check for.
+     * @param {Object} obj The object to query.
+     * @return {Boolean} Whether the property exists.
+     * @example
+     *
+     *      var obj = {
+     *        foo: 1,
+     *        bar: 2,
+     *      };
+     *      R.has('foo', obj);  //=> true
+     *
+     *      var list = [{foo: 1}, {foo: 2}, {bar: 3}];
+     *      R.filter(R.has('foo'), list);  //=> [{foo: 1}, {foo: 2}]
+     */
+    R.has = curry2(function(prop, obj) {
+        return hasOwnProperty.call(obj, prop);
+    });
+
+    /**
+     * Returns whether or not an object or its prototype chain has
+     * a property with the specified name
+     *
+     * @func
+     * @memberOf R
+     * @category Object
+     * @sig s -> {s: x} -> Boolean
+     * @param {String} prop The name of the property to check for.
+     * @param {Object} obj The object to query.
+     * @return {Boolean} Whether the property exists.
+     * @example
+     *
+     *      function Rectangle(width, height) {
+     *          this.width = width;
+     *          this.height = height;
+     *      }
+     *      Rectangle.prototype.area = function() {
+     *          return this.width * this.height;
+     *      };
+     *
+     *      var square = new Rectangle(2, 2);
+     *      R.hasIn('width', square);  //=> true
+     *      R.hasIn('area', square);  //=> true
+     */
+    R.hasIn = curry2(function(prop, obj) {
+        return prop in obj;
+    });
 
     /**
      * Calls the specified function on the supplied object. Any additional arguments

--- a/test/test.objectBasics.js
+++ b/test/test.objectBasics.js
@@ -48,6 +48,74 @@ describe('propOr', function() {
     });
 });
 
+describe('has', function() {
+    var fred = {name: 'Fred', age: 23};
+    var anon = {age: 99};
+
+    it('should return a function that checks the appropriate property', function() {
+        var nm = R.has('name');
+        assert.equal(typeof nm, 'function');
+        assert.equal(nm(fred), true);
+        assert.equal(nm(anon), false);
+    });
+
+    it('should not check properties from the prototype chain', function() {
+        var Person = function() {};
+        Person.prototype.age = function() {};
+
+        var bob = new Person();
+        assert.equal(R.has('age', bob), false);
+    });
+
+    it('throws for null and undefined objects', function() {
+        assert.throws(function() {R.has('name', null);}, TypeError);
+        assert.throws(function() {R.has('name', undefined);}, TypeError);
+    });
+
+    it('works properly when called with two arguments', function() {
+        assert.equal(R.has('name', fred), true);
+        assert.equal(R.has('name', anon), false);
+    });
+
+    it('throws if given no arguments', function() {
+        assert.throws(R.has, TypeError);
+    });
+});
+
+describe('hasIn', function() {
+    var fred = {name: 'Fred', age: 23};
+    var anon = {age: 99};
+
+    it('should return a function that checks the appropriate property', function() {
+        var nm = R.hasIn('name');
+        assert.equal(typeof nm, 'function');
+        assert.equal(nm(fred), true);
+        assert.equal(nm(anon), false);
+    });
+
+    it('should check properties from the prototype chain', function() {
+        var Person = function() {};
+        Person.prototype.age = function() {};
+
+        var bob = new Person();
+        assert.equal(R.hasIn('age', bob), true);
+    });
+
+    it('throws for null and undefined objects', function() {
+        assert.throws(function() {R.has('name', null);}, TypeError);
+        assert.throws(function() {R.has('name', undefined);}, TypeError);
+    });
+
+    it('works properly when called with two arguments', function() {
+        assert.equal(R.hasIn('name', fred), true);
+        assert.equal(R.hasIn('name', anon), false);
+    });
+
+    it('throws if given no arguments', function() {
+        assert.throws(R.hasIn, TypeError);
+    });
+});
+
 describe('func', function() {
     it('should return a function that applies the appropriate function to the supplied object', function() {
         var fred = {first: 'Fred', last: 'Flintstone', getName: function() {


### PR DESCRIPTION
I put together this PR to add the `R.has` function. It is similar to [underscore's](http://underscorejs.org/#has) `_.has` function, except with the arguments reversed to make partial application more useful. Here are a couple of examples of its use:

``` javascript
var obj = {
  foo: 1,
  bar: 2,
};
R.has('foo', obj);  //=> true

var list = [{foo: 1}, {foo: 2}, {bar: 3}];
R.filter(R.has('foo'), list);  //=> [{foo: 1}, {foo: 2}]
```

This is one of the few functions that I find myself reaching back to underscore for so it would be great to get an even better version of this in Ramda!
