### PR TITLE
s/CrossEye/ramda/

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@ Project Ramda
 
 A practical functional library for Javascript programmers.
 
-[![Build Status](https://travis-ci.org/CrossEye/ramda.svg?branch=master)](https://travis-ci.org/CrossEye/ramda)
+[![Build Status](https://travis-ci.org/ramda/ramda.svg?branch=master)](https://travis-ci.org/ramda/ramda)
 [![npm module](https://badge.fury.io/js/ramda.svg)](https://www.npmjs.org/package/ramda)
-[![dependencies](https://david-dm.org/CrossEye/ramda.png)](https://david-dm.org/CrossEye/ramda)
+[![dependencies](https://david-dm.org/ramda/ramda.png)](https://david-dm.org/ramda/ramda)
 
 Goals
 -----

--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "ramda",
   "main": "ramda.js",
   "version": "0.6.0",
-  "homepage": "https://github.com/CrossEye/ramda",
+  "homepage": "https://github.com/ramda/ramda",
   "authors": [
     "(Scott Sauyet <scott@sauyet.com>)",
     "(buzzdecafe <mh@buzzdecafe.com>)"

--- a/docs/ramda.html
+++ b/docs/ramda.html
@@ -28,7 +28,7 @@
                 <a class="pilcrow" href="#section-1">&#182;</a>
               </div>
               <pre><code>ramda.js <span class="hljs-number">0.3</span><span class="hljs-number">.0</span>
-https:<span class="hljs-comment">//github.com/CrossEye/ramda</span>
+https:<span class="hljs-comment">//github.com/ramda/ramda</span>
 (c) <span class="hljs-number">2013</span>-<span class="hljs-number">2014</span> Scott Sauyet and Michael Hurley
 Ramda may be freely distributed under the MIT license.
 </code></pre>

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "author": "CrossEye <scott@sauyet.com> (scott.sauyet.com)",
+  "author": "Scott Sauyet <scott@sauyet.com> (scott.sauyet.com)",
   "contributors": [
     {
       "name": "buzzdecafe",
@@ -10,16 +10,21 @@
       "name": "Scott Sauyet",
       "email": "scott@sauyet.com",
       "web": "http://fr.umio.us"
+    },
+    {
+      "name": "David Chambers",
+      "email": "dc@davidchambers.me",
+      "web": "http://davidchambers.me"
     }
   ],
   "name": "ramda",
   "description": "A practical functional library for JavaScript programmers.",
   "version": "0.6.0",
-  "homepage": "https://www.github.com/CrossEye/ramda",
+  "homepage": "https://www.github.com/ramda/ramda",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git://github.com/CrossEye/ramda.git"
+    "url": "git://github.com/ramda/ramda.git"
   },
   "main": "ramda.js",
   "scripts": {

--- a/ramda.js
+++ b/ramda.js
@@ -1,5 +1,5 @@
 //     ramda.js
-//     https://github.com/CrossEye/ramda
+//     https://github.com/ramda/ramda
 //     (c) 2013-2014 Scott Sauyet and Michael Hurley
 //     Ramda may be freely distributed under the MIT license.
 

--- a/tpl/README.md
+++ b/tpl/README.md
@@ -3,7 +3,7 @@ Project Ramda
 
 A practical functional library for Javascript programmers.
 
-[![Build Status](https://travis-ci.org/CrossEye/ramda.svg?branch=master)](https://travis-ci.org/CrossEye/ramda)
+[![Build Status](https://travis-ci.org/ramda/ramda.svg?branch=master)](https://travis-ci.org/ramda/ramda)
 
 Goals
 -----


### PR DESCRIPTION
This can be merged when we're ready to switch to [ramda/ramda](https://github.com/ramda/ramda).

Note that we'll need to delete ramda/ramda, then _move_ CrossEye/ramda to ramda/ramda. This will ensure we carry over stars, pull requests, etc.
