### PR TITLE
add R.createMapEntry

### DIFF
--- a/ramda.js
+++ b/ramda.js
@@ -2944,6 +2944,31 @@
 
 
     /**
+     * Creates an object containing a single key:value pair.
+     *
+     * @func
+     * @memberOf R
+     * @category Object
+     * @sig String -> a -> {String:a}
+     * @param {String} key
+     * @param {*} val
+     * @return {Object}
+     * @example
+     *
+     *      var matchPhrases = R.compose(
+     *          R.createMapEntry('must'),
+     *          R.map(R.createMapEntry('match_phrase'))
+     *      );
+     *      matchPhrases(['foo', 'bar', 'baz']); //=> {must: [{match_phrase: 'foo'}, {match_phrase: 'bar'}, {match_phrase: 'baz'}]}
+     */
+    R.createMapEntry = curry2(function(key, val) {
+        var obj = {};
+        obj[key] = val;
+        return obj;
+    });
+
+
+    /**
      * Creates a new list out of the two supplied by applying the function
      * to each possible pair in the lists.
      *

--- a/test/test.createMapEntry.js
+++ b/test/test.createMapEntry.js
@@ -1,0 +1,13 @@
+var assert = require('assert');
+var R = require('..');
+
+
+describe('mapEntry', function() {
+    it('creates an object containing a single key:value pair', function() {
+        assert.deepEqual(R.createMapEntry('foo', 42), {foo: 42});
+    });
+
+    it('is automatically curried', function() {
+        assert.deepEqual(R.createMapEntry('foo')(42), {foo: 42});
+    });
+});


### PR DESCRIPTION
This simple function is useful when working with objects in point-free style. Here's an example from actual code:

``` javascript
// toQuestionnaire :: Object -> {type,send:{questions:[{question}]}}
var toQuestionnaire = R.pipe(
  R.prop('credentials'),                // :: {questions:[{question}]}
  R.prop('questions'),                  // :: [{question}]
  R.last,                               // :: {question}
  R.pick(['question']),                 // :: {question}
  R.of,                                 // :: [{question}]
  R.mapEntry('questions'),              // :: {questions:[{question}]}
  R.mapEntry('send'),                   // :: {send:{questions:[{question}]}}
  R.mixin(R.mapEntry('type', 'questions'))
);
```
