### PR TITLE
remove unnecessary tests for aliases

### DIFF
--- a/test/test.core.js
+++ b/test/test.core.js
@@ -136,7 +136,6 @@ describe('size', function() {
     });
 
     it('should be aliased by `length`', function() {
-        assert.equal(R.length([2, 4, 6, 8, 10]), 5);
         assert.strictEqual(R.length, R.size);
     });
 

--- a/test/test.fold.js
+++ b/test/test.fold.js
@@ -25,7 +25,6 @@ describe('foldl', function() {
     });
 
     it('should be aliased by `reduce`', function() {
-        assert.equal(R.reduce(add, 0, [1, 2, 3, 4]), 10);
         assert.strictEqual(R.reduce, R.foldl);
     });
 
@@ -63,7 +62,6 @@ describe('foldr', function() {
     });
 
     it('should be aliased by `reduceRight`', function() {
-        assert.equal(R.reduceRight(avg, 54, [12, 4, 10, 6]), 12);
         assert.strictEqual(R.reduceRight, R.foldr);
     });
 

--- a/test/test.objectBasics.js
+++ b/test/test.objectBasics.js
@@ -11,7 +11,6 @@ describe('prop', function() {
     });
 
     it('is aliased by `get`', function() { // TODO: should it?
-        assert.equal(R.get('age')(fred), 23);
         assert.strictEqual(R.get, R.prop);
     });
 


### PR DESCRIPTION
There's no need to test each reference to a function individually.
