### PR TITLE
Reverse argument order in R.tap. Solve #453

### DIFF
--- a/ramda.js
+++ b/ramda.js
@@ -3360,18 +3360,18 @@
      * @func
      * @memberOf R
      * @category Function
-     * @sig a -> (a -> *) -> a
-     * @param {*} x
+     * @sig (a -> *) -> a -> a
      * @param {Function} fn The function to call with `x`. The return value of `fn` will be thrown away.
+     * @param {*} x
      * @return {*} x
      * @example
      *
      *      var sayX = function(x) { console.log('x is ' + x); };
-     *      R.tap(100, sayX); //=> 100
+     *      R.tap(sayX, 100); //=> 100
      *      //-> 'x is 100')
      */
-    R.tap = curry2(function _tap(x, fn) {
-        if (typeof fn === 'function') { fn(x); }
+    R.tap = curry2(function _tap(fn, x) {
+        fn(x);
         return x;
     });
 

--- a/test/test.tapeq.js
+++ b/test/test.tapeq.js
@@ -2,28 +2,20 @@ var assert = require('assert');
 var R = require('..');
 
 describe('tap', function() {
-    it("returns a function that returns tap's argument", function() {
-        var f = R.tap(100);
+    it('returns a function that always returns its argument', function() {
+        var f = R.tap(R.I);
         assert.equal(typeof f, 'function');
-        assert.equal(f(null), 100);
+        assert.equal(f(100), 100);
     });
 
-    it("may take a function for a second argument that executes with tap's argument", function() {
+    it("may take a function as the first argument that executes with tap's argument", function() {
         var sideEffect = 0;
         assert.equal(sideEffect, 0);
-        var rv = R.tap(200, function(x) { sideEffect = 'string ' + x; });
+        var rv = R.tap(function(x) { sideEffect = 'string ' + x; }, 200);
         assert.equal(rv, 200);
         assert.equal(sideEffect, 'string 200');
     });
 
-    it("ignores the scond argument if it's not a function", function() {
-        assert(R.tap(300, 400), 300);
-        assert(R.tap(300, [400]), 300);
-        assert(R.tap(300, {x: 400}), 300);
-        assert(R.tap(300, '400'), 300);
-        assert(R.tap(300, false), 300);
-        assert(R.tap(300, null), 300);
-    });
 });
 
 describe('eq', function() {


### PR DESCRIPTION
R.tap took its arguments value first, function second but it was
generally agreed that the function is more extensible if the arguments
were reversed.
