### PR TITLE
add R.apply

### DIFF
--- a/ramda.js
+++ b/ramda.js
@@ -1075,6 +1075,29 @@
     // --------
 
     /**
+     * Applies function `fn` to the argument list `args`. This is useful for
+     * creating a fixed-arity function from a variadic function. `fn` should
+     * be a bound function if context is significant.
+     *
+     * @func
+     * @memberOf R
+     * @category core
+     * @category Function
+     * @sig (*... -> a) -> [*] -> a
+     * @param {Function} fn
+     * @param {Array} args
+     * @return {*}
+     * @example
+     *
+     *      var nums = [1, 2, 3, -99, 42, 6, 7];
+     *      R.apply(Math.max, nums); //=> 42
+     */
+    R.apply = curry2(function _apply(fn, args) {
+        return fn.apply(this, args);
+    });
+
+
+    /**
      * Basic, right-associative composition function. Accepts two functions and returns the
      * composite function; this composite function represents the operation `var h = f(g(x))`,
      * where `f` is the first argument, `g` is the second argument, and `x` is whatever

--- a/test/test.functionBasics.js
+++ b/test/test.functionBasics.js
@@ -1,6 +1,22 @@
 var assert = require('assert');
 var R = require('..');
 
+describe('apply', function() {
+    it('applies function to argument list', function() {
+        assert.strictEqual(R.apply(Math.max, [1, 2, 3, -99, 42, 6, 7]), 42);
+    });
+
+    it('is automatically curried', function() {
+        assert.strictEqual(R.apply(Math.max)([1, 2, 3, -99, 42, 6, 7]), 42);
+    });
+
+    it('provides no way to specify context', function() {
+        var obj = {method: function() { return this === obj; }};
+        assert.strictEqual(R.apply(obj.method, []), false);
+        assert.strictEqual(R.apply(R.bind(obj.method, obj), []), true);
+    });
+});
+
 describe('flip', function() {
     it('should return a function which inverts the first two arguments to the supplied function', function() {
         var f = function(a, b, c) {return a + ' ' + b + ' ' + c;};


### PR DESCRIPTION
I'm surprised this function isn't yet defined. It's similar to [clojure.core/apply](http://clojuredocs.org/clojure.core/apply), the difference being that Clojure's apply is variadic whereas Ramda's is a curried binary function.
