### PR TITLE
Change category of path functions from string to object

### DIFF
--- a/ramda.js
+++ b/ramda.js
@@ -5111,7 +5111,7 @@
      *
      * @private
      * @memberOf R
-     * @category string
+     * @category object
      * @param {Array} paths An array of strings to map to object properties
      * @param {Object} obj The object to find the path in
      * @return {Array} The value at the end of the path or `undefined`.
@@ -5136,7 +5136,7 @@
      *
      * @func
      * @memberOf R
-     * @category string
+     * @category object
      * @sig String -> String -> {*} -> *
      * @param {string} sep The separator to use in `path`.
      * @param {string} path The path to use.
@@ -5155,7 +5155,7 @@
      *
      * @func
      * @memberOf R
-     * @category string
+     * @category object
      * @sig String -> {*} -> *
      * @param {string} path The dot path to use.
      * @return {*} The data at `path`.


### PR DESCRIPTION
R.path and R.pathOn were categorized as string functions but does really
operate on objects since their purpose is to find nested properties of
objects. Their categories were changed so that the documentation will
reflect this.
