### PR TITLE
Add R.replace

### DIFF
--- a/ramda.js
+++ b/ramda.js
@@ -4980,6 +4980,30 @@
 
 
     /**
+     * Replace a substring or regex match in a string with a replacement.
+     *
+     * @func
+     * @memberOf R
+     * @category string
+     * @sig RegExp|String -> String -> String -> String
+     * @param {RegExp|String} pattern A regular expression or a substring to match.
+     * @param {String} replacement The string to replace the matches with.
+     * @param {String} str The String to do the search and replacement in.
+     * @return {String} A string with all the matches replaced.
+     * @example
+     *
+     *      R.replace(/\d+/g, 'number', '1 2 three'); //=> 'number number three'
+     *
+     *      var replaceSemicolon = R.replace(';');
+     *      var removeSemicolon = replaceSemicolon('');
+     *      removeSemicolon('return 42;'); //=> 'return 42'
+     */
+    R.replace = curry3(function _replace(regex, replacement, str) {
+        return str.replace(regex, replacement);
+    });
+
+
+    /**
      * Finds the first index of a substring in a string, returning -1 if it's not present
      *
      * @func

--- a/test/test.replace.js
+++ b/test/test.replace.js
@@ -1,0 +1,23 @@
+var assert = require('assert');
+var R = require('..');
+
+describe('replace', function() {
+
+    it('replaces substrings of the input string', function() {
+        assert.equal(R.replace('1', 'one', '1 two three'), 'one two three');
+    });
+
+    it('replaces regex matches of the input string', function() {
+        assert.equal(R.replace(/\d+/g, 'num', '1 2 three'), 'num num three');
+    });
+
+    it('is curried up to 3 arguments', function() {
+        assert(R.replace(null) instanceof Function);
+        assert(R.replace(null, null) instanceof Function);
+
+        var replaceSemicolon = R.replace(';');
+        var removeSemicolon = replaceSemicolon('');
+        assert.equal(removeSemicolon('return 42;'), 'return 42');
+    });
+
+});


### PR DESCRIPTION
This adds R.replace witch replaces parts of a string with a replacement
string. All it really does is to call the replace method on the string
object.

The order of the arguments is:
1. RegExp or substring to match what is to be replaced
2. The replacement string
3. The string to do the replacement in.
   It could perhaps be argued that the order of the first two arguments
   should be reversed. With the current implementation it is possible to
   construct functions like these:
   
   var replaceSemicolon = R.replace(';');
   var removeSemicolon = replaceSemicolon('');

If the arguments were reversed, this would be possible:

  var clearStringOf = R.replace('');
  var removeSemicolon = clearStringOf(';');

I choose this way since it is the order that the underlying
string.replace() method accepts them.

It could also be argued that ramda should not have a function that can
accept _either_ a string or a RegExp as one of its arguments, but if the
function was split in two, it would still just call the same underlying
method.
