### PR TITLE
Add R.scanl

### DIFF
--- a/ramda.js
+++ b/ramda.js
@@ -1907,6 +1907,33 @@
         }, {}, keys(obj));
     });
 
+    /**
+     * Scanl is similar to reduce, but returns a list of successively reduced values from the left
+     *
+     * @func
+     * @memberOf R
+     * @category List
+     * @sig (a,b -> a) -> a -> [b] -> [a]
+     * @param {Function} fn The iterator function. Receives two values, the accumulator and the
+     *        current element from the array
+     * @param {*} acc The accumulator value.
+     * @param {Array} list The list to iterate over.
+     * @return {Array} A list of all intermediately reduced values
+     * @example
+     *
+     *      var numbers = [1, 2, 3, 4];
+     *      var factorials = R.scanl(R.multiply, 1, numbers); //=> [1, 1, 2, 6, 24]
+     */
+    R.scanl = curry3(function _scanl(fn, acc, list) {
+        var idx = 0, len = list.length + 1, result = new Array(len);
+        result[idx] = acc;
+        while (++idx < len) {
+            acc = fn(acc, list[idx - 1]);
+            result[idx] = acc;
+        }
+        return result;
+    });
+
 
     /**
      * "lifts" a function to be the specified arity, so that it may "map over" that many

--- a/test/test.scanl.js
+++ b/test/test.scanl.js
@@ -1,0 +1,38 @@
+var assert = require('assert');
+var R = require('..');
+
+describe('scanl', function() {
+    var add = function(a, b) {return a + b;};
+    var mult = function(a, b) {return a * b;};
+
+    it('scans simple functions over arrays with the supplied accumulator', function() {
+        assert.deepEqual(R.scanl(add, 0, [1, 2, 3, 4]), [0, 1, 3, 6, 10]);
+        assert.deepEqual(R.scanl(mult, 1, [1, 2, 3, 4]), [1, 1, 2, 6, 24]);
+    });
+
+    it('should return the accumulator for an empty array', function() {
+        assert.deepEqual(R.scanl(add, 0, []), [0]);
+        assert.deepEqual(R.scanl(mult, 1, []), [1]);
+    });
+
+    it('should be automatically curried', function() {
+        var addOrConcat = R.scanl(add);
+        var sum = addOrConcat(0);
+        var cat = addOrConcat('');
+        assert.deepEqual(sum([1, 2, 3, 4]), [0, 1, 3, 6, 10]);
+        assert.deepEqual(cat(['1', '2', '3', '4']), ['', '1', '12', '123', '1234']);
+    });
+
+    it('should correctly report the arity of curried versions', function() {
+        var sum = R.scanl(add, 0);
+        assert.equal(sum.length, 1);
+    });
+
+    it('throws if called with no arguments', function() {
+        assert.throws(R.scanl, TypeError);
+    });
+
+    it('returns a function which throws if called with no arguments', function() {
+        assert.throws(R.scanl(R.add), TypeError);
+    });
+});


### PR DESCRIPTION
Found myself wanting this functionality recently. It's nice for building up a collection of intermediate values while reducing. Here's an example of where one could be applying an increasingly stringent set of filters to an ElasticSearch or MongoDB style query:

``` javascript
> var location = {state: 'CA', city: 'San Francisco', zip: 94108};
> R.scanl(R.mixin, {}, [{state: trans.state}, {city: trans.city}, {zip: trans.zip}]);
<
[
  {},                                                     // no filter
  {"state": "CA"},                                        // just state
  {"state": "CA", "city": "San Francisco"},               // state and city
  {"state": "CA", "city": "San Francisco", "zip": 94108}  // state, city and zip
]

```

Inspired by Haskell [scanl](http://en.wikibooks.org/wiki/Haskell/List_processing#Scans)
