### PR TITLE
remove R.get

### DIFF
--- a/ramda.js
+++ b/ramda.js
@@ -3473,14 +3473,6 @@
         return obj[p];
     };
 
-    /**
-     * @func
-     * @memberOf R
-     * @category Object
-     * @see R.prop
-     */
-    R.get = R.prop;
-
 
     /**
      * Returns the value at the specified property.

--- a/test/test.objectBasics.js
+++ b/test/test.objectBasics.js
@@ -10,10 +10,6 @@ describe('prop', function() {
         assert.equal(nm(fred), 'Fred');
     });
 
-    it('is aliased by `get`', function() { // TODO: should it?
-        assert.strictEqual(R.get, R.prop);
-    });
-
     it('throws when called with no arguments', function() {
         assert.throws(R.prop, TypeError);
     });


### PR DESCRIPTION
Aliases are, by definition, unnecessary. This one is also inconsistent as we don't provide `R.getEq` or `R.getOr`. Let's remove it.
