### PR TITLE
move string functions to R.string namespace

### DIFF
--- a/ramda.js
+++ b/ramda.js
@@ -34,7 +34,10 @@
      *
      * @namespace R
      */
-    var R = {version: '0.7.1'};
+    var R = {
+        version: '0.7.1',
+        string: {}
+    };
 
     // Internal Functions and Properties
     // ---------------------------------
@@ -984,6 +987,27 @@
 
 
     /**
+     * Returns the result of concatenating two strings.
+     *
+     * @func
+     * @memberOf R
+     * @category core
+     * @category string
+     * @sig String -> String -> String
+     * @param {String} str1 The first string.
+     * @param {String} str2 The second string.
+     * @return {Array} The result of concatenating the two strings.
+     * @example
+     *
+     *      R.string.concat('ABC', 'DEF'); // 'ABCDEF'
+     *      R.string.concat(1234, 5678); // '12345678'
+     */
+    R.string.concat = curry2(function(str1, str2) {
+        return '' + str1 + str2;
+    });
+
+
+    /**
      * A function that does nothing but return the parameter supplied to it. Good as a default
      * or placeholder function.
      *
@@ -1392,7 +1416,7 @@
      * @example
      *
      *      var slashify = R.wrap(R.flip(add)('/'), function(f, x) {
-     *        return R.match(/\/$/, x) ? x : f(x);
+     *        return R.string.match(/\/$/, x) ? x : f(x);
      *      });
      *
      *      slashify('a');  //=> 'a/'
@@ -4908,9 +4932,9 @@
      * @see R.invoker
      * @example
      *
-     *      R.substring(2, 5, 'abcdefghijklm'); //=> 'cde'
+     *      R.string.substring(2, 5, 'abcdefghijklm'); //=> 'cde'
      */
-    var substring = R.substring = invoker(String.prototype.substring);
+    var substring = R.string.substring = invoker(String.prototype.substring);
 
 
     /**
@@ -4926,9 +4950,9 @@
      * @see R.invoker
      * @example
      *
-     *      R.substringFrom(8, 'abcdefghijklm'); //=> 'ijklm'
+     *      R.string.substringFrom(8, 'abcdefghijklm'); //=> 'ijklm'
      */
-    R.substringFrom = flip(substring)(void 0);
+    R.string.substringFrom = flip(substring)(void 0);
 
 
     /**
@@ -4944,9 +4968,9 @@
      * @see R.invoker
      * @example
      *
-     *      R.substringTo(8, 'abcdefghijklm'); //=> 'abcdefgh'
+     *      R.string.substringTo(8, 'abcdefghijklm'); //=> 'abcdefgh'
      */
-    R.substringTo = substring(0);
+    R.string.substringTo = substring(0);
 
 
     /**
@@ -4962,9 +4986,9 @@
      * @see R.invoker
      * @example
      *
-     *      R.charAt(8, 'abcdefghijklm'); //=> 'i'
+     *      R.string.charAt(8, 'abcdefghijklm'); //=> 'i'
      */
-    R.charAt = invoker(String.prototype.charAt);
+    R.string.charAt = invoker(String.prototype.charAt);
 
 
     /**
@@ -4980,10 +5004,10 @@
      * @see R.invoker
      * @example
      *
-     *      R.charCodeAt(8, 'abcdefghijklm'); //=> 105
+     *      R.string.charCodeAt(8, 'abcdefghijklm'); //=> 105
      *      // (... 'a' ~ 97, 'b' ~ 98, ... 'i' ~ 105)
      */
-    R.charCodeAt = invoker(String.prototype.charCodeAt);
+    R.string.charCodeAt = invoker(String.prototype.charCodeAt);
 
 
     /**
@@ -4999,9 +5023,9 @@
      * @see R.invoker
      * @example
      *
-     *      R.match(/([a-z]a)/g, 'bananas'); //=> ['ba', 'na', 'na']
+     *      R.string.match(/([a-z]a)/g, 'bananas'); //=> ['ba', 'na', 'na']
      */
-    R.match = invoker(String.prototype.match);
+    R.string.match = invoker(String.prototype.match);
 
 
     /**
@@ -5041,9 +5065,9 @@
      * @see R.invoker
      * @example
      *
-     *      R.strIndexOf('c', 'abcdefg'); //=> 2
+     *      R.string.indexOf('c', 'abcdefg'); //=> 2
      */
-    R.strIndexOf = curry2(function _strIndexOf(c, str) {
+    R.string.indexOf = curry2(function _strIndexOf(c, str) {
         return str.indexOf(c);
     });
 
@@ -5062,9 +5086,9 @@
      * @see R.invoker
      * @example
      *
-     *      R.strLastIndexOf('a', 'banana split'); //=> 5
+     *      R.string.lastIndexOf('a', 'banana split'); //=> 5
      */
-    R.strLastIndexOf = curry2(function(c, str) {
+    R.string.lastIndexOf = curry2(function(c, str) {
         return str.lastIndexOf(c);
     });
 
@@ -5080,9 +5104,9 @@
      * @return {string} The upper case version of `str`.
      * @example
      *
-     *      R.toUpperCase('abc'); //=> 'ABC'
+     *      R.string.toUpperCase('abc'); //=> 'ABC'
      */
-    R.toUpperCase = invoker(String.prototype.toUpperCase);
+    R.string.toUpperCase = invoker(String.prototype.toUpperCase);
 
 
     /**
@@ -5096,9 +5120,9 @@
      * @return {string} The lower case version of `str`.
      * @example
      *
-     *      R.toLowerCase('XYZ'); //=> 'xyz'
+     *      R.string.toLowerCase('XYZ'); //=> 'xyz'
      */
-    R.toLowerCase = invoker(String.prototype.toLowerCase);
+    R.string.toLowerCase = invoker(String.prototype.toLowerCase);
 
 
     /**
@@ -5112,10 +5136,10 @@
      * @returns {String} Trimmed version of `str`.
      * @example
      *
-     *      R.trim('   xyz  '); //=> 'xyz'
-     *      R.map(R.trim, R.split(',', 'x, y, z')); //=> ['x', 'y', 'z']
+     *      R.string.trim('   xyz  '); //=> 'xyz'
+     *      R.map(R.string.trim, R.string.split(',', 'x, y, z')); //=> ['x', 'y', 'z']
      */
-    R.trim = (function() {
+    R.string.trim = (function() {
         var ws = '\x09\x0A\x0B\x0C\x0D\x20\xA0\u1680\u180E\u2000\u2001\u2002\u2003' +
             '\u2004\u2005\u2006\u2007\u2008\u2009\u200A\u202F\u205F\u3000\u2028' +
             '\u2029\uFEFF';
@@ -5145,12 +5169,12 @@
      * @return {Array} The array of strings from `str` separated by `str`.
      * @example
      *
-     *      var pathComponents = R.split('/');
+     *      var pathComponents = R.string.split('/');
      *      R.tail(pathComponents('/usr/local/bin/node')); //=> ['usr', 'local', 'bin', 'node']
      *
-     *      R.split('.', 'a.b.c.xyz.d'); //=> ['a', 'b', 'c', 'xyz', 'd']
+     *      R.string.split('.', 'a.b.c.xyz.d'); //=> ['a', 'b', 'c', 'xyz', 'd']
      */
-    R.split = invokerN(1, String.prototype.split);
+    R.string.split = invokerN(1, String.prototype.split);
 
 
     /**
@@ -5546,7 +5570,7 @@
      * @example
      *
      *      var sortByFirstItem = R.sortBy(prop(0));
-     *      var sortByNameCaseInsensitive = R.sortBy(compose(R.toLowerCase, prop('name')));
+     *      var sortByNameCaseInsensitive = R.sortBy(compose(R.string.toLowerCase, prop('name')));
      *      var pairs = [[-1, 1], [-2, 2], [-3, 3]];
      *      sortByFirstItem(pairs); //=> [[-3, 3], [-2, 2], [-1, 1]]
      *      var alice = {
@@ -5586,9 +5610,9 @@
      * @example
      *
      *      var numbers = [1.0, 1.1, 1.2, 2.0, 3.0, 2.2];
-     *      var letters = R.split('', 'abcABCaaaBBc');
+     *      var letters = R.string.split('', 'abcABCaaaBBc');
      *      R.countBy(Math.floor)(numbers);    //=> {'1': 3, '2': 2, '3': 1}
-     *      R.countBy(R.toLowerCase)(letters);   //=> {'a': 5, 'b': 4, 'c': 3}
+     *      R.countBy(R.string.toLowerCase)(letters);   //=> {'a': 5, 'b': 4, 'c': 3}
      */
     R.countBy = curry2(function countBy(fn, list) {
         return foldl(function(counts, obj) {

--- a/test/test.examplesRunner.js
+++ b/test/test.examplesRunner.js
@@ -22,7 +22,7 @@ ExampleTest.prototype.getFunctionName = function(code) {
         return matches[1];
     } else if ((matches = func_line.match(/([\w\.]+\s*=\s*)+/)) !== null) {
         var names = R.reject(R.isEmpty, R.map(R.invoker(String.prototype.trim), matches[0].split('=')));
-        var ramda_func = R.find(R.match(/^R\./), names);
+        var ramda_func = R.find(R.string.match(/^R\./), names);
         return (names.length === 0) ? false : ((R.isEmpty(ramda_func)) ? names[0] : ramda_func);
     } else {
         return false;

--- a/test/test.stringBasics.js
+++ b/test/test.stringBasics.js
@@ -1,59 +1,73 @@
 var assert = require('assert');
 var R = require('..');
 
-describe('substring', function() {
-    it('returns the substring of a string', function() {
-        assert.equal(R.substring(2, 5, 'abcdefghijklm'), 'cde');
+describe('concat', function() {
+    it('concatenates two strings', function() {
+        assert.strictEqual(R.string.concat('foo', 'bar'), 'foobar');
+    });
+
+    it('coerces non-string arguments', function() {
+        assert.strictEqual(R.string.concat(123, 456), '123456');
     });
 
     it('is automatically curried', function() {
-        var from2 = R.substring(2);
+        assert.strictEqual(R.string.concat('foo')('bar'), 'foobar');
+    });
+});
+
+describe('substring', function() {
+    it('returns the substring of a string', function() {
+        assert.equal(R.string.substring(2, 5, 'abcdefghijklm'), 'cde');
+    });
+
+    it('is automatically curried', function() {
+        var from2 = R.string.substring(2);
         assert.equal(from2(5, 'abcdefghijklm'), 'cde');
-        var from2to5 = R.substring(2, 5);
+        var from2to5 = R.string.substring(2, 5);
         assert.equal(from2to5('abcdefghijklm'), 'cde');
     });
 });
 
 describe('substringFrom', function() {
     it('returns the trailing substring of a string', function() {
-        assert.equal(R.substringFrom(8, 'abcdefghijklm'), 'ijklm');
+        assert.equal(R.string.substringFrom(8, 'abcdefghijklm'), 'ijklm');
     });
 
     it('is automatically curried', function() {
-        var after8 = R.substringFrom(8);
+        var after8 = R.string.substringFrom(8);
         assert.equal(after8('abcdefghijklm'), 'ijklm');
     });
 });
 
 describe('substringTo', function() {
     it('returns the trailing substring of a string', function() {
-        assert.equal(R.substringTo(8, 'abcdefghijklm'), 'abcdefgh');
+        assert.equal(R.string.substringTo(8, 'abcdefghijklm'), 'abcdefgh');
     });
 
     it('is automatically curried', function() {
-        var through8 = R.substringTo(8);
+        var through8 = R.string.substringTo(8);
         assert.equal(through8('abcdefghijklm'), 'abcdefgh');
     });
 });
 
 describe('charAt', function() {
     it('returns the character at the nth position of a string', function() {
-        assert.equal(R.charAt(8, 'abcdefghijklm'), 'i');
+        assert.equal(R.string.charAt(8, 'abcdefghijklm'), 'i');
     });
 
     it('is automatically curried', function() {
-        var at8 = R.charAt(8);
+        var at8 = R.string.charAt(8);
         assert.equal(at8('abcdefghijklm'), 'i');
     });
 });
 
 describe('charCodeAt', function() {
     it('returns the ascii character at the nth position of a string', function() {
-        assert.equal(R.charCodeAt(8, 'abcdefghijklm'), 105);  // 'a' ~ 97, 'b' ~ 98, ... 'i' ~ 105
+        assert.equal(R.string.charCodeAt(8, 'abcdefghijklm'), 105);  // 'a' ~ 97, 'b' ~ 98, ... 'i' ~ 105
     });
 
     it('is automatically curried', function() {
-        var at8 = R.charCodeAt(8);
+        var at8 = R.string.charCodeAt(8);
         assert.equal(at8('abcdefghijklm'), 105);
     });
 });
@@ -62,56 +76,56 @@ describe('match', function() {
     var re = /[A-Z]\d\d\-[a-zA-Z]+/;
 
     it('determines whether a string matches a regex', function() {
-        assert.equal(R.match(re, 'B17-afn').length, 1);
-        assert.equal(R.match(re, 'B1-afn'), null);
+        assert.equal(R.string.match(re, 'B17-afn').length, 1);
+        assert.equal(R.string.match(re, 'B1-afn'), null);
     });
 
     it('is automatically curried', function() {
-        var format = R.match(re);
+        var format = R.string.match(re);
         assert.equal(format('B17-afn').length, 1);
         assert.equal(format('B1-afn'), null);
     });
 });
 
-describe('strIndexOf', function() {
+describe('indexOf', function() {
     it('finds the index of a substring inside a string', function() {
-        assert.equal(R.strIndexOf('c', 'abcdefg'), 2);
+        assert.equal(R.string.indexOf('c', 'abcdefg'), 2);
     });
 
     it('returns -1 if the value is not found', function() {
-        assert.equal(R.strIndexOf('x', 'abcdefg'), -1);
+        assert.equal(R.string.indexOf('x', 'abcdefg'), -1);
     });
 
     it('is automatically curried', function() {
-        var findD = R.strIndexOf('d');
+        var findD = R.string.indexOf('d');
         assert.equal(findD('abcdefg'), 3);
     });
 });
 
-describe('strLastIndexOf', function() {
+describe('lastIndexOf', function() {
     it('finds the index of a substring inside a string', function() {
-        assert.equal(R.strLastIndexOf('a', 'bananas'), 5);
+        assert.equal(R.string.lastIndexOf('a', 'bananas'), 5);
     });
 
     it('returns -1 if the value is not found', function() {
-        assert.equal(R.strLastIndexOf('x', 'abcdefg'), -1);
+        assert.equal(R.string.lastIndexOf('x', 'abcdefg'), -1);
     });
 
     it('is automatically curried', function() {
-        var findA = R.strLastIndexOf('a');
+        var findA = R.string.lastIndexOf('a');
         assert.equal(findA('banana split'), 5);
     });
 });
 
 describe('toUpperCase', function() {
     it('returns the upper-case equivalent of the input string', function() {
-        assert.equal(R.toUpperCase('abc'), 'ABC');
+        assert.equal(R.string.toUpperCase('abc'), 'ABC');
     });
 });
 
 describe('toLowerCase', function() {
     it('returns the lower-case equivalent of the input string', function() {
-        assert.equal(R.toLowerCase('XYZ'), 'xyz');
+        assert.equal(R.string.toLowerCase('XYZ'), 'xyz');
     });
 });
 
@@ -119,36 +133,36 @@ describe('trim', function() {
     var test = '\x09\x0A\x0B\x0C\x0D\x20\xA0\u1680\u180E\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200A\u202F\u205F\u3000\u2028\u2029\uFEFFHello, World!\x09\x0A\x0B\x0C\x0D\x20\xA0\u1680\u180E\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200A\u202F\u205F\u3000\u2028\u2029\uFEFF';
 
     it('trims a string', function() {
-        assert.equal(R.trim('   xyz  '), 'xyz');
+        assert.equal(R.string.trim('   xyz  '), 'xyz');
     });
 
     it('trims all ES5 whitespace', function() {
-        assert.equal(R.trim(test), 'Hello, World!');
-        assert.equal(R.trim(test).length, 13);
+        assert.equal(R.string.trim(test), 'Hello, World!');
+        assert.equal(R.string.trim(test).length, 13);
     });
 
     it('does not trim the zero-width space', function() {
-        assert.equal(R.trim('\u200b'), '\u200b');
-        assert.equal(R.trim('\u200b').length, 1);
+        assert.equal(R.string.trim('\u200b'), '\u200b');
+        assert.equal(R.string.trim('\u200b').length, 1);
     });
 
     if (typeof String.prototype.trim !== 'function') {
         it('falls back to a shim if String.prototype.trim is not present', function() {
-            assert.equal(R.trim('   xyz  '), 'xyz');
-            assert.equal(R.trim(test), 'Hello, World!');
-            assert.equal(R.trim(test).length, 13);
-            assert.equal(R.trim('\u200b'), '\u200b');
-            assert.equal(R.trim('\u200b').length, 1);
+            assert.equal(R.string.trim('   xyz  '), 'xyz');
+            assert.equal(R.string.trim(test), 'Hello, World!');
+            assert.equal(R.string.trim(test).length, 13);
+            assert.equal(R.string.trim('\u200b'), '\u200b');
+            assert.equal(R.string.trim('\u200b').length, 1);
         });
     }
 });
 
 describe('split', function() {
     it('splits a string into an array', function() {
-        assert.deepEqual(R.split('.', 'a.b.c.xyz.d'), ['a', 'b', 'c', 'xyz', 'd']);
+        assert.deepEqual(R.string.split('.', 'a.b.c.xyz.d'), ['a', 'b', 'c', 'xyz', 'd']);
     });
 
     it('the split string can be arbitrary', function() {
-        assert.deepEqual(R.split('at', 'The Cat in the Hat sat on the mat'), ['The C', ' in the H', ' s', ' on the m', '']);
+        assert.deepEqual(R.string.split('at', 'The Cat in the Hat sat on the mat'), ['The C', ' in the H', ' s', ' on the m', '']);
     });
 });


### PR DESCRIPTION
`R.string.indexOf` is much nicer than `R.strIndexOf`. :)

I expect others will suggest using `R.str` as the namespace. If so, what would we use for other namespaces in future? `R.string` sets a clear precedent for Number, RegExp, etc.: `R[ctor.name.toLowerCase()]`.
