### PR TITLE
preserve currying in R.compose and R.pipe

### DIFF
--- a/ext/types/IO.js
+++ b/ext/types/IO.js
@@ -11,8 +11,7 @@
         // Browser globals (root is window)
         root.returnExports = factory(root.ramda);
     }
-}(this, function(R) {
-    var compose = R.compose;
+}(this, function() {
 
     function IO(fn) {
         if (!(this instanceof IO)) {
@@ -31,7 +30,9 @@
 
     IO.prototype.map = function(f) {
         var io = this;
-        return new IO(compose(f, io.fn));
+        return new IO(function() {
+            return f(io.fn.apply(io, arguments));
+        });
     };
 
     // `this` IO must wrap a function `f` that takes an IO (`thatIo`) as input

--- a/ramda.js
+++ b/ramda.js
@@ -1195,9 +1195,15 @@
      *      squareThenDouble(5); //≅ double(square(5)) => 50
      */
     function internalCompose(f, g) {
-        return function() {
-            return f.call(this, g.apply(this, arguments));
-        };
+        return arity(g.length, function() {
+            if (arguments.length < g.length) {
+                return internalCompose(f, g.apply(this, arguments));
+            } else {
+                var gArgs = _slice(arguments, 0, g.length);
+                var excessArgs = _slice(arguments, g.length);
+                return f.apply(this, [g.apply(this, gArgs)].concat(excessArgs));
+            }
+        });
     }
 
 
@@ -1235,11 +1241,11 @@
             case 0: throw noArgsException();
             case 1: return arguments[0];
             default:
-                var idx = arguments.length - 1, fn = arguments[idx], length = fn.length;
+                var idx = arguments.length - 1, fn = arguments[idx];
                 while (idx--) {
                     fn = internalCompose(arguments[idx], fn);
                 }
-                return arity(length, fn);
+                return fn;
         }
     };
 

--- a/test/test.compose.js
+++ b/test/test.compose.js
@@ -61,6 +61,15 @@ describe('compose', function() {
         assert.strictEqual(R.compose(f), f);
     });
 
+    it('forwards excess arguments', function() {
+        assert.strictEqual(R.compose(R.concat, R.I)('foo', 'bar', 'baz'), 'foobar');
+        function concat3(a, b, c) { return a + b + c; }
+        assert.strictEqual(R.compose(concat3, R.I)('foo', 'bar', 'baz'), 'foobarbaz');
+    });
+
+    it('preserves currying', function() {
+        assert.strictEqual(R.compose(Number, R.concat)('123')('456'), 123456);
+    });
 });
 
 describe('pipe', function() {
@@ -106,6 +115,16 @@ describe('pipe', function() {
     it('returns argument if given exactly one argument', function() {
         function f() {}
         assert.strictEqual(R.pipe(f), f);
+    });
+
+    it('forwards excess arguments', function() {
+        assert.strictEqual(R.pipe(R.I, R.concat)('foo', 'bar', 'baz'), 'foobar');
+        function concat3(a, b, c) { return a + b + c; }
+        assert.strictEqual(R.pipe(R.I, concat3)('foo', 'bar', 'baz'), 'foobarbaz');
+    });
+
+    it('preserves currying', function() {
+        assert.strictEqual(R.pipe(R.concat, Number)('123')('456'), 123456);
     });
 });
 


### PR DESCRIPTION
``` javascript
var f = R.pipe(R.concat, Number);
f.length;     // => 2
f('4', '2');  // => 42
f('4')('2');  // => Uncaught TypeError: number is not a function
```

My intuition suggested the last two expressions are equivalent.
