### PR TITLE
do not treat null/undefined as the empty list

### DIFF
--- a/ramda.js
+++ b/ramda.js
@@ -74,7 +74,7 @@
             case 1: return _slice(args, 0, args.length);
             case 2: return _slice(args, from, args.length);
             default:
-                var length = to - from, list = new Array(length), idx = -1;
+                var length = Math.max(0, to - from), list = new Array(length), idx = -1;
                 while (++idx < length) {
                     list[idx] = args[from + idx];
                 }
@@ -937,7 +937,7 @@
      *      R.nth(-1, list); //=> 'quux'
      *      R.nth(-99, list); //=> undefined
      */
-    R.nth = curry2(function nth(n, list) {
+    var nth = R.nth = curry2(function nth(n, list) {
         return n < 0 ? list[list.length + n] : list[n];
     });
 
@@ -957,10 +957,7 @@
      *
      *      R.head(['fi', 'fo', 'fum']); //=> 'fi'
      */
-    R.head = function head(list) {
-        list = list || [];
-        return list[0];
-    };
+    R.head = nth(0);
 
     /**
      * @func
@@ -984,10 +981,7 @@
      *
      *      R.last(['fi', 'fo', 'fum']); //=> 'fum'
      */
-    R.last = function _last(list) {
-        list = list || [];
-        return list[list.length - 1];
-    };
+    R.last = nth(-1);
 
 
     /**
@@ -1007,8 +1001,7 @@
      *      R.tail(['fi', 'fo', 'fum']); //=> ['fo', 'fum']
      */
     R.tail = checkForMethod('tail', function(list) {
-        list = list || [];
-        return (list.length > 1) ? _slice(list, 1) : [];
+        return _slice(list, 1);
     });
 
     /**

--- a/test/test.core.js
+++ b/test/test.core.js
@@ -114,17 +114,23 @@ describe('nth', function() {
     it('is curried', function() {
         assert.strictEqual(R.nth(0)(list), 'foo');
     });
+    it('throws if applied to null or undefined', function() {
+        assert.throws(function() { R.nth(0, null); }, TypeError);
+        assert.throws(function() { R.nth(0, undefined); }, TypeError);
+    });
 });
 
 describe('head', function() {
     it('returns undefined for an empty list', function() {
         assert.equal(typeof(R.head([])),  'undefined');
     });
-    it('returns undefined for no arguments', function() {
-        assert.equal(typeof(R.head()), 'undefined');
-    });
     it('returns the first element of a list', function() {
         assert.equal(R.head(['a', 'b', 'c', 'd']), 'a');
+    });
+    it('throws if applied to null or undefined', function() {
+        assert.throws(function() { R.head(null); }, TypeError);
+        assert.throws(function() { R.head(undefined); }, TypeError);
+        assert.throws(function() { R.head(); }, TypeError);
     });
 });
 
@@ -132,11 +138,13 @@ describe('last', function() {
     it('returns undefined for an empty list', function() {
         assert.equal(typeof(R.last([])),  'undefined');
     });
-    it('returns undefined for no arguments', function() {
-        assert.equal(typeof(R.last()), 'undefined');
-    });
     it('returns the first element of a list', function() {
         assert.equal(R.last(['a', 'b', 'c', 'd']), 'd');
+    });
+    it('throws if applied to null or undefined', function() {
+        assert.throws(function() { R.last(null); }, TypeError);
+        assert.throws(function() { R.last(undefined); }, TypeError);
+        assert.throws(function() { R.last(); }, TypeError);
     });
 });
 
@@ -144,11 +152,13 @@ describe('tail', function() {
     it('returns an empty list for an empty list', function() {
         assert.deepEqual(R.tail([]), []);
     });
-    it('returns an empty list for no arguments', function() {
-        assert.deepEqual(R.tail(), []);
-    });
     it('returns a new list containing all the elements after the first element of a list', function() {
         assert.deepEqual(['b', 'c', 'd'], R.tail(['a', 'b', 'c', 'd']));
+    });
+    it('throws if applied to null or undefined', function() {
+        assert.throws(function() { R.tail(null); }, TypeError);
+        assert.throws(function() { R.tail(undefined); }, TypeError);
+        assert.throws(function() { R.tail(); }, TypeError);
     });
 });
 


### PR DESCRIPTION
Ideally one knows the types of one's values. When this is not the case, one can apply `Object` to the value in question. For example:

``` javascript
var x = null;

R.head(x);
// => TypeError: Cannot read property '0' of null
R.head(Object(x));
// => undefined
```

I very much like the explicitness this change enforces. It is a breaking change, of course, but we're pre-1.0. ;)
