### PR TITLE
integrate envvar

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,10 +1,20 @@
+var envvar = require('envvar');
 var sauceConf = require('./sauce/conf');
 var sauceSrv = require('./sauce/server');
+
+var ORCHESTRATE_API_KEY = envvar.string('ORCHESTRATE_API_KEY', '');
+var SAUCE_ACCESS_KEY    = envvar.string('SAUCE_ACCESS_KEY', '');
+var TRAVIS_BRANCH       = envvar.string('TRAVIS_BRANCH', '');
+var TRAVIS_BUILD_ID     = envvar.string('TRAVIS_BUILD_ID', '');
+var TRAVIS_COMMIT       = envvar.string('TRAVIS_COMMIT', '');
+var TRAVIS_COMMIT_RANGE = envvar.string('TRAVIS_COMMIT_RANGE', '');
+var TRAVIS_NODE_VERSION = envvar.string('TRAVIS_NODE_VERSION', process.versions.node);
+var TRAVIS_TAG          = envvar.string('TRAVIS_TAG', '');
 
 module.exports = function(grunt) {
     grunt.initConfig({
 
-        orchestrate_token: process.env.ORCHESTRATE_API_KEY,
+        orchestrate_token: ORCHESTRATE_API_KEY,
 
         mocha: {
             browser: ['test/**/*.html'],
@@ -72,12 +82,12 @@ module.exports = function(grunt) {
                 json.timestamp = timestamp;
                 json.datestamp = (new Date(+timestamp)).toISOString();
                 json.platform = {
-                    branch: process.env.TRAVIS_BRANCH,
-                    buildId: process.env.TRAVIS_BUILD_ID,
-                    commit: process.env.TRAVIS_COMMIT,
-                    commitRange: process.env.TRAVIS_COMMIT_RANGE,
-                    tag: process.env.TRAVIS_TAG,
-                    node: process.env.TRAVIS_NODE_VERSION || process.versions.node
+                    branch:       TRAVIS_BRANCH,
+                    buildId:      TRAVIS_BUILD_ID,
+                    commit:       TRAVIS_COMMIT,
+                    commitRange:  TRAVIS_COMMIT_RANGE,
+                    tag:          TRAVIS_TAG,
+                    node:         TRAVIS_NODE_VERSION
                 };
                 json.report = grunt.file.readJSON(abspath);
                 db.put('benchmarks', json.timestamp, json)
@@ -95,8 +105,6 @@ module.exports = function(grunt) {
     });
 
     grunt.registerTask('bench', ['benchmark', 'uploadBenchmarks']);
-    grunt.registerTask('sauce', (function() {
-        return (typeof process.env.SAUCE_ACCESS_KEY === 'undefined') ? [] : ['connect', 'saucelabs-mocha'];
-    }()));
+    grunt.registerTask('sauce', SAUCE_ACCESS_KEY === '' ? [] : ['connect', 'saucelabs-mocha']);
     grunt.registerTask('test', ['jshint', 'jscs', 'mochaTest:test']);
 };

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "benchmark": "~1.0.0",
     "deedpoll": "0.2.x",
     "dox": "latest",
+    "envvar": "1.x.x",
     "grunt": "~0.4.5",
     "grunt-benchmark": "https://github.com/buzzdecafe/grunt-benchmark/archive/09999a8c3fbfff04a1695846c1ccd0bd8a0ef5ab.tar.gz",
     "grunt-cli": "~0.1.13",

--- a/sauce/conf.js
+++ b/sauce/conf.js
@@ -1,9 +1,10 @@
+var envvar = require('envvar');
 var browsers = require('./browsers');
 module.exports = {
     all: {
         options: {
             urls: ['localhost:3210/test/index.html'],
-            build: process.env.CI_BUILD_NUMBER || 0,
+            build: envvar.number('CI_BUILD_NUMBER', 0),
             testname: 'Ramda Sauce Unit Test',
             browsers: browsers
         }


### PR DESCRIPTION
[envvar](https://github.com/plaid/envvar) is a tiny package for dealing with environment variables in a more rigorous manner.

There's so much imprecision in an expression such as the following:

``` javascript
process.env.CI_BUILD_NUMBER || 0
```

The result of the expression will be a string or a number depending on whether `CI_BUILD_NUMBER` is set and, if so, whether its value is `''`. There's no validation, so the result may be `'XXX'`.

I realize this imprecision is _usually_ okay in practice, so I won't be offended if you decide not to merge this pull request. :)
