### PR TITLE
fix hasMethod to fix R.concat('')

### DIFF
--- a/ramda.js
+++ b/ramda.js
@@ -377,7 +377,7 @@
      *      hasMethod('foo', person); //=> false
      */
     var hasMethod = function _hasMethod(methodName, obj) {
-        return obj && !isArray(obj) && typeof obj[methodName] === 'function';
+        return obj != null && !isArray(obj) && typeof obj[methodName] === 'function';
     };
 
 

--- a/test/test.core.js
+++ b/test/test.core.js
@@ -80,6 +80,9 @@ describe('concat', function() {
     });
     it('works on strings', function() {
         assert.equal(R.concat('foo', 'bar'), 'foobar');
+        assert.equal(R.concat('x', ''), 'x');
+        assert.equal(R.concat('', 'x'), 'x');
+        assert.equal(R.concat('', ''), '');
     });
     it('delegates to non-String object with a concat method, as second param', function() {
         assert.equal(R.concat(z1, z2), 'z1 z2');


### PR DESCRIPTION
Current behaviour:

``` javascript
R.concat('', 'x');
// => TypeError: can't concat string
```
