### PR TITLE
add R.unapply

### DIFF
--- a/ramda.js
+++ b/ramda.js
@@ -1246,6 +1246,39 @@
 
 
     /**
+     * Takes a function `fn`, which takes a single array argument, and returns
+     * a function which:
+     *
+     *   - takes any number of positional arguments;
+     *   - passes these arguments to `fn` as an array; and
+     *   - returns the result.
+     *
+     * In other words, R.unapply derives a variadic function from a function
+     * which takes an array. R.unapply is the inverse of R.apply.
+     *
+     * @func
+     * @memberOf R
+     * @category core
+     * @category Function
+     * @sig ([*...] -> a) -> (*... -> a)
+     * @param {Function} fn
+     * @return {Function}
+     * @see R.apply
+     * @example
+     *
+     *      R.unapply(JSON.stringify)(1, 2, 3); //=> '[1,2,3]'
+     */
+    R.unapply = function unapply(fn) {
+        if (arguments.length === 0) {
+            throw _noArgsException();
+        }
+        return function() {
+            return fn(_slice(arguments));
+        };
+    };
+
+
+    /**
      * Basic, right-associative composition function. Accepts two functions and returns the
      * composite function; this composite function represents the operation `var h = f(g(x))`,
      * where `f` is the first argument, `g` is the second argument, and `x` is whatever

--- a/test/test.functionBasics.js
+++ b/test/test.functionBasics.js
@@ -17,6 +17,56 @@ describe('apply', function() {
     });
 });
 
+describe('unapply', function() {
+    it('returns a function which is always passed one argument', function() {
+        var fn = R.unapply(function() { return arguments.length; });
+        assert.strictEqual(fn(), 1);
+        assert.strictEqual(fn('x'), 1);
+        assert.strictEqual(fn('x', 'y'), 1);
+        assert.strictEqual(fn('x', 'y', 'z'), 1);
+    });
+
+    it('forwards arguments to decorated function as an array', function() {
+        var fn = R.unapply(JSON.stringify);
+        assert.strictEqual(fn(), '[]');
+        assert.strictEqual(fn(2), '[2]');
+        assert.strictEqual(fn(2, 4), '[2,4]');
+        assert.strictEqual(fn(2, 4, 6), '[2,4,6]');
+    });
+
+    it('returns a function with length 0', function() {
+        var fn = R.unapply(R.identity);
+        assert.strictEqual(fn.length, 0);
+    });
+
+    it('throws on zero arguments', function() {
+        assert.throws(R.unapply, TypeError);
+    });
+
+    it('is the inverse of R.apply', function() {
+        var a, b, c, d, e, f, g, idx;
+        var rand = function() {
+            return Math.floor(200 * Math.random()) - 100;
+        };
+
+        f = Math.max;
+        g = R.unapply(R.apply(f));
+        idx = 100;
+        while (idx--) {
+            a = rand(); b = rand(); c = rand(); d = rand(); e = rand();
+            assert.strictEqual(f(a, b, c, d, e), g(a, b, c, d, e));
+        }
+
+        f = JSON.stringify;
+        g = R.apply(R.unapply(f));
+        idx = 100;
+        while (idx--) {
+            a = rand(); b = rand(); c = rand(); d = rand(); e = rand();
+            assert.strictEqual(f([a, b, c, d, e]), g([a, b, c, d, e]));
+        }
+    });
+});
+
 describe('flip', function() {
     it('returns a function which inverts the first two arguments to the supplied function', function() {
         var f = function(a, b, c) {return a + ' ' + b + ' ' + c;};


### PR DESCRIPTION
I've wanted this confusing function several times in the last month or so. It stewed in the back of my mind while I thought of possible names. Today I decided the placeholder name, `unapply`, is in fact the right name, given the `f`/`unapply(apply(f))` equivalence.

This function _could_ be used to define the identity functions discussed in #511:

``` javascript
var identity1 = R.compose(R.nth(1), R.unapply(R.identity));
var identity2 = R.compose(R.nth(2), R.unapply(R.identity));

identity1('a', 'b', 'c');  // => 'b'
identity2('a', 'b', 'c');  // => 'c'
```

`R.unapply` is useful for the same reason these identity functions are useful: one can reference specific elements of the arguments object, facilitating composition. `R.unapply` is more general, though, so I'm confident other uses will emerge. Even having a function for creating arrays is useful at times:

``` javascript
R.unapply(R.identity)(1, 2, 3, 4, 5);  // => [1, 2, 3, 4, 5]
```
