### PR TITLE
add R.cond and rename existing function of that name

### DIFF
--- a/ramda.js
+++ b/ramda.js
@@ -4640,16 +4640,66 @@
      * @example
      *
      *      // Flatten all arrays in the list and return whatever is not an array
-     *      var flattenArrays = R.map(R.cond(Array.isArray, R.flatten, R.identity));
+     *      var flattenArrays = R.map(R.ifElse(Array.isArray, R.flatten, R.identity));
      *
      *      flattenArrays([[0], [[10], [8]], 1234, {}]); //=> [[0], [10, 8], 1234, {}]
      *      flattenArrays([[[10], 123], [8, [10]], "hello"]); //=> [[10, 123], [8, 10], "hello"]
      */
-    R.cond = _curry3(function cond(condition, onTrue, onFalse) {
-        return function _cond() {
+    var ifElse = R.ifElse = _curry3(function ifElse(condition, onTrue, onFalse) {
+        return function _ifElse() {
             return condition.apply(this, arguments) ? onTrue.apply(this, arguments) : onFalse.apply(this, arguments);
         };
     });
+
+    /**
+     * This function can safely be referenced as `R.if` in some environments
+     * (e.g. Node.js) or when writing code in a language which transcompiles
+     * to JavaScript. In such situations, `R.if` is the preferred name.
+     *
+     * @func
+     * @memberOf R
+     * @category Core
+     * @see R.ifElse
+     */
+    R['if'] = ifElse;
+
+
+    /**
+     * Returns a function, `fn`, which encapsulates if/else-if/else logic.
+     * Each argument to `R.cond` is a [predicate, transform] pair. All of
+     * the arguments to `fn` are applied to each of the predicates in turn
+     * until one returns a "truthy" value, at which point `fn` returns the
+     * result of applying its arguments to the corresponding transformer.
+     * If none of the predicates matches, `fn` returns undefined.
+     *
+     * @func
+     * @memberOf R
+     * @category logic
+     * @sig [(*... -> Boolean),(*... -> *)]... -> (*... -> *)
+     * @param {...Function} functions
+     * @returns {Function}
+     * @example
+     *
+     *      var fn = R.cond(
+     *          [R.eq(0),      R.always('water freezes at 0°C')],
+     *          [R.eq(100),    R.always('water boils at 100°C')],
+     *          [R.alwaysTrue, function(temp) { return 'nothing special happens at ' + temp + '°C'; }]
+     *      );
+     *      fn(0); //=> 'water freezes at 0°C'
+     *      fn(50); //=> 'nothing special happens at 50°C'
+     *      fn(100); //=> 'water boils at 100°C'
+     */
+    R.cond = function cond() {
+        var pairs = arguments;
+        return function() {
+            var idx = -1;
+            while (++idx < pairs.length) {
+                if (pairs[idx][0].apply(this, arguments)) {
+                    return pairs[idx][1].apply(this, arguments);
+                }
+            }
+        };
+    };
 
 
     // Arithmetic Functions

--- a/test/test.cond.js
+++ b/test/test.cond.js
@@ -1,24 +1,24 @@
 var assert = require('assert');
 var R = require('..');
 
-describe('cond', function() {
+describe('ifElse', function() {
     var t = function(a) { return a + 1; };
     var identity = function(a) { return a; };
     var isArray = function(a) { return Object.prototype.toString.call(a) === '[object Array]'; };
 
     it('calls the truth case function if the validator returns a truthy value', function() {
         var v = function(a) { return typeof a === 'number'; };
-        assert.equal(R.cond(v, t, identity)(10), 11);
+        assert.equal(R.ifElse(v, t, identity)(10), 11);
     });
 
     it('calls the false case function if the validator returns a falsey value', function() {
         var v = function(a) { return typeof a === 'number'; };
-        assert.equal(R.cond(v, t, identity)('hello'), 'hello');
+        assert.equal(R.ifElse(v, t, identity)('hello'), 'hello');
     });
 
     it('calls the true case on array items and the false case on non array items', function() {
         var list = [[1, 2, 3, 4, 5], 10, [0, 1], 15];
-        var arrayToLength = R.map(R.cond(isArray, R.prop('length'), identity));
+        var arrayToLength = R.map(R.ifElse(isArray, R.prop('length'), identity));
         assert.deepEqual(arrayToLength(list), [5, 10, 2, 15]);
     });
 
@@ -28,7 +28,7 @@ describe('cond', function() {
             assert.equal(a, 123);
             assert.equal(b, 'abc');
         };
-        R.cond(v, onTrue, identity)(123, 'abc');
+        R.ifElse(v, onTrue, identity)(123, 'abc');
     });
 
     it('passes the arguments to the false case function', function() {
@@ -37,14 +37,58 @@ describe('cond', function() {
             assert.equal(a, 123);
             assert.equal(b, 'abc');
         };
-        R.cond(v, identity, onFalse)(123, 'abc');
+        R.ifElse(v, identity, onFalse)(123, 'abc');
     });
 
     it('returns a curried function', function() {
         var v = function(a) { return typeof a === 'number'; };
-        var ifIsNumber = R.cond(v);
+        var ifIsNumber = R.ifElse(v);
         assert.equal(ifIsNumber(t, identity)(15), 16);
         assert.equal(ifIsNumber(t, identity)('hello'), 'hello');
     });
+
+    it('is aliased by `if`', function() {
+        assert.strictEqual(R['if'], R.ifElse);
+    });
 });
 
+describe('cond', function() {
+    it('returns a function', function() {
+        assert.strictEqual(typeof R.cond(), 'function');
+    });
+
+    it('returns a conditional function', function() {
+        var fn = R.cond(
+            [R.eq(0),      R.always('water freezes at 0°C')],
+            [R.eq(100),    R.always('water boils at 100°C')],
+            [R.alwaysTrue, function(temp) { return 'nothing special happens at ' + temp + '°C'; }]
+        );
+        assert.strictEqual(fn(0), 'water freezes at 0°C');
+        assert.strictEqual(fn(50), 'nothing special happens at 50°C');
+        assert.strictEqual(fn(100), 'water boils at 100°C');
+    });
+
+    it('returns a function which returns undefined if none of the predicates matches', function() {
+        var fn = R.cond(
+            [R.eq('foo'), R.always(1)],
+            [R.eq('bar'), R.always(2)]
+        );
+        assert.strictEqual(fn('quux'), undefined);
+    });
+
+    it('predicates are tested in order', function() {
+        var fn = R.cond(
+            [R.alwaysTrue, R.always('foo')],
+            [R.alwaysTrue, R.always('bar')],
+            [R.alwaysTrue, R.always('baz')]
+        );
+        assert.strictEqual(fn(), 'foo');
+    });
+
+    it('forwards all arguments to predicates and to transformers', function() {
+        var fn = R.cond(
+            [function(_, x) { return x == 42; }, function() { return arguments.length; }]
+        );
+        assert.strictEqual(fn(21, 42, 84), 3);
+    });
+});


### PR DESCRIPTION
This is a function from the Lisp world I would very much like to use in my Ramda code. It can be used similarly to `R.type` to switch based on type:

``` javascript
var sumNested = R.cond(
  [R.is(Number), R.identity],
  [R.is(Array), function(xs) { return R.sum(R.map(sumNested, xs)); }],
  [R.alwaysTrue, R.alwaysZero]
);

sumNested([1, [2, [3, [4, 'foo'], true, 5]]]);  // => 15
```

It's more general than `R.type`, though, so I'm sure we'll find plenty of other uses. :)
