### PR TITLE
Adding promise-aware function composition.

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "grunt-saucelabs": "^8.3.1",
     "lodash": "latest",
     "orchestrate": "~0.3.4",
+    "q": "^1.1.1",
     "testem": "^0.6.18",
     "uglify-js": "2.4.x",
     "xyz": "0.4.x"


### PR DESCRIPTION
Compose would now handle promises returned by any of the composed functions. The resulting function
will evaluate to a promise if any one of the composed functions returns a promise. If all of the composed functions return something other than a promise, then the behaviour of compose() is the same as it was before. In this sense the change is fully backwards compatible.

I added one new test and modified two tests to test promises. I added Q to dev dependencies to test promise support. However, Q is not necessary at run time, and this implementation should work with any promise implementation.

See https://github.com/ramda/ramda/issues/512 for discussion.
