### PR TITLE
commute and commuteMap

### DIFF
--- a/ramda.js
+++ b/ramda.js
@@ -1947,7 +1947,7 @@
         return result;
     }
 
-    R.map = _curry2(_checkForMethod('map', _map));
+    var map = R.map = _curry2(_checkForMethod('map', _map));
 
 
     /**
@@ -2223,6 +2223,70 @@
     R.chain = _curry2(_checkForMethod('chain', function chain(f, list) {
         return unnest(_map(f, list));
     }));
+
+
+    /**
+     * Turns a list of Functors into a Functor of a list, applying
+     * a mapping function to the elements of the list along the way.
+     *
+     * Note: `commuteMap` may be more useful to convert a list of non-Array Functors (e.g.
+     * Maybe, Either, etc.) to Functor of a list.
+     *
+     * @func
+     * @memberOf R
+     * @category List
+     * @see R.commute
+     * @sig (a -> (b -> c)) -> (x -> [x]) -> [[*]...]
+     * @param {Function} fn The transformation function
+     * @param {Function} of A function that returns the data type to return
+     * @param {Array} list An Array (or other Functor) of Arrays (or other Functors)
+     * @return {Array}
+     * @example
+     *
+     *     var plus10map = R.map(function(x) { return x + 10; });
+     *     var as = [[1], [3, 4]];
+     *     R.commuteMap(R.map(function(x) { return x + 10; }), R.of, as); //=> [[11, 13], [11, 14]]
+     *
+     *     var bs = [[1, 2], [3]];
+     *     R.commuteMap(plus10map, R.of, bs); //=> [[11, 13], [12, 13]]
+     *
+     *     var cs = [[1, 2], [3, 4]];
+     *     R.commuteMap(plus10map, R.of, cs); //=> [[11, 13], [12, 13], [11, 14], [12, 14]]
+     *
+     */
+    var commuteMap = R.commuteMap = _curry3(function commuteMap(fn, of, list) {
+        function consF(acc, ftor) {
+            return ap(map(append, fn(ftor)), acc);
+        }
+        return reduce(consF, of([]), list);
+    });
+
+    /**
+     * Turns a list of Functors into a Functor of a list.
+     *
+     * Note: `commute` may be more useful to convert a list of non-Array Functors (e.g.
+     * Maybe, Either, etc.) to Functor of a list.
+     *
+     * @func
+     * @memberOf R
+     * @category List
+     * @see R.commuteMap
+     * @sig (x -> [x]) -> [[*]...]
+     * @param {Function} of A function that returns the data type to return
+     * @param {Array} list An Array (or other Functor) of Arrays (or other Functors)
+     * @return {Array}
+     * @example
+     *
+     *     var as = [[1], [3, 4]];
+     *     R.commute(R.of, as); //=> [[1, 3], [1, 4]]
+     *
+     *     var bs = [[1, 2], [3]];
+     *     R.commute(R.of, bs); //=> [[1, 3], [2, 3]]
+     *
+     *     var cs = [[1, 2], [3, 4]];
+     *     R.commute(R.of, cs); //=> [[1, 3], [2, 3], [1, 4], [2, 4]]
+     */
+    R.commute = commuteMap(map(identity));
 
 
     /**

--- a/test/index.html
+++ b/test/index.html
@@ -58,6 +58,7 @@
   <script src="test.is.js"></script>
   <script src="test.bind.js"></script>
   <script src="test.lens.js"></script>
+  <script src="test.commute.js"></script>
   <script src="../ext/lazylist/test/test.lazy.js"></script>
   <script src="../sauce/mocharun.js"></script>
 </body>

--- a/test/test.commute.js
+++ b/test/test.commute.js
@@ -1,0 +1,43 @@
+var assert = require('assert');
+var R = require('..');
+
+var as = [[1], [3, 4]];
+var bs = [[1, 2], [3]];
+var cs = [[1, 2], [3, 4]];
+
+describe('commute', function() {
+    it('"pivots" a list (list of functors => functor of a list)', function() {
+        assert.deepEqual(R.commute(R.of, as), [[1, 3], [1, 4]]);
+        assert.deepEqual(R.commute(R.of, bs), [[1, 3], [2, 3]]);
+        assert.deepEqual(R.commute(R.of, cs), [[1, 3], [2, 3], [1, 4], [2, 4]]);
+    });
+
+    it('is curried', function() {
+        var cmtArr = R.commute(R.of);
+        assert(typeof cmtArr === 'function');
+        assert.deepEqual(cmtArr(as), [[1, 3], [1, 4]]);
+        assert.deepEqual(cmtArr(bs), [[1, 3], [2, 3]]);
+        assert.deepEqual(cmtArr(cs), [[1, 3], [2, 3], [1, 4], [2, 4]]);
+
+    });
+});
+
+describe('commuteMap', function() {
+    var plus10map = R.map(function(x) { return x + 10; });
+    it('"pivots" a list (list of functors => functor of a list) and applies a transformation', function() {
+        assert.deepEqual(R.commuteMap(plus10map, R.of, as), [[11, 13], [11, 14]]);
+        assert.deepEqual(R.commuteMap(plus10map, R.of, bs), [[11, 13], [12, 13]]);
+        assert.deepEqual(R.commuteMap(plus10map, R.of, cs), [[11, 13], [12, 13], [11, 14], [12, 14]]);
+    });
+
+    it('is curried', function() {
+        var cmtPlus10 = R.commuteMap(plus10map);
+        assert(typeof cmtPlus10 === 'function');
+
+        var cmtmArr = cmtPlus10(R.of);
+        assert(typeof cmtmArr === 'function');
+        assert.deepEqual(cmtmArr(as), [[11, 13], [11, 14]]);
+        assert.deepEqual(cmtmArr(bs), [[11, 13], [12, 13]]);
+        assert.deepEqual(cmtmArr(cs), [[11, 13], [12, 13], [11, 14], [12, 14]]);
+    });
+});


### PR DESCRIPTION
Been thinking this over for a while (see #441). The utility of `commute` in Array-of-Array scenarios is not obvious--but `commute` shines in situations where you want to convert a list of Functors (Maybe, Either, even Promise?, etc.) to a Functor of a list. 
