### PR TITLE
allow examples to require()

### DIFF
--- a/test/test.examplesRunner.js
+++ b/test/test.examplesRunner.js
@@ -92,6 +92,7 @@ function assertPairEqual(test_info) {
 
 function requireFromStr(src, filename) {
     var m = new module.constructor();
+    m.paths = module.paths;
     m._compile(src, filename);
     return m.exports;
 }


### PR DESCRIPTION
Re https://github.com/ramda/ramda/pull/524#issuecomment-63263691

Solution from:

http://stackoverflow.com/questions/17581830/load-node-js-module-from-string-in-memory
