### PR TITLE
update R.isEmpty to return false for 0, -0, and NaN

### DIFF
--- a/ramda.js
+++ b/ramda.js
@@ -864,24 +864,25 @@
 
 
     /**
-     * Reports whether an array is empty.
+     * Reports whether a value is "empty".
+     * Empty values are null, undefined, "", and every object with a length
+     * property whose value is 0 (such as an empty array).
      *
      * @func
      * @memberOf R
-     * @category List
-     * @sig [a] -> Boolean
-     * @param {Array} list The array to consider.
-     * @return {Boolean} `true` if the `list` argument has a length of 0 or
-     *         if `list` is a falsy value (e.g. undefined).
+     * @category Core
+     * @sig * -> Boolean
+     * @param {*} val
+     * @return {Boolean}
      * @example
      *
      *      R.isEmpty([1, 2, 3]); //=> false
      *      R.isEmpty([]); //=> true
-     *      R.isEmpty(); //=> true
+     *      R.isEmpty(''); //=> true
      *      R.isEmpty(null); //=> true
      */
-    var isEmpty = R.isEmpty = function isEmpty(list) {
-        return !list || !list.length;
+    var isEmpty = R.isEmpty = function isEmpty(val) {
+        return val == null || val.length === 0;
     };
 
 

--- a/test/test.core.js
+++ b/test/test.core.js
@@ -2,21 +2,46 @@ var assert = require('assert');
 var R = require('..');
 
 describe('isEmpty', function() {
-    it('returns true if the list is empty', function() {
-        assert.equal(R.isEmpty([]), true);
+    it('returns true for null', function() {
+        assert.strictEqual(R.isEmpty(null), true);
     });
 
-    it('returns false if the list is not empty', function() {
-        assert.equal(R.isEmpty(['']), false);
+    it('returns true for undefined', function() {
+        assert.strictEqual(R.isEmpty(undefined), true);
+        assert.strictEqual(R.isEmpty(), true);
     });
 
-    it('returns `true` for falsy arguments', function() {
-        assert.equal(R.isEmpty(), true);
-        assert.equal(R.isEmpty(null), true);
-        assert.equal(R.isEmpty(0), true);
-        assert.equal(R.isEmpty(''), true);
-        assert.equal(R.isEmpty(NaN), true);
-        assert.equal(R.isEmpty({valueOf: function() { return false; }}), true);
+    it('returns true for empty string', function() {
+        assert.strictEqual(R.isEmpty(''), true);
+    });
+
+    it('returns true for empty array', function() {
+        assert.strictEqual(R.isEmpty([]), true);
+    });
+
+    it('returns true for empty arguments object', function() {
+        assert.strictEqual(R.isEmpty((function() { return arguments; }())), true);
+    });
+
+    it('returns true for object with own length property whose value is 0', function() {
+        assert.strictEqual(R.isEmpty({length: 0, x: 1, y: 2}), true);
+    });
+
+    it('returns true for object with inherited length property whose value is 0', function() {
+        function Empty() {}
+        Empty.prototype.length = 0;
+        assert.strictEqual(R.isEmpty(new Empty()), true);
+    });
+
+    it('returns false for every other value', function() {
+        assert.strictEqual(R.isEmpty(0), false);
+        assert.strictEqual(R.isEmpty(NaN), false);
+        assert.strictEqual(R.isEmpty(['']), false);
+        assert.strictEqual(R.isEmpty({}), false);
+
+        function Nonempty() {}
+        Nonempty.prototype.length = 1;
+        assert.strictEqual(R.isEmpty(new Nonempty()), false);
     });
 });
 


### PR DESCRIPTION
The current semantics offend me: it's nonsensical to ask whether a number is empty, so short of throwing a TypeError the only sensible response to such a question is “no”. Only _collections_ can be empty/nonempty, strictly speaking. Since `{}` is an empty collection, I argue `R.isEmpty({})` should return true. If others agree I will open a separate pull request for that change. I'd like this PR to remain focused on `0`, `-0`, and `NaN`.
