### PR TITLE
fix converge doc to accept 2 functions

### DIFF
--- a/ramda.js
+++ b/ramda.js
@@ -1645,7 +1645,7 @@
      * @func
      * @memberOf R
      * @category Function
-     * @sig ((*... -> c) -> (((* -> a), (* -> b), ...) -> c)
+     * @sig ((*... -> c) -> (((* -> a), ...) -> c)
      * @param {Function} after A function. `after` will be invoked with the return values of
      *        `fn1` and `fn2` as its arguments.
      * @param {...Function} functions A variable number of functions.


### PR DESCRIPTION
R.converge also works with 2 functions, fixed the doc.

``` js
var split = R.converge(R.split('.'), R.I)
log(
    split('H.e.l.l.l.o') // => ["H", "e", "l", "l", "l", "o"]
)
```
