### PR TITLE
make R.isEmpty equivalent to _.isEmpty

### DIFF
--- a/ramda.js
+++ b/ramda.js
@@ -870,8 +870,8 @@
 
     /**
      * Reports whether a value is "empty".
-     * Empty values are null, undefined, "", and every object with a length
-     * property whose value is 0 (such as an empty array).
+     * Empty values are null, undefined, "", array-likes with length 0,
+     * and objects with no enumerable own-properties.
      *
      * @func
      * @memberOf R
@@ -883,11 +883,23 @@
      *
      *      R.isEmpty([1, 2, 3]); //=> false
      *      R.isEmpty([]); //=> true
+     *      R.isEmpty({}); //=> true
      *      R.isEmpty(''); //=> true
      *      R.isEmpty(null); //=> true
      */
-    var isEmpty = R.isEmpty = function isEmpty(val) {
-        return val == null || val.length === 0;
+    R.isEmpty = function isEmpty(val) {
+        if (val == null) {
+            return true;
+        }
+        if (isArrayLike(val)) {
+            return val.length === 0;
+        }
+        for (var prop in val) {
+            if (_hasOwnProperty.call(val, prop)) {
+                return false;
+            }
+        }
+        return true;
     };
 
 
@@ -3298,7 +3310,7 @@
      *      R.xprod([1, 2], ['a', 'b']); //=> [[1, 'a'], [1, 'b'], [2, 'a'], [2, 'b']]
      */
     R.xprod = _curry2(function xprod(a, b) { // = xprodWith(prepend); (takes about 3 times as long...)
-        if (isEmpty(a) || isEmpty(b)) {
+        if (a.length === 0 || b.length === 0) {
             return [];
         }
         var idx = -1;

--- a/test/test.core.js
+++ b/test/test.core.js
@@ -13,35 +13,44 @@ describe('isEmpty', function() {
 
     it('returns true for empty string', function() {
         assert.strictEqual(R.isEmpty(''), true);
+        assert.strictEqual(R.isEmpty(' '), false);
     });
 
     it('returns true for empty array', function() {
         assert.strictEqual(R.isEmpty([]), true);
+        assert.strictEqual(R.isEmpty(['']), false);
+    });
+
+    it('returns true for empty object', function() {
+        assert.strictEqual(R.isEmpty({}), true);
+        assert.strictEqual(R.isEmpty({'': ''}), false);
     });
 
     it('returns true for empty arguments object', function() {
         assert.strictEqual(R.isEmpty((function() { return arguments; }())), true);
+        assert.strictEqual(R.isEmpty((function() { return arguments; }(''))), false);
     });
 
-    it('returns true for object with own length property whose value is 0', function() {
+    it('returns true for array-like with length 0', function() {
+        assert.strictEqual(R.isEmpty({length: 0}), true);
         assert.strictEqual(R.isEmpty({length: 0, x: 1, y: 2}), true);
+        assert.strictEqual(R.isEmpty({length: 1, 0: ''}), false);
+        assert.strictEqual(R.isEmpty({length: '0'}), false);
     });
 
-    it('returns true for object with inherited length property whose value is 0', function() {
-        function Empty() {}
-        Empty.prototype.length = 0;
-        assert.strictEqual(R.isEmpty(new Empty()), true);
+    it('returns true for object with inherited properties only', function() {
+        assert.strictEqual(R.isEmpty(new RegExp('x')), true);
     });
 
-    it('returns false for every other value', function() {
-        assert.strictEqual(R.isEmpty(0), false);
-        assert.strictEqual(R.isEmpty(NaN), false);
-        assert.strictEqual(R.isEmpty(['']), false);
-        assert.strictEqual(R.isEmpty({}), false);
-
-        function Nonempty() {}
-        Nonempty.prototype.length = 1;
-        assert.strictEqual(R.isEmpty(new Nonempty()), false);
+    it('returns true for number', function() {
+        assert.strictEqual(R.isEmpty(0), true);
+        assert.strictEqual(R.isEmpty(42), true);
+        assert.strictEqual(R.isEmpty(Infinity), true);
+        assert.strictEqual(R.isEmpty(-Infinity), true);
+        assert.strictEqual(R.isEmpty(NaN), true);
+        /* jshint -W053 */
+        assert.strictEqual(R.isEmpty(new Number(-1)), true);
+        /* jshint +W053 */
     });
 });
 


### PR DESCRIPTION
Closes #538

[Underscore](https://github.com/jashkenas/underscore/blob/1.7.0/underscore.js#L1068-L1075):

``` javascript
// Is a given array, string, or object empty?
// An "empty" object has no enumerable own-properties.
_.isEmpty = function(obj) {
  if (obj == null) return true;
  if (_.isArray(obj) || _.isString(obj) || _.isArguments(obj)) return obj.length === 0;
  for (var key in obj) if (_.has(obj, key)) return false;
  return true;
};
```
