### PR TITLE
rename R.size and handle null/undefined argument

### DIFF
--- a/ramda.js
+++ b/ramda.js
@@ -2434,23 +2434,15 @@
      * @category List
      * @sig [a] -> Number
      * @param {Array} list The array to inspect.
-     * @return {Number} The size of the array.
+     * @return {Number} The length of the array.
      * @example
      *
-     *      R.size([]); //=> 0
-     *      R.size([1, 2, 3]); //=> 3
+     *      R.length([]); //=> 0
+     *      R.length([1, 2, 3]); //=> 3
      */
-    var size = R.size = function size(list) {
-        return list.length;
+    R.length = function length(list) {
+        return list != null && is(Number, list.length) ? list.length : NaN;
     };
-
-    /**
-     * @func
-     * @memberOf R
-     * @category List
-     * @see R.size
-     */
-    R.length = size;
 
 
     function _filter(fn, list) {

--- a/test/test.core.js
+++ b/test/test.core.js
@@ -230,15 +230,44 @@ describe('tail', function() {
     });
 });
 
-describe('size', function() {
-    it('counts the elements of a list', function() {
-        assert.equal(R.size(['a', 'b', 'c', 'd']), 4);
+describe('length', function() {
+    it('returns the length of a list', function() {
+        assert.strictEqual(R.length([]), 0);
+        assert.strictEqual(R.length(['a', 'b', 'c', 'd']), 4);
     });
 
-    it('is aliased by `length`', function() {
-        assert.strictEqual(R.length, R.size);
+    it('returns the length of a string', function() {
+        assert.strictEqual(R.length(''), 0);
+        assert.strictEqual(R.length('xyz'), 3);
     });
 
+    it('returns the length of a function', function() {
+        assert.strictEqual(R.length(function() {}), 0);
+        assert.strictEqual(R.length(function(x, y, z) { return z; }), 3);
+    });
+
+    it('returns the length of an arguments object', function() {
+        assert.strictEqual(R.length((function() { return arguments; }())), 0);
+        assert.strictEqual(R.length((function() { return arguments; }('x', 'y', 'z'))), 3);
+    });
+
+    it('returns NaN for value of unexpected type', function() {
+        function isNaN_(x) { return x !== x; }
+        assert(isNaN_(R.length(0)));
+        assert(isNaN_(R.length({})));
+        assert(isNaN_(R.length(null)));
+        assert(isNaN_(R.length(undefined)));
+        assert(isNaN_(R.length()));
+    });
+
+    it('returns NaN for length property of unexpected type', function() {
+        function isNaN_(x) { return x !== x; }
+        assert(isNaN_(R.length({length: ''})));
+        assert(isNaN_(R.length({length: '1.23'})));
+        assert(isNaN_(R.length({length: null})));
+        assert(isNaN_(R.length({length: undefined})));
+        assert(isNaN_(R.length({})));
+    });
 });
 
 describe('sort', function() {


### PR DESCRIPTION
I suggest we remove this function: `R.prop('length')` is short and wonderfully explicit.

If we decide to keep this function it should be named `R.length` rather than `R.size`. I'd expect `R.size({})` to return 1 rather than undefined. `R.length` is clearer. `R.prop('length')` is best of all. ;)

For consistency with `R.isEmpty` we should handle a null/undefined argument.
