### PR TITLE
reference 'objects' in eqProps documentation description

### DIFF
--- a/ramda.js
+++ b/ramda.js
@@ -4426,7 +4426,7 @@
 
 
     /**
-     * Reports whether two functions have the same value for the specified property.  Useful as a curried predicate.
+     * Reports whether two objects have the same value for the specified property.  Useful as a curried predicate.
      *
      * @func
      * @memberOf R


### PR DESCRIPTION
Tidies up a documentation inaccuracy for eqProps.

Please see issue [544](https://github.com/ramda/ramda/issues/544)
