### PR TITLE
Fix UMD globals for browser-like environments in types.

### DIFF
--- a/ext/types/Either.js
+++ b/ext/types/Either.js
@@ -9,7 +9,7 @@
         module.exports = factory();
     } else {
         // Browser globals
-        this.returnExports = factory();
+        this.Either = factory();
     }
 }(function() {
 

--- a/ext/types/Future.js
+++ b/ext/types/Future.js
@@ -9,7 +9,7 @@
         module.exports = factory();
     } else {
         // Browser globals
-        this.returnExports = factory();
+        this.Future = factory();
     }
 }(function() {
     // `f` is a function that takes two function arguments: `reject` (failure) and `resolve` (success)

--- a/ext/types/IO.js
+++ b/ext/types/IO.js
@@ -9,7 +9,7 @@
         module.exports = factory(require('../..'));
     } else {
         // Browser globals
-        this.returnExports = factory(this.R);
+        this.IO = factory(this.R);
     }
 }(function(R) {
     var compose = R.compose;

--- a/ext/types/Identity.js
+++ b/ext/types/Identity.js
@@ -9,7 +9,7 @@
         module.exports = factory();
     } else {
         // Browser globals
-        this.returnExports = factory();
+        this.Identity = factory();
     }
 }(function() {
 

--- a/ext/types/Maybe.js
+++ b/ext/types/Maybe.js
@@ -9,7 +9,7 @@
         module.exports = factory();
     } else {
         // Browser globals
-        this.returnExports = factory();
+        this.Maybe = factory();
     }
 }(function() {
     function Maybe(x) {

--- a/ext/types/Reader.js
+++ b/ext/types/Reader.js
@@ -9,7 +9,7 @@
         module.exports = factory(require('../..'));
     } else {
         // Browser globals
-        this.returnExports = factory(this.R);
+        this.Reader = factory(this.R);
     }
 }(function() {
 


### PR DESCRIPTION
Replacing this.returnExports with this.<name-of-type> in ext/types to make them work correctly in browser-like environments.
