### PR TITLE
init implementation and tests

### DIFF
--- a/ramda.js
+++ b/ramda.js
@@ -3492,8 +3492,23 @@
      *      var xs = R.range(0, 10);
      *      R.slice(2, 5)(xs); //=> [2, 3, 4]
      */
-    R.slice = invokerN(2, 'slice');
+    var slice = R.slice = invokerN(2, 'slice');
 
+    /**
+     * Returns all but the last element of a list.
+     *
+     * @func
+     * @memberOf R
+     * @category List
+     * @sig [a] -> [a]
+     * @param {Array} [list=[]] The array to consider.
+     * @return {Array} A new array containing all but the last element of the input list, or an
+     *         empty list if the input list is empty.
+     * @example
+     *
+     *      R.init(['fi', 'fo', 'fum']); //=> ['fi', 'fo']
+     */
+    R.init = slice(0, -1);
 
     /**
      * Removes the sub-list of `list` starting at index `start` and containing

--- a/test/test.core.js
+++ b/test/test.core.js
@@ -216,6 +216,20 @@ describe('last', function() {
     });
 });
 
+describe('init', function() {
+    it('returns an empty list for an empty list', function() {
+        assert.deepEqual(R.init([]), []);
+    });
+    it('returns a new list containing all the elements except the last element of a list', function() {
+        assert.deepEqual(R.init(['a', 'b', 'c', 'd']), ['a', 'b', 'c']);
+    });
+    it('throws if applied to null or undefined', function() {
+        assert.throws(function() { R.init(null); }, TypeError);
+        assert.throws(function() { R.init(undefined); }, TypeError);
+        assert.throws(function() { R.init(); }, TypeError);
+    });
+});
+
 describe('tail', function() {
     it('returns an empty list for an empty list', function() {
         assert.deepEqual(R.tail([]), []);


### PR DESCRIPTION
Had a real world situation where I wanted all elements of a list except the last one.

In Haskell, the four usual suspects are `head`, `tail`, `init`, and `last`.

Could find `head`, `tail`, and `last` but no init implementation? It is possible it comes under a different name but I couldn't find it.  Also, lodash does have an initial function which is sort of haskell `init` on steroids.

So I am tentatively raising this PR without any expectations, but hopes such a function already exists if declined. Would rather not have to compose this one all the time. :)

My only concern over the proposed implementation was what to do about the case where an empty array is passed in. Am assuming here that returning an empty array is ok. This seems consistent with `tail` etc.
