### PR TITLE
add npm run target for jshint

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   },
   "main": "ramda.js",
   "scripts": {
+    "jshint": "grunt jshint",
     "test": "grunt test"
   },
   "dependencies": {},


### PR DESCRIPTION
Find it very handy just being able to run jshint and unit tests as NPM commands. This addition just caters for developers with a similar workflow. Granted, using grunt off the command line achieves the same thing but hoping there is no compelling reason not to include this mechanism too.
