### PR TITLE
make R.times throw if given an invalid array length

### DIFF
--- a/ramda.js
+++ b/ramda.js
@@ -1167,9 +1167,10 @@
      *      R.times(R.identity, 5); //=> [0, 1, 2, 3, 4]
      */
     var times = R.times = _curry2(function times(fn, n) {
-        var list = new Array(n);
+        var list = new Array(Number(n));
+        var len = list.length;
         var idx = -1;
-        while (++idx < n) {
+        while (++idx < len) {
             list[idx] = fn(idx);
         }
         return list;

--- a/test/test.list.js
+++ b/test/test.list.js
@@ -112,6 +112,11 @@ describe('times', function() {
         var mapid = R.times(R.identity);
         assert.deepEqual(mapid(5), [0, 1, 2, 3, 4]);
     });
+
+    it('throws if second argument is not a valid array length', function() {
+        assert.throws(function() { R.times(3)('cheers!'); }, RangeError);
+        assert.throws(function() { R.times(R.identity, -1); }, RangeError);
+    });
 });
 
 describe('repeatN', function() {


### PR DESCRIPTION
This is rather fitting, given the strange behaviour was highlighted by a remark in a thread celebrating 1000 stars:

<img alt="1000 passing" src="https://cloud.githubusercontent.com/assets/210406/5174016/77adf184-73e2-11e4-8e79-8080c0eacfe0.png" width="224" height="56">
