### PR TITLE
remove R.alwaysZero

### DIFF
--- a/ramda.js
+++ b/ramda.js
@@ -4678,21 +4678,6 @@
                toString.call(val).slice(8, -1);
     };
 
-    /**
-     * A function that always returns `0`. Any passed in parameters are ignored.
-     *
-     * @func
-     * @memberOf R
-     * @category function
-     * @sig * -> 0
-     * @see R.always
-     * @return {Number} 0. Always zero.
-     * @example
-     *
-     *      R.alwaysZero(); //=> 0
-     */
-    R.alwaysZero = always(0);
-
 
     /**
      * A function that always returns `false`. Any passed in parameters are ignored.

--- a/test/test.always.js
+++ b/test/test.always.js
@@ -21,14 +21,6 @@ describe('always', function() {
     });
 });
 
-describe ('alwaysZero', function() {
-    it('always returns zero', function() {
-        assert.equal(R.alwaysZero(), 0);
-        assert.equal(R.alwaysZero(10), 0);
-        assert.equal(R.alwaysZero(false), 0);
-    });
-});
-
 describe ('alwaysFalse', function() {
     it('always returns false', function() {
         assert.equal(R.alwaysFalse(), false);


### PR DESCRIPTION
This :alien: is actually shorter than its equivalent:

``` javascript
R.alwaysZero
R.always(0)
```

Admittedly, these aren't equivalent in terms of memory usage, but idiomatic Ramda code doesn't define functions in loops so that's not a significant factor.
