### PR TITLE
rename R.alwaysTrue and R.alwaysFalse

### DIFF
--- a/ramda.js
+++ b/ramda.js
@@ -4656,9 +4656,9 @@
      * @return {Boolean} false
      * @example
      *
-     *      R.alwaysFalse(); //=> false
+     *      R.F(); //=> false
      */
-    R.alwaysFalse = always(false);
+    R.F = always(false);
 
 
     /**
@@ -4672,9 +4672,9 @@
      * @return {Boolean} `true`.
      * @example
      *
-     *      R.alwaysTrue(); //=> true
+     *      R.T(); //=> true
      */
-    R.alwaysTrue = always(true);
+    R.T = always(true);
 
 
 
@@ -4877,9 +4877,9 @@
      * @example
      *
      *      var fn = R.cond(
-     *          [R.eq(0),      R.always('water freezes at 0°C')],
-     *          [R.eq(100),    R.always('water boils at 100°C')],
-     *          [R.alwaysTrue, function(temp) { return 'nothing special happens at ' + temp + '°C'; }]
+     *          [R.eq(0),   R.always('water freezes at 0°C')],
+     *          [R.eq(100), R.always('water boils at 100°C')],
+     *          [R.T,       function(temp) { return 'nothing special happens at ' + temp + '°C'; }]
      *      );
      *      fn(0); //=> 'water freezes at 0°C'
      *      fn(50); //=> 'nothing special happens at 50°C'

--- a/test/test.always.js
+++ b/test/test.always.js
@@ -21,18 +21,18 @@ describe('always', function() {
     });
 });
 
-describe ('alwaysFalse', function() {
+describe('F', function() {
     it('always returns false', function() {
-        assert.strictEqual(R.alwaysFalse(), false);
-        assert.strictEqual(R.alwaysFalse(10), false);
-        assert.strictEqual(R.alwaysFalse(true), false);
+        assert.strictEqual(R.F(), false);
+        assert.strictEqual(R.F(10), false);
+        assert.strictEqual(R.F(true), false);
     });
 });
 
-describe ('alwaysTrue', function() {
+describe('T', function() {
     it('always returns true', function() {
-        assert.strictEqual(R.alwaysTrue(), true);
-        assert.strictEqual(R.alwaysTrue(10), true);
-        assert.strictEqual(R.alwaysTrue(true), true);
+        assert.strictEqual(R.T(), true);
+        assert.strictEqual(R.T(10), true);
+        assert.strictEqual(R.T(true), true);
     });
 });

--- a/test/test.cond.js
+++ b/test/test.cond.js
@@ -55,9 +55,9 @@ describe('cond', function() {
 
     it('returns a conditional function', function() {
         var fn = R.cond(
-            [R.eq(0),      R.always('water freezes at 0°C')],
-            [R.eq(100),    R.always('water boils at 100°C')],
-            [R.alwaysTrue, function(temp) { return 'nothing special happens at ' + temp + '°C'; }]
+            [R.eq(0),   R.always('water freezes at 0°C')],
+            [R.eq(100), R.always('water boils at 100°C')],
+            [R.T,       function(temp) { return 'nothing special happens at ' + temp + '°C'; }]
         );
         assert.strictEqual(fn(0), 'water freezes at 0°C');
         assert.strictEqual(fn(50), 'nothing special happens at 50°C');
@@ -74,9 +74,9 @@ describe('cond', function() {
 
     it('predicates are tested in order', function() {
         var fn = R.cond(
-            [R.alwaysTrue, R.always('foo')],
-            [R.alwaysTrue, R.always('bar')],
-            [R.alwaysTrue, R.always('baz')]
+            [R.T, R.always('foo')],
+            [R.T, R.always('bar')],
+            [R.T, R.always('baz')]
         );
         assert.strictEqual(fn(), 'foo');
     });

--- a/test/test.containsuniq.js
+++ b/test/test.containsuniq.js
@@ -42,15 +42,19 @@ describe('uniq', function() {
 });
 
 describe('uniqWith', function() {
-    var T = R.alwaysTrue;
-    var F = R.alwaysFalse;
-    var objs = [{x: T, i: 0}, {x: F, i: 1}, {x: T, i: 2}, {x: T, i: 3}, {x: F, i: 4}, {x: F, i: 5}, {x: T, i: 6}, {x: F, i: 7}];
-    var objs2 = [{x: T, i: 0}, {x: F, i: 1}, {x: T, i: 2}, {x: T, i: 3}, {x: F, i: 0}, {x: T, i: 1}, {x: F, i: 2}, {x: F, i: 3}];
+    var objs = [
+        {x: R.T, i: 0}, {x: R.F, i: 1}, {x: R.T, i: 2}, {x: R.T, i: 3},
+        {x: R.F, i: 4}, {x: R.F, i: 5}, {x: R.T, i: 6}, {x: R.F, i: 7}
+    ];
+    var objs2 = [
+        {x: R.T, i: 0}, {x: R.F, i: 1}, {x: R.T, i: 2}, {x: R.T, i: 3},
+        {x: R.F, i: 0}, {x: R.T, i: 1}, {x: R.F, i: 2}, {x: R.F, i: 3}
+    ];
     function eqI(x, accX) { return x.i === accX.i; }
 
     it('returns a set from any array (i.e. purges duplicate elements) based on predicate', function() {
         assert.deepEqual(R.uniqWith(eqI, objs), objs);
-        assert.deepEqual(R.uniqWith(eqI, objs2), [{x: T, i: 0}, {x: F, i: 1}, {x: T, i: 2}, {x: T, i: 3}]);
+        assert.deepEqual(R.uniqWith(eqI, objs2), [{x: R.T, i: 0}, {x: R.F, i: 1}, {x: R.T, i: 2}, {x: R.T, i: 3}]);
     });
 
     it('keeps elements from the left', function() {
@@ -64,7 +68,7 @@ describe('uniqWith', function() {
     it('is curried', function() {
         assert.strictEqual(typeof R.uniqWith(eqI), 'function');
         assert.deepEqual(R.uniqWith(eqI)(objs), objs);
-        assert.deepEqual(R.uniqWith(eqI)(objs2), [{x: T, i: 0}, {x: F, i: 1}, {x: T, i: 2}, {x: T, i: 3}]);
+        assert.deepEqual(R.uniqWith(eqI)(objs2), [{x: R.T, i: 0}, {x: R.F, i: 1}, {x: R.T, i: 2}, {x: R.T, i: 3}]);
     });
 
     it('throws on zero arguments', function() {

--- a/test/test.objectBasics.js
+++ b/test/test.objectBasics.js
@@ -264,7 +264,7 @@ describe('pickBy', function() {
     });
 
     it('when returning truthy, keeps the key', function() {
-        assert.deepEqual(R.pickBy(R.alwaysTrue, obj), obj);
+        assert.deepEqual(R.pickBy(R.T, obj), obj);
         assert.deepEqual(R.pickBy(R.always({}), obj), obj);
         assert.deepEqual(R.pickBy(R.always(1), obj), obj);
     });
@@ -292,7 +292,7 @@ describe('pickBy', function() {
 
 
     it('is automatically curried', function() {
-        var copier = R.pickBy(R.alwaysTrue);
+        var copier = R.pickBy(R.T);
         assert.deepEqual(copier(obj), obj);
     });
 });
@@ -418,12 +418,12 @@ describe('where', function() {
 
     it('matches inherited functions', function() {
         var spec = {
-            toString: R.alwaysTrue
+            toString: R.T
         };
         assert.strictEqual(R.where(spec, {}), true);
         assert.strictEqual(R.where(spec, {a: 1}), true);
         assert.strictEqual(R.where(spec, {toString: 1}), true);
-        assert.strictEqual(R.where({a: R.alwaysTrue}, {x: 1}), false);
+        assert.strictEqual(R.where({a: R.T}, {x: 1}), false);
     });
 
     it('matches inherited props', function() {


### PR DESCRIPTION
Now that we have a Scheme-like `cond`, it'd be nice to have a shorter name for `R.alwaysTrue` as this function is useful to match every value not satisfied be one of the preceding predicates.
