### PR TITLE
Fix a testem bug in chrome (probably others) that reports an undefined fn

### DIFF
--- a/test/test.list.js
+++ b/test/test.list.js
@@ -4,7 +4,7 @@ var R = require('..');
 describe('join', function() {
     it("concatenates a list's elements to a string, with an seperator string between elements", function() {
         var list = [1, 2, 3, 4];
-        assert.equal(R.join('~', list), '1~2~3~4');
+        assert.deepEqual(R.join('~', list), '1~2~3~4');
     });
 });
 


### PR DESCRIPTION
Testem failed when it couldn't find the assert.equal function, so I changed it to deepEqual.

BTW this is my first pull request ever on github, so I fully expect it to be rejected :)
