### PR TITLE
refactor example test runner to separate out doc parsing

### DIFF
--- a/scripts/doc-parser.js
+++ b/scripts/doc-parser.js
@@ -1,0 +1,100 @@
+var R = require('..');
+var fs = require('fs');
+var dox = require('dox');
+
+var pickPair = R.curry(function pickBestPartner(first, secondOptions, obj) {
+    var idx = -1;
+    var tmp;
+    while (++idx < secondOptions.length) {
+        tmp = secondOptions[idx];
+        if (tmp in obj) {
+            return [obj[first], obj[tmp]];
+        }
+    }
+    // didn't find, return with first key that isn't first
+    for (tmp in obj) {
+        if (tmp !== first) {
+            return [obj[first], obj[tmp]];
+        }
+    }
+    // return undefined
+});
+
+var toPairs = function toPairs(o) {
+    var a = [];
+    var k;
+    for (k in o) {
+        a.push([k, o[k]]);
+    }
+    return a;
+};
+
+var gatherer = function() {
+    var listKeys = arguments[0];
+    return function gather(obj, k, v) {
+        var newVal = v;
+        if (k in obj) {
+            if (R.contains(k, listKeys)) {
+                newVal = R.append(v, obj[k]);
+            }
+        } else {
+            if (R.contains(k, listKeys)) {
+                newVal = [v];
+            }
+        }
+        return R.mixin(obj, R.createMapEntry(k, newVal));
+    };
+};
+
+var tagsToMap = function tagsToMap(a) {
+    var idx = -1;
+    var listKeys = arguments[1] || [];
+    var obj = {};
+    var gatherFn = gatherer(listKeys);
+    var pair;
+    while (++idx < a.length) {
+        // get first key and value
+        pair = toPairs(a[idx])[0];
+        obj = gatherFn(obj, pair[0], pair[1]);
+    }
+    return obj;
+};
+
+var newMix = function newMix() {
+    var idx = 0;
+    var mixed = arguments[0];
+    while (++idx < arguments.length) {
+        mixed = R.mixin(mixed, arguments[idx]);
+    }
+    return mixed;
+};
+
+var doxTransformer = function doxTransformer(dox) {
+    if (dox == null || dox.ctx == null) {
+        return false;
+    }
+    var tags = R.map(
+        R.compose(R.apply(R.createMapEntry), pickPair('type', ['types', 'string'])),
+        dox.tags
+    );
+    var tagMap = tagsToMap(tags, ['param', 'category']);
+    // omit code: doesn't seem to be correctly populated
+    // description: full and summary seem to be the same thing, body is empty, just get summary
+    return newMix(
+        R.createMapEntry('name', dox.ctx.name),
+        tagMap,
+        R.createMapEntry('description', dox.description.summary),
+        R.omit(['tags', 'ctx', 'code', 'description'], dox)
+    );
+};
+
+// get ramda source
+var ramdaSource = String(fs.readFileSync('./ramda.js'));
+
+// build dox
+var ramdaDox = dox.parseComments(ramdaSource);
+
+// make more user friendly
+var niceDocs = R.filter(R.I, R.map(doxTransformer, ramdaDox));
+
+module.exports = niceDocs;

--- a/test/test.examplesRunner.js
+++ b/test/test.examplesRunner.js
@@ -1,185 +1,114 @@
 var assert = require('assert');
 var fs = require('fs');
 var R = require('..');
-var dox = require('dox');
+var ramdaDocs = require('./../scripts/doc-parser');
 
-// simple object to hold info about our examples
-function ExampleTest(dox_info, original_source, alias_of) {
-    this.func_name = this.getFunctionName(dox_info.code);
-    this.line_number = dox_info.line;
-    this.original_source = original_source;
-    this.alias_of = alias_of;
-    this.testable_source = this.getTestableSource();
-}
+var assertPairEqual = function assertPairEqual(testInfo) {
+    var msg = testInfo.description + ' === ' + testInfo.expected;
+    return assert.deepEqual(testInfo.expression, testInfo.expected, msg);
+};
 
-ExampleTest.prototype.getFunctionName = function(code) {
-    var func_lines = code.split('\n').slice(0, 2);
-    if (func_lines.length === 0) {
-        return false;
+var requireFromStr = function requireFromStr(src, filename) {
+    var m = new module.constructor();
+    m.paths = module.paths;
+    m._compile(src, filename);
+    return m.exports;
+};
+
+var wrap = R.curry(function(pre, post, s) {
+    return pre + s + post;
+});
+
+var mixWith = R.curry(function mixWith(keyFnPairs, obj) {
+    var idx = -1;
+    var newData = {};
+    var pair;
+    while (++idx < keyFnPairs.length) {
+        pair = keyFnPairs[idx];
+        newData[pair[0]] = pair[1](obj);
     }
-    var matches, func_line = (func_lines[0].indexOf('TODO') !== -1 && func_lines.length > 1) ? func_lines[1] : func_lines[0];
-    if ((matches = func_line.match(/^function (\w+)/)) !== null) {
-        return matches[1];
-    } else if ((matches = func_line.match(/([\w\.]+\s*=\s*)+/)) !== null) {
-        var names = R.reject(R.isEmpty, R.map(R.trim, matches[0].split('=')));
-        return names.length > 0 && (R.find(R.match(/^R\./), names) || names[0]);
-    } else {
-        return false;
+    return R.mixin(obj, newData);
+});
+
+var processExample = function processExample(docs) {
+    if (docs.testExample) {
+        // we have testable source, run example
+        var fnName = 'runExample_' + docs.name.replace(/\W/g, '_') + '_' + docs.line;
+        var fn = getNamedExampleFunction(fnName);
+        fn(docs);
     }
 };
 
-// make some minor adjustments to our example source so we can test output
-ExampleTest.prototype.getTestableSource = function() {
-    if (!this.original_source) {
-        return false;
-    }
+var getNamedExampleFunction = function getNamedExampleFunction(fnName) {
+    var tmp = new Function('runExampleFn', 'return function ' + fnName + '(docs){ runExampleFn(docs); };');
+    return tmp(runExample);
+};
+
+var runExample = function runExample(docs) {
+    var RTest = requireFromStr(docs.testWrapper(docs.testExample), 'exampleTester');
+    var testData = RTest.testExample();
+    it('compile and test ' + docs.name + ' examples (' + testData.length + ')', function() {
+        R.map(assertPairEqual, testData);
+    });
+};
+
+var getTestExample = function getExampleSource(docs) {
     // convert multiline command + output to single line for testing
-    var testable_source = this.original_source.replace(/^(.*?;.*)$\s*?(\/\/=>.*)$/mg, '$1 $2');
+    var testableSource = docs.example.replace(/^(.*?;.*)$\s*?(\/\/=>.*)$/mg, '$1 $2');
 
     // convert lines of the form
     // var x = myFunc('something'); //=> 'output'
     // to two test_lines so we can test output
-    testable_source = testable_source.replace(/^\s*(var (\w+).*?;).*?(\/\/=>\s*.*)$/mg, '$1\n$2; $3\n');
+    testableSource = testableSource.replace(/^\s*(var (\w+).*?;).*?(\/\/=>\s*.*)$/mg, '$1\n$2; $3\n');
 
     // get rid of console.log so we're not printing stuff while running tests
-    testable_source = testable_source.replace(/console\.log\(.*\);/mg, ';');
+    testableSource = testableSource.replace(/console\.log\(.*\);/mg, ';');
 
-    var test_lines = R.map(this.getTestLine.bind(this), testable_source.split('\n'));
-    return test_lines.join('\n');
+    return R.map(getTestLine, testableSource.split('\n')).join('\n');
 };
 
-// check line for sample output, add to our _tests array
-ExampleTest.prototype.getTestLine = function(line) {
+var getTestLine = function getTestLine(line) {
     line = line.trim();
+    // check for test output
     var matches = line.match(/^(.*);\s*\/\/=>\s*(.+?)(\/\/.+$|$)/);
     if (matches) {
-        var expression = matches[1],
-          expected = matches[2],
-          test_info_str = '';
+        var expression = matches[1];
+        var expected = matches[2];
+        var testInfoStr = '';
 
         // special case for NaN (NaN === NaN => false)
         if (expected === 'NaN') {
             expression = 'String(' + expression + ')';
             expected = 'String(NaN)';
         }
-        test_info_str += '_tests.push({';
-        test_info_str += 'expression:'   + expression + ',';
-        test_info_str += 'expected:'     + expected + ',';
-        test_info_str += 'description:"(' + expression.replace(/"/g, '\\"') + ' => "+' + expression + '+")"';
-        test_info_str += '});';
-        return test_info_str;
+        testInfoStr += '_tests.push({';
+        testInfoStr += 'expression:'   + expression + ',';
+        testInfoStr += 'expected:'     + expected + ',';
+        testInfoStr += 'description:"(' + expression.replace(/"/g, '\\"') + ' => "+' + expression + '+")"';
+        testInfoStr += '});';
+        return testInfoStr;
     } else {
         return line;
     }
 };
 
-function splitAt(str, target) {
-    if (!R.is(String, str)) {
-        str = String(str);
-    }
-    var idx = str.indexOf(target);
-    if (idx < 0) {
-        return false;
-    }
-    return [str.substr(0, idx), str.substr(idx)];
-}
-
-function assertPairEqual(test_info) {
-    var msg = test_info.description + ' === ' + test_info.expected;
-    return assert.deepEqual(test_info.expression, test_info.expected, msg);
-}
-
-function requireFromStr(src, filename) {
-    var m = new module.constructor();
-    m.paths = module.paths;
-    m._compile(src, filename);
-    return m.exports;
-}
-
-function processExample(e, idx, all_examples) {
-    // dox ends up with a few local functions and extra
-    // functions from comments we don't need to worry about
-    if (e.func_name === false) {
-        return;
-    }
-    if (e.testable_source) {
-        // we have testable source, run example
-        var run_func_name = 'runExample_' + e.func_name.replace(/\W/g, '_') + '_' + e.line_number;
-        runExample[run_func_name] = function(etmp) { runExample(etmp); };
-        runExample[run_func_name](e);
-    } else {
-        // see if e is alias for function with example
-        checkForAliasExample(e, all_examples);
-    }
-}
-
-function runExample(e) {
-    var Rtest = requireFromStr(ramda_wrap(example_wrap(e.testable_source)), 'example_tester');
-    var test_data = Rtest.example_test();
-    it('compile and test ' + e.func_name + ' examples (' + test_data.length + ')', function() {
-        R.map(assertPairEqual, test_data);
-    });
-}
-
-function checkForAliasExample(e) {
-    it(e.func_name + ' has example or is an alias for function that has example', function() {
-        // TODO: uncomment to enforce this
-      //   if (R.isEmpty(e.alias_of)) {
-      //       fail('undefined', 'example source', 'function has no example and no alias');
-      //   } else {
-      //       var alias_example = R.find(R.propEq('func_name', e.alias_of), examples);
-      //       assert(!R.isEmpty(alias_example), 'was able to find original function for alias');
-      //       assert(!R.isEmpty(alias_example.testable_source), 'original has a testable example');
-      //   }
-    });
-}
-
-// wrap a string
-var wrap = R.curry(function(pre, post, s) {
-    return pre + s + post;
-});
-
-// get the tags we need as a map
-function tagListToMap(targets, list) {
-    var map = {};
-    R.forEach(function(x) {
-        var val_key = targets[x.type];
-        map[x.type] = x[val_key];
-    }, list);
-    return map;
-}
-
-var propIn = R.curry(function(prop_name, prop_vals, object) {
-    return R.some(R.I, R.ap(R.map(R.propEq(prop_name), prop_vals), [object]));
-});
-
-// create our example objects from dox
-function getExampleFromDox(dox_info) {
-    var tags = R.filter(propIn('type', ['example', 'see', 'namespace']), dox_info.tags);
-    var tag_map = tagListToMap({example: 'string', namespace: 'string', see: 'local'}, tags);
-    if (tag_map.namespace) {
-        // ignore namespaces
-        return false;
-    } else {
-        return new ExampleTest(dox_info, tag_map.example, tag_map.see);
-    }
-}
-
 // get ramda source
-var ramda_source = String(fs.readFileSync('./ramda.js'));
-
-// build dox
-var ramda_dox = dox.parseComments(ramda_source);
-
-// get our examples
-var examples = R.filter(R.not(R.eq(false)), R.map.idx(getExampleFromDox, ramda_dox));
+var ramdaSource = String(fs.readFileSync('./ramda.js'));
 
 // prepare our source code to inject examples
-var source_for_compliation = splitAt(ramda_source, '// All the functional goodness, wrapped in a nice little package, just for you!');
-var ramda_wrap = wrap(source_for_compliation[0], source_for_compliation[1]);
-var example_wrap = wrap('R.example_test = function(){\nvar _tests = [];\n', '\nreturn _tests;\n};\n');
+var sourceForCompliation = R.split('// All the functional goodness, wrapped in a nice little package, just for you!', ramdaSource);
+var exampleStart = 'R.testExample = function(){\nvar _tests = [];\n';
+var exampleEnd = '\nreturn _tests;\n};\n';
+var testWrapper = wrap(sourceForCompliation[0] + exampleStart, exampleEnd + sourceForCompliation[1]);
+
+// filter functions that have examples
+var testFuncs = R.filter(R.and(R.has('func'), R.has('example')), ramdaDocs);
+testFuncs = R.map(mixWith([
+    ['testExample', getTestExample],
+    ['testWrapper', R.always(testWrapper)]
+]), testFuncs);
 
 // process examples
 describe('example tests', function() {
-    R.forEach.idx(processExample, examples);
+    R.forEach(processExample, testFuncs);
 });


### PR DESCRIPTION
I've split out the document parsing from running the example tests. I put `doc-parser.js` in `scripts`, is that a good place for it?

Now from anywhere you can do

`var ramdaDocs = require('path/to/doc-parser');`

and you get an array back of objects representing the docs for a given function. Objects are of the form

```
{
    name: 'countBy',
    func: '',
    memberOf: 'R',
    category: [ 'relation' ],
    sig: '(a -> String) -> [a] -> {*}',
    param: [ [ 'Function' ], [ 'Array' ] ],
    return: [ 'Object' ],
    example: '\n     var numbers = [1.0, 1.1, 1.2, 2.0, 3.0, 2.2];\n     var letters = R.split(\'\', \'abcABCaaaBBc\');\n     R.countBy(Math.floor)(numbers);    //=> {\'1\': 3, \'2\': 2, \'3\': 1}\n     R.countBy(R.toLowerCase)(letters);   //=> {\'a\': 5, \'b\': 4, \'c\': 3}',
    description: '<p>Counts the elements of a list according to how many match each value<br />of a key generated by the supplied function. Returns an object<br />mapping the keys produced by <code>fn</code> to the number of occurrences in<br />the list. Note that all keys are coerced to strings because of how<br />JavaScript objects work.</p>',
    isPrivate: false,
    isConstructor: false,
    isEvent: false,
    ignore: false,
    line: 6092,
    codeStart: 6113
}
```

This is slight re-organization of what you get back from `dox`. Might be more useful to index by function name? Anyway more stuff could be done here, but hopefully this is a decent start and something useful.
