### PR TITLE
remove R.push

### DIFF
--- a/ramda.js
+++ b/ramda.js
@@ -1037,14 +1037,6 @@
      */
     var append = R.append = _curry2(_append);
 
-    /**
-     * @func
-     * @memberOf R
-     * @category List
-     * @see R.append
-     */
-    R.push = append;
-
 
     /**
      * Flipped version of R.append.


### PR DESCRIPTION
This is a particularly harmful :alien: as it shares the name of a built-in _mutator_ method.
