### PR TITLE
remove R.slice.from

### DIFF
--- a/ramda.js
+++ b/ramda.js
@@ -3532,29 +3532,6 @@
 
 
     /**
-     * Returns the elements from `xs` starting at `a` going to the end of `xs`.
-     *
-     * @func
-     * @memberOf R
-     * @category List
-     * @sig Number -> [a] -> [a]
-     * @param {Number} a The starting index.
-     * @param {Array} xs The list to take elements from.
-     * @return {Array} The items from `a` to the end of `xs`.
-     * @example
-     *
-     *      var xs = R.range(0, 10);
-     *      R.slice.from(2)(xs); //=> [2, 3, 4, 5, 6, 7, 8, 9]
-     *
-     *      var ys = R.range(4, 8);
-     *      var tail = R.slice.from(1);
-     *      tail(ys); //=> [5, 6, 7]
-     */
-    R.slice.from = _curry2(function(a, xs) {
-        return xs.slice(a, xs.length);
-    });
-
-    /**
      * Removes the sub-list of `list` starting at index `start` and containing
      * `count` elements.  _Note that this is not destructive_: it returns a
      * copy of the list with the changes.

--- a/test/test.list.js
+++ b/test/test.list.js
@@ -93,13 +93,6 @@ describe('slice', function() {
     // });
 });
 
-describe('slice.from', function() {
-    it('retrieves the proper suffix sublist of a list starting with the desired index', function() {
-        var list = [8, 6, 7, 5, 3, 0, 9];
-        assert.deepEqual(R.slice.from(2, list), [7, 5, 3, 0, 9]);
-    });
-});
-
 describe('times', function() {
     it('takes a map func', function() {
         assert.deepEqual(R.times(R.identity, 5), [0, 1, 2, 3, 4]);


### PR DESCRIPTION
This is (almost) equivalent to `R.skip`, is it not? Let's remove the clumsy one.
