### PR TITLE
do not rely on reported arity in R.memoize

### DIFF
--- a/ramda.js
+++ b/ramda.js
@@ -1622,9 +1622,6 @@
      *      numberOfCalls; //=> 3
      */
     R.memoize = function memoize(fn) {
-        if (!fn.length) {
-            return once(fn);
-        }
         var cache = {};
         return function() {
             if (!arguments.length) {return;}
@@ -1654,7 +1651,7 @@
      *      addOneOnce(10); //=> 11
      *      addOneOnce(addOneOnce(50)); //=> 11
      */
-    var once = R.once = function once(fn) {
+    R.once = function once(fn) {
         var called = false, result;
         return function() {
             if (called) {

--- a/test/test.functionBasics.js
+++ b/test/test.functionBasics.js
@@ -163,6 +163,12 @@ describe('memoize', function() {
         var fib = R.memoize(function(n) {return n < 2 ? n : fib(n - 2) + fib(n - 1);});
         assert.strictEqual(typeof fib(), 'undefined');
     });
+
+    it('does not rely on reported arity', function() {
+        var identity = R.memoize(function() { return arguments[0]; });
+        assert.strictEqual(identity('x'), 'x');
+        assert.strictEqual(identity('y'), 'y');
+    });
 });
 
 describe('construct', function() {


### PR DESCRIPTION
I just got bitten by this when passing the result of a call to `R.pipe` to `R.memoize`. >.<
