### PR TITLE
remove R.version

### DIFF
--- a/ramda.js
+++ b/ramda.js
@@ -34,7 +34,7 @@
      *
      * @namespace R
      */
-    var R = {version: '0.8.0'};
+    var R = {};
 
     // Internal Functions and Properties
     // ---------------------------------

--- a/scripts/prepublish
+++ b/scripts/prepublish
@@ -7,10 +7,5 @@ README="${README//"${PREVIOUS_VERSION%.*}/ramda.min.js"/"${VERSION%.*}/ramda.min
 echo "$README" >README.md
 git add README.md
 
-RAMDA="$(cat ramda.js)"
-RAMDA="${RAMDA//$PREVIOUS_VERSION/$VERSION}"
-echo "$RAMDA" >ramda.js
-git add ramda.js
-
 make ramda.min.js
 git add ramda.min.js


### PR DESCRIPTION
Reasons to keep `R.version`:
- Being able to type `R.version` into a REPL is occasionally useful.

Reasons to remove `R.version`:
- It provides an additional and nonstandard way to access the version of the npm package: `require('x/package.json').version` works for every `x`.
- It adds complexity to the release process (though this is largely mitigated by our automated release process).
- In the near future we'll have custom builds, at which point a version string alone is not terribly useful. At that point I'd like to include the version string in the header along with the build options:
  
  ``` javascript
  //     Ramda v0.9.0 custom build: +logic +math
  ```
