### PR TITLE
remove unnecessary use of _checkForMethod

### DIFF
--- a/ramda.js
+++ b/ramda.js
@@ -1928,13 +1928,13 @@
      *
      *      R.reduceRight(flattenPairs, [], pairs); //=> [ 'c', 3, 'b', 2, 'a', 1 ]
      */
-    var reduceRight = R.reduceRight = _curry3(_checkForMethod('reduceRight', function reduceRight(fn, acc, list) {
+    var reduceRight = R.reduceRight = _curry3(function reduceRight(fn, acc, list) {
         var idx = list.length;
         while (idx--) {
             acc = fn(acc, list[idx]);
         }
         return acc;
-    }));
+    });
 
     /**
      * @func


### PR DESCRIPTION
The remaining uses of `_checkForMethod` are to support the lazy-list extension or to conform to the [Fantasy Land Specification](https://github.com/fantasyland/fantasy-land):

``` console
$ ack '=.*checkForMethod' | sed "s:.*'\(.*\)'.*:\1:" | sort
chain
filter
map
skip
tail
take
takeWhile
```
