### PR TITLE
switch order of arguments to R.repeatN

### DIFF
--- a/ramda.js
+++ b/ramda.js
@@ -1172,13 +1172,13 @@
      * @return {Array} A new array containing `n` `value`s.
      * @example
      *
-     *      R.repeatN('hi', 5); //=> ['hi', 'hi', 'hi', 'hi', 'hi']
+     *      R.repeatN(5, 'hi'); //=> ['hi', 'hi', 'hi', 'hi', 'hi']
      *
      *      var obj = {};
-     *      var repeatedObjs = R.repeatN(obj, 5); //=> [{}, {}, {}, {}, {}]
+     *      var repeatedObjs = R.repeatN(5, obj); //=> [{}, {}, {}, {}, {}]
      *      repeatedObjs[0] === repeatedObjs[1]; //=> true
      */
-    R.repeatN = _curry2(function repeatN(value, n) {
+    R.repeatN = _curry2(function repeatN(n, value) {
         return times(always(value), n);
     });
 

--- a/test/test.functionBasics.js
+++ b/test/test.functionBasics.js
@@ -300,7 +300,7 @@ describe('nAry', function() {
         assert.deepEqual(fn.apply(null, R.range(0, 25)), R.range(0, 10));
 
         var undefs = fn();
-        var ns = R.repeatN(undefined, 10);
+        var ns = R.repeatN(10, undefined);
         assert(undefs.length === ns.length);
         var idx = undefs.length;
         while (--idx) {

--- a/test/test.keysvals.js
+++ b/test/test.keysvals.js
@@ -25,7 +25,7 @@ describe('keys', function() {
         var result = R.map(function(val) {
             return R.keys(val);
         }, [null, undefined, 55, '', true, false, NaN, Infinity, , []]);
-        assert.deepEqual(result, R.repeatN([], 10));
+        assert.deepEqual(result, R.repeatN(10, []));
     });
 
     it("does not include the given object's prototype properties", function() {
@@ -52,7 +52,7 @@ describe('keysIn', function() {
         var result = R.map(function(val) {
             return R.keys(val);
         }, [null, undefined, 55, '', true, false, NaN, Infinity, , []]);
-        assert.deepEqual(result, R.repeatN([], 10));
+        assert.deepEqual(result, R.repeatN(10, []));
     });
 });
 
@@ -90,7 +90,7 @@ describe('values', function() {
         var result = R.map(function(val) {
             return R.keys(val);
         }, [null, undefined, 55, '', true, false, NaN, Infinity, , []]);
-        assert.deepEqual(result, R.repeatN([], 10));
+        assert.deepEqual(result, R.repeatN(10, []));
     });
 });
 
@@ -125,6 +125,6 @@ describe('valuesIn', function() {
         var result = R.map(function(val) {
             return R.values(val);
         }, [null, undefined, 55, '', true, false, NaN, Infinity, , []]);
-        assert.deepEqual(result, R.repeatN([], 10));
+        assert.deepEqual(result, R.repeatN(10, []));
     });
 });

--- a/test/test.list.js
+++ b/test/test.list.js
@@ -114,16 +114,17 @@ describe('times', function() {
 
 describe('repeatN', function() {
     it('returns a lazy list of identical values', function() {
-        assert.deepEqual(R.repeatN(0, 5), [0, 0, 0, 0, 0]);
+        assert.deepEqual(R.repeatN(5, 0), [0, 0, 0, 0, 0]);
     });
 
     it('can accept any value, including `null`', function() {
-        assert.deepEqual(R.repeatN(null, 3), [null, null, null]);
+        assert.deepEqual(R.repeatN(3, null), [null, null, null]);
     });
 
     it('is automatically curried', function() {
-        var nTrues = R.repeatN(true);
-        assert.deepEqual(nTrues(4), [true, true, true, true]);
+        var thrice = R.repeatN(3);
+        assert.deepEqual(thrice('foo'), ['foo', 'foo', 'foo']);
+        assert.deepEqual(thrice('bar'), ['bar', 'bar', 'bar']);
     });
 });
 


### PR DESCRIPTION
Every other xxxN function takes the N as the first argument:

``` console
$ grep 'R[.].*N =' ramda.js
    var curryN = R.curryN = function curryN(length, fn) {
    var invokerN = R.invokerN = function invokerN(arity, method) {
    R.argN = function argN(n) {
    R.repeatN = _curry2(function repeatN(n, value) {
    var constructN = R.constructN = _curry2(function constructN(n, Fn) {
    var liftN = R.liftN = _curry2(function liftN(arity, fn) {
```

I can't imagine partially applying `R.repeatN` very often. (Please correct me if I'm wrong!) This being the case, we should switch the argument order so all the xxxN functions take the N as the first argument.
