### PR TITLE
remove R.indexOf.from and R.lastIndexOf.from

### DIFF
--- a/ramda.js
+++ b/ramda.js
@@ -2890,31 +2890,6 @@
 
 
     /**
-     * Returns the position of the first occurrence of an item (by strict equality) in
-     * an array, or -1 if the item is not included in the array. However,
-     * `indexOf.from` will only search the tail of the array, starting from the
-     * `fromIdx` parameter.
-     *
-     * @func
-     * @memberOf R
-     * @category List
-     * @sig a -> Number -> [a] -> Number
-     * @param {*} target The item to find.
-     * @param {Array} list The array to search in.
-     * @param {Number} fromIdx the index to start searching from
-     * @return {Number} the index of the target, or -1 if the target is not found.
-     *
-     * @example
-     *
-     *      R.indexOf.from(3, 2, [-1,0,1,2,3,4]); //=> 4
-     *      R.indexOf.from(10, 2, [1,2,3,4]); //=> -1
-     */
-    R.indexOf.from = _curry3(function indexOfFrom(target, fromIdx, list) {
-        return _indexOf(list, target, fromIdx);
-    });
-
-
-    /**
      * Returns the position of the last occurrence of an item (by strict equality) in
      * an array, or -1 if the item is not included in the array.
      *
@@ -2933,31 +2908,6 @@
      */
     R.lastIndexOf = _curry2(function lastIndexOf(target, list) {
         return _lastIndexOf(list, target);
-    });
-
-
-    /**
-     * Returns the position of the last occurrence of an item (by strict equality) in
-     * an array, or -1 if the item is not included in the array. However,
-     * `lastIndexOf.from` will only search the tail of the array, starting from the
-     * `fromIdx` parameter.
-     *
-     * @func
-     * @memberOf R
-     * @category List
-     * @sig a -> Number -> [a] -> Number
-     * @param {*} target The item to find.
-     * @param {Array} list The array to search in.
-     * @param {Number} fromIdx the index to start searching from
-     * @return {Number} the index of the target, or -1 if the target is not found.
-     *
-     * @example
-     *
-     *      R.lastIndexOf.from(3, 2, [-1,3,3,0,1,2,3,4]); //=> 2
-     *      R.lastIndexOf.from(10, 2, [1,2,3,4]); //=> -1
-     */
-    R.lastIndexOf.from = _curry3(function lastIndexOfFrom(target, fromIdx, list) {
-        return _lastIndexOf(list, target, fromIdx);
     });
 
 

--- a/test/test.indexof.js
+++ b/test/test.indexof.js
@@ -45,45 +45,6 @@ describe('indexOf', function() {
     });
 });
 
-describe('indexOf.from', function() {
-    var list = [1, 2, 3];
-    list[-2] = 4; // Throw a wrench in the gears by assigning a non-valid array index as object property.
-    it('from index 1', function() {
-        assert.strictEqual(R.indexOf.from(2, 1, list), 1);
-    });
-    it('from index 2', function() {
-        assert.strictEqual(R.indexOf.from(2, 2, list), -1);
-    });
-    it('from index 3', function() {
-        assert.strictEqual(R.indexOf.from(2, 3, list), -1);
-    });
-    it('from index 4', function() {
-        assert.strictEqual(R.indexOf.from(2, 4, list), -1);
-    });
-    it('from index -1', function() {
-        assert.strictEqual(R.indexOf.from(3, -1, list), 2);
-    });
-    it('from index -2', function() {
-        assert.strictEqual(R.indexOf.from(3, -2, list), 2);
-    });
-    it('from index -3', function() {
-        assert.strictEqual(R.indexOf.from(3, -3, list), 2);
-    });
-    it('from index -4', function() {
-        assert.strictEqual(R.indexOf.from(3, -4, list), 2);
-    });
-    it('returns -1 for an empty array', function() {
-        assert.strictEqual(R.indexOf.from('x', 3, []), -1);
-        assert.strictEqual(R.indexOf.from('x', -3, []), -1);
-    });
-
-    it('is curried', function() {
-        var curried = R.indexOf.from(3);
-        assert.strictEqual(curried(0)(list), 2);
-        assert.strictEqual(curried(0, list), 2);
-    });
-});
-
 describe('lastIndexOf', function() {
     it("returns a number indicating an object's last position in a list", function() {
         var list = [0, 10, 20, 30, 0, 10, 20, 30, 0, 10];
@@ -114,33 +75,6 @@ describe('lastIndexOf', function() {
     it('Uses strict equality', function() {
         assert.strictEqual(R.lastIndexOf('1', list), -1);
     });
-    it('from index 1', function() {
-        assert.strictEqual(R.lastIndexOf.from('a', 1, list), 0);
-    });
-    it('from index 2', function() {
-        assert.strictEqual(R.lastIndexOf.from('a', 2, list), 2);
-    });
-    it('from index 3', function() {
-        assert.strictEqual(R.lastIndexOf.from('a', 3, list), 2);
-    });
-    it('from index 4', function() {
-        assert.strictEqual(R.lastIndexOf.from('a', 4, list), 2);
-    });
-    it('from index 0', function() {
-        assert.strictEqual(R.lastIndexOf.from('a', 0, list), 0);
-    });
-    it('from index -1', function() {
-        assert.strictEqual(R.lastIndexOf.from('a', -1, list), 2);
-    });
-    it('from index -2', function() {
-        assert.strictEqual(R.lastIndexOf.from('a', -2, list), 0);
-    });
-    it('from index -3', function() {
-        assert.strictEqual(R.lastIndexOf.from('a', -3, list), 0);
-    });
-    it('from index -4', function() {
-        assert.strictEqual(R.lastIndexOf.from('a', -4, list), -1);
-    });
     it('returns -1 for an empty array', function() {
         assert.strictEqual(R.lastIndexOf('x', 2, []), -1);
         assert.strictEqual(R.lastIndexOf('x', -5, []), -1);
@@ -149,47 +83,5 @@ describe('lastIndexOf', function() {
     it('is curried', function() {
         var curried = R.lastIndexOf('a');
         assert.strictEqual(curried(list), 2);
-    });
-});
-
-describe('lastIndexOf.from', function() {
-    var list = ['a', 1, 'a'];
-    list[-2] = 'a'; // Throw a wrench in the gears by assigning a non-valid array index as object property.
-
-    it('from index 1', function() {
-        assert.strictEqual(R.lastIndexOf.from('a', 1, list), 0);
-    });
-    it('from index 2', function() {
-        assert.strictEqual(R.lastIndexOf.from('a', 2, list), 2);
-    });
-    it('from index 3', function() {
-        assert.strictEqual(R.lastIndexOf.from('a', 3, list), 2);
-    });
-    it('from index 4', function() {
-        assert.strictEqual(R.lastIndexOf.from('a', 4, list), 2);
-    });
-    it('from index 0', function() {
-        assert.strictEqual(R.lastIndexOf.from('a', 0, list), 0);
-    });
-    it('from index -1', function() {
-        assert.strictEqual(R.lastIndexOf.from('a', -1, list), 2);
-    });
-    it('from index -2', function() {
-        assert.strictEqual(R.lastIndexOf.from('a', -2, list), 0);
-    });
-    it('from index -3', function() {
-        assert.strictEqual(R.lastIndexOf.from('a', -3, list), 0);
-    });
-    it('from index -4', function() {
-        assert.strictEqual(R.lastIndexOf.from('a', -4, list), -1);
-    });
-    it('returns -1 for an empty array', function() {
-        assert.strictEqual(R.lastIndexOf.from('x', 2, []), -1);
-        assert.strictEqual(R.lastIndexOf.from('x', -5, []), -1);
-    });
-    it('is curried', function() {
-        var curried = R.lastIndexOf.from('a');
-        assert.strictEqual(curried(3)(list), 2);
-        assert.strictEqual(curried(3, list), 2);
     });
 });


### PR DESCRIPTION
I imagine these functions were added because [`Array.prototype.indexOf`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/indexOf) takes an optional second argument. I haven't used either function, and even when they're useful they're not necessary (though they avoid array cloning).

If we decide to _keep_ these functions, let's make them top-level functions.
