### PR TITLE
rename R.insert.all

### DIFF
--- a/ramda.js
+++ b/ramda.js
@@ -3519,9 +3519,9 @@
      * @return {Array} A new Array with `elts` inserted starting at `index`.
      * @example
      *
-     *      R.insert.all(2, ['x','y','z'], [1,2,3,4]); //=> [1,2,'x','y','z',3,4]
+     *      R.insertAll(2, ['x','y','z'], [1,2,3,4]); //=> [1,2,'x','y','z',3,4]
      */
-    R.insert.all = _curry3(function insertAll(idx, elts, list) {
+    R.insertAll = _curry3(function insertAll(idx, elts, list) {
         idx = idx < list.length && idx >= 0 ? idx : list.length;
         return _concat(_concat(_slice(list, 0, idx), elts), _slice(list, idx));
     });

--- a/test/test.list.js
+++ b/test/test.list.js
@@ -62,20 +62,20 @@ describe('insert', function() {
 });
 
 
-describe('insert.all', function() {
+describe('insertAll', function() {
     it('inserts a list of elements into the given list', function() {
         var list = ['a', 'b', 'c', 'd', 'e'];
-        assert.deepEqual(R.insert.all(2, ['x', 'y', 'z'], list), ['a', 'b', 'x', 'y', 'z', 'c', 'd', 'e']);
+        assert.deepEqual(R.insertAll(2, ['x', 'y', 'z'], list), ['a', 'b', 'x', 'y', 'z', 'c', 'd', 'e']);
     });
 
     it('appends to the end of the list if the index is too large', function() {
         var list = ['a', 'b', 'c', 'd', 'e'];
-        assert.deepEqual(R.insert.all(8, ['p', 'q', 'r'], list), ['a', 'b', 'c', 'd', 'e', 'p', 'q', 'r']);
+        assert.deepEqual(R.insertAll(8, ['p', 'q', 'r'], list), ['a', 'b', 'c', 'd', 'e', 'p', 'q', 'r']);
     });
 
     it('is curried', function() {
         var list = ['a', 'b', 'c', 'd', 'e'];
-        assert.deepEqual(R.insert.all(8)(['p', 'q', 'r'], list), ['a', 'b', 'c', 'd', 'e', 'p', 'q', 'r']);
+        assert.deepEqual(R.insertAll(8)(['p', 'q', 'r'], list), ['a', 'b', 'c', 'd', 'e', 'p', 'q', 'r']);
     });
 });
 


### PR DESCRIPTION
With the exception of the `.idx` functions, this is the last remaining "namespaced" function. I see no reason for it to be a second-class citizen.
