### PR TITLE
rename R.argN

### DIFF
--- a/ramda.js
+++ b/ramda.js
@@ -1122,11 +1122,12 @@
      * @return {Function}
      * @example
      *
-     *      R.argN(1)('a', 'b', 'c'); //=> 'b'
+     *      R.nthArg(1)('a', 'b', 'c'); //=> 'b'
+     *      R.nthArg(-1)('a', 'b', 'c'); //=> 'c'
      */
-    R.argN = function argN(n) {
+    R.nthArg = function nthArg(n) {
         return function() {
-            return arguments[n];
+            return nth(n, arguments);
         };
     };
 

--- a/test/test.identity.js
+++ b/test/test.identity.js
@@ -17,14 +17,20 @@ describe('identity', function() {
     });
 });
 
-describe('argN', function() {
+describe('nthArg', function() {
     it('returns a function which returns its nth argument', function() {
-        assert.strictEqual(R.argN(0)('foo', 'bar'), 'foo');
-        assert.strictEqual(R.argN(1)('foo', 'bar'), 'bar');
-        assert.strictEqual(R.argN(2)('foo', 'bar'), undefined);
+        assert.strictEqual(R.nthArg(0)('foo', 'bar'), 'foo');
+        assert.strictEqual(R.nthArg(1)('foo', 'bar'), 'bar');
+        assert.strictEqual(R.nthArg(2)('foo', 'bar'), undefined);
+    });
+
+    it('accepts negative offsets', function() {
+        assert.strictEqual(R.nthArg(-1)('foo', 'bar'), 'bar');
+        assert.strictEqual(R.nthArg(-2)('foo', 'bar'), 'foo');
+        assert.strictEqual(R.nthArg(-3)('foo', 'bar'), undefined);
     });
 
     it('returns a function with length 0', function() {
-        assert.strictEqual(R.argN(2).length, 0);
+        assert.strictEqual(R.nthArg(2).length, 0);
     });
 });


### PR DESCRIPTION
`R.nthArg` is a much better name for this function. I've also implemented the function in terms of `nth` to support negative offsets.
