### PR TITLE
rename .idx functions

### DIFF
--- a/ramda.js
+++ b/ramda.js
@@ -730,7 +730,7 @@
      *
      * `fn` receives three arguments: *(value, index, list)*.
      *
-     * Note: `R.forEach.idx` does not skip deleted or unassigned indices (sparse arrays),
+     * Note: `R.forEachIndexed` does not skip deleted or unassigned indices (sparse arrays),
      * unlike the native `Array.prototype.forEach` method. For more details on this behavior,
      * see:
      * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach#Description
@@ -746,15 +746,14 @@
      *        (`value`, `index`, `list`).
      * @param {Array} list The list to iterate over.
      * @return {Array} The original list.
-     * @alias forEach.idx
      * @example
      *
      *      // Note that having access to the original `list` allows for
      *      // mutation. While you *can* do this, it's very un-functional behavior:
      *      var plusFive = function(num, idx, list) { list[idx] = num + 5 };
-     *      R.forEach.idx(plusFive, [1, 2, 3]); //=> [6, 7, 8]
+     *      R.forEachIndexed(plusFive, [1, 2, 3]); //=> [6, 7, 8]
      */
-    R.forEach.idx = _curry2(function forEachIdx(fn, list) {
+    R.forEachIndexed = _curry2(function forEachIndexed(fn, list) {
         var idx = -1, len = list.length;
         while (++idx < len) {
             fn(list[idx], idx, list);
@@ -1848,7 +1847,7 @@
      *
      * The iterator function receives four values: *(acc, value, index, list)*
      *
-     * Note: `R.foldl.idx` does not skip deleted or unassigned indices (sparse arrays),
+     * Note: `R.foldlIndexed` does not skip deleted or unassigned indices (sparse arrays),
      * unlike the native `Array.prototype.reduce` method. For more details on this behavior,
      * see:
      * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/reduce#Description
@@ -1870,9 +1869,9 @@
      *        return accObject;
      *      };
      *
-     *      R.foldl.idx(objectify, {}, letters); //=> { 'a': 0, 'b': 1, 'c': 2 }
+     *      R.foldlIndexed(objectify, {}, letters); //=> { 'a': 0, 'b': 1, 'c': 2 }
      */
-    R.foldl.idx = _curry3(function foldlIdx(fn, acc, list) {
+    R.foldlIndexed = _curry3(function foldlIndexed(fn, acc, list) {
         var idx = -1, len = list.length;
         while (++idx < len) {
             acc = fn(acc, list[idx], idx, list);
@@ -1927,7 +1926,7 @@
      *
      * The iterator function receives four values: *(acc, value, index, list)*.
      *
-     * Note: `R.foldr.idx` does not skip deleted or unassigned indices (sparse arrays),
+     * Note: `R.foldrIndexed` does not skip deleted or unassigned indices (sparse arrays),
      * unlike the native `Array.prototype.reduce` method. For more details on this behavior,
      * see:
      * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/reduceRight#Description
@@ -1949,9 +1948,9 @@
      *        return accObject;
      *      };
      *
-     *      R.foldr.idx(objectify, {}, letters); //=> { 'c': 2, 'b': 1, 'a': 0 }
+     *      R.foldrIndexed(objectify, {}, letters); //=> { 'c': 2, 'b': 1, 'a': 0 }
      */
-    R.foldr.idx = _curry3(function foldrIdx(fn, acc, list) {
+    R.foldrIndexed = _curry3(function foldrIndexed(fn, acc, list) {
         var idx = list.length;
         while (idx--) {
             acc = fn(acc, list[idx], idx, list);
@@ -2031,7 +2030,7 @@
      * Like `map`, but but passes additional parameters to the mapping function.
      * `fn` receives three arguments: *(value, index, list)*.
      *
-     * Note: `R.map.idx` does not skip deleted or unassigned indices (sparse arrays), unlike
+     * Note: `R.mapIndexed` does not skip deleted or unassigned indices (sparse arrays), unlike
      * the native `Array.prototype.map` method. For more details on this behavior, see:
      * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map#Description
      *
@@ -2042,7 +2041,6 @@
      * @param {Function} fn The function to be called on every element of the input `list`.
      * @param {Array} list The list to be iterated over.
      * @return {Array} The new list.
-     * @alias map.idx
      * @example
      *
      *      var squareEnds = function(elt, idx, list) {
@@ -2052,9 +2050,9 @@
      *        return elt;
      *      };
      *
-     *      R.map.idx(squareEnds, [8, 5, 3, 0, 9]); //=> [64, 5, 3, 0, 81]
+     *      R.mapIndexed(squareEnds, [8, 5, 3, 0, 9]); //=> [64, 5, 3, 0, 81]
      */
-    R.map.idx = _curry2(function mapIdx(fn, list) {
+    R.mapIndexed = _curry2(function mapIndexed(fn, list) {
         var idx = -1, len = list.length, result = new Array(len);
         while (++idx < len) {
             result[idx] = fn(list[idx], idx, list);
@@ -2086,7 +2084,7 @@
      *
      *      R.mapObj(double, values); //=> { x: 2, y: 4, z: 6 }
      */
-    // TODO: consider mapObj.key in parallel with mapObj.idx.  Also consider folding together with `map` implementation.
+    // TODO: consider mapObj.key in parallel with mapObjIndexed.  Also consider folding together with `map` implementation.
     R.mapObj = _curry2(function mapObject(fn, obj) {
         return foldl(function(acc, key) {
             acc[key] = fn(obj[key]);
@@ -2108,7 +2106,6 @@
      * @param {Object} obj The object to iterate over.
      * @return {Object} A new object with the same keys as `obj` and values that are the result
      *         of running each property through `fn`.
-     * @alias mapObj.idx
      * @example
      *
      *      var values = { x: 1, y: 2, z: 3 };
@@ -2116,9 +2113,9 @@
      *        return key + (num * 2);
      *      };
      *
-     *      R.mapObj.idx(prependKeyAndDouble, values); //=> { x: 'x2', y: 'y4', z: 'z6' }
+     *      R.mapObjIndexed(prependKeyAndDouble, values); //=> { x: 'x2', y: 'y4', z: 'z6' }
      */
-    R.mapObj.idx = _curry2(function mapObjectIdx(fn, obj) {
+    R.mapObjIndexed = _curry2(function mapObjectIndexed(fn, obj) {
         return foldl(function(acc, key) {
             acc[key] = fn(obj[key], key, obj);
             return acc;
@@ -2430,15 +2427,14 @@
      * @param {Function} fn The function called per iteration.
      * @param {Array} list The collection to iterate over.
      * @return {Array} The new filtered array.
-     * @alias filter.idx
      * @example
      *
      *      var lastTwo = function(val, idx, list) {
      *        return list.length - idx <= 2;
      *      };
-     *      R.filter.idx(lastTwo, [8, 6, 7, 5, 3, 0, 9]); //=> [0, 9]
+     *      R.filterIndexed(lastTwo, [8, 6, 7, 5, 3, 0, 9]); //=> [0, 9]
      */
-    function filterIdx(fn, list) {
+    function filterIndexed(fn, list) {
         var idx = -1, len = list.length, result = [];
         while (++idx < len) {
             if (fn(list[idx], idx, list)) {
@@ -2447,7 +2443,7 @@
         }
         return result;
     }
-    R.filter.idx = _curry2(filterIdx);
+    R.filterIndexed = _curry2(filterIndexed);
 
 
     /**
@@ -2485,17 +2481,16 @@
      * @param {Function} fn The function called per iteration.
      * @param {Array} list The collection to iterate over.
      * @return {Array} The new filtered array.
-     * @alias reject.idx
      * @example
      *
      *      var lastTwo = function(val, idx, list) {
      *        return list.length - idx <= 2;
      *      };
      *
-     *      R.reject.idx(lastTwo, [8, 6, 7, 5, 3, 0, 9]); //=> [8, 6, 7, 5, 3]
+     *      R.rejectIndexed(lastTwo, [8, 6, 7, 5, 3, 0, 9]); //=> [8, 6, 7, 5, 3]
      */
-    R.reject.idx = _curry2(function rejectIdx(fn, list) {
-        return filterIdx(not(fn), list);
+    R.rejectIndexed = _curry2(function rejectIndexed(fn, list) {
+        return filterIndexed(not(fn), list);
     });
 
 

--- a/test/test.each.js
+++ b/test/test.each.js
@@ -33,34 +33,34 @@ describe('forEach', function() {
     });
 });
 
-describe('forEach.idx', function() {
+describe('forEachIndexed', function() {
     var list = [{x: 1, y: 2}, {x: 100, y: 200}, {x: 300, y: 400}, {x: 234, y: 345}];
 
     it('performs the passed in function on each element of the list and passes in the index and list as well', function() {
         var sideEffect = {};
-        R.forEach.idx(function(elem, idx) { sideEffect[elem.x] = idx; }, list);
+        R.forEachIndexed(function(elem, idx) { sideEffect[elem.x] = idx; }, list);
         assert.deepEqual(sideEffect, {1: 0, 100: 1, 300: 2, 234: 3});
     });
 
     it('returns the original list', function() {
         var s = '';
-        assert.deepEqual(R.forEach.idx(function(obj) { s += obj.x; }, list), list);
+        assert.deepEqual(R.forEachIndexed(function(obj) { s += obj.x; }, list), list);
         assert.strictEqual('1100300234', s);
     });
 
     it('handles empty list', function() {
-        assert.deepEqual(R.forEach.idx(function(x, idx) { return x + idx; }, []), []);
+        assert.deepEqual(R.forEachIndexed(function(x, idx) { return x + idx; }, []), []);
     });
 
     it('is curried', function() {
         var sum = 0;
-        var xe = R.forEach.idx(function(x, idx) { sum += (x + idx); });
+        var xe = R.forEachIndexed(function(x, idx) { sum += (x + idx); });
         assert.strictEqual(typeof xe, 'function');
         xe([1, 2, 4]);
         assert.strictEqual(sum, 10);
     });
 
     it('throws on zero arguments', function() {
-        assert.throws(R.forEach.idx, TypeError);
+        assert.throws(R.forEachIndexed, TypeError);
     });
 });

--- a/test/test.examplesRunner.js
+++ b/test/test.examplesRunner.js
@@ -172,7 +172,7 @@ var ramda_source = String(fs.readFileSync('./ramda.js'));
 var ramda_dox = dox.parseComments(ramda_source);
 
 // get our examples
-var examples = R.filter(R.not(R.eq(false)), R.map.idx(getExampleFromDox, ramda_dox));
+var examples = R.filter(R.not(R.eq(false)), R.mapIndexed(getExampleFromDox, ramda_dox));
 
 // prepare our source code to inject examples
 var source_for_compliation = splitAt(ramda_source, '// All the functional goodness, wrapped in a nice little package, just for you!');
@@ -181,5 +181,5 @@ var example_wrap = wrap('R.example_test = function(){\nvar _tests = [];\n', '\nr
 
 // process examples
 describe('example tests', function() {
-    R.forEach.idx(processExample, examples);
+    R.forEachIndexed(processExample, examples);
 });

--- a/test/test.filter.js
+++ b/test/test.filter.js
@@ -31,38 +31,38 @@ describe('filter', function() {
     });
 });
 
-describe('filter.idx', function() {
+describe('filterIndexed', function() {
     var even = function(x) {return x % 2 === 0;};
     var everyOther = function(val, idx) {return idx % 2 === 0;};
     var lastTwo = function(val, idx, list) {return list.length - idx < 3;};
 
     it('works just like a normal filter', function() {
-        assert.deepEqual(R.filter.idx(even, [1, 2, 3, 4, 5]), [2, 4]);
+        assert.deepEqual(R.filterIndexed(even, [1, 2, 3, 4, 5]), [2, 4]);
     });
 
     it('passes the index as a second parameter to the predicate', function() {
-        assert.deepEqual(R.filter.idx(everyOther, [8, 6, 7, 5, 3, 0, 9]), [8, 7, 3, 9]);
+        assert.deepEqual(R.filterIndexed(everyOther, [8, 6, 7, 5, 3, 0, 9]), [8, 7, 3, 9]);
     });
 
     it('passes the entire list as a third parameter to the predicate', function() {
-        assert.deepEqual(R.filter.idx(lastTwo, [8, 6, 7, 5, 3, 0, 9]), [0, 9]);
+        assert.deepEqual(R.filterIndexed(lastTwo, [8, 6, 7, 5, 3, 0, 9]), [0, 9]);
     });
 
     it('returns an empty array if no element matches', function() {
-        assert.deepEqual(R.filter.idx(function(x) { return x > 100; }, [1, 9, 99]), []);
+        assert.deepEqual(R.filterIndexed(function(x) { return x > 100; }, [1, 9, 99]), []);
     });
 
     it('returns an empty array if asked to filter an empty array', function() {
-        assert.deepEqual(R.filter.idx(function(x) { return x > 100; }, []), []);
+        assert.deepEqual(R.filterIndexed(function(x) { return x > 100; }, []), []);
     });
 
     it('is automatically curried', function() {
-        var everyOtherPosition = R.filter.idx(everyOther);
+        var everyOtherPosition = R.filterIndexed(everyOther);
         assert.deepEqual(everyOtherPosition([8, 6, 7, 5, 3, 0, 9]), [8, 7, 3, 9]);
     });
 
     it('throws on zero arguments', function() {
-        assert.throws(R.filter.idx, TypeError);
+        assert.throws(R.filterIndexed, TypeError);
     });
 });
 
@@ -95,42 +95,42 @@ describe('reject', function() {
     });
 
     it('throws on zero arguments', function() {
-        assert.throws(R.reject.idx, TypeError);
+        assert.throws(R.rejectIndexed, TypeError);
     });
 });
 
-describe('reject.idx', function() {
+describe('rejectIndexed', function() {
     var even = function(x) {return x % 2 === 0;};
     var everyOther = function(val, idx) {return idx % 2 === 0;};
     var lastTwo = function(val, idx, list) {return list.length - idx < 3;};
 
     it('works just like a normal reject', function() {
-        assert.deepEqual(R.reject.idx(even, [1, 2, 3, 4, 5]), [1, 3, 5]);
+        assert.deepEqual(R.rejectIndexed(even, [1, 2, 3, 4, 5]), [1, 3, 5]);
     });
 
     it('passes the index as a second parameter to the predicate', function() {
-        assert.deepEqual(R.reject.idx(everyOther, [8, 6, 7, 5, 3, 0, 9]), [6, 5, 0]);
+        assert.deepEqual(R.rejectIndexed(everyOther, [8, 6, 7, 5, 3, 0, 9]), [6, 5, 0]);
     });
 
     it('passes the entire list as a third parameter to the predicate', function() {
-        assert.deepEqual(R.reject.idx(lastTwo, [8, 6, 7, 5, 3, 0, 9]), [8, 6, 7, 5, 3]);
+        assert.deepEqual(R.rejectIndexed(lastTwo, [8, 6, 7, 5, 3, 0, 9]), [8, 6, 7, 5, 3]);
     });
 
     it('returns an empty array if no element matches', function() {
-        assert.deepEqual(R.reject.idx(function(x) { return x < 100; }, [1, 9, 99]), []);
+        assert.deepEqual(R.rejectIndexed(function(x) { return x < 100; }, [1, 9, 99]), []);
     });
 
     it('returns an empty array if asked to filter an empty array', function() {
-        assert.deepEqual(R.reject.idx(function(x) { return x > 100; }, []), []);
+        assert.deepEqual(R.rejectIndexed(function(x) { return x > 100; }, []), []);
     });
 
     it('is automatically curried', function() {
-        var everyOtherPosition = R.reject.idx(everyOther);
+        var everyOtherPosition = R.rejectIndexed(everyOther);
         assert.deepEqual(everyOtherPosition([8, 6, 7, 5, 3, 0, 9]), [6, 5, 0]);
     });
 
     it('throws on zero arguments', function() {
-        assert.throws(R.reject.idx, TypeError);
+        assert.throws(R.rejectIndexed, TypeError);
     });
 });
 

--- a/test/test.fold.js
+++ b/test/test.fold.js
@@ -68,30 +68,30 @@ describe('foldr', function() {
     });
 });
 
-describe('foldl.idx', function() {
-    var timesIdx = function(tot, num, idx) {return tot + (num * idx);};
+describe('foldlIndexed', function() {
+    var timesIndexed = function(tot, num, idx) {return tot + (num * idx);};
     var objectify = function(acc, elem, idx) { acc[elem] = idx; return acc;};
 
     it('works just like normal foldl', function() {
-        assert.strictEqual(R.foldl.idx(R.add, 0, [1, 2, 3, 4]), 10);
-        assert.strictEqual(R.foldl.idx(R.multiply, 1, [1, 2, 3, 4]), 24);
+        assert.strictEqual(R.foldlIndexed(R.add, 0, [1, 2, 3, 4]), 10);
+        assert.strictEqual(R.foldlIndexed(R.multiply, 1, [1, 2, 3, 4]), 24);
     });
 
     it('passes the index as a third parameter to the predicate', function() {
-        assert.strictEqual(R.foldl.idx(timesIdx, 0, [1, 2, 3, 4, 5]), 40);
-        assert.deepEqual(R.foldl.idx(objectify, {}, ['a', 'b', 'c', 'd', 'e']), {a: 0, b: 1, c: 2, d: 3, e: 4});
+        assert.strictEqual(R.foldlIndexed(timesIndexed, 0, [1, 2, 3, 4, 5]), 40);
+        assert.deepEqual(R.foldlIndexed(objectify, {}, ['a', 'b', 'c', 'd', 'e']), {a: 0, b: 1, c: 2, d: 3, e: 4});
     });
 
     it('passes the entire list as a fourth parameter to the predicate', function() {
         var list = [1, 2, 3];
-        R.foldl.idx(function(acc, x, idx, ls) {
+        R.foldlIndexed(function(acc, x, idx, ls) {
             assert.strictEqual(ls, list);
             return acc;
         }, 0, list);
     });
 
     it('is automatically curried', function() {
-        var addOrConcat = R.foldl.idx(R.add);
+        var addOrConcat = R.foldlIndexed(R.add);
         var sum = addOrConcat(0);
         var cat = addOrConcat('');
         assert.strictEqual(sum([1, 2, 3, 4]), 10);
@@ -99,53 +99,53 @@ describe('foldl.idx', function() {
     });
 
     it('throws on zero arguments', function() {
-        assert.throws(R.foldl.idx, TypeError);
-        assert.throws(R.foldl.idx(R.add), TypeError);
+        assert.throws(R.foldlIndexed, TypeError);
+        assert.throws(R.foldlIndexed(R.add), TypeError);
     });
 });
 
-describe('foldr.idx', function() {
-    var timesIdx = function(tot, num, idx) {return tot + (num * idx);};
+describe('foldrIndexed', function() {
+    var timesIndexed = function(tot, num, idx) {return tot + (num * idx);};
     var objectify = function(acc, elem, idx) { acc[elem] = idx; return acc;};
 
     it('folds lists in the right order', function() {
-        assert.strictEqual(R.foldr.idx(function(a, b, idx) {return a + idx + b;}, '', ['a', 'b', 'c', 'd']), '3d2c1b0a');
+        assert.strictEqual(R.foldrIndexed(function(a, b, idx) {return a + idx + b;}, '', ['a', 'b', 'c', 'd']), '3d2c1b0a');
     });
 
     it('folds simple functions over arrays with the supplied accumulator', function() {
-        assert.deepEqual(R.foldr.idx(function(acc, n, idx) { return acc.concat([idx, n]); }, [], [12, 4, 10, 6]), [3, 6, 2, 10, 1, 4, 0, 12]);
+        assert.deepEqual(R.foldrIndexed(function(acc, n, idx) { return acc.concat([idx, n]); }, [], [12, 4, 10, 6]), [3, 6, 2, 10, 1, 4, 0, 12]);
     });
 
     it('returns the accumulator for an empty array', function() {
         var memo = [];
-        assert.strictEqual(R.foldr.idx(function(a, n, idx) { return a.concat(idx); }, memo, []), memo);
+        assert.strictEqual(R.foldrIndexed(function(a, n, idx) { return a.concat(idx); }, memo, []), memo);
     });
 
     it('is automatically curried', function() {
-        var something = R.foldr.idx(function(acc, b, idx) { return acc += idx + b; }, 54);
+        var something = R.foldrIndexed(function(acc, b, idx) { return acc += idx + b; }, 54);
         assert.strictEqual(something([12, 4, 10, 6]), 92);
     });
 
     it('correctly reports the arity of curried versions', function() {
-        var something = R.foldr.idx(function(acc, b, idx) { return acc += idx + b; }, 0);
+        var something = R.foldrIndexed(function(acc, b, idx) { return acc += idx + b; }, 0);
         assert.strictEqual(something.length, 1);
     });
 
     it('passes the index as a third parameter to the predicate', function() {
-        assert.strictEqual(R.foldr.idx(timesIdx, 0, [1, 2, 3, 4, 5]), 40);
-        assert.deepEqual(R.foldr.idx(objectify, {}, ['a', 'b', 'c', 'd', 'e']), {a: 0, b: 1, c: 2, d: 3, e: 4});
+        assert.strictEqual(R.foldrIndexed(timesIndexed, 0, [1, 2, 3, 4, 5]), 40);
+        assert.deepEqual(R.foldrIndexed(objectify, {}, ['a', 'b', 'c', 'd', 'e']), {a: 0, b: 1, c: 2, d: 3, e: 4});
     });
 
     it('passes the entire list as a fourth parameter to the predicate', function() {
         var list = [1, 2, 3];
-        R.foldr.idx(function(acc, x, idx, ls) {
+        R.foldrIndexed(function(acc, x, idx, ls) {
             assert.strictEqual(ls, list);
             return acc;
         }, 0, list);
     });
 
     it('is automatically curried', function() {
-        var addOrConcat = R.foldr.idx(R.add);
+        var addOrConcat = R.foldrIndexed(R.add);
         var sum = addOrConcat(0);
         var cat = addOrConcat('');
         assert.strictEqual(sum([1, 2, 3, 4]), 10);
@@ -153,7 +153,7 @@ describe('foldr.idx', function() {
     });
 
     it('throws on zero arguments', function() {
-        assert.throws(R.foldr.idx, TypeError);
-        assert.throws(R.foldr.idx(R.add), TypeError);
+        assert.throws(R.foldrIndexed, TypeError);
+        assert.throws(R.foldrIndexed(R.add), TypeError);
     });
 });

--- a/test/test.map.js
+++ b/test/test.map.js
@@ -21,27 +21,27 @@ describe('map', function() {
 
 });
 
-describe('map.idx', function() {
+describe('mapIndexed', function() {
     var times2 = function(x) {return x * 2;};
-    var addIdx = function(x, idx) {return x + idx;};
+    var addIndexed = function(x, idx) {return x + idx;};
     var squareEnds = function(x, idx, list) {
         return (idx === 0 || idx === list.length - 1) ? x * x : x;
     };
 
     it('works just like a normal map', function() {
-        assert.deepEqual(R.map.idx(times2, [1, 2, 3, 4]), [2, 4, 6, 8]);
+        assert.deepEqual(R.mapIndexed(times2, [1, 2, 3, 4]), [2, 4, 6, 8]);
     });
 
     it('passes the index as a second parameter to the callback', function() {
-        assert.deepEqual(R.map.idx(addIdx, [8, 6, 7, 5, 3, 0, 9]), [8 + 0, 6 + 1, 7 + 2, 5 + 3, 3 + 4, 0 + 5, 9 + 6]);
+        assert.deepEqual(R.mapIndexed(addIndexed, [8, 6, 7, 5, 3, 0, 9]), [8 + 0, 6 + 1, 7 + 2, 5 + 3, 3 + 4, 0 + 5, 9 + 6]);
     });
 
     it('passes the entire list as a third parameter to the callback', function() {
-        assert.deepEqual(R.map.idx(squareEnds, [8, 6, 7, 5, 3, 0, 9]), [64, 6, 7, 5, 3, 0, 81]);
+        assert.deepEqual(R.mapIndexed(squareEnds, [8, 6, 7, 5, 3, 0, 9]), [64, 6, 7, 5, 3, 0, 81]);
     });
 
     it('is automatically curried', function() {
-        var makeSquareEnds = R.map.idx(squareEnds);
+        var makeSquareEnds = R.mapIndexed(squareEnds);
         assert.deepEqual(makeSquareEnds([8, 6, 7, 5, 3, 0, 9]), [64, 6, 7, 5, 3, 0, 81]);
     });
 });
@@ -55,30 +55,30 @@ describe('mapObj', function() {
     });
 });
 
-describe('mapObj.idx', function() {
+describe('mapObjIndexed', function() {
     var times2 = function(x) {return x * 2;};
-    var addIdx = function(x, key) {return x + key;};
+    var addIndexed = function(x, key) {return x + key;};
     var squareVowels = function(x, key) {
         var vowels = ['a', 'e', 'i', 'o', 'u'];
         return R.contains(key, vowels) ? x * x : x;
     };
 
     it('works just like a normal mapObj', function() {
-        assert.deepEqual(R.mapObj.idx(times2, {a: 1, b: 2, c: 3, d: 4}), {a: 2, b: 4, c: 6, d: 8});
+        assert.deepEqual(R.mapObjIndexed(times2, {a: 1, b: 2, c: 3, d: 4}), {a: 2, b: 4, c: 6, d: 8});
     });
 
     it('passes the index as a second parameter to the callback', function() {
-        assert.deepEqual(R.mapObj.idx(addIdx, {a: 8, b: 6, c: 7, d: 5, e: 3, f: 0, g: 9}),
+        assert.deepEqual(R.mapObjIndexed(addIndexed, {a: 8, b: 6, c: 7, d: 5, e: 3, f: 0, g: 9}),
           {a: '8a', b: '6b', c: '7c', d: '5d', e: '3e', f: '0f', g: '9g'});
     });
 
     it('passes the entire list as a third parameter to the callback', function() {
-        assert.deepEqual(R.mapObj.idx(squareVowels, {a: 8, b: 6, c: 7, d: 5, e: 3, f: 0, g: 9}),
+        assert.deepEqual(R.mapObjIndexed(squareVowels, {a: 8, b: 6, c: 7, d: 5, e: 3, f: 0, g: 9}),
           {a: 64, b: 6, c: 7, d: 5, e: 9, f: 0, g: 9});
     });
 
     it('is automatically curried', function() {
-        var makeSquareVowels = R.mapObj.idx(squareVowels);
+        var makeSquareVowels = R.mapObjIndexed(squareVowels);
         assert.deepEqual(makeSquareVowels({a: 8, b: 6, c: 7, d: 5, e: 3, f: 0, g: 9}),
           {a: 64, b: 6, c: 7, d: 5, e: 9, f: 0, g: 9});
     });


### PR DESCRIPTION
**I'd like to remove these functions.** If others agree, I'll close this pull request and open a new one which does exactly that.

If we're to keep these functions I'd like to stop treating them specially. Renaming them will simplify the build script in #618.
