### PR TITLE
refactor example test runner to separate out doc parsing

### DIFF
--- a/scripts/doc-parser
+++ b/scripts/doc-parser
@@ -1,0 +1,127 @@
+#!/usr/bin/env node
+
+'use strict';
+
+var R = require('..');
+var fs = require('fs');
+var dox = require('dox');
+var normalize = require('path').normalize;
+
+var pickPair = R.curry(function pickBestPartner(first, secondOptions, obj) {
+    var idx = -1;
+    var tmp;
+    while (++idx < secondOptions.length) {
+        tmp = secondOptions[idx];
+        if (tmp in obj) {
+            return [obj[first], obj[tmp]];
+        }
+    }
+    // didn't find, return with first key that isn't first
+    for (tmp in obj) {
+        if (tmp !== first) {
+            return [obj[first], obj[tmp]];
+        }
+    }
+    // return undefined
+});
+
+var gatherer = function() {
+    var listKeys = arguments[0];
+    return function gather(obj, k, v) {
+        var newVal = v;
+        if (k in obj) {
+            if (R.contains(k, listKeys)) {
+                newVal = R.append(v, obj[k]);
+            }
+        } else {
+            if (R.contains(k, listKeys)) {
+                newVal = [v];
+            }
+        }
+        return R.mixin(obj, R.createMapEntry(k, newVal));
+    };
+};
+
+var tagsToMap = function tagsToMap(a) {
+    var idx = -1;
+    var listKeys = arguments[1] || [];
+    var obj = {};
+    var gatherFn = gatherer(listKeys);
+    var pair;
+    while (++idx < a.length) {
+        // get first key and value
+        pair = R.toPairs(a[idx])[0];
+        obj = gatherFn(obj, pair[0], pair[1]);
+    }
+    return obj;
+};
+
+var newMix = function newMix() {
+    var idx = 0;
+    var mixed = arguments[0];
+    while (++idx < arguments.length) {
+        mixed = R.mixin(mixed, arguments[idx]);
+    }
+    return mixed;
+};
+
+var doxTransformer = function doxTransformer(dox) {
+    if (dox == null || dox.ctx == null) {
+        return false;
+    }
+    var tags = R.map(
+        R.compose(R.apply(R.createMapEntry), pickPair('type', ['types', 'string'])),
+        dox.tags
+    );
+    var tagMap = tagsToMap(tags, ['param', 'category']);
+    // omit code: doesn't seem to be correctly populated
+    // description: full and summary seem to be the same thing, body is empty, just get summary
+    return newMix(
+        tagMap,
+        R.createMapEntry('description', dox.description.summary),
+        R.omit(['tags', 'ctx', 'code', 'description'], dox)
+    );
+};
+
+var fileFilter = function fileFilter(pattern, files) {
+    return R.filter(R.match(pattern), files);
+};
+
+var dirFilter = function dirFilter(files) {
+    return R.filter(function(path) {
+        return fs.statSync(path).isDirectory();
+    }, files);
+};
+
+var getDirFilesRecur = R.curry(function getDirFiles(pattern, path) {
+    path = normalize(path);
+    var r = R.map(R.concat(path + '/'), fs.readdirSync(path));
+    var files = fileFilter(pattern, r);
+    var dirs = dirFilter(r);
+    return R.concat(files, R.flatten(R.map(getDirFilesRecur(pattern), dirs)));
+});
+
+var getDox = R.compose(
+    R.head,
+    dox.parseComments,
+    String,
+    fs.readFileSync
+);
+
+// cannot get function name from jsdocs
+// add it in now as we can extract from path
+var buildDox = function buildDox(path) {
+    return R.mixin(
+        getDox(path),
+        {name:path.match(/(\w+)\.js$/)[1]}
+    );
+};
+
+// get src file paths
+var srcFiles = getDirFilesRecur(/.*\.js$/, './src');
+// build dox
+var ramdaDox = R.map(buildDox, srcFiles);
+// make more user friendly
+var niceDocs = R.filter(R.I, R.map(doxTransformer, ramdaDox));
+
+module.exports = niceDocs;

--- a/test/test.examplesRunner.js
+++ b/test/test.examplesRunner.js
@@ -1,185 +1,108 @@
 var assert = require('assert');
 var fs = require('fs');
 var R = require('..');
-var dox = require('dox');
+var ramdaDocs = require('../scripts/doc-parser');
 
-// simple object to hold info about our examples
-function ExampleTest(dox_info, original_source, alias_of) {
-    this.func_name = this.getFunctionName(dox_info.code);
-    this.line_number = dox_info.line;
-    this.original_source = original_source;
-    this.alias_of = alias_of;
-    this.testable_source = this.getTestableSource();
-}
+var assertPairEqual = function assertPairEqual(testInfo) {
+    var msg = testInfo.description + ' === ' + testInfo.expected;
+    return assert.deepEqual(testInfo.expression, testInfo.expected, msg);
+};
 
-ExampleTest.prototype.getFunctionName = function(code) {
-    var func_lines = code.split('\n').slice(0, 2);
-    if (func_lines.length === 0) {
-        return false;
+var requireFromStr = function requireFromStr(src, filename) {
+    var m = new module.constructor();
+    m.paths = module.paths;
+    m._compile(src, filename);
+    return m.exports;
+};
+
+var wrap = R.curry(function(pre, post, s) {
+    return pre + s + post;
+});
+
+var mixWith = R.curry(function mixWith(keyFnPairs, obj) {
+    var idx = -1;
+    var newData = {};
+    var pair;
+    while (++idx < keyFnPairs.length) {
+        pair = keyFnPairs[idx];
+        newData[pair[0]] = pair[1](obj);
     }
-    var matches, func_line = (func_lines[0].indexOf('TODO') !== -1 && func_lines.length > 1) ? func_lines[1] : func_lines[0];
-    if ((matches = func_line.match(/^function (\w+)/)) !== null) {
-        return matches[1];
-    } else if ((matches = func_line.match(/([\w\.]+\s*=\s*)+/)) !== null) {
-        var names = R.reject(R.isEmpty, R.map(R.trim, matches[0].split('=')));
-        return names.length > 0 && (R.find(R.match(/^R\./), names) || names[0]);
-    } else {
-        return false;
+    return R.mixin(obj, newData);
+});
+
+var processExample = function processExample(docs) {
+    if (docs.testExample) {
+        // we have testable source, run example
+        var fnName = 'runExample_' + docs.name.replace(/\W/g, '_') + '_' + docs.line;
+        var fn = getNamedExampleFunction(fnName);
+        fn(docs);
     }
 };
 
-// make some minor adjustments to our example source so we can test output
-ExampleTest.prototype.getTestableSource = function() {
-    if (!this.original_source) {
-        return false;
-    }
-    // convert multiline command + output to single line for testing
-    var testable_source = this.original_source.replace(/^(.*?;.*)$\s*?(\/\/=>.*)$/mg, '$1 $2');
+var getNamedExampleFunction = function getNamedExampleFunction(fnName) {
+    var tmp = new Function('runExampleFn', 'return function ' + fnName + '(docs){ runExampleFn(docs); };');
+    return tmp(runExample);
+};
 
+var runExample = function runExample(docs) {
+    var RTest = requireFromStr(docs.testWrapper(docs.testExample), 'exampleTester');
+    var testData = RTest.testExample();
+    it('compile and test ' + docs.name + ' examples (' + testData.length + ')', function() {
+        R.map(assertPairEqual, testData);
+    });
+};
+
+var getTestExample = function getExampleSource(docs) {
+    // convert multiline command + output to single line for testing
+    var testableSource = docs.example.replace(/^(.*?;.*)$\s*?(\/\/=>.*)$/mg, '$1 $2');
     // convert lines of the form
     // var x = myFunc('something'); //=> 'output'
     // to two test_lines so we can test output
-    testable_source = testable_source.replace(/^\s*(var (\w+).*?;).*?(\/\/=>\s*.*)$/mg, '$1\n$2; $3\n');
-
+    testableSource = testableSource.replace(/^\s*(var (\w+).*?;).*?(\/\/=>\s*.*)$/mg, '$1\n$2; $3\n');
     // get rid of console.log so we're not printing stuff while running tests
-    testable_source = testable_source.replace(/console\.log\(.*\);/mg, ';');
-
-    var test_lines = R.map(this.getTestLine.bind(this), testable_source.split('\n'));
-    return test_lines.join('\n');
+    testableSource = testableSource.replace(/console\.log\(.*\);/mg, ';');
+    return R.map(getTestLine, testableSource.split('\n')).join('\n');
 };
 
-// check line for sample output, add to our _tests array
-ExampleTest.prototype.getTestLine = function(line) {
+var getTestLine = function getTestLine(line) {
     line = line.trim();
+    // check for test output
     var matches = line.match(/^(.*);\s*\/\/=>\s*(.+?)(\/\/.+$|$)/);
     if (matches) {
-        var expression = matches[1],
-          expected = matches[2],
-          test_info_str = '';
-
+        var expression = matches[1];
+        var expected = matches[2];
+        var testInfoStr = '';
         // special case for NaN (NaN === NaN => false)
         if (expected === 'NaN') {
             expression = 'String(' + expression + ')';
             expected = 'String(NaN)';
         }
-        test_info_str += '_tests.push({';
-        test_info_str += 'expression:'   + expression + ',';
-        test_info_str += 'expected:'     + expected + ',';
-        test_info_str += 'description:"(' + expression.replace(/"/g, '\\"') + ' => "+' + expression + '+")"';
-        test_info_str += '});';
-        return test_info_str;
+        testInfoStr += '_tests.push({';
+        testInfoStr += 'expression:' + expression + ',';
+        testInfoStr += 'expected:' + expected + ',';
+        testInfoStr += 'description:"(' + expression.replace(/"/g, '\\"') + ' => "+' + expression + '+")"';
+        testInfoStr += '});';
+        return testInfoStr;
     } else {
         return line;
     }
 };
 
-function splitAt(str, target) {
-    if (!R.is(String, str)) {
-        str = String(str);
-    }
-    var idx = str.indexOf(target);
-    if (idx < 0) {
-        return false;
-    }
-    return [str.substr(0, idx), str.substr(idx)];
-}
-
-function assertPairEqual(test_info) {
-    var msg = test_info.description + ' === ' + test_info.expected;
-    return assert.deepEqual(test_info.expression, test_info.expected, msg);
-}
-
-function requireFromStr(src, filename) {
-    var m = new module.constructor();
-    m.paths = module.paths;
-    m._compile(src, filename);
-    return m.exports;
-}
-
-function processExample(e, idx, all_examples) {
-    // dox ends up with a few local functions and extra
-    // functions from comments we don't need to worry about
-    if (e.func_name === false) {
-        return;
-    }
-    if (e.testable_source) {
-        // we have testable source, run example
-        var run_func_name = 'runExample_' + e.func_name.replace(/\W/g, '_') + '_' + e.line_number;
-        runExample[run_func_name] = function(etmp) { runExample(etmp); };
-        runExample[run_func_name](e);
-    } else {
-        // see if e is alias for function with example
-        checkForAliasExample(e, all_examples);
-    }
-}
-
-function runExample(e) {
-    var Rtest = requireFromStr(ramda_wrap(example_wrap(e.testable_source)), 'example_tester');
-    var test_data = Rtest.example_test();
-    it('compile and test ' + e.func_name + ' examples (' + test_data.length + ')', function() {
-        R.map(assertPairEqual, test_data);
-    });
-}
-
-function checkForAliasExample(e) {
-    it(e.func_name + ' has example or is an alias for function that has example', function() {
-        // TODO: uncomment to enforce this
-      //   if (R.isEmpty(e.alias_of)) {
-      //       fail('undefined', 'example source', 'function has no example and no alias');
-      //   } else {
-      //       var alias_example = R.find(R.propEq('func_name', e.alias_of), examples);
-      //       assert(!R.isEmpty(alias_example), 'was able to find original function for alias');
-      //       assert(!R.isEmpty(alias_example.testable_source), 'original has a testable example');
-      //   }
-    });
-}
-
-// wrap a string
-var wrap = R.curry(function(pre, post, s) {
-    return pre + s + post;
-});
-
-// get the tags we need as a map
-function tagListToMap(targets, list) {
-    var map = {};
-    R.forEach(function(x) {
-        var val_key = targets[x.type];
-        map[x.type] = x[val_key];
-    }, list);
-    return map;
-}
-
-var propIn = R.curry(function(prop_name, prop_vals, object) {
-    return R.any(R.I, R.ap(R.map(R.propEq(prop_name), prop_vals), [object]));
-});
-
-// create our example objects from dox
-function getExampleFromDox(dox_info) {
-    var tags = R.filter(propIn('type', ['example', 'see', 'namespace']), dox_info.tags);
-    var tag_map = tagListToMap({example: 'string', namespace: 'string', see: 'local'}, tags);
-    if (tag_map.namespace) {
-        // ignore namespaces
-        return false;
-    } else {
-        return new ExampleTest(dox_info, tag_map.example, tag_map.see);
-    }
-}
-
-// get ramda source
-var ramda_source = String(fs.readFileSync('./dist/ramda.js'));
-
-// build dox
-var ramda_dox = dox.parseComments(ramda_source);
-
-// get our examples
-var examples = R.filter(R.not(R.eq(false)), R.mapIndexed(getExampleFromDox, ramda_dox));
-
 // prepare our source code to inject examples
-var source_for_compliation = splitAt(ramda_source, '// All the functional goodness, wrapped in a nice little package, just for you!');
-var ramda_wrap = wrap(source_for_compliation[0], source_for_compliation[1]);
-var example_wrap = wrap('R.example_test = function(){\nvar _tests = [];\n', '\nreturn _tests;\n};\n');
+var ramdaSource = String(fs.readFileSync('./dist/ramda.js'));
+var injectPoint = ramdaSource.lastIndexOf('}.call(this));') - 1;
+var exampleStart = 'R.testExample = function(){\nvar _tests = [];\n';
+var exampleEnd = '\nreturn _tests;\n};\n';
+var testWrapper = wrap(ramdaSource.substr(0, injectPoint) + exampleStart, exampleEnd + ramdaSource.substr(injectPoint));
+
+// filter functions that have examples
+var testFuncs = R.filter(R.and(R.has('func'), R.has('example')), ramdaDocs);
+testFuncs = R.map(mixWith([
+    ['testExample', getTestExample],
+    ['testWrapper', R.always(testWrapper)]
+]), testFuncs);
 
 // process examples
 describe('example tests', function() {
-    R.forEachIndexed(processExample, examples);
+    R.forEach(processExample, testFuncs);
 });


### PR DESCRIPTION
Resubmitting after #618

Only real thing of note I think is that `dox` can no longer determine function names from the comments/source code, as they are no longer there. Easy to get around by using file names. And actually as I'm writing this comment it occurred to me `scripts/build` must do something similar and I see

    var filenameToIdentifier =
        R.pipe(R.split('/'),
               R.last,
               R.split('.'),
               R.head);

. My version was

`path.match(/(\w+)\.js$/)[1]`

ha! I still have a long way to go to get used to this functional stuff :) I was thinking it might make sense to add the function name to all the `@func` tags we have, but if the build script uses the filenames maybe this is not necessary. Also should we add `scripts/common` or what have you for shared functionality like this?