### PR TITLE
rename R.not

### DIFF
--- a/dist/ramda.js
+++ b/dist/ramda.js
@@ -371,6 +371,12 @@
         };
     };
 
+    var complement = function complement(f) {
+        return function () {
+            return !f.apply(this, arguments);
+        };
+    };
+
     var cond = function cond() {
         var pairs = arguments;
         return function () {
@@ -552,12 +558,6 @@
         default:
             throw new Error('First argument to nAry must be a non-negative integer no greater than ten');
         }
-    };
-
-    var not = function not(f) {
-        return function () {
-            return !f.apply(this, arguments);
-        };
     };
 
     var nthArg = function nthArg(n) {
@@ -1295,11 +1295,11 @@
     });
 
     var reject = _curry2(function reject(fn, list) {
-        return _filter(not(fn), list);
+        return _filter(complement(fn), list);
     });
 
     var rejectIndexed = _curry2(function rejectIndexed(fn, list) {
-        return _filterIndexed(not(fn), list);
+        return _filterIndexed(complement(fn), list);
     });
 
     var remove = _curry3(function remove(start, count, list) {
@@ -1777,6 +1777,7 @@
         commute: commute,
         commuteMap: commuteMap,
         comparator: comparator,
+        complement: complement,
         compose: compose,
         concat: concat,
         cond: cond,
@@ -1868,7 +1869,6 @@
         multiply: multiply,
         nAry: nAry,
         negate: negate,
-        not: not,
         nth: nth,
         nthArg: nthArg,
         of: of,

--- a/src/complement.js
+++ b/src/complement.js
@@ -11,10 +11,12 @@
  * @example
  *
  *      var gt10 = function(x) { return x > 10; };
- *      var f = R.not(gt10);
+ *      var f = R.complement(gt10);
  *      f(11); //=> false
  *      f(9); //=> true
  */
-module.exports = function not(f) {
-    return function() {return !f.apply(this, arguments);};
+module.exports = function complement(f) {
+    return function() {
+        return !f.apply(this, arguments);
+    };
 };

--- a/src/reject.js
+++ b/src/reject.js
@@ -1,6 +1,6 @@
 var _curry2 = require('./internal/_curry2');
 var _filter = require('./internal/_filter');
-var not = require('./not');
+var complement = require('./complement');
 
 
 /**
@@ -22,5 +22,5 @@ var not = require('./not');
  *      R.reject(isOdd, [1, 2, 3, 4]); //=> [2, 4]
  */
 module.exports = _curry2(function reject(fn, list) {
-    return _filter(not(fn), list);
+    return _filter(complement(fn), list);
 });

--- a/src/rejectIndexed.js
+++ b/src/rejectIndexed.js
@@ -1,6 +1,6 @@
 var _curry2 = require('./internal/_curry2');
 var _filterIndexed = require('./internal/_filterIndexed');
-var not = require('./not');
+var complement = require('./complement');
 
 
 /**
@@ -23,5 +23,5 @@ var not = require('./not');
  *      R.rejectIndexed(lastTwo, [8, 6, 7, 5, 3, 0, 9]); //=> [8, 6, 7, 5, 3]
  */
 module.exports = _curry2(function rejectIndexed(fn, list) {
-    return _filterIndexed(not(fn), list);
+    return _filterIndexed(complement(fn), list);
 });

--- a/test/complement.js
+++ b/test/complement.js
@@ -3,17 +3,17 @@ var assert = require('assert');
 var R = require('..');
 
 
-describe('not', function() {
+describe('complement', function() {
     it('creates boolean-returning function that reverses another', function() {
         var even = function(x) {return x % 2 === 0;};
-        var f = R.not(even);
+        var f = R.complement(even);
         assert.strictEqual(f(8), false);
         assert.strictEqual(f(13), true);
     });
 
     it('accepts a function that take multiple parameters', function() {
         var between = function(a, b, c) {return a < b && b < c;};
-        var f = R.not(between);
+        var f = R.complement(between);
         assert.strictEqual(f(4, 5, 11), false);
         assert.strictEqual(f(12, 2, 6), true);
     });

--- a/test/test.examplesRunner.js
+++ b/test/test.examplesRunner.js
@@ -164,7 +164,7 @@ var ramda_source = String(fs.readFileSync('./dist/ramda.js'));
 var ramda_dox = dox.parseComments(ramda_source);
 
 // get our examples
-var examples = R.filter(R.not(R.eq(false)), R.mapIndexed(getExampleFromDox, ramda_dox));
+var examples = R.reject(R.eq(false), R.mapIndexed(getExampleFromDox, ramda_dox));
 
 // prepare our source code to inject examples
 var source_for_compliation = splitAt(ramda_source, '// All the functional goodness, wrapped in a nice little package, just for you!');


### PR DESCRIPTION
This function is named `complement` in Clojure. Renaming this function will allow its current name to be given to the logical negation function:

``` javascript
R.not = function not(x) { return !x; };
```
