### PR TITLE
rename R.toUpperCase and R.toLowerCase

### DIFF
--- a/dist/ramda.js
+++ b/dist/ramda.js
@@ -1378,11 +1378,11 @@
         return list;
     });
 
-    var toLowerCase = invokerN(0, 'toLowerCase');
+    var toLower = invokerN(0, 'toLowerCase');
 
     var toPairs = _pairWith(keys);
 
-    var toUpperCase = invokerN(0, 'toUpperCase');
+    var toUpper = invokerN(0, 'toUpperCase');
 
     var unfoldr = _curry2(function unfoldr(fn, seed) {
         var pair = fn(seed);
@@ -1921,10 +1921,10 @@
         takeWhile: takeWhile,
         tap: tap,
         times: times,
-        toLowerCase: toLowerCase,
+        toLower: toLower,
         toPairs: toPairs,
         toPairsIn: toPairsIn,
-        toUpperCase: toUpperCase,
+        toUpper: toUpper,
         trim: trim,
         type: type,
         unapply: unapply,

--- a/scripts/build
+++ b/scripts/build
@@ -81,7 +81,7 @@ var dependenciesOf =
                                          R.replace(/^[.]{1,2}[/]/, ''),
                                          R.replace(/[.]([a-z])/g,
                                                    R.pipe(R.nthArg(1),
-                                                          R.toUpperCase)))))),
+                                                          R.toUpper)))))),
            R.map(R.path('id.name')));
 
 //  createDependencyGraph :: [String] -> StrMap [String]

--- a/src/countBy.js
+++ b/src/countBy.js
@@ -22,7 +22,7 @@ var _keyValue = require('./internal/_keyValue');
  *      var numbers = [1.0, 1.1, 1.2, 2.0, 3.0, 2.2];
  *      var letters = R.split('', 'abcABCaaaBBc');
  *      R.countBy(Math.floor)(numbers);    //=> {'1': 3, '2': 2, '3': 1}
- *      R.countBy(R.toLowerCase)(letters);   //=> {'a': 5, 'b': 4, 'c': 3}
+ *      R.countBy(R.toLower)(letters);   //=> {'a': 5, 'b': 4, 'c': 3}
  */
 module.exports = _curry2(function countBy(fn, list) {
     return _foldl(function(counts, obj) {

--- a/src/lens.js
+++ b/src/lens.js
@@ -40,7 +40,7 @@ var _curry2 = require('./internal/_curry2');
  *     phraseLens(obj1); // => 'Absolute filth . . . and I LOVED it!'
  *     phraseLens(obj2); // => "What's all this, then?"
  *     phraseLens.set('Ooh Betty', obj1); //=> { phrase: 'Ooh Betty'}
- *     phraseLens.map(R.toUpperCase, obj2); //=> { phrase: "WHAT'S ALL THIS, THEN?"}
+ *     phraseLens.map(R.toUpper, obj2); //=> { phrase: "WHAT'S ALL THIS, THEN?"}
  */
 module.exports = _curry2(function lens(get, set) {
     var lns = function(a) { return get(a); };

--- a/src/sortBy.js
+++ b/src/sortBy.js
@@ -17,7 +17,7 @@ var _pluck = require('./internal/_pluck');
  * @example
  *
  *      var sortByFirstItem = R.sortBy(prop(0));
- *      var sortByNameCaseInsensitive = R.sortBy(compose(R.toLowerCase, prop('name')));
+ *      var sortByNameCaseInsensitive = R.sortBy(compose(R.toLower, prop('name')));
  *      var pairs = [[-1, 1], [-2, 2], [-3, 3]];
  *      sortByFirstItem(pairs); //=> [[-3, 3], [-2, 2], [-1, 1]]
  *      var alice = {

--- a/src/toLower.js
+++ b/src/toLower.js
@@ -12,6 +12,6 @@ var invokerN = require('./invokerN');
  * @return {String} The lower case version of `str`.
  * @example
  *
- *      R.toLowerCase('XYZ'); //=> 'xyz'
+ *      R.toLower('XYZ'); //=> 'xyz'
  */
 module.exports = invokerN(0, 'toLowerCase');

--- a/src/toUpper.js
+++ b/src/toUpper.js
@@ -12,6 +12,6 @@ var invokerN = require('./invokerN');
  * @return {String} The upper case version of `str`.
  * @example
  *
- *      R.toUpperCase('abc'); //=> 'ABC'
+ *      R.toUpper('abc'); //=> 'ABC'
  */
 module.exports = invokerN(0, 'toUpperCase');

--- a/test/toLower.js
+++ b/test/toLower.js
@@ -3,8 +3,8 @@ var assert = require('assert');
 var R = require('..');
 
 
-describe('toLowerCase', function() {
+describe('toLower', function() {
     it('returns the lower-case equivalent of the input string', function() {
-        assert.strictEqual(R.toLowerCase('XYZ'), 'xyz');
+        assert.strictEqual(R.toLower('XYZ'), 'xyz');
     });
 });

--- a/test/toUpper.js
+++ b/test/toUpper.js
@@ -3,8 +3,8 @@ var assert = require('assert');
 var R = require('..');
 
 
-describe('toUpperCase', function() {
+describe('toUpper', function() {
     it('returns the upper-case equivalent of the input string', function() {
-        assert.strictEqual(R.toUpperCase('abc'), 'ABC');
+        assert.strictEqual(R.toUpper('abc'), 'ABC');
     });
 });


### PR DESCRIPTION
1.0 is probably six months away. Between now and then we must agree on the name and type of each existing function. After 1.0 we're free to change implementations, and to add new functions in minor releases, but renaming functions will be off the table until 2.0. Thus, I'm keen to continue initiating naming discussions.

I consider this is a slight improvement. Shortening these names does not introduce ambiguity, and all else being equal I prefer shorter names.
