### PR TITLE
Implement euclid mathmod

### DIFF
--- a/dist/ramda.js
+++ b/dist/ramda.js
@@ -150,10 +150,6 @@
         return val != null && val.length >= 0 && Object.prototype.toString.call(val) === '[object Array]';
     };
 
-    var _isInteger = Number.isInteger || function _isInteger(n) {
-        return n << 0 === n;
-    };
-
     var _isThenable = function _isThenable(value) {
         return value != null && value === Object(value) && typeof value.then === 'function';
     };
@@ -1753,13 +1749,8 @@
     });
 
     var mathMod = op(function mathMod(m, p) {
-        if (!_isInteger(m)) {
-            return NaN;
-        }
-        if (!_isInteger(p) || p < 1) {
-            return NaN;
-        }
-        return (m % p + p) % p;
+        var rem = m % p;
+        return rem < 0 ? rem + Math.abs(p) : rem;
     });
 
     var modulo = op(function modulo(a, b) {

--- a/src/mathMod.js
+++ b/src/mathMod.js
@@ -1,9 +1,7 @@
-var _isInteger = require('./internal/_isInteger');
 var op = require('./op');
 
-
 /**
- * mathMod behaves like the modulo operator should mathematically, unlike the `%`
+ * mathMod behaves like the modulo operator should mathematically (euclidean), unlike the `%`
  * operator (and by extension, R.modulo). So while "-17 % 5" is -2,
  * mathMod(-17, 5) is 3. mathMod requires Integer arguments, and returns NaN
  * when the modulus is zero or negative.
@@ -38,7 +36,6 @@ var op = require('./op');
  *      seventeenMod(10); //=> 7
  */
 module.exports = op(function mathMod(m, p) {
-    if (!_isInteger(m)) { return NaN; }
-    if (!_isInteger(p) || p < 1) { return NaN; }
-    return ((m % p) + p) % p;
+    var rem = m % p;
+    return rem < 0 ? rem + Math.abs(p) : rem;
 });

--- a/test/mathMod.js
+++ b/test/mathMod.js
@@ -4,32 +4,27 @@ var R = require('..');
 
 
 describe('mathMod', function() {
-    it('requires integer arguments', function() {
-        assert.notStrictEqual(R.mathMod('s', 3), R.mathMod('s', 3));
-        assert.notStrictEqual(R.mathMod(3, 's'), R.mathMod(3, 's'));
-        assert.notStrictEqual(R.mathMod(12.2, 3), R.mathMod(12.2, 3));
-        assert.notStrictEqual(R.mathMod(3, 12.2), R.mathMod(3, 12.2));
+    it('requires numerical arguments', function() {
+        assert.ok(isNaN(R.mathMod('s', 3)));
+        assert.ok(isNaN(R.mathMod(3, 's')));
+        assert.ok(isNaN(R.mathMod(3, {})));
     });
 
     it('behaves differently than JS modulo', function() {
-        assert.notStrictEqual(R.mathMod(-17, 5), -17 % 5);
-        assert.notStrictEqual(R.mathMod(17.2, 5), 17.2 % 5);
-        assert.notStrictEqual(R.mathMod(17, -5), 17 % -5);
+        assert.strictEqual(R.mathMod(-17, 5), 3);
+        assert.strictEqual(R.mathMod(17, -5), 2);
     });
 
-    it('computes the true modulo function', function() {
+    it('computes the euclidean modulo function', function() {
         assert.strictEqual(R.mathMod(-17, 5), 3);
-        assert.strictEqual(isNaN(R.mathMod(17, -5)), true);
         assert.strictEqual(isNaN(R.mathMod(17, 0)), true);
-        assert.strictEqual(isNaN(R.mathMod(17.2, 5)), true);
-        assert.strictEqual(isNaN(R.mathMod(17, 5.5)), true);
+        assert.strictEqual(R.mathMod(17, 5.5), 0.5);
     });
 
     it('is curried', function() {
         var f = R.mathMod(29);
         assert.strictEqual(f(6), 5);
     });
-
 
     it('behaves right curried when passed `undefined` for its first argument', function() {
         var mod5 = R.modulo(void 0, 5);
@@ -39,5 +34,13 @@ describe('mathMod', function() {
 
     it('throws if given no arguments', function() {
         assert.throws(R.mathMod);
+    });
+
+    it('should return a positive value with a positive dividend and a negative divisor', function() {
+        assert.strictEqual(R.mathMod(5, -3), 2);
+    });
+
+    it('should return a positive value with a negative dividend and a negative divisor', function() {
+        assert.strictEqual(R.mathMod(-5, -3), 1);
     });
 });


### PR DESCRIPTION
modulus is [well defined for negative integers](http://en.wikipedia.org/wiki/Modulo_operation#Remainder_calculation_for_the_modulo_operation). This handles it as specced. /cc https://github.com/kchapelier/node-mathp/issues/2

See http://research.microsoft.com/en-us/um/people/daan/download/papers/divmodnote.pdf for proof and implementation details

The examples have to be updated, let me know if this is going through and I'll do so
