### PR TITLE
editorconfig: apply formatting rules more selectively

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,11 +5,13 @@ root = true
 [*]
 charset = utf-8
 end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.js]
 indent_style = space
 indent_size = 4
 max_line_length = 100
-insert_final_newline = true
-trim_trailing_whitespace = true
 
 [*.md]
 # Two trailing spaces => newline in GitHub-flavored markdown


### PR DESCRIPTION
I worked out why Vim was using spaces for indentation in the makefile!
