### PR TITLE
Added 'typed' option to jshint

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,4 +1,5 @@
 {
+  "typed": true,
   "evil": true,
   "eqnull": true,
   "predef": ["beforeEach", "console", "define", "describe", "it", "module", "process", "require"],


### PR DESCRIPTION
I was trying to write some tests using typed arrays but jshint was complaining that it didn't recognize the typed array constructors.

See http://jshint.com/docs/options/#typed for the 'typed' option documentation