### PR TITLE
Revert "Added 'typed' option to jshint"

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,5 +1,4 @@
 {
-  "typed": true,
   "evil": true,
   "eqnull": true,
   "predef": ["beforeEach", "console", "define", "describe", "it", "module", "process", "require"],


### PR DESCRIPTION
reason: We want to warn about typed array usage since not all browsers we support have typed arrays implemented.