### PR TITLE
made R.eq behave as Object.is from ES6

### DIFF
--- a/dist/ramda.js
+++ b/dist/ramda.js
@@ -1940,9 +1940,15 @@
      *      R.eq(o, {}); //=> false
      *      R.eq(1, 1); //=> true
      *      R.eq(1, '1'); //=> false
+     *      R.eq(0, -0); //=> false
+     *      R.eq(NaN, NaN); //=> true
      */
     var eq = _curry2(function eq(a, b) {
-        return a === b;
+        if (a === 0) {
+            return 1 / a === 1 / b;
+        } else {
+            return a === b || a !== a && b !== b;
+        }
     });
 
     /**

--- a/src/eq.js
+++ b/src/eq.js
@@ -19,5 +19,13 @@ var _curry2 = require('./internal/_curry2');
  *      R.eq(o, {}); //=> false
  *      R.eq(1, 1); //=> true
  *      R.eq(1, '1'); //=> false
+ *      R.eq(0, -0); //=> false
+ *      R.eq(NaN, NaN); //=> true
  */
-module.exports = _curry2(function eq(a, b) { return a === b; });
+module.exports = _curry2(function eq(a, b) {
+    if (a === 0) {
+        return 1 / a === 1 / b;
+    } else {
+        return a === b || (a !== a && b !== b);
+    }
+});

--- a/test/eq.js
+++ b/test/eq.js
@@ -9,8 +9,13 @@ describe('eq', function() {
     it('tests for strict equality of its operands', function() {
         assert.strictEqual(R.eq(100, 100), true);
         assert.strictEqual(R.eq(100, '100'), false);
+        assert.strictEqual(R.eq('string', 'string'), true);
         assert.strictEqual(R.eq([], []), false);
         assert.strictEqual(R.eq(a, b), true);
+        assert.strictEqual(R.eq(0, -0), false);
+        assert.strictEqual(R.eq(NaN, NaN), true);
+        assert.strictEqual(R.eq(undefined, undefined), true);
+        assert.strictEqual(R.eq(null, undefined), false);
     });
 
     it('is curried', function() {


### PR DESCRIPTION
Related to #724, almost a direct copy of https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is#Polyfill