### PR TITLE
Update documentation on R.or and R.and

### DIFF
--- a/dist/ramda.js
+++ b/dist/ramda.js
@@ -1810,8 +1810,9 @@
 
     /**
      *
-     * A function wrapping calls to the two functions in an `&&` operation, returning `true` or `false`.  Note that
-     * this is short-circuited, meaning that the second function will not be invoked if the first returns a false-y
+     * A function wrapping calls to the two functions in an `&&` operation, returning the result of the first
+     * function if it is false-y and the result of the second function otherwise.  Note that this is
+     * short-circuited, meaning that the second function will not be invoked if the first returns a false-y
      * value.
      *
      * @func
@@ -3569,8 +3570,9 @@
     });
 
     /**
-     * A function wrapping calls to the two functions in an `||` operation, returning `true` or `false`.  Note that
-     * this is short-circuited, meaning that the second function will not be invoked if the first returns a truth-y
+     * A function wrapping calls to the two functions in an `||` operation, returning the result of the first
+     * function if it is truth-y and the result of the second function otherwise.  Note that this is
+     * short-circuited, meaning that the second function will not be invoked if the first returns a truth-y
      * value.
      *
      * @func

--- a/src/and.js
+++ b/src/and.js
@@ -3,8 +3,9 @@ var _curry2 = require('./internal/_curry2');
 
 /**
  *
- * A function wrapping calls to the two functions in an `&&` operation, returning `true` or `false`.  Note that
- * this is short-circuited, meaning that the second function will not be invoked if the first returns a false-y
+ * A function wrapping calls to the two functions in an `&&` operation, returning the result of the first
+ * function if it is false-y and the result of the second function otherwise.  Note that this is
+ * short-circuited, meaning that the second function will not be invoked if the first returns a false-y
  * value.
  *
  * @func

--- a/src/or.js
+++ b/src/or.js
@@ -2,8 +2,9 @@ var _curry2 = require('./internal/_curry2');
 
 
 /**
- * A function wrapping calls to the two functions in an `||` operation, returning `true` or `false`.  Note that
- * this is short-circuited, meaning that the second function will not be invoked if the first returns a truth-y
+ * A function wrapping calls to the two functions in an `||` operation, returning the result of the first
+ * function if it is truth-y and the result of the second function otherwise.  Note that this is
+ * short-circuited, meaning that the second function will not be invoked if the first returns a truth-y
  * value.
  *
  * @func


### PR DESCRIPTION
This clarifies the documentation to indicate that `R.or` and `R.and` operate just like Javascript `||` and `&&`.