### PR TITLE
remove R.__

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -30,7 +30,7 @@ var filenameToIdentifier = R.rPartial(path.basename, '.js');
 
 //  identifierToFilename :: String -> String
 var identifierToFilename =
-    R.pipe(R.ifElse(RegExp.prototype.test.bind(/^(?!__$)_/),
+    R.pipe(R.ifElse(RegExp.prototype.test.bind(/^_/),
                     R.lPartial(path.join, __dirname, '..', 'src', 'internal'),
                     R.lPartial(path.join, __dirname, '..', 'src')),
            R.rPartial(R.concat, '.js'));

--- a/src/__.js
+++ b/src/__.js
@@ -1,1 +1,0 @@
-module.exports = void 0;

--- a/src/concat.js
+++ b/src/concat.js
@@ -19,7 +19,7 @@ var op = require('./op');
  *         object with a `concat` method on it, `concat` will call `list1.concat`
  *         and pass it the value of `list2`.
  * @note Operator: Since this is a non-commutative infix operator converted to prefix, it can
- *         be curried right by explicitly passing `R.__` for its first argument.
+ *         be curried right by explicitly passing `undefined` for its first argument.
  *
  * @example
  *
@@ -28,7 +28,7 @@ var op = require('./op');
  *      R.concat('ABC', 'DEF'); // 'ABCDEF'
  *
  *      // operator-style:
- *      R.concat(R.__)([4, 5, 6], [1, 2, 3]); //=> [1, 2, 3, 4, 5, 6]
+ *      R.concat(undefined)([4, 5, 6], [1, 2, 3]); //=> [1, 2, 3, 4, 5, 6]
  *
  */
 module.exports = op(function(set1, set2) {

--- a/src/contains.js
+++ b/src/contains.js
@@ -14,7 +14,7 @@ var op = require('./op');
  * @param {Array} list The array to consider.
  * @return {Boolean} `true` if the item is in the list, `false` otherwise.
  * @note Operator: Since this is a non-commutative infix operator converted to prefix, it can
- *       be curried right by explicitly passing `R.__` for its first argument.
+ *       be curried right by explicitly passing `undefined` for its first argument.
  *
  * @example
  *
@@ -25,7 +25,7 @@ var op = require('./op');
  *      R.contains(obj)([{}, obj, {}]); //=> true
  *
  *      // operator-style
- *      R.contains(R.__)([1, 2, 3], 3) //=> true
+ *      R.contains(undefined)([1, 2, 3], 3) //=> true
  *
  */
 module.exports = op(_contains);

--- a/src/divide.js
+++ b/src/divide.js
@@ -17,8 +17,7 @@ var op = require('./op');
  *
  *      R.divide(71, 100); //=> 0.71
  *
- *      // note: In this example, `__`  is just an `undefined` value.  You could use `void 0` instead
- *      var half = R.divide(__, 2);
+ *      var half = R.divide(undefined, 2);
  *      half(42); //=> 21
  *
  *      var reciprocal = R.divide(1);

--- a/src/gt.js
+++ b/src/gt.js
@@ -19,8 +19,7 @@ var op = require('./op');
  *      R.gt(2, 6); //=> false
  *      R.gt(2, 0); //=> true
  *      R.gt(2, 2); //=> false
- *      R.gt(__, 2)(10); //=> true
+ *      R.gt(undefined, 2)(10); //=> true
  *      R.gt(2)(10); //=> false
- *      R.lte(__)(4, 5) // => true
  */
 module.exports = op(_gt);

--- a/src/gte.js
+++ b/src/gte.js
@@ -17,8 +17,8 @@ var op = require('./op');
  *      R.gte(2, 6); //=> false
  *      R.gte(2, 0); //=> true
  *      R.gte(2, 2); //=> true
- *      R.gte(__, 6)(2); //=> false
+ *      R.gte(undefined, 6)(2); //=> false
  *      R.gte(2)(0); //=> true
- *      R.gte(__)(1, 2); //=> true
+ *      R.gte(undefined)(1, 2); //=> true
  */
 module.exports = op(function gte(a, b) { return a >= b; });

--- a/src/lt.js
+++ b/src/lt.js
@@ -20,6 +20,6 @@ var op = require('./op');
  *      R.lt(2, 0); //=> false
  *      R.lt(2, 2); //=> false
  *      R.lt(5)(10); //=> true
- *      R.lt(__, 5)(10); //=> false // right-sectioned currying
+ *      R.lt(undefined, 5)(10); //=> false // right-sectioned currying
  */
 module.exports = op(_lt);

--- a/src/lte.js
+++ b/src/lte.js
@@ -18,8 +18,8 @@ var op = require('./op');
  *      R.lte(2, 6); //=> true
  *      R.lte(2, 0); //=> false
  *      R.lte(2, 2); //=> true
- *      R.lte(__, 2)(1); //=> true
+ *      R.lte(undefined, 2)(1); //=> true
  *      R.lte(2)(10); //=> true
- *      R.lte(__)(5, 4) // => true
+ *      R.lte(undefined)(5, 4) // => true
  */
 module.exports = op(function lte(a, b) { return a <= b; });

--- a/src/mathMod.js
+++ b/src/mathMod.js
@@ -27,11 +27,10 @@ var op = require('./op');
  *      R.mathMod(17.2, 5); //=> NaN
  *      R.mathMod(17, 5.3); //=> NaN
  *
- *      var clock = R.mathMod(__, 12);
+ *      var clock = R.mathMod(undefined, 12);
  *      clock(15); //=> 3
  *      clock(24); //=> 0
  *
- *      // note: In this example, `_`  is just an `undefined` value.  You could use `void 0` instead
  *      var seventeenMod = R.mathMod(17);
  *      seventeenMod(3);  //=> 2
  *      seventeenMod(4);  //=> 1

--- a/src/modulo.js
+++ b/src/modulo.js
@@ -23,7 +23,7 @@ var op = require('./op');
  *      R.modulo(-17, 3); //=> -2
  *      R.modulo(17, -3); //=> 2
  *
- *      var isOdd = R.modulo(__, 2);
+ *      var isOdd = R.modulo(undefined, 2);
  *      isOdd(42); //=> 0
  *      isOdd(21); //=> 1
  */

--- a/src/op.js
+++ b/src/op.js
@@ -1,15 +1,11 @@
-var __ = require('./internal/__');
 var _noArgsException = require('./internal/_noArgsException');
-var binary = require('./binary');
 var flip = require('./flip');
 var lPartial = require('./lPartial');
-var rPartial = require('./rPartial');
-var unary = require('./unary');
 
 
 /**
  * Uses a placeholder to convert a binary function into something like an infix operation.
- * When called with an `undefined` placeholder (e.g. `R.__`) the second argument is applied to the
+ * When called with the `undefined` placeholder the second argument is applied to the
  * second position, and it returns a function waiting for its first argument.
  * This can allow for more natural processing of functions which are really binary operators.
  *
@@ -26,19 +22,19 @@ var unary = require('./unary');
  *
  *      div(6, 3); //=> 2
  *      div(6)(3); //=> 2
- *      div(__, 3)(6); //=> 2 // note: `__` here is just an `undefined` value.  You could use `void 0` instead
- *      div(__)(3, 6); //=> 2
- *      div(__)(3)(6); //=> 2
+ *      div(undefined, 3)(6); //=> 2
+ *      div(undefined)(3, 6); //=> 2
+ *      div(undefined)(3)(6); //=> 2
  */
 module.exports = function op(fn) {
-    var length = fn.length;
-    if (length !== 2) {throw new Error('Expected binary function.');}
-
+    if (fn.length !== 2) {
+        throw new Error('Expected binary function.');
+    }
     return function _op(a, b) {
         switch (arguments.length) {
             case 0: throw _noArgsException();
-            case 1: return a === __ ? binary(flip(_op)) : unary(lPartial(fn, a));
-            default: return a === __ ? unary(rPartial(fn, b)) : fn(a, b);
+            case 1: return a === void 0 ? flip(_op) : lPartial(fn, a);
+            default: return a === void 0 ? flip(fn)(b) : fn(a, b);
         }
     };
 };

--- a/src/subtract.js
+++ b/src/subtract.js
@@ -17,10 +17,9 @@ var op = require('./op');
  *
  *      R.subtract(10, 8); //=> 2
  *
- *      var minus5 = R.subtract(__, 5); // '__' stands for any `undefined` value
+ *      var minus5 = R.subtract(undefined, 5);
  *      minus5(17); //=> 12
  *
- *      // note: In this example, `_`  is just an `undefined` value.  You could use `void 0` instead
  *      var complementaryAngle = R.subtract(90);
  *      complementaryAngle(30); //=> 60
  *      complementaryAngle(72); //=> 18

--- a/test/concat.js
+++ b/test/concat.js
@@ -36,11 +36,11 @@ describe('concat', function() {
         assert.deepEqual(conc123(['a', 'b', 'c']), [1, 2, 3, 'a', 'b', 'c']);
     });
     it('is curried like a binary operator, that accepts an inital placeholder', function() {
-        assert(typeof R.concat(R.__) === 'function');
-        assert(typeof R.concat(R.__)('bar') === 'function');
-        assert(R.concat(R.__)('bar')('foo') === 'foobar');
-        assert(R.concat(R.__, 'bar')('foo') === 'foobar');
-        assert(R.concat(R.__)('bar', 'foo') === 'foobar');
+        assert(typeof R.concat(undefined) === 'function');
+        assert(typeof R.concat(undefined)('bar') === 'function');
+        assert(R.concat(undefined)('bar')('foo') === 'foobar');
+        assert(R.concat(undefined, 'bar')('foo') === 'foobar');
+        assert(R.concat(undefined)('bar', 'foo') === 'foobar');
     });
     it('throws if not an array, String, or object with a concat method', function() {
         assert.throws(function() { return R.concat({}, {}); }, TypeError);

--- a/test/contains.js
+++ b/test/contains.js
@@ -24,11 +24,11 @@ describe('contains', function() {
 
     it('is curried like a binary operator, that accepts an inital placeholder', function() {
         var fbb = ['foo', 'bar', 'baz'];
-        assert(typeof R.contains(R.__) === 'function');
-        assert(typeof R.contains(R.__)('bar') === 'function');
-        assert(R.contains(R.__)(fbb)('bar'));
-        assert(R.contains(R.__, fbb)('bar'));
-        assert(R.contains(R.__)(fbb, 'bar'));
+        assert(typeof R.contains(undefined) === 'function');
+        assert(typeof R.contains(undefined)('bar') === 'function');
+        assert(R.contains(undefined)(fbb)('bar'));
+        assert(R.contains(undefined, fbb)('bar'));
+        assert(R.contains(undefined)(fbb, 'bar'));
     });
 
     it('throws on zero arguments', function() {

--- a/test/divide.js
+++ b/test/divide.js
@@ -14,7 +14,7 @@ describe('divide', function() {
     });
 
     it('behaves right curried when passed `undefined` for its first argument', function() {
-        var half = R.divide(void 0, 2);
+        var half = R.divide(undefined, 2);
         assert.strictEqual(half(40), 20);
     });
 

--- a/test/gt.js
+++ b/test/gt.js
@@ -4,7 +4,6 @@ var R = require('..');
 
 
 describe('gt', function() {
-    var __ = void 0;
     it('reports whether one item is less than another', function() {
         assert(!R.gt(3, 5));
         assert(R.gt(6, 4));
@@ -21,7 +20,7 @@ describe('gt', function() {
     });
 
     it('behaves right curried when passed `undefined` for its first argument', function() {
-        var gt20 = R.gt(__, 20);
+        var gt20 = R.gt(undefined, 20);
         assert(!gt20(10));
         assert(!gt20(20));
         assert(gt20(25));

--- a/test/gte.js
+++ b/test/gte.js
@@ -20,8 +20,7 @@ describe('gte', function() {
     });
 
     it('behaves right curried when passed `undefined` for its first argument', function() {
-        var __ = void 0;
-        var gte20 = R.gte(__, 20);
+        var gte20 = R.gte(undefined, 20);
         assert(!gte20(10));
         assert(gte20(20));
         assert(gte20(25));

--- a/test/lt.js
+++ b/test/lt.js
@@ -4,7 +4,6 @@ var R = require('..');
 
 
 describe('lt', function() {
-    var __ = void 0;
     it('reports whether one item is less than another', function() {
         assert(R.lt(3, 5));
         assert(!R.lt(6, 4));
@@ -21,7 +20,7 @@ describe('lt', function() {
     });
 
     it('behaves right curried when passed `undefined` for its first argument', function() {
-        var lt5 = R.lt(__, 5);
+        var lt5 = R.lt(undefined, 5);
         assert(!lt5(10));
         assert(!lt5(5));
         assert(lt5(3));

--- a/test/lte.js
+++ b/test/lte.js
@@ -4,7 +4,6 @@ var R = require('..');
 
 
 describe('lte', function() {
-    var __ = void 0;
     it('reports whether one item is less than another', function() {
         assert(R.lte(3, 5));
         assert(!R.lte(6, 4));
@@ -21,7 +20,7 @@ describe('lte', function() {
     });
 
     it('behaves right curried when passed `undefined` for its first argument', function() {
-        var upTo20 = R.lte(__, 20);
+        var upTo20 = R.lte(undefined, 20);
         assert(upTo20(10));
         assert(upTo20(20));
         assert(!upTo20(25));

--- a/test/mathMod.js
+++ b/test/mathMod.js
@@ -32,7 +32,7 @@ describe('mathMod', function() {
 
 
     it('behaves right curried when passed `undefined` for its first argument', function() {
-        var mod5 = R.modulo(void 0, 5);
+        var mod5 = R.modulo(undefined, 5);
         assert.strictEqual(mod5(12), 2);
         assert.strictEqual(mod5(8), 3);
     });

--- a/test/modulo.js
+++ b/test/modulo.js
@@ -19,7 +19,7 @@ describe('modulo', function() {
     });
 
     it('behaves right curried when passed `undefined` for its first argument', function() {
-        var isOdd = R.modulo(void 0, 2);
+        var isOdd = R.modulo(undefined, 2);
         assert.strictEqual(typeof isOdd, 'function');
         assert.strictEqual(isOdd(3), 1);
         assert.strictEqual(isOdd(198), 0);

--- a/test/op.js
+++ b/test/op.js
@@ -6,7 +6,6 @@ var R = require('..');
 describe('op', function() {
     function lt(a, b) { return a < b; }
     var olt = R.op(lt);
-    var placeholder = R.__;
 
     it('converts a binary function to enable infix-style behavior via placeholder', function() {
         assert(typeof olt === 'function');
@@ -20,13 +19,13 @@ describe('op', function() {
     });
 
     it('can take a placeholder for the first arg', function() {
-        var lt100 = olt(placeholder, 100);
+        var lt100 = olt(undefined, 100);
         assert(typeof lt100 === 'function');
         assert(lt100(99));
     });
 
     it('can take a placeholder for its only arg', function() {
-        var ltX = olt(placeholder);
+        var ltX = olt(undefined);
         var lt99 = ltX(99);
         assert(typeof ltX === 'function');
         assert(typeof lt99 === 'function');
@@ -35,8 +34,8 @@ describe('op', function() {
 
     it('returns functions with the correct arity', function() {
         assert.strictEqual(R.op(lt).length, 2);
-        assert.strictEqual(R.op(lt)(placeholder).length, 2);
-        assert.strictEqual(R.op(lt)(placeholder, 1000).length, 1);
+        assert.strictEqual(R.op(lt)(undefined).length, 2);
+        assert.strictEqual(R.op(lt)(undefined, 1000).length, 1);
         assert.strictEqual(R.op(lt)(1000).length, 1);
     });
 
@@ -51,11 +50,11 @@ describe('op', function() {
         var gt = R.op(function(a, b) { return a > b; });
         if (Array.prototype.filter) {
             assert.deepEqual(items.filter(R.where({value: gt(3)})), [{value: 1}, {value: 2}]);
-            assert.deepEqual(items.filter(R.where({value: gt(R.__, 3)})), [{value: 4}, {value: 5}]);
-            assert.deepEqual(items.filter(R.where({value: gt(R.__)(3)})), [{value: 4}, {value: 5}]);
+            assert.deepEqual(items.filter(R.where({value: gt(undefined, 3)})), [{value: 4}, {value: 5}]);
+            assert.deepEqual(items.filter(R.where({value: gt(undefined)(3)})), [{value: 4}, {value: 5}]);
         }
-        assert(gt(R.__, 3)(4));
-        assert(gt(R.__, 3)(4, {}));
+        assert(gt(undefined, 3)(4));
+        assert(gt(undefined, 3)(4, {}));
     });
 
     it('throws an exception given no arguments', function() {

--- a/test/subtract.js
+++ b/test/subtract.js
@@ -14,7 +14,7 @@ describe('subtract', function() {
     });
 
     it('behaves right curried when passed `undefined` for its first argument', function() {
-        var minus5 = R.subtract(void 0, 5);
+        var minus5 = R.subtract(undefined, 5);
         assert.strictEqual(minus5(17), 12);
     });
 


### PR DESCRIPTION
This is the alternative to #746. I see no reason to provide `R.__` if its value is and will always be `undefined`. `R.__` will be `undefined` even *after* this change. ;)
