### PR TITLE
prepublish: ensure generated files are freshly generated

### DIFF
--- a/dist/ramda.js
+++ b/dist/ramda.js
@@ -1,4 +1,4 @@
-//  Ramda v0.8.0
+//  Ramda v0.9.0
 //  https://github.com/ramda/ramda
 //  (c) 2013-2015 Scott Sauyet and Michael Hurley
 //  Ramda may be freely distributed under the MIT license.

--- a/scripts/prepublish
+++ b/scripts/prepublish
@@ -7,5 +7,6 @@ README="${README//"${PREVIOUS_VERSION%.*}/ramda.min.js"/"${VERSION%.*}/ramda.min
 echo "$README" >README.md
 git add README.md
 
+rm -f dist/ramda{,.min}.js
 make dist/ramda{,.min}.js
 git add dist/ramda{,.min}.js


### PR DESCRIPTION
I noticed after publishing 0.9.0 that the header of __ramda.js__ still mentions v0.8.0. The reason for this is that none of the file's dependencies had changed since the file was last built, so Make did not rebuild the file.
