### PR TITLE
make countBy handles reserved words in prototype

### DIFF
--- a/src/countBy.js
+++ b/src/countBy.js
@@ -28,5 +28,5 @@ module.exports = _curry2(function countBy(fn, list) {
     return _foldl(function(counts, obj) {
         counts[obj.key] = (counts[obj.key] || 0) + 1;
         return counts;
-    }, {}, _keyValue(fn, list));
+    }, Object.create(null), _keyValue(fn, list));
 });


### PR DESCRIPTION
Current implementation doesn't handle reserved words in prototype
> c(function (e) { return e; }, ['abc', 'toString'])
{ abc: 1, toString: 'function toString() { [native code] }1' }

Proposed change can handle that
c(function (e) { return e; }, ['abc', 'toString'])
{ abc: 1, toString: 1 }