### PR TITLE
Fix issue where memoize does not work for falsy values

### DIFF
--- a/src/memoize.js
+++ b/src/memoize.js
@@ -42,9 +42,9 @@ module.exports = function memoize(fn) {
     return function() {
         if (!arguments.length) {return;}
         var position = _foldl(function(cache, arg) {
-            return cache[arg] || (cache[arg] = {});
+            return cache.hasOwnProperty(arg) ? cache[arg] : (cache[arg] = {});
         }, cache, _slice(arguments, 0, arguments.length - 1));
         var arg = arguments[arguments.length - 1];
-        return (position[arg] || (position[arg] = fn.apply(this, arguments)));
+        return position.hasOwnProperty(arg) ? position[arg] : (position[arg] = fn.apply(this, arguments));
     };
 };

--- a/test/memoize.js
+++ b/test/memoize.js
@@ -30,4 +30,21 @@ describe('memoize', function() {
         assert.strictEqual(identity('x'), 'x');
         assert.strictEqual(identity('y'), 'y');
     });
+
+    it('can memoize falsy values', function() {
+        var ctr = 0;
+        var f = R.memoize(function(x) { ctr++; return '' + x; });
+        var values = [0, false, null, undefined, '', NaN];
+        checkFunctionIsIdentityOn(values);
+        // check function has been called once per value
+        assert.equal(values.length, ctr);
+        checkFunctionIsIdentityOn(values);
+        // check function has not been called again for any of the values
+        assert.equal(values.length, ctr);
+        function checkFunctionIsIdentityOn(values) {
+            for (var i = 0; i < values.length; i++) {
+                assert.equal('' + values[i], f(values[i]));
+            }
+        }
+    });
 });


### PR DESCRIPTION
Falsy values (e.g. null, 0, empty string) were not being memoized by memoize().
Additionally, there was an unnecessary conversion of arguments to an array.