### PR TITLE
Fixing lift to work with other Applicatives

### DIFF
--- a/dist/ramda.js
+++ b/dist/ramda.js
@@ -5409,7 +5409,7 @@
             throw _noArgsException();
         }
         return curryN(arity, function () {
-            return _foldl(_ap, _map(lifted, arguments[0]), _slice(arguments, 1));
+            return _foldl(_ap, map(lifted, arguments[0]), _slice(arguments, 1));
         });
     });
 

--- a/src/liftN.js
+++ b/src/liftN.js
@@ -1,10 +1,10 @@
 var _ap = require('./internal/_ap');
 var _curry2 = require('./internal/_curry2');
 var _foldl = require('./internal/_foldl');
-var _map = require('./internal/_map');
 var _noArgsException = require('./internal/_noArgsException');
 var _slice = require('./internal/_slice');
 var curryN = require('./curryN');
+var map = require('./map');
 
 
 /**
@@ -31,6 +31,6 @@ module.exports = _curry2(function liftN(arity, fn) {
         throw _noArgsException();
     }
     return curryN(arity, function() {
-        return _foldl(_ap, _map(lifted, arguments[0]), _slice(arguments, 1));
+        return _foldl(_ap, map(lifted, arguments[0]), _slice(arguments, 1));
     });
 });

--- a/test/lift.js
+++ b/test/lift.js
@@ -3,6 +3,7 @@
 var assert = require('assert');
 
 var R = require('..');
+var Maybe = require('./shared/Maybe');
 
 
 var add3 = R.curry(function add3(a, b, c) {
@@ -40,4 +41,10 @@ describe('lift', function() {
     it('throws on zero arguments', function() {
         assert.throws(R.lift);
     });
+
+    it('works with other functors such as "Maybe"', function() {
+        var addM = R.lift(R.add);
+        assert.deepEqual(addM(Maybe(3), Maybe(5)), Maybe(8));
+    });
+
 });

--- a/test/liftN.js
+++ b/test/liftN.js
@@ -3,6 +3,7 @@
 var assert = require('assert');
 
 var R = require('..');
+var Maybe = require('./shared/Maybe');
 
 
 var addN = function() {
@@ -46,6 +47,11 @@ describe('liftN', function() {
     });
 
     it('throws on zero arguments', function() {
-        assert.throws(R.lift);
+        assert.throws(R.liftN);
+    });
+
+    it('works with other functors such as "Maybe"', function() {
+        var addM = R.liftN(2, R.add);
+        assert.deepEqual(addM(Maybe(3), Maybe(5)), Maybe(8));
     });
 });

--- a/test/shared/Maybe.js
+++ b/test/shared/Maybe.js
@@ -1,0 +1,45 @@
+module.exports = Maybe;
+
+function Maybe(x) {
+    if (!(this instanceof Maybe)) {
+        return new Maybe(x);
+    }
+    this.value = x;
+}
+
+Maybe.of = function(x) {
+    return new Maybe(x);
+};
+
+// functor
+Maybe.prototype.map = function(f) {
+    return this.value == null ? this : new Maybe(f(this.value));
+};
+
+// apply
+// takes a Maybe that wraps a function (`app`) and applies its `map`
+// method to this Maybe's value, which must be a function.
+Maybe.prototype.ap = function(m) {
+    return typeof this.value !== 'function' ? new Maybe(null) : m.map(this.value);
+};
+
+// applicative
+Maybe.prototype.of = Maybe.of;
+
+// chain
+//  f must be a function which returns a value
+//  f must return a value of the same Chain
+//  chain must return a value of the same Chain
+//
+Maybe.prototype.chain = function(f) {
+    return this.value == null ? this : f(this.value);
+};
+
+// monad
+// A value that implements the Monad specification must also implement the Applicative and Chain specifications.
+// see above.
+
+// equality method to enable testing
+Maybe.prototype.equals = function(that) {
+    return this.value === that.value;
+};


### PR DESCRIPTION
Somewhere along the way, `lift` got broken.  This is just a quick fix and the addition of some regression tests.

To do this, though, I added the `Maybe` type from ramda-fantasy to `test/shared`.

Obviously my git-fu is still a bit lacking as the commit messages are a bit screwed up.