### PR TITLE
remove dispatch from R.of

### DIFF
--- a/dist/ramda.js
+++ b/dist/ramda.js
@@ -1125,6 +1125,27 @@
     };
 
     /**
+     * Returns a singleton array containing the value provided.
+     *
+     * Note this `of` is different from the ES6 `of`; See
+     * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/of
+     *
+     * @func
+     * @memberOf R
+     * @category Function
+     * @sig a -> [a]
+     * @param {*} x any value
+     * @return {Array} An array wrapping `x`.
+     * @example
+     *
+     *      R.of(null); //=> [null]
+     *      R.of([42]); //=> [[42]]
+     */
+    var of = function of(x) {
+        return [x];
+    };
+
+    /**
      * Accepts a function `fn` and returns a function that guards invocation of `fn` such that
      * `fn` can only ever be called once, no matter how many times the returned function is
      * invoked.
@@ -3459,29 +3480,6 @@
      *      R.nth(-99, list); //=> undefined
      */
     var nth = _curry2(_nth);
-
-    /**
-     *
-     * `of` wraps any object in an Array. This implementation is compatible with the
-     * Fantasy-land Applicative spec, and will work with types that implement that spec.
-     * Note this `of` is different from the ES6 `of`; See
-     * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/of
-     *
-     * @func
-     * @memberOf R
-     * @category Function
-     * @sig a -> [a]
-     * @param {*} x any value
-     * @return {Array} An array wrapping `x`.
-     * @example
-     *
-     *      R.of(1); //=> [1]
-     *      R.of([2]); //=> [[2]]
-     *      R.of({}); //=> [{}]
-     */
-    var of = function of(x, container) {
-        return _hasMethod('of', container) ? container.of(x) : [x];
-    };
 
     /**
      * Returns a partial copy of an object omitting the keys specified.

--- a/src/of.js
+++ b/src/of.js
@@ -1,10 +1,6 @@
-var _hasMethod = require('./internal/_hasMethod');
-
-
 /**
+ * Returns a singleton array containing the value provided.
  *
- * `of` wraps any object in an Array. This implementation is compatible with the
- * Fantasy-land Applicative spec, and will work with types that implement that spec.
  * Note this `of` is different from the ES6 `of`; See
  * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/of
  *
@@ -16,10 +12,7 @@ var _hasMethod = require('./internal/_hasMethod');
  * @return {Array} An array wrapping `x`.
  * @example
  *
- *      R.of(1); //=> [1]
- *      R.of([2]); //=> [[2]]
- *      R.of({}); //=> [{}]
+ *      R.of(null); //=> [null]
+ *      R.of([42]); //=> [[42]]
  */
-module.exports = function of(x, container) {
-    return (_hasMethod('of', container)) ? container.of(x) : [x];
-};
+module.exports = function of(x) { return [x]; };


### PR DESCRIPTION
@buzzdecafe and I discussed this change and decided it's a good idea for two reasons:

  - it's one of the few (or perhaps the only) Ramda function with an optional argument; and
  - it's unnecessary, since `R.of(42, Id)` can be written as `Id.of(42)`.
