### PR TITLE
prevent cache misses in R.memoize caused by use of || operator

### DIFF
--- a/dist/ramda.js
+++ b/dist/ramda.js
@@ -920,55 +920,6 @@
     };
 
     /**
-     * Creates a new function that, when invoked, caches the result of calling `fn` for a given
-     * argument set and returns the result. Subsequent calls to the memoized `fn` with the same
-     * argument set will not result in an additional call to `fn`; instead, the cached result
-     * for that set of arguments will be returned.
-     *
-     * Note that this version of `memoize` effectively handles only string and number
-     * parameters.  Also note that it does not work on variadic functions.
-     *
-     * @func
-     * @memberOf R
-     * @category Function
-     * @sig (a... -> b) -> (a... -> b)
-     * @param {Function} fn The function to be wrapped by `memoize`.
-     * @return {Function}  Returns a memoized version of `fn`.
-     * @example
-     *
-     *      var numberOfCalls = 0;
-     *      var trackedAdd = function(a, b) {
-     *        numberOfCalls += 1;
-     *        return a + b;
-     *      };
-     *      var memoTrackedAdd = R.memoize(trackedAdd);
-     *
-     *      memoTrackedAdd(1, 2); //=> 3
-     *      numberOfCalls; //=> 1
-     *      memoTrackedAdd(1, 2); //=> 3
-     *      numberOfCalls; //=> 1
-     *      memoTrackedAdd(2, 3); //=> 5
-     *      numberOfCalls; //=> 2
-     *
-     *      // Note that argument order matters
-     *      memoTrackedAdd(2, 1); //=> 3
-     *      numberOfCalls; //=> 3
-     */
-    var memoize = function memoize(fn) {
-        var cache = {};
-        return function () {
-            if (!arguments.length) {
-                return;
-            }
-            var position = _reduce(function (cache, arg) {
-                return cache[arg] || (cache[arg] = {});
-            }, cache, _slice(arguments, 0, arguments.length - 1));
-            var arg = arguments[arguments.length - 1];
-            return position[arg] || (position[arg] = fn.apply(this, arguments));
-        };
-    };
-
-    /**
      * Wraps a function of any arity (including nullary) in a function that accepts exactly `n`
      * parameters. Any extraneous parameters will not be passed to the supplied function.
      *
@@ -5441,6 +5392,55 @@
             return _reduce(_ap, _map(lifted, arguments[0]), _slice(arguments, 1));
         });
     });
+
+    /**
+     * Creates a new function that, when invoked, caches the result of calling `fn` for a given
+     * argument set and returns the result. Subsequent calls to the memoized `fn` with the same
+     * argument set will not result in an additional call to `fn`; instead, the cached result
+     * for that set of arguments will be returned.
+     *
+     * Note that this version of `memoize` effectively handles only string and number
+     * parameters.  Also note that it does not work on variadic functions.
+     *
+     * @func
+     * @memberOf R
+     * @category Function
+     * @sig (a... -> b) -> (a... -> b)
+     * @param {Function} fn The function to be wrapped by `memoize`.
+     * @return {Function}  Returns a memoized version of `fn`.
+     * @example
+     *
+     *      var numberOfCalls = 0;
+     *      var trackedAdd = function(a, b) {
+     *        numberOfCalls += 1;
+     *        return a + b;
+     *      };
+     *      var memoTrackedAdd = R.memoize(trackedAdd);
+     *
+     *      memoTrackedAdd(1, 2); //=> 3
+     *      numberOfCalls; //=> 1
+     *      memoTrackedAdd(1, 2); //=> 3
+     *      numberOfCalls; //=> 1
+     *      memoTrackedAdd(2, 3); //=> 5
+     *      numberOfCalls; //=> 2
+     *
+     *      // Note that argument order matters
+     *      memoTrackedAdd(2, 1); //=> 3
+     *      numberOfCalls; //=> 3
+     */
+    var memoize = function memoize(fn) {
+        var cache = {};
+        return function () {
+            if (!arguments.length) {
+                return;
+            }
+            var position = _reduce(function (cache, arg) {
+                return has(arg, cache) ? cache[arg] : cache[arg] = {};
+            }, cache, arguments);
+            var arg = last(arguments);
+            return has(arg, position) ? position[arg] : position[arg] = fn.apply(this, arguments);
+        };
+    };
 
     /**
      * Uses a placeholder to convert a binary function into something like an infix operation.

--- a/src/memoize.js
+++ b/src/memoize.js
@@ -1,5 +1,6 @@
 var _reduce = require('./internal/_reduce');
-var _slice = require('./internal/_slice');
+var has = require('./has');
+var last = require('./last');
 
 
 /**
@@ -42,9 +43,9 @@ module.exports = function memoize(fn) {
     return function() {
         if (!arguments.length) {return;}
         var position = _reduce(function(cache, arg) {
-            return cache[arg] || (cache[arg] = {});
-        }, cache, _slice(arguments, 0, arguments.length - 1));
-        var arg = arguments[arguments.length - 1];
-        return (position[arg] || (position[arg] = fn.apply(this, arguments)));
+            return has(arg, cache) ? cache[arg] : (cache[arg] = {});
+        }, cache, arguments);
+        var arg = last(arguments);
+        return has(arg, position) ? position[arg] : (position[arg] = fn.apply(this, arguments));
     };
 };

--- a/test/memoize.js
+++ b/test/memoize.js
@@ -30,4 +30,16 @@ describe('memoize', function() {
         assert.strictEqual(identity('x'), 'x');
         assert.strictEqual(identity('y'), 'y');
     });
+
+    it('memoizes "false" values', function() {
+        var count = 0;
+        var inc = R.memoize(function(n) {
+            count += 1;
+            return n + 1;
+        });
+        assert.strictEqual(inc(-1), 0);
+        assert.strictEqual(inc(-1), 0);
+        assert.strictEqual(inc(-1), 0);
+        assert.strictEqual(count, 1);
+    });
 });


### PR DESCRIPTION
Supersedes #776
