### PR TITLE
Add internal function _depricationWarning.

### DIFF
--- a/deprecation-demo.js
+++ b/deprecation-demo.js
@@ -1,0 +1,7 @@
+var mixin = require('./src/mixin');
+
+var a = {foo: 'bar', baz: 'qux'};
+var b = {foo: 'baz', qux: 'out'};
+
+console.log(mixin(a, b));
+console.log(mixin(a, b));

--- a/dist/ramda.js
+++ b/dist/ramda.js
@@ -6103,6 +6103,42 @@
     // passing `identity` gives correct arity
     var project = useWith(_map, pickAll, identity);
 
+    var _deprecationWarning = function () {
+        var alreadyLogged = [];
+        function _addLogged(name) {
+            alreadyLogged = append(name, alreadyLogged);
+        }
+        function _isLogged(name) {
+            return contains(name, alreadyLogged);
+        }
+        function logMessage(opts) {
+            var message;
+            if (console) {
+                message = join('', [
+                    'R.',
+                    opts.oldName,
+                    ' has been deprecated. Please use R.',
+                    opts.newName,
+                    ' instead.'
+                ]);
+                if (opts.optionalMessage) {
+                    message = join(' ', [
+                        message,
+                        opts.optionalMessage
+                    ]);
+                }
+                console.warn(message);
+                _addLogged(opts.oldName);
+            }
+        }
+        return function _deprecationWarning(opts) {
+            if (!_isLogged(opts.oldName)) {
+                logMessage(opts);
+            }
+            return opts.fn;
+        };
+    }();
+
     /**
      * Wraps a constructor function inside a curried function that can be called with the same
      * arguments and returns the same type.
@@ -6130,6 +6166,13 @@
     var construct = function construct(Fn) {
         return constructN(Fn.length, Fn);
     };
+
+    var mixin = _deprecationWarning({
+        oldName: 'mixin',
+        newName: 'merge',
+        fn: merge,
+        optionalMessage: 'R.mixin will be removed in v1.0.0'
+    });
 
     var R = {
         F: F,
@@ -6249,6 +6292,7 @@
         merge: merge,
         min: min,
         minBy: minBy,
+        mixin: mixin,
         modulo: modulo,
         multiply: multiply,
         nAry: nAry,

--- a/src/internal/_deprecationWarning.js
+++ b/src/internal/_deprecationWarning.js
@@ -1,0 +1,35 @@
+var append = require('../append');
+var contains = require('../contains');
+var join = require('../join');
+
+module.exports = (function() {
+
+    var alreadyLogged = [];
+
+    function _addLogged(name) {
+        alreadyLogged = append(name, alreadyLogged);
+    }
+
+    function _isLogged(name) {
+        return contains(name, alreadyLogged);
+    }
+
+    function logMessage(opts) {
+        var message;
+        if (console) {
+            message = join('', ['R.', opts.oldName, ' has been deprecated. Please use R.', opts.newName, ' instead.']);
+            if (opts.optionalMessage) {
+                message = join(' ', [message, opts.optionalMessage]);
+            }
+            console.warn(message);
+            _addLogged(opts.oldName);
+        }
+    }
+
+    return function _deprecationWarning(opts) {
+        if (!_isLogged(opts.oldName)) {
+            logMessage(opts);
+        }
+        return opts.fn;
+    };
+}());

--- a/src/mixin.js
+++ b/src/mixin.js
@@ -1,0 +1,9 @@
+var _deprecationWarning = require('./internal/_deprecationWarning');
+var merge = require('./merge');
+
+module.exports = _deprecationWarning({
+    oldName: 'mixin',
+    newName: 'merge',
+    fn: merge,
+    optionalMessage: 'R.mixin will be removed in v1.0.0'
+});


### PR DESCRIPTION
The _depricationWarning function provides an easy way to show a
deprication message around a function that has been renamed. By default
it prints the name of the old function and what it has been renamed to.
It also provides the possibility to add an additional message.

_depricationWarning makes sure that it only prints the error message
once per depricated function.