### PR TITLE
fix behaviour of memoized functions when given no arguments

### DIFF
--- a/src/memoize.js
+++ b/src/memoize.js
@@ -1,6 +1,5 @@
-var _reduce = require('./internal/_reduce');
+var _map = require('./internal/_map');
 var has = require('./has');
-var last = require('./last');
 
 
 /**
@@ -9,43 +8,56 @@ var last = require('./last');
  * argument set will not result in an additional call to `fn`; instead, the cached result
  * for that set of arguments will be returned.
  *
- * Note that this version of `memoize` effectively handles only string and number
- * parameters.  Also note that it does not work on variadic functions.
+ * Note that this version of `memoize` should not be applied to functions which
+ * take objects as arguments.
  *
  * @func
  * @memberOf R
  * @category Function
- * @sig (a... -> b) -> (a... -> b)
- * @param {Function} fn The function to be wrapped by `memoize`.
- * @return {Function}  Returns a memoized version of `fn`.
+ * @sig (*... -> a) -> (*... -> a)
+ * @param {Function} fn The function to memoize.
+ * @return {Function} Memoized version of `fn`.
  * @example
  *
- *      var numberOfCalls = 0;
- *      var trackedAdd = function(a, b) {
- *        numberOfCalls += 1;
- *        return a + b;
- *      };
- *      var memoTrackedAdd = R.memoize(trackedAdd);
- *
- *      memoTrackedAdd(1, 2); //=> 3
- *      numberOfCalls; //=> 1
- *      memoTrackedAdd(1, 2); //=> 3
- *      numberOfCalls; //=> 1
- *      memoTrackedAdd(2, 3); //=> 5
- *      numberOfCalls; //=> 2
- *
- *      // Note that argument order matters
- *      memoTrackedAdd(2, 1); //=> 3
- *      numberOfCalls; //=> 3
+ *      var count = 0;
+ *      var factorial = R.memoize(function(n) {
+ *          count += 1;
+ *          return R.product(R.range(1, n + 1));
+ *      });
+ *      factorial(5); //=> 120
+ *      factorial(5); //=> 120
+ *      factorial(5); //=> 120
+ *      count; //=> 1
  */
-module.exports = function memoize(fn) {
-    var cache = {};
-    return function() {
-        if (!arguments.length) {return;}
-        var position = _reduce(function(cache, arg) {
-            return has(arg, cache) ? cache[arg] : (cache[arg] = {});
-        }, cache, arguments);
-        var arg = last(arguments);
-        return has(arg, position) ? position[arg] : (position[arg] = fn.apply(this, arguments));
+module.exports = (function() {
+    // Returns a string representation of the given value suitable for use as
+    // a property name.
+    //
+    // > repr(42)
+    // '42::[object Number]'
+    var repr = function(x) {
+        return x + '::' + Object.prototype.toString.call(x);
     };
-};
+
+    // Serializes an array-like object. The approach is similar to that taken
+    // by [CANON](https://github.com/davidchambers/CANON), though it does not
+    // differentiate between objects at all (!) and, since it is not applied
+    // recursively, does not distinguish between [[42]] and [['42']].
+    //
+    // > serialize(['foo', 42])
+    // '2:{foo::[object String],42::[object Number]}'
+    var serialize = function(args) {
+        return args.length + ':{' + _map(repr, args).join(',') + '}';
+    };
+
+    return function memoize(fn) {
+        var cache = {};
+        return function() {
+            var key = serialize(arguments);
+            if (!has(key, cache)) {
+                cache[key] = fn.apply(this, arguments);
+            }
+            return cache[key];
+        };
+    };
+}());

--- a/test/memoize.js
+++ b/test/memoize.js
@@ -20,11 +20,6 @@ describe('memoize', function() {
         assert.strictEqual(f('Hello', 'World' , '!'), 'Hello, World!');
     });
 
-    it('returns undefined if supplied no parameters for a positive arity function', function() {
-        var fib = R.memoize(function(n) {return n < 2 ? n : fib(n - 2) + fib(n - 1);});
-        assert.strictEqual(typeof fib(), 'undefined');
-    });
-
     it('does not rely on reported arity', function() {
         var identity = R.memoize(function() { return arguments[0]; });
         assert.strictEqual(identity('x'), 'x');
@@ -41,5 +36,39 @@ describe('memoize', function() {
         assert.strictEqual(inc(-1), 0);
         assert.strictEqual(inc(-1), 0);
         assert.strictEqual(count, 1);
+    });
+
+    it('can be applied to nullary function', function() {
+        var count = 0;
+        var f = R.memoize(function() {
+            count += 1;
+            return 42;
+        });
+        assert.strictEqual(f(), 42);
+        assert.strictEqual(f(), 42);
+        assert.strictEqual(f(), 42);
+        assert.strictEqual(count, 1);
+    });
+
+    it('can be applied to function with optional arguments', function() {
+        var count = 0;
+        var f = R.memoize(function concat(a, b) {
+            count += 1;
+            switch (arguments.length) {
+                case 0: return concat('foo');
+                case 1: return concat(a, 'bar');
+                default: return a + b;
+            }
+        });
+        assert.strictEqual(f(), 'foobar');
+        assert.strictEqual(f(), 'foobar');
+        assert.strictEqual(f(), 'foobar');
+        assert.strictEqual(count, 3);
+    });
+
+    it('differentiates values with same string representation', function() {
+        var f = R.memoize(function(x) { return x; });
+        assert.strictEqual(f(42), 42);
+        assert.strictEqual(f('42'), '42');
     });
 });


### PR DESCRIPTION
Fixes #791

We *could* add extra logic to handle caching of nullary functions, but this doesn't seem useful enough to justify the increase in code complexity.
