### PR TITLE
update misleading tests for R.invert and R.invertObj

### DIFF
--- a/test/invert.js
+++ b/test/invert.js
@@ -6,14 +6,20 @@ describe('invert', function() {
     it('takes a list or object and returns an object of lists', function() {
         assert.equal(typeof R.invert([]), 'object');
         assert.equal(typeof R.invert({}), 'object');
-        assert.throws(R.invert(1));
-        assert.throws(R.invert('1'));
-        assert.throws(R.invert(null));
-        assert.throws(R.invert(undefined));
 
         var inverted = R.invert([0]);
         var keys = R.keys(inverted);
         assert(R.is(Array, inverted[keys.pop()]));
+    });
+
+    it('returns an empty object when applied to a primitive', function() {
+        assert.deepEqual(R.invert(42), {});
+        assert.deepEqual(R.invert('abc'), {});
+    });
+
+    it('returns an empty object when applied to null/undefined', function() {
+        assert.deepEqual(R.invert(null), {});
+        assert.deepEqual(R.invert(undefined), {});
     });
 
     it('returns the input\'s values as keys, and keys as values of an array', function() {

--- a/test/invertObj.js
+++ b/test/invertObj.js
@@ -6,10 +6,16 @@ describe('invertObj', function() {
     it('takes a list or object and returns an object', function() {
         assert.equal(typeof R.invertObj([]), 'object');
         assert.equal(typeof R.invertObj({}), 'object');
-        assert.throws(R.invertObj(1));
-        assert.throws(R.invertObj('1'));
-        assert.throws(R.invertObj(null));
-        assert.throws(R.invertObj(undefined));
+    });
+
+    it('returns an empty object when applied to a primitive', function() {
+        assert.deepEqual(R.invertObj(42), {});
+        assert.deepEqual(R.invertObj('abc'), {});
+    });
+
+    it('returns an empty object when applied to null/undefined', function() {
+        assert.deepEqual(R.invertObj(null), {});
+        assert.deepEqual(R.invertObj(undefined), {});
     });
 
     it('returns the input\'s values as keys, and keys as values', function() {


### PR DESCRIPTION
As discovered in #780, `R.invert(1)` and friends all evaluate to `{}`. Inexplicably `assert.throws({})` is not a type error, so these tests test nothing. Were these tests correctly written they would fail as these expressions do *not* throw when evaluated. A comedy of errors. :)
