### PR TITLE
dispatch to "filter" in R.reject

### DIFF
--- a/dist/ramda.js
+++ b/dist/ramda.js
@@ -1,3 +1,8 @@
+//  Ramda v0.9.1
+//  https://github.com/ramda/ramda
+//  (c) 2013-2015 Scott Sauyet and Michael Hurley
+//  Ramda may be freely distributed under the MIT license.
+
 ;(function() {
 
     'use strict';
@@ -3968,7 +3973,7 @@
      *      R.reject(isOdd, [1, 2, 3, 4]); //=> [2, 4]
      */
     var reject = _curry2(function reject(fn, list) {
-        return _filter(not(fn), list);
+        return filter(not(fn), list);
     });
 
     /**
@@ -6163,6 +6168,10 @@
     };
 
     var R = {
+        F: F,
+        I: I,
+        T: T,
+        __: __,
         add: add,
         all: all,
         allPass: allPass,
@@ -6212,7 +6221,6 @@
         eqDeep: eqDeep,
         eqProps: eqProps,
         evolve: evolve,
-        F: F,
         filter: filter,
         filterIndexed: filterIndexed,
         find: find,
@@ -6234,7 +6242,6 @@
         has: has,
         hasIn: hasIn,
         head: head,
-        I: I,
         identity: identity,
         ifElse: ifElse,
         inc: inc,
@@ -6335,7 +6342,6 @@
         substringTo: substringTo,
         subtract: subtract,
         sum: sum,
-        T: T,
         tail: tail,
         take: take,
         takeWhile: takeWhile,
@@ -6363,8 +6369,7 @@
         xprod: xprod,
         zip: zip,
         zipObj: zipObj,
-        zipWith: zipWith,
-        __: __
+        zipWith: zipWith
     };
 
     /* TEST_ENTRY_POINT */

--- a/src/reject.js
+++ b/src/reject.js
@@ -1,5 +1,5 @@
 var _curry2 = require('./internal/_curry2');
-var _filter = require('./internal/_filter');
+var filter = require('./filter');
 var not = require('./not');
 
 
@@ -22,5 +22,5 @@ var not = require('./not');
  *      R.reject(isOdd, [1, 2, 3, 4]); //=> [2, 4]
  */
 module.exports = _curry2(function reject(fn, list) {
-    return _filter(not(fn), list);
+    return filter(not(fn), list);
 });

--- a/test/reject.js
+++ b/test/reject.js
@@ -26,6 +26,25 @@ describe('reject', function() {
         assert.deepEqual(R.reject(function(x) { return x > 100; }, []), []);
     });
 
+    it('dispatches to `filter` method', function() {
+        function Nothing() {}
+        Nothing.value = new Nothing();
+        Nothing.prototype.filter = function() {
+            return this;
+        };
+
+        function Just(x) { this.value = x; }
+        Just.prototype.filter = function(pred) {
+            return pred(this.value) ? this : Nothing.value;
+        };
+
+        var m = new Just(42);
+        assert.strictEqual(R.filter(R.T, m), m);
+        assert.strictEqual(R.filter(R.F, m), Nothing.value);
+        assert.strictEqual(R.reject(R.T, m), Nothing.value);
+        assert.strictEqual(R.reject(R.F, m), m);
+    });
+
     it('is automatically curried', function() {
         var odd = R.reject(even);
         assert.deepEqual(odd([1, 2, 3, 4, 5, 6, 7]), [1, 3, 5, 7]);


### PR DESCRIPTION
This is nice sugar. Assume I have a value `m` of type `Maybe String`, and I wish to perform the following transformation:

```
Nothing -> Nothing
Just '' -> Nothing
Just a  -> Just a
```

With Ramda I could write:

```javascript
R.filter(R.not(R.isEmpty), m)
```

What I'd really like to write, though, is:

```javascript
R.reject(R.isEmpty, m)
```

This change will enable me (and everyone else) to do so. :)
