### PR TITLE
Fixes #803: "make clean" no longer removes ramda.min.js

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ dist/ramda.min.js: dist/ramda.js scripts/header
 
 .PHONY: clean
 clean:
-	rm -f -- dist/ramda.js dist/ramda.min.js ramda.js.tmp
+	rm -f -- dist/ramda.js ramda.js.tmp
 
 
 .PHONY: lint


### PR DESCRIPTION
`make clean; make` doesn't rebuild ramda.min.js so `git status` marks
it as deleted.

@davidchambers says ramda.min.js is only updated when a new version is
published, so let's not remove it on clean.