### PR TITLE
API docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ javascript:(function(){var el=document.createElement('div'),b=document.getElemen
 Documentation
 -------------
 
-Please review the [API documentation](http://ramdajs.com/).
+Please review the [API documentation](http://ramdajs.com/docs/).
 
 
 


### PR DESCRIPTION
The API docs link pointed to the site and not the docs directly. Figured I'd try to save future visitors the extra click :)