### PR TITLE
corrected bower.json  main path

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "ramda",
-  "main": "ramda.js",
+  "main": "dist/ramda.js",
   "version": "0.9.1",
   "homepage": "https://github.com/ramda/ramda",
   "authors": [


### PR DESCRIPTION
corrected bower.json  main path so that build tool auto-injectors (wiredep, main-bower-files, etc.) can find and include ramda.js