### PR TITLE
build: remove dependence on file system ordering

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -156,6 +156,7 @@ var getModifiedSource = function getModifiedSource(identifier) {
 //  build :: [String] -> String
 var build =
     R.pipe(R.map(filenameToIdentifier),
+           R.sortBy(R.I),
            R.converge(R.concat,
                       R.pipe(createDependencyGraph,
                              orderDependencies,


### PR DESCRIPTION
Different platforms sort `A.js B.js a.js b.js` differently.

This change has another benefit, which is ensuring that…

    $ scripts/build -- src/{foo,bar}.js

and…

    $ scripts/build -- src/{bar,foo}.js

produce the same output.
