### PR TITLE
Fix type signature of zip

### DIFF
--- a/src/zip.js
+++ b/src/zip.js
@@ -10,7 +10,7 @@ var _curry2 = require('./internal/_curry2');
  * @func
  * @memberOf R
  * @category List
- * @sig a -> b -> [[a,b]]
+ * @sig [a] -> [b] -> [[a,b]]
  * @param {Array} list1 The first array to consider.
  * @param {Array} list2 The second array to consider.
  * @return {Array} The list made by pairing up same-indexed elements of `list1` and `list2`.


### PR DESCRIPTION
Hi,
I've just seen in the docs that `zip` is typed as `a -> b -> [[a,b]]` while it should be `[a] -> [b] -> [[a,b]]`.