### PR TITLE
preserve arity in R.bind

### DIFF
--- a/dist/ramda.js
+++ b/dist/ramda.js
@@ -1869,9 +1869,9 @@
      * @return {Function} A function that will execute in the context of `thisObj`.
      */
     var bind = _curry2(function bind(fn, thisObj) {
-        return function () {
+        return arity(fn.length, function () {
             return fn.apply(thisObj, arguments);
-        };
+        });
     });
 
     /**

--- a/src/bind.js
+++ b/src/bind.js
@@ -1,4 +1,5 @@
 var _curry2 = require('./internal/_curry2');
+var arity = require('./arity');
 
 
 /**
@@ -16,7 +17,7 @@ var _curry2 = require('./internal/_curry2');
  * @return {Function} A function that will execute in the context of `thisObj`.
  */
 module.exports = _curry2(function bind(fn, thisObj) {
-    return function() {
+    return arity(fn.length, function() {
         return fn.apply(thisObj, arguments);
-    };
+    });
 });

--- a/test/bind.js
+++ b/test/bind.js
@@ -81,4 +81,16 @@ describe('bind', function() {
     it('throws on zero arguments', function() {
         assert.throws(R.bind, TypeError);
     });
+
+    it('preserves arity', function() {
+        var f0 = function() { return 0; };
+        var f1 = function(a) { return a; };
+        var f2 = function(a, b) { return a + b; };
+        var f3 = function(a, b, c) { return a + b + c; };
+
+        assert.strictEqual(R.bind(f0, {}).length, 0);
+        assert.strictEqual(R.bind(f1, {}).length, 1);
+        assert.strictEqual(R.bind(f2, {}).length, 2);
+        assert.strictEqual(R.bind(f3, {}).length, 3);
+    });
 });


### PR DESCRIPTION
I discovered this bug while using `R.bind` to assert that `R.curry` and `R.curryN` preserve context.
