### PR TITLE
update @param for list functions

### DIFF
--- a/dist/ramda.js
+++ b/dist/ramda.js
@@ -4653,7 +4653,7 @@
      * @memberOf R
      * @category List
      * @sig [a] -> [a]
-     * @param {Array} [list=[]] The array to consider.
+     * @param {Array} list The array to consider.
      * @return {Array} A new array containing all but the first element of the input list, or an
      *         empty list if the input list is empty.
      * @example
@@ -5598,7 +5598,7 @@
      * @memberOf R
      * @category List
      * @sig [a] -> a
-     * @param {Array} [list=[]] The array to consider.
+     * @param {Array} list The array to consider.
      * @return {*} The first element of the list, or `undefined` if the list is empty.
      * @example
      *
@@ -5613,7 +5613,7 @@
      * @memberOf R
      * @category List
      * @sig [a] -> [a]
-     * @param {Array} [list=[]] The array to consider.
+     * @param {Array} list The array to consider.
      * @return {Array} A new array containing all but the last element of the input list, or an
      *         empty list if the input list is empty.
      * @example
@@ -5793,7 +5793,7 @@
      * @memberOf R
      * @category List
      * @sig [a] -> a
-     * @param {Array} [list=[]] The array to consider.
+     * @param {Array} list The array to consider.
      * @return {*} The last element of the list, or `undefined` if the list is empty.
      * @example
      *

--- a/src/head.js
+++ b/src/head.js
@@ -9,7 +9,7 @@ var nth = require('./nth');
  * @memberOf R
  * @category List
  * @sig [a] -> a
- * @param {Array} [list=[]] The array to consider.
+ * @param {Array} list The array to consider.
  * @return {*} The first element of the list, or `undefined` if the list is empty.
  * @example
  *

--- a/src/init.js
+++ b/src/init.js
@@ -8,7 +8,7 @@ var slice = require('./slice');
  * @memberOf R
  * @category List
  * @sig [a] -> [a]
- * @param {Array} [list=[]] The array to consider.
+ * @param {Array} list The array to consider.
  * @return {Array} A new array containing all but the last element of the input list, or an
  *         empty list if the input list is empty.
  * @example

--- a/src/last.js
+++ b/src/last.js
@@ -8,7 +8,7 @@ var nth = require('./nth');
  * @memberOf R
  * @category List
  * @sig [a] -> a
- * @param {Array} [list=[]] The array to consider.
+ * @param {Array} list The array to consider.
  * @return {*} The last element of the list, or `undefined` if the list is empty.
  * @example
  *

--- a/src/tail.js
+++ b/src/tail.js
@@ -10,7 +10,7 @@ var _slice = require('./internal/_slice');
  * @memberOf R
  * @category List
  * @sig [a] -> [a]
- * @param {Array} [list=[]] The array to consider.
+ * @param {Array} list The array to consider.
  * @return {Array} A new array containing all but the first element of the input list, or an
  *         empty list if the input list is empty.
  * @example


### PR DESCRIPTION
Surprisingly the `list` parameter to `R.head` and friends was once optional. This pull request updates each function's `@param` to match current behaviour.
