### PR TITLE
fix require paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,10 @@
 /lib/bench/report/
 /lib/docs/public/
 /node_modules/
+/index.js
 /npm-debug.log
 /ramda.js.tmp
 /test/bundle.js
+/tmp
 /bower_components/
 /dist/gh-pages/

--- a/.npmignore
+++ b/.npmignore
@@ -16,6 +16,8 @@
 /Gruntfile.js
 /Makefile
 /bower.json
+/index.js
 /npm-debug.log
 /ramda.js.tmp
 /testem.json
+/tmp

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ DEEDPOLL = node_modules/.bin/deedpoll \
 	--rename fnArity:length \
 	--rename i:idx \
 	--rename index:idx
+MOCHA = node_modules/.bin/mocha
 UGLIFY = node_modules/.bin/uglifyjs
 XYZ = node_modules/.bin/xyz --repo git@github.com:ramda/ramda.git --script scripts/prepublish
 
@@ -48,3 +49,10 @@ setup:
 .PHONY: test
 test: dist/ramda.js
 	npm test
+	find src -name '*.js' -not -path 'src/internal/*' \
+	| sed 's:src/\(.*\)[.]js:exports.\1 = require("./src/\1");:' >index.js
+	sed '/"main":/d' package.json >tmp
+	mv tmp package.json
+	$(MOCHA) -- $(shell find test -name '*.js' -not -name 'installTo.js' -not -name 'test.examplesRunner.js')
+	git checkout -- package.json
+	rm index.js

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "js-yaml": "^3.2.5",
     "lodash": "latest",
     "marked": "^0.3.2",
+    "mocha": "2.x.x",
     "orchestrate": "~0.3.4",
     "q": "^1.1.1",
     "ramda": "0.10.0",

--- a/src/countBy.js
+++ b/src/countBy.js
@@ -1,5 +1,5 @@
 var _curry2 = require('./internal/_curry2');
-var _has = require('./_has');
+var _has = require('./internal/_has');
 
 
 /**

--- a/src/curryN.js
+++ b/src/curryN.js
@@ -1,4 +1,4 @@
-var __ = require('../__');
+var __ = require('./__');
 var _curry2 = require('./internal/_curry2');
 var _noArgsException = require('./internal/_noArgsException');
 var _slice = require('./internal/_slice');

--- a/src/internal/_eqDeep.js
+++ b/src/internal/_eqDeep.js
@@ -1,4 +1,4 @@
-var _has = require('../_has');
+var _has = require('./_has');
 var eq = require('../eq');
 var keys = require('../keys');
 var type = require('../type');

--- a/src/invert.js
+++ b/src/invert.js
@@ -1,4 +1,4 @@
-var _has = require('./_has');
+var _has = require('./internal/_has');
 var keys = require('./keys');
 
 /**

--- a/src/keys.js
+++ b/src/keys.js
@@ -1,5 +1,5 @@
 var _contains = require('./internal/_contains');
-var _has = require('./_has');
+var _has = require('./internal/_has');
 
 
 /**

--- a/src/memoize.js
+++ b/src/memoize.js
@@ -1,4 +1,4 @@
-var _has = require('./_has');
+var _has = require('./internal/_has');
 var _map = require('./internal/_map');
 
 

--- a/src/propOr.js
+++ b/src/propOr.js
@@ -1,5 +1,5 @@
 var _curry3 = require('./internal/_curry3');
-var _has = require('./_has');
+var _has = require('./internal/_has');
 
 
 /**


### PR DESCRIPTION
The build script goes to [great lengths][1] to ensure that the various modules can be safely concatenated to produce __dist/ramda.js__. It ensures for each `require('...')` that the variable name matches the last path component. It does not, however, ensure that the path component is valid. As a result, one could write…

```javascript
var _has = require('./does/not/exist/_has');
```

and the build script would not complain. __dist/ramda.js__ would be valid, but requiring the module above would lead to an import error.

The solution to this problem is to run the test suite twice: once against __dist/ramda.js__ and once against __index.js__, a temporary file which simply requires and exports each of the individual modules.


[1]: https://github.com/ramda/ramda/blob/v0.10.0/scripts/build#L76-L95
