### PR TITLE
Improve wording for ap

### DIFF
--- a/dist/ramda.js
+++ b/dist/ramda.js
@@ -5288,7 +5288,7 @@
      * @sig [f] -> [a] -> [f a]
      * @param {Array} fns An array of functions
      * @param {Array} vs An array of values
-     * @return {Array} The value of applying each the function `fns` to each value in `vs`.
+     * @return {Array} An array of results of applying each of `fns` to all of `vs` in turn.
      * @example
      *
      *      R.ap([R.multiply(2), R.add(3)], [1,2,3]); //=> [2, 4, 6, 4, 5, 6]

--- a/src/ap.js
+++ b/src/ap.js
@@ -11,7 +11,7 @@ var _curry2 = require('./internal/_curry2');
  * @sig [f] -> [a] -> [f a]
  * @param {Array} fns An array of functions
  * @param {Array} vs An array of values
- * @return {Array} The value of applying each the function `fns` to each value in `vs`.
+ * @return {Array} An array of results of applying each of `fns` to all of `vs` in turn.
  * @example
  *
  *      R.ap([R.multiply(2), R.add(3)], [1,2,3]); //=> [2, 4, 6, 4, 5, 6]


### PR DESCRIPTION
Looking at the example code, I couldn’t figure out how the result array came out:

```javascript
R.ap([R.multiply(2), R.add(3)], [1,2,3]); //=> [2, 4, 6, 4, 5, 6]
```

(I’ve read the guidelines for contributing, but I’m not creating a branch because the change is too small.)