### PR TITLE
Fix jsDelivr site link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ or from a CDN, either cdnjs:
 <script src="//cdnjs.cloudflare.com/ajax/libs/ramda/0.10.0/ramda.min.js"></script>
 ```
 
-or one of the below links from [jsDelivr](http://jsdelivr.net):
+or one of the below links from [jsDelivr](http://jsdelivr.com):
 
 ```html
 <script src="//cdn.jsdelivr.net/ramda/0.10.0/ramda.min.js"></script>


### PR DESCRIPTION
For some reason, jsDelivr uses `.com` TLD for the actual website.