### PR TITLE
test: remove redundant test cases for R.__

### DIFF
--- a/test/concat.js
+++ b/test/concat.js
@@ -35,11 +35,6 @@ describe('concat', function() {
         assert.deepEqual(conc123([4, 5, 6]), [1, 2, 3, 4, 5, 6]);
         assert.deepEqual(conc123(['a', 'b', 'c']), [1, 2, 3, 'a', 'b', 'c']);
     });
-    it('is curried like a binary operator, that accepts an inital placeholder', function() {
-        var appendBar = R.concat(R.__, 'bar');
-        assert.strictEqual(typeof appendBar, 'function');
-        assert.strictEqual(appendBar('foo'), 'foobar');
-    });
     it('throws if not an array, String, or object with a concat method', function() {
         assert.throws(function() { return R.concat({}, {}); }, TypeError);
     });

--- a/test/contains.js
+++ b/test/contains.js
@@ -21,12 +21,4 @@ describe('contains', function() {
         assert.strictEqual(R.contains(7)([1, 2, 3]), false);
         assert.strictEqual(R.contains(7)([1, 2, 7, 3]), true);
     });
-
-    it('is curried like a binary operator, that accepts an inital placeholder', function() {
-        var isDigit = R.contains(R.__, ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']);
-        assert.strictEqual(typeof isDigit, 'function');
-        assert.strictEqual(isDigit('0'), true);
-        assert.strictEqual(isDigit('1'), true);
-        assert.strictEqual(isDigit('x'), false);
-    });
 });

--- a/test/divide.js
+++ b/test/divide.js
@@ -12,9 +12,4 @@ describe('divide', function() {
         var into28 = R.divide(28);
         assert.strictEqual(into28(7), 4);
     });
-
-    it('behaves right curried when passed `R.__` for its first argument', function() {
-        var half = R.divide(R.__, 2);
-        assert.strictEqual(half(40), 20);
-    });
 });

--- a/test/gt.js
+++ b/test/gt.js
@@ -18,11 +18,4 @@ describe('gt', function() {
         assert(!lt20(20));
         assert(!lt20(25));
     });
-
-    it('behaves right curried when passed `R.__` for its first argument', function() {
-        var gt20 = R.gt(R.__, 20);
-        assert(!gt20(10));
-        assert(!gt20(20));
-        assert(gt20(25));
-    });
 });

--- a/test/gte.js
+++ b/test/gte.js
@@ -18,11 +18,4 @@ describe('gte', function() {
         assert(lte20(20));
         assert(!lte20(25));
     });
-
-    it('behaves right curried when passed `R.__` for its first argument', function() {
-        var gte20 = R.gte(R.__, 20);
-        assert(!gte20(10));
-        assert(gte20(20));
-        assert(gte20(25));
-    });
 });

--- a/test/has.js
+++ b/test/has.js
@@ -23,15 +23,9 @@ describe('has', function() {
         assert.strictEqual(R.has('age', bob), false);
     });
 
-    it('is curried, op-style', function() {
+    it('is curried', function() {
         var hasName = R.has('name');
         assert.strictEqual(hasName(fred), true);
         assert.strictEqual(hasName(anon), false);
-
-        var point = {x: 0, y: 0};
-        var pointHas = R.has(R.__, point);
-        assert.strictEqual(pointHas('x'), true);
-        assert.strictEqual(pointHas('y'), true);
-        assert.strictEqual(pointHas('z'), false);
     });
 });

--- a/test/lt.js
+++ b/test/lt.js
@@ -18,11 +18,4 @@ describe('lt', function() {
         assert(!gt5(5));
         assert(!gt5(3));
     });
-
-    it('behaves right curried when passed `R.__` for its first argument', function() {
-        var lt5 = R.lt(R.__, 5);
-        assert(!lt5(10));
-        assert(!lt5(5));
-        assert(lt5(3));
-    });
 });

--- a/test/lte.js
+++ b/test/lte.js
@@ -18,11 +18,4 @@ describe('lte', function() {
         assert(gte20(20));
         assert(gte20(25));
     });
-
-    it('behaves right curried when passed `R.__` for its first argument', function() {
-        var upTo20 = R.lte(R.__, 20);
-        assert(upTo20(10));
-        assert(upTo20(20));
-        assert(!upTo20(25));
-    });
 });

--- a/test/mathMod.js
+++ b/test/mathMod.js
@@ -29,11 +29,4 @@ describe('mathMod', function() {
         var f = R.mathMod(29);
         assert.strictEqual(f(6), 5);
     });
-
-
-    it('behaves right curried when passed `R.__` for its first argument', function() {
-        var mod5 = R.modulo(R.__, 5);
-        assert.strictEqual(mod5(12), 2);
-        assert.strictEqual(mod5(8), 3);
-    });
 });

--- a/test/merge.js
+++ b/test/merge.js
@@ -36,9 +36,4 @@ describe('merge', function() {
         var b = {y: 3, z: 4};
         assert.deepEqual(curried(b), {w: 1, x: 2, y: 3, z: 4});
     });
-
-    it('is curried', function() {
-        var curried = R.merge(R.__, {w: 1, x: 2});
-        assert.deepEqual(curried({x: 3, y: 4}), {w: 1, x: 2, y: 4});
-    });
 });

--- a/test/modulo.js
+++ b/test/modulo.js
@@ -18,13 +18,6 @@ describe('modulo', function() {
         assert.strictEqual(hundredMod(17), 15);
     });
 
-    it('behaves right curried when passed `R.__` for its first argument', function() {
-        var isOdd = R.modulo(R.__, 2);
-        assert.strictEqual(typeof isOdd, 'function');
-        assert.strictEqual(isOdd(3), 1);
-        assert.strictEqual(isOdd(198), 0);
-    });
-
     it('preserves javascript-style modulo evaluation for negative numbers', function() {
         assert.strictEqual(R.modulo(-5, 4), -1);
     });

--- a/test/subtract.js
+++ b/test/subtract.js
@@ -12,9 +12,4 @@ describe('subtract', function() {
         var ninesCompl = R.subtract(9);
         assert.strictEqual(ninesCompl(6), 3);
     });
-
-    it('behaves right curried when passed `R.__` for its first argument', function() {
-        var minus5 = R.subtract(R.__, 5);
-        assert.strictEqual(minus5(17), 12);
-    });
 });


### PR DESCRIPTION
Thanks to #836 we needn't test this for each function individually.
