### PR TITLE
Implement dissocPath

### DIFF
--- a/dist/ramda.js
+++ b/dist/ramda.js
@@ -5765,6 +5765,38 @@
     });
 
     /**
+     * Makes a shallow clone of an object, omitting the property at the
+     * given path. Note that this copies and flattens prototype properties
+     * onto the new object as well.  All non-primitive properties are copied
+     * by reference.
+     *
+     * @func
+     * @memberOf R
+     * @category Object
+     * @sig String -> {k: v} -> {k: v}
+     * @param {String} path the dot-delimited path to set
+     * @param {Object} obj the object to clone
+     * @return {Object} a new object without the property at path
+     * @example
+     *
+     *      var obj1 = {a: 1, b: {c: 2, d: 3}, e: 4};
+     *      var obj2 = R.dissocPath('b.c', obj1);
+     *      //=> {a: 1, b: {d: 3}, e: 4}
+     */
+    var dissocPath = function () {
+        function dissocPath(parts, obj) {
+            if (parts.length === 1) {
+                return dissoc(parts[0], obj);
+            }
+            var current = obj[parts[0]];
+            return is(Object, current) ? assoc(parts[0], dissocPath(_slice(parts, 1), current), obj) : obj;
+        }
+        return _curry2(function (path, obj) {
+            return dissocPath(split('.', path), obj);
+        });
+    }();
+
+    /**
      * Performs a deep test on whether two items are equal.
      * Equality implies the two items are semmatically equivalent.
      * Cyclic structures are handled as expected
@@ -6203,6 +6235,7 @@
         difference: difference,
         differenceWith: differenceWith,
         dissoc: dissoc,
+        dissocPath: dissocPath,
         divide: divide,
         drop: drop,
         dropWhile: dropWhile,

--- a/src/dissocPath.js
+++ b/src/dissocPath.js
@@ -1,0 +1,37 @@
+var _curry2 = require('./internal/_curry2');
+var _slice = require('./internal/_slice');
+var assoc = require('./assoc');
+var dissoc = require('./dissoc');
+var is = require('./is');
+var split = require('./split');
+
+
+/**
+ * Makes a shallow clone of an object, omitting the property at the
+ * given path. Note that this copies and flattens prototype properties
+ * onto the new object as well.  All non-primitive properties are copied
+ * by reference.
+ *
+ * @func
+ * @memberOf R
+ * @category Object
+ * @sig String -> {k: v} -> {k: v}
+ * @param {String} path the dot-delimited path to set
+ * @param {Object} obj the object to clone
+ * @return {Object} a new object without the property at path
+ * @example
+ *
+ *      var obj1 = {a: 1, b: {c: 2, d: 3}, e: 4};
+ *      var obj2 = R.dissocPath('b.c', obj1);
+ *      //=> {a: 1, b: {d: 3}, e: 4}
+ */
+module.exports = (function() {
+    function dissocPath(parts, obj) {
+        if (parts.length === 1) {return dissoc(parts[0], obj);}
+        var current = obj[parts[0]];
+        return is(Object, current) ? assoc(parts[0], dissocPath(_slice(parts, 1), current), obj) : obj;
+    }
+    return _curry2(function(path, obj) {
+        return dissocPath(split('.', path), obj);
+    });
+}());

--- a/test/dissocPath.js
+++ b/test/dissocPath.js
@@ -1,0 +1,55 @@
+var assert = require('assert');
+
+var R = require('..');
+
+
+describe('dissocPath', function() {
+    it('makes a shallow clone of an object, omitting only what is necessary for the path', function() {
+        var obj1 = {a: {b: 1, c: 2, d: {e: 3}}, f: {g: {h: 4, i: 5, j: {k: 6, l: 7}}}, m: 8};
+        var obj2 = R.dissocPath('f.g.i', obj1);
+        assert.deepEqual(obj2,
+            {a: {b: 1, c: 2, d: {e: 3}}, f: {g: {h: 4, j: {k: 6, l: 7}}}, m: 8}
+        );
+        // Note: reference equality below!
+        assert.strictEqual(obj2.a, obj1.a);
+        assert.strictEqual(obj2.m, obj1.m);
+        assert.strictEqual(obj2.f.g.h, obj1.f.g.h);
+        assert.strictEqual(obj2.f.g.j, obj1.f.g.j);
+    });
+
+    it('does not try to omit inner properties that do not exist', function() {
+        var obj1 = {a: 1, b: {c: 2, d: 3}, e: 4, f: 5};
+        var obj2 = R.dissocPath('x.y.z', obj1);
+        assert.deepEqual(obj2, {a: 1, b: {c: 2, d: 3}, e: 4, f: 5});
+        // Note: reference equality below!
+        assert.strictEqual(obj2.a, obj1.a);
+        assert.strictEqual(obj2.b, obj1.b);
+        assert.strictEqual(obj2.f, obj1.f);
+    });
+
+    it('leaves an empty object when all properties omitted', function() {
+        var obj1 = {a: 1, b: {c: 2}, d: 3};
+        var obj2 = R.dissocPath('b.c', obj1);
+        assert.deepEqual(obj2,
+            {a: 1, b: {}, d: 3}
+        );
+    });
+
+    it('flattens properties from prototype', function() {
+        var F = function() {};
+        F.prototype.a = 1;
+        var obj1 = new F();
+        obj1.b = {c: 2, d: 3};
+        var obj2 = R.dissocPath('b.c', obj1);
+        assert.deepEqual(obj2,
+            {a: 1, b: {d: 3}}
+        );
+    });
+
+    it('is curried', function() {
+        var obj1 = {a: {b: 1, c: 2, d: {e: 3}}, f: {g: {h: 4, i: 5, j: {k: 6, l: 7}}}, m: 8};
+        var expected = {a: {b: 1, c: 2, d: {e: 3}}, f: {g: {h: 4, j: {k: 6, l: 7}}}, m: 8};
+        var f = R.dissocPath('f.g.i');
+        assert.deepEqual(f(obj1), expected);
+    });
+});


### PR DESCRIPTION
Implement `dissocPath` function. I used the implementation of `assocPath` as a starting point and this is quite similar to it. `dissocPath` was mentioned in https://github.com/ramda/ramda/pull/781 and I decided to implement it because I needed it for my own project.