### PR TITLE
transducers initial commit

### DIFF
--- a/dist/eg.js
+++ b/dist/eg.js
@@ -1,0 +1,3 @@
+function inc(x) { return x + 1; };
+function even(x) { return x % 2 === 0; };
+function square(x) { return x * x; };

--- a/dist/eg0.map.html
+++ b/dist/eg0.map.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html>
+<head>
+<script src="ramda.js"></script>
+<script src="eg.js"></script>
+<script>
+var list = R.range(0, 5);
+debugger;
+var r = R.map(inc, list);
+console.log(r);
+</script>
+</head>
+<body>
+</body>
+</html>

--- a/dist/eg1.nested.html
+++ b/dist/eg1.nested.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html>
+<head>
+<script src="ramda.js"></script>
+<script src="eg.js"></script>
+<script>
+var lists = [
+    R.range(0, 5),
+    R.range(5, 10)
+];
+debugger;
+var filterEven = R.filter(even);
+var mapFilter = R.map(filterEven);
+var r = mapFilter(lists);
+console.log(r);
+</script>
+</head>
+<body>
+</body>
+</html>

--- a/dist/eg2.pipe.html
+++ b/dist/eg2.pipe.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html>
+<head>
+<script src="ramda.js"></script>
+<script src="eg.js"></script>
+<script>
+var list = R.range(0, 5);
+var filterEven = R.filter(even);
+var mapInc = R.map(inc);
+debugger;
+var filterMap = R.pipe(filterEven, mapInc);
+var r = filterMap(list);
+console.log(r);
+</script>
+</head>
+<body>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -68,6 +68,8 @@
     "highlight.js": "^8.4.0",
     "js-yaml": "^3.2.5",
     "lodash": "latest",
+    "immutable": "latest",
+    "transducers-js": "latest",
     "marked": "^0.3.2",
     "mocha": "2.x.x",
     "orchestrate": "~0.3.4",

--- a/src/filter.js
+++ b/src/filter.js
@@ -25,4 +25,4 @@ var _filter = require('./internal/_filter');
  *      };
  *      R.filter(isEven, [1, 2, 3, 4]); //=> [2, 4]
  */
-module.exports = _curry2(_checkForMethod('filter', _filter));
+module.exports = _filter;

--- a/src/internal/_FN_TYPE_KEY.js
+++ b/src/internal/_FN_TYPE_KEY.js
@@ -1,0 +1,2 @@
+// this is an object key so must be a string
+module.exports = '__RAMDA_FN_TYPE__';

--- a/src/internal/_XF_TRANSIENT_FLAG.js
+++ b/src/internal/_XF_TRANSIENT_FLAG.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/src/internal/_executeComposition.js
+++ b/src/internal/_executeComposition.js
@@ -1,0 +1,10 @@
+
+module.exports = function _executeComposition(fns, args) {
+    var startIdx = fns.length - 1;
+    var val = fns[startIdx].apply(this, args);
+    var idx = startIdx;
+    while (idx--) {
+        val = fns[idx].call(this, val);
+    }
+    return val;
+};

--- a/src/internal/_executePipe.js
+++ b/src/internal/_executePipe.js
@@ -1,0 +1,10 @@
+
+module.exports = function _executePipe(fns, args) {
+    var endIdx = fns.length - 1;
+    var val = fns[0].apply(this, args);
+    var idx = 0;
+    while (idx++ < endIdx) {
+        val = fns[idx].call(this, val);
+    }
+    return val;
+};

--- a/src/internal/_filter.js
+++ b/src/internal/_filter.js
@@ -1,9 +1,18 @@
-module.exports = function _filter(fn, list) {
-    var idx = -1, len = list.length, result = [];
-    while (++idx < len) {
-        if (fn(list[idx])) {
-            result[result.length] = list[idx];
-        }
+var _makeXf = require('./_makeXf');
+
+module.exports = _makeXf({
+    init:function filterInit() {
+        return this.xf.init();
+    },
+    result:function filterResult(result) {
+        return this.xf.result(result);
+    },
+    step:function filterStep(result, value, key, coll) {
+        return (
+            this.f(value, key, coll) ?
+                this.xf.step(result, value, key, coll) :
+            // else
+                result
+        );
     }
-    return result;
-};
+});

--- a/src/internal/_getFunctionType.js
+++ b/src/internal/_getFunctionType.js
@@ -1,0 +1,5 @@
+var _FN_TYPE_KEY = require('./_FN_TYPE_KEY');
+
+module.exports = function _getFunctionType(f) {
+    return f == null ? null : f[_FN_TYPE_KEY];
+};

--- a/src/internal/_getTypedFunction.js
+++ b/src/internal/_getTypedFunction.js
@@ -1,0 +1,6 @@
+var _FN_TYPE_KEY = require('./_FN_TYPE_KEY');
+
+module.exports = function _getTypedFunction(type, f) {
+    f[_FN_TYPE_KEY] = type;
+    return f;
+};

--- a/src/internal/_isIterable.js
+++ b/src/internal/_isIterable.js
@@ -1,0 +1,3 @@
+module.exports = function _isIterable(x) {
+    return typeof Symbol !== 'undefined' && x != null && typeof x[Symbol.iterator] === 'function';
+};

--- a/src/internal/_isTransientXf.js
+++ b/src/internal/_isTransientXf.js
@@ -1,0 +1,8 @@
+var _XF_TRANSIENT_FLAG = require('./_XF_TRANSIENT_FLAG');
+var _getFunctionType = require('./_getFunctionType');
+
+// is our function the result of a transducer that has been
+// given a function but is still waiting for a reducing function
+module.exports = function _isTransientXf(x) {
+    return _getFunctionType(x) === _XF_TRANSIENT_FLAG;
+};

--- a/src/internal/_isXf.js
+++ b/src/internal/_isXf.js
@@ -1,0 +1,5 @@
+var is = require('../is');
+
+module.exports = function _isXf(x) {
+    return x != null && is(Function, x.init) && is(Function, x.result) && is(Function, x.step)
+};

--- a/src/internal/_makeXf.js
+++ b/src/internal/_makeXf.js
@@ -1,0 +1,50 @@
+var _XF_TRANSIENT_FLAG = require('./_XF_TRANSIENT_FLAG');
+var __ = require('../__');
+var _getTypedFunction = require('./_getTypedFunction');
+var _isXf = require('./_isXf');
+var _transduce = require('./_transduce');
+var _xfMakeType = require('./_xfMakeType');
+var is = require('../is');
+
+module.exports = function(){
+    
+    var transducable = function transducable(xfType, f) {
+        return function innerTransducable(xf) {
+            return new xfType(f, xf);
+        };
+    };
+
+    var _dispatchXf = function _dispatchXf(xfType, f, xfOrCollection) {
+        // got our reducing function, return our transformer
+        if (_isXf(xfOrCollection)) {
+            return new xfType(f, xfOrCollection);
+        }
+        // got a collection, transduce
+        else {
+            // todo? use apply here so user can pass in however many arguments they want
+            // and they will get passed along to transduce
+            return _transduce(transducable(xfType, f), xfOrCollection);
+        }
+    };
+    
+    var _xfWrapper = function _xfWrapper(xfType) {
+        // all our transducers are wrapped by this function
+        // ie when Ramda is loaded, we are at this point with map, filter, take, etc
+        return _getTypedFunction(_XF_TRANSIENT_FLAG, function _innerXfWrapper(f, xfOrCollectionOrUndefined) {
+            // got our collection
+            if (arguments.length > 1) {
+                return _dispatchXf(xfType, f, xfOrCollectionOrUndefined);
+            }
+            else {
+                return _getTypedFunction(_XF_TRANSIENT_FLAG, function _curryInnerXfWrapper(xfOrCollection){
+                    return _dispatchXf(xfType, f, xfOrCollection);
+                });
+            }
+        });
+    };
+    
+    return function _makeXf(xfDefinition) {
+        var type = _xfMakeType(xfDefinition);
+        return _xfWrapper(type);
+    };
+}();

--- a/src/internal/_map.js
+++ b/src/internal/_map.js
@@ -1,7 +1,13 @@
-module.exports = function _map(fn, list) {
-    var idx = -1, len = list.length, result = new Array(len);
-    while (++idx < len) {
-        result[idx] = fn(list[idx]);
+var _makeXf = require('./_makeXf');
+
+module.exports = _makeXf({
+    init:function mapInit() {
+        return this.xf.init();
+    },
+    result:function mapResult(result) {
+        return this.xf.result(result);
+    },
+    step:function mapStep(result, value, key, coll) {
+        return this.xf.step(result, this.f(value, key, coll), key, coll);
     }
-    return result;
-};
+});

--- a/src/internal/_mapcat.js
+++ b/src/internal/_mapcat.js
@@ -1,0 +1,16 @@
+var _makeXf = require('./_makeXf');
+var flatten = require('../flatten');
+
+// maps over a collection and then concatenates the result
+// see https://clojuredocs.org/clojure.core/mapcat
+module.exports = _makeXf({
+    init:function mapCatInit() {
+        return this.xf.init();
+    },
+    result:function mapCatResult(result) {
+        return this.xf.result(flatten(result));
+    },
+    step:function mapCatStep(result, value, key, coll) {
+        return this.xf.step(result, this.f(value, key, coll), key, coll);
+    }
+});

--- a/src/internal/_pipeWrapper.js
+++ b/src/internal/_pipeWrapper.js
@@ -1,0 +1,9 @@
+var _executePipe = require('./_executePipe');
+
+module.exports = function _pipeWrapper(fns) {
+    return function _innerPipeWrapper() {
+        return _executePipe.call(this, fns, arguments);
+        _log('compose', 'pipe wrap execute');
+        return _executeComposition(fns, arguments, 0, fns.length, 1);
+    };
+};

--- a/src/internal/_reduce.js
+++ b/src/internal/_reduce.js
@@ -1,7 +1,126 @@
-module.exports = function _reduce(fn, acc, list) {
-    var idx = -1, len = list.length;
-    while (++idx < len) {
-        acc = fn(acc, list[idx]);
-    }
-    return acc;
-};
+var _isArray = require('./_isArray');
+var _isIterable = require('./_isIterable');
+var _isXf = require('./_isXf');
+var _xfDefaultInit = require('./_xfDefaultInit');
+var _xfReducer = require('./_xfReducer');
+
+module.exports = function (){
+
+    var isReduced = function(x) {
+        return x.__transducers_reduced__ === true;
+    };
+    
+    var isObject = function isObject(x) {
+        return x instanceof Object;
+    };
+    
+    var arrayReduce = function arrayReduce(xf, init, list) {
+        var acc = init;
+        var i;
+        for (i = 0; i < list.length; ++i) {
+            acc = xf.step(acc, list[i], i, list);
+            if (isReduced(acc)) {
+                acc = acc.value;
+                break;
+            }
+        }
+        return xf.result(acc);
+    };
+    
+    var objectReduce = function objectReduce(xf, init, obj) {
+        var acc = init;
+        var p;
+        for (p in obj) {
+            if (obj.hasOwnProperty(p)) {
+                acc = xf.step(acc, obj[p], p, obj);
+                if (isReduced(acc)) {
+                    acc = acc.value;
+                    break;
+                }
+            }
+        }
+        return xf.result(acc);
+    };
+    
+    var iterableReduce = function(xf, init, iterable) {
+        if (iterable.entries instanceof Function) {
+            return iteratorKeyValReduce(xf, init, iterable, iterable.entries());
+        }
+        else if (typeof Symbol !== 'undefined' && iterable[Symbol.iterator]) {
+            return iteratorValOnlyReduce(xf, init, iterable, iterable[Symbol.iterator]());
+        }
+        else if (iterable['@@iterator']) {
+            return iteratorValOnlyReduce(xf, init, iterable, iterable['@@iterator']());
+        }
+        else if (iterable.next instanceof Function) {
+            return iteratorValOnlyReduce(xf, init, iterable, iterable);
+        }
+        else {
+            throw 'Could not get iterator from ' + iterable.toString();
+        }
+    };
+
+    var iteratorValOnlyReduce = function iteratorValOnlyReduce(xf, init, iterable, iterator) {
+        var acc = init;
+        var step;
+        for (step = iterator.next(); !step.done; step = iterator.next()) {
+            acc = xf.step(acc, step.value, void 0, iterable);
+            if (isReduced(acc)) {
+                acc = acc.value;
+                break;
+            }
+        }
+        return xf.result(acc);
+    };
+
+    var iteratorKeyValReduce = function iteratorKeyValReduce(xf, init, iterable, iterator) {
+        var acc = init;
+        var step;
+        for (step = iterator.next(); !step.done; step = iterator.next()) {
+            acc = xf.step(acc, step.value[1], step.value[0], iterable);
+            if (isReduced(acc)) {
+                acc = acc.value;
+                break;
+            }
+        }
+        return xf.result(acc);
+    };
+
+    var observableReduce = function observableReduce(xf, init, observable, cb) {
+        var acc = init;
+        var i = 0;
+        var listener = function listener(chunk) {
+            acc = xf.step(acc, chunk, i, observable);
+            if (isReduced(acc)) {
+                // stop listening for data events
+                observable.removeListener('data', listener);
+                acc = acc.value;
+            }
+            i++;
+        };
+        observable.on('data', listener);
+        observable.on('end', function() { cb(null, xf.result(acc)); });
+        observable.on('error', function(e) { cb(e); });
+    };
+    
+    return function _reduce(xf, init, coll) {
+        if (arguments.length === 2) {
+            coll = init;
+            init = _xfDefaultInit(coll);
+        }
+        if (!_isXf(xf)) {
+            xf = new _xfReducer(xf);
+        }
+        // reduce based on type of collection
+        if (_isArray(coll)) {
+            return arrayReduce(xf, init, coll);
+        }
+        else if (_isIterable(coll)) {
+            return iterableReduce(xf, init, coll);
+        }
+        else if (isObject(coll)) {
+            return objectReduce(xf, init, coll);
+        }
+        throw 'Cannot reduce "' + coll.toString() + '"';
+    };
+}();

--- a/src/internal/_take.js
+++ b/src/internal/_take.js
@@ -1,0 +1,24 @@
+var _makeXf = require('./_makeXf');
+var _xfReduced = require('./_xfReduced');
+
+module.exports = _makeXf({
+    Ctor:function takeCtor(n, xf) {
+        this.n = n;
+        this.xf = xf;
+        this.nTaken = 0;
+    },
+    init:function mapInit() {
+        return this.xf.init();
+    },
+    result:function mapResult(result) {
+        return this.xf.result(result);
+    },
+    step:function takeStep(result, value, key, coll) {
+        if (this.nTaken++ < this.n) {
+            return this.xf.step(result, value, key, coll);
+        }
+        else {
+            return _xfReduced(result);
+        }
+    }
+});

--- a/src/internal/_transduce.js
+++ b/src/internal/_transduce.js
@@ -1,0 +1,12 @@
+var _reduce = require('./_reduce');
+var _xfDefaultAccumulate = require('./_xfDefaultAccumulate');
+var _xfDefaultInit = require('./_xfDefaultInit');
+var _xfReducer = require('./_xfReducer');
+
+module.exports = function _transduce(xf, coll) {
+    var f = new _xfReducer(_xfDefaultAccumulate(coll));
+    var init = _xfDefaultInit(coll);
+    // build our transducer stack!
+    xf = xf(f);
+    return _reduce(xf, init, coll);
+};

--- a/src/internal/_xfComposeConsecutive.js
+++ b/src/internal/_xfComposeConsecutive.js
@@ -1,0 +1,15 @@
+var _isTransientXf = require('./_isTransientXf');
+var _xfComposeDispatch = require('./_xfComposeDispatch');
+var head = require('../head');
+
+module.exports = function _xfComposeConsecutive(fns) {
+    // after partition, fns in each subarray are either all transformers or
+    // all not transformers
+    // if we have more than 1, and 1st (ie all) is transformer compose them
+    if (fns.length > 1 && _isTransientXf(head(fns))) {
+        return _xfComposeDispatch(fns);
+    }
+    else {
+        return fns;
+    }
+};

--- a/src/internal/_xfComposeDispatch.js
+++ b/src/internal/_xfComposeDispatch.js
@@ -1,0 +1,20 @@
+var _XF_TRANSIENT_FLAG = require('./_XF_TRANSIENT_FLAG');
+var _executeComposition = require('./_executeComposition');
+var _getTypedFunction = require('./_getTypedFunction');
+var _isXf = require('./_isXf');
+var _transduce = require('./_transduce');
+var head = require('../head');
+
+module.exports = function _xfComposeDispatch(fns) {
+    return _getTypedFunction(_XF_TRANSIENT_FLAG, function _inner_xfComposeDispatch() {
+        // check what we are composing
+        // if first arg is an xf, 
+        var firstArg = head(arguments);
+        if (_isXf(firstArg)) {
+            return _executeComposition.call(this, fns, arguments);
+        }
+        else {
+            return _transduce(_xfComposeDispatch(fns), firstArg);
+        }
+    });
+};

--- a/src/internal/_xfDefaultAccumulate.js
+++ b/src/internal/_xfDefaultAccumulate.js
@@ -1,0 +1,43 @@
+var _isArray = require('./_isArray');
+var _isIterable = require('./_isIterable');
+var is = require('../is');
+
+module.exports = function(){
+    
+    var arrayAccumulate = function arrayAccumulate(acc, value) {
+        return acc.concat([value]);
+    };
+    
+    var objectAccumulate = function objectAccumulate(acc, value, key) {
+        acc[key] = value;
+        return acc;
+    };
+    
+    var iterablePush = function iterablePush(acc, value) {
+        return acc.push(value);
+    };
+    
+    var iterableSet = function iterableSet(acc, value, key) {
+        return acc.set(key, value);
+    };
+    
+    return function _xfDefaultAccumulate(coll) {
+        if (_isArray(coll)) {
+            return arrayAccumulate;
+        }
+        else if (_isIterable(coll)) {
+            if (is(Function, coll.push)) {
+                return iterablePush;
+            }
+            else if (is(Function, coll.set)) {
+                return iterableSet;
+            }
+            else {
+                throw 'No method to accumulate iterable ' + coll.toString();
+            }
+        }
+        else if (is(Object, coll)) {
+            return objectAccumulate;
+        }
+    };
+}();

--- a/src/internal/_xfDefaultInit.js
+++ b/src/internal/_xfDefaultInit.js
@@ -1,0 +1,23 @@
+var _isArray = require('./_isArray');
+var _isIterable = require('./_isIterable');
+var is = require('../is');
+
+module.exports = function _xfDefaultInit(coll) {
+    if (_isArray(coll)) {
+        return [];
+    }
+    else if (_isIterable(coll)) {
+        if (is(Function, coll.empty)) {
+            return coll.empty();
+        }
+        else if (is(Function, coll.clear)) {
+            return coll.clear();
+        }
+        else {
+            throw new Error('Could not create empty collection from iterable ' + coll.toString());
+        }
+    }
+    else if (is(Object, coll)) {
+        return {};
+    }
+};

--- a/src/internal/_xfMakeType.js
+++ b/src/internal/_xfMakeType.js
@@ -1,0 +1,22 @@
+var _isXf = require('./_isXf');
+var is = require('../is');
+
+module.exports = function _xfMakeType(x) {
+    if (is(Function, x)) {
+        if (!_isXf(x.prototype)) {
+            throw new Error('Cannot create transducer from ' + x.toString());
+        }
+        return x;
+    }
+    else {
+        if (!_isXf(x)) {
+            throw new Error('Cannot create transducer from ' + x.toString());
+        }
+        var Ctor = is(Function, x.Ctor) ? x.Ctor : function xfCtor(f, xf) {
+            this.f = f;
+            this.xf = xf;
+        };
+        Ctor.prototype = x;
+        return Ctor;
+    }
+};

--- a/src/internal/_xfReduced.js
+++ b/src/internal/_xfReduced.js
@@ -1,0 +1,7 @@
+// https://github.com/cognitect-labs/transducers-js/blob/master/README.md#reduced
+module.exports = function _xfReduced(x) {
+    return {
+        __transducers_reduced__:true,
+        value:x
+    }
+};

--- a/src/internal/_xfReducer.js
+++ b/src/internal/_xfReducer.js
@@ -1,0 +1,10 @@
+var _xfMakeType = require('./_xfMakeType');
+var identity = require('../identity');
+
+module.exports = _xfMakeType({
+    step: function reduceStepFn(result, value, key, coll) {
+        return this.f(result, value, key, coll);
+    },
+    init:function reduceInitFn(){},
+    result:identity
+});

--- a/src/makeXf.js
+++ b/src/makeXf.js
@@ -1,0 +1,4 @@
+var _makeXf = require('./internal/_makeXf');
+
+// should probably call this makeTransducer if public
+module.exports = _makeXf;

--- a/src/map.js
+++ b/src/map.js
@@ -26,4 +26,8 @@ var _map = require('./internal/_map');
  *
  *      R.map(double, [1, 2, 3]); //=> [2, 4, 6]
  */
-module.exports = _curry2(_checkForMethod('map', _map));
+module.exports = _map;
+// function(){
+//     var fn = _checkForMethod('map', _map);
+//     return fn === _map ? fn : _curry2(fn);
+// }();

--- a/src/mapcat.js
+++ b/src/mapcat.js
@@ -1,0 +1,2 @@
+var _mapcat = require('./internal/_mapcat');
+module.exports = _mapcat;

--- a/src/partitionBy.js
+++ b/src/partitionBy.js
@@ -1,0 +1,50 @@
+// see https://clojuredocs.org/clojure.core/partition-by
+var _makeXf = require('./_makeXf');
+
+module.exports = _makeXf({
+    Ctor: function PartitionByCtor(f, xf) {
+        this.f = f;
+        this.xf = xf;
+        this.firstStep = false;
+        this.toggle = null;
+        this.batch = [];
+    },
+    init: function partitionByInit(result) {
+        return this.xf.init();
+    },
+    result: function partitionByResult(result) {
+        if (this.batch.length > 0) {
+            result = this.xf.step(result, this.batch, void 0);
+            this.batch = null;
+            return this.xf.result(result);
+        }
+        // empty collection was passed in
+        else {
+            return this.xf.result(result);
+        }
+    },
+    step: function partitionByStep(result, value, key, coll) {
+        // first step, init some stuff
+        if (this.firstStep === false) {
+            this.firstStep = true;
+            this.batch = [value];
+            this.toggle = this.f(value, key, coll);
+            return result;
+        }
+        else {
+            var partitionVal = this.f(value, key, coll);
+            // hit a new value
+            // step with our current batch of values, start new batch
+            if (partitionVal !== this.toggle) {
+                result = this.xf.step(result, this.batch, key, coll);
+                this.toggle = partitionVal;
+                this.batch = [value];
+            }
+            // same value as current batch, mix in
+            else {
+                this.batch.push(value);
+            }
+            return result;
+        }
+    }
+});

--- a/src/take.js
+++ b/src/take.js
@@ -1,6 +1,7 @@
 var _checkForMethod = require('./internal/_checkForMethod');
 var _curry2 = require('./internal/_curry2');
 var _slice = require('./internal/_slice');
+var _take = require('./internal/_take');
 
 
 /**
@@ -15,6 +16,7 @@ var _slice = require('./internal/_slice');
  * @param {Array} list The array to query.
  * @return {Array} A new array containing the first elements of `list`.
  */
-module.exports = _curry2(_checkForMethod('take', function(n, list) {
-    return _slice(list, 0, Math.min(n, list.length));
-}));
+module.exports = _take;
+// module.exports = _curry2(_checkForMethod('take', function(n, list) {
+//     return _slice(list, 0, Math.min(n, list.length));
+// }));

--- a/test/mapcat.js
+++ b/test/mapcat.js
@@ -1,0 +1,20 @@
+var assert = require('assert');
+
+var R = require('..');
+
+
+describe('mapcat', function() {
+    
+    it('maps and concatenates', function(){
+        var reSplit = R.curry(function(re, s) {
+            var matches = s.match(re);
+            return matches ? matches.slice(1) : [s];
+        });
+        assert.deepEqual(R.mapcat(R.reverse, [[3, 2, 1, 0], [6, 5, 4], [9, 8, 7]]), [ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 ]);
+        assert.deepEqual(R.mapcat(reSplit(/^(.+)\d+(.+)$/), ["aa1bb", "cc2dd", "ee3ff"]), ["aa", "bb", "cc", "dd", "ee", "ff"]);
+    });
+    
+    it('handles empty lists', function(){
+        assert.deepEqual(R.mapcat(R.add, []), []);
+    });
+});

--- a/test/partitionBy.js
+++ b/test/partitionBy.js
@@ -1,0 +1,25 @@
+var assert = require('assert');
+
+var R = require('..');
+
+
+describe('partitionBy', function() {
+    var isOdd = function(x) { return x % 2 === 1; };
+    
+    var l0 = [1, 1, 1, 2, 3, 4, 4, 4];
+    
+    it('partitions each time f returns a new value', function(){
+        assert.deepEqual(R.partitionBy(isOdd, l0), [ [ 1, 1, 1 ], [ 2 ], [ 3 ], [ 4, 4, 4 ] ]);
+        assert.deepEqual(R.partitionBy(R.eq(true), [false, true, false]), [[false], [true], [false]]);
+    });
+    
+    it('handles empty lists', function(){
+        assert.deepEqual(R.partitionBy(isOdd, []), []);
+    });
+
+    // var sumPipe = pipe(
+    //     partition(isOdd),
+    //     map(sum)
+    // );
+    // assert.equal(sumPipe(l0), [3,2,3,12]);
+});

--- a/test/transduce.js
+++ b/test/transduce.js
@@ -1,0 +1,109 @@
+var assert = require('assert');
+var Immutable = require('immutable');
+var thirdPartyTransducers = require('transducers-js')
+var R = require('..');
+
+
+describe('transduce', function() {
+    var even = function(x) {return x % 2 === 0;};
+    var divis3 = function(x) {return x % 3 === 0;};
+    var inc = function(x) {return x + 1;};
+    var square = function(x) {return x * x;};
+    
+    var list = R.range(0, 5);
+    var obj = R.zipObj(
+        R.map(R.unary(String.fromCharCode), R.range(65, 70)),
+        R.range(0, 5)
+    );
+    var nested = [
+        R.range(0, 5),
+        R.range(5, 10)
+    ];
+    
+    it('maps', function(){
+        assert.deepEqual(R.map(inc, list), [ 1, 2, 3, 4, 5 ]);
+        assert.deepEqual(R.map(inc, obj), { A: 1, B: 2, C: 3, D: 4, E: 5 });
+    });
+    
+    it('can use key and collection', function(){
+        var weirdMap = R.map(function(val, key, coll) { return val + key + coll.length; });
+        assert.deepEqual(weirdMap(list), [ 5, 7, 9, 11, 13 ]);
+    })
+    
+    it('composes consecutive transducers', function() {
+        var filterMap = R.pipe(R.filter(even), R.map(inc));
+        assert.deepEqual(filterMap(list), [ 1, 3, 5 ]);
+        assert.deepEqual(filterMap(obj), { A: 1, C: 3, E: 5 });
+    });
+    
+    it('composes consecutive transducers and then calls non-transducer', function() {
+        assert.deepEqual(R.pipe(R.filter(even), R.map(inc), R.sum, square)(list), 81);
+    });
+    
+    it('pipes pipe', function() {
+        var even_inc = R.pipe(R.filter(even), R.map(inc));
+        var divis3_square_inc = R.pipe(R.filter(divis3), R.map(square), R.map(inc));
+        var pipes = R.pipe(even_inc, divis3_square_inc);
+        assert.deepEqual(pipes(list), [ 10 ]);
+    });
+    
+    it('works with nested data', function() {
+        assert.deepEqual(R.map(R.pipe(R.filter(even), R.map(square)), nested), [ [ 0, 4, 16 ], [ 36, 64 ] ]);
+    });
+    
+    it('nests and pipes', function() {
+        var even_square = R.pipe(R.filter(even), R.map(square));
+        var sum_too = R.pipe(even_square, R.sum);
+        assert.deepEqual(R.map(sum_too, nested), [ 20, 100 ]);
+    });
+    
+    it('terminates early if we tell it to', function() {
+        var taken = R.pipe(R.filter(even), R.take(2), R.map(square));
+        assert.deepEqual(taken(list), [ 0 , 4 ]);
+    });
+    
+    it('reduces over objects', function(){
+        assert.deepEqual(R.reduce(R.add, 0, obj), 10);
+    });
+    
+    it('works with objects that support the iterator protocol', function(){
+        var ilist = Immutable.List(R.range(0, 5));
+        var imap = Immutable.Map(obj);
+        var pipe = R.pipe(R.filter(even), R.map(inc));
+        assert.deepEqual(pipe(ilist).toJS(), [ 1, 3, 5 ]);
+        assert.deepEqual(pipe(imap).toJS(), { A: 1, C: 3, E: 5 });
+    });
+    
+    it('can make our own transducers', function(){
+        var doubleFn = R.makeXf({
+            init:function doubleFnInit() {
+                return this.xf.init();
+            },
+            result:function doubleFnResult(result) {
+                return this.xf.result(result);
+            },
+            step:function doubleFnStep(result, val, key, coll) {
+                return this.xf.step(result, this.f(this.f(val, key, coll), key, coll), key, coll);
+            }
+        });
+        
+        assert.deepEqual(doubleFn(square, list), [ 0, 1, 16, 81, 256 ]);
+    });
+    
+    it('works with third party transducers', function(){
+        var dropWhile = R.makeXf(thirdPartyTransducers.DropWhile);
+        
+        assert.deepEqual(dropWhile(function(x) { return x < 3; }, list), [ 3, 4 ]);
+    });
+    
+    it('does not harm pipes that do not use transducers', function(){
+        var obj = {
+            a:'hello'
+        };
+        var objPipe = R.pipe(
+            R.get('a'),
+            R.toUpper
+        );
+        assert.deepEqual(objPipe(obj), 'HELLO');
+    });
+});


### PR DESCRIPTION
Well, I'll start very briefly with some good bits:

- Everyone gets to write the same awesome Ramda code they've always been writing, only difference is now behind the scenes you'll find transducers for some operations.
- We can get rid of `mapObj`, `mapObjIndexed` (all transducer callbacks will get `value`, `key` and `collection`), `filterIndexed`, etc.
- It is very easy to add support for anything that follows the iterator protocol (Immutable.js already supported, need to have a discussion about how to generalize), streams, etc. (#695, #860, etc)
- Transducer speed scales very well to large data structures.

The bad (one of the? the worst?) part: the code I think is quite difficult to follow. I *really* wanted to find a way to properly visualize the code paths before submitting this PR, but I haven't come up with a great solution. However, I believe things are more or less working so that the core contributors can get an idea of what is going on, decide if you'd like to move in this direction, another direction with transducers, or somewhere else.

You can see some basic usage in `test/transduce.js`. I have simply been running

`make && ./node_modules/.bin/mocha test/transduce.js`

during development. I've also included in `dist/` some examples that follow a couple different code paths (obviouly these would be deleted if any of this is ever merged). I've added a `debugger;` line so if you open up the html examples in a browser and have your console open it should break before it starts doing anything important and you can step through to get a better idea of what's happening. I've started building some UML-ish diagrams as well which I think will be pretty nice when they are done, but not sure when that will be.

### Some notes in no particular order

As http://clojure.org/transducers tells us,

> Composition of the transformer runs right-to-left but builds a transformation stack that runs left-to-right

Now, if you've got pipes and compositions and some of their constituent functions are transducers and some are not, things could get really weird really fast. So all transducers in a **composition** are **piped** left-to-right so that they run right-to-left as you would expect in a composition (actually I've only implemented pipe as that is what I used in my work, we can just deprecate `compose`, right? Jokes! :stuck_out_tongue_winking_eye:  I just did not take the time to implement `compose` as it is simply the mirror of pipe). Let's look at a quick example here. Say you build a pipe

`pipe(a, b, c, d, e, f)`

where a-f are functions. If b, c and d are transducers, they will be composed when the pipe is built, so that when the pipe is actually run you still get a -> (b -> c -> d transducer stack) -> e -> f.

I haven't used this PR to re-implement everything that might possibly be a transducer yet, just 

- `map` and `filter` cause everyone loves mapping and filtering
- `take` to test terminating transduction
- `partitionBy` and `mapcat` because we use those in our implementation

Need to implement curry anywhere since we are "manually" currying.

This also causes problems with `checkForMethod` as currently used (`filter` tests for this and fails), I've just removed that call while the PR is under review.

I took out stream stuff as the default output collection (a write stream?) deserves some discussion.

There are some nice helper functions that are easy to implement like `into` (convert anything to anything else), `toList` (convert anything to a list), `toMap` (you get the idea) which I've not included.

Alright, it's getting late, I'm sure I'm forgetting plenty and regardless there are more todos and questions, but I figured it's best to just get this up and let you guys take the lead from here.