### PR TITLE
Initial transducers implementation

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,6 +1,10 @@
 {
   "evil": true,
   "eqnull": true,
+  "globals": {
+    "Symbol": true
+  },
+  "newcap": false,
   "predef": ["beforeEach", "console", "define", "describe", "it", "module", "process", "require"],
   "undef": true,
   "unused": true

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,6 @@ test: dist/ramda.js
 	| sed 's:src/\(.*\)[.]js:exports.\1 = require("./src/\1");:' >index.js
 	sed '/"main":/d' package.json >tmp
 	mv tmp package.json
-	$(MOCHA) -- $(shell find test -name '*.js' -not -name 'installTo.js' -not -name 'test.examplesRunner.js')
+	$(MOCHA) -- $(shell find test -name '*.js' -not -name 'installTo.js' -not -name 'test.examplesRunner.js' -not -path 'test/helpers/*')
 	git checkout -- package.json
 	rm index.js

--- a/src/all.js
+++ b/src/all.js
@@ -1,10 +1,15 @@
 var _all = require('./internal/_all');
 var _curry2 = require('./internal/_curry2');
+var _dispatchable = require('./internal/_dispatchable');
+var _xall = require('./internal/_xall');
 
 
 /**
  * Returns `true` if all elements of the list match the predicate, `false` if there are any
  * that don't.
+ *
+ * Acts as a transducer if a transformer is given in list position.
+ * @see R.transduce
  *
  * @func
  * @memberOf R
@@ -23,4 +28,4 @@ var _curry2 = require('./internal/_curry2');
  *      R.all(lessThan2)(xs); //=> false
  *      R.all(lessThan3)(xs); //=> true
  */
-module.exports = _curry2(_all);
+module.exports = _curry2(_dispatchable('all', _xall, _all));

--- a/src/any.js
+++ b/src/any.js
@@ -1,10 +1,15 @@
 var _any = require('./internal/_any');
 var _curry2 = require('./internal/_curry2');
+var _dispatchable = require('./internal/_dispatchable');
+var _xany = require('./internal/_xany');
 
 
 /**
  * Returns `true` if at least one of elements of the list match the predicate, `false`
  * otherwise.
+ *
+ * Acts as a transducer if a transformer is given in list position.
+ * @see R.transduce
  *
  * @func
  * @memberOf R
@@ -23,4 +28,4 @@ var _curry2 = require('./internal/_curry2');
  *      R.any(lessThan0)(xs); //=> false
  *      R.any(lessThan2)(xs); //=> true
  */
-module.exports = _curry2(_any);
+module.exports = _curry2(_dispatchable('any', _xany, _any));

--- a/src/appendTo.js
+++ b/src/appendTo.js
@@ -1,5 +1,5 @@
-var _append = require('./internal/_append');
-var flip = require('./flip');
+var _appendTo = require('./internal/_appendTo');
+var _curry2 = require('./internal/_curry2');
 
 
 /**
@@ -19,4 +19,4 @@ var flip = require('./flip');
  *      R.appendTo([1, 2, 3], 4); //=> [1, 2, 3, 4]
  *      R.appendTo([1, 2, 3], [4, 5, 6]); //=> [1, 2, 3, [4, 5, 6]]
  */
-module.exports = flip(_append);
+module.exports = _curry2(_appendTo);

--- a/src/drop.js
+++ b/src/drop.js
@@ -1,10 +1,14 @@
-var _checkForMethod = require('./internal/_checkForMethod');
 var _curry2 = require('./internal/_curry2');
+var _dispatchable = require('./internal/_dispatchable');
 var _slice = require('./internal/_slice');
+var _xdrop = require('./internal/_xdrop');
 
 
 /**
  * Returns a new list containing all but the first `n` elements of the given `list`.
+ *
+ * Acts as a transducer if a transformer is given in list position.
+ * @see R.transduce
  *
  * @func
  * @memberOf R
@@ -17,6 +21,6 @@ var _slice = require('./internal/_slice');
  *
  *     R.drop(3, [1,2,3,4,5,6,7]); //=> [4,5,6,7]
  */
-module.exports = _curry2(_checkForMethod('drop', function drop(n, list) {
+module.exports = _curry2(_dispatchable('drop', _xdrop, function drop(n, list) {
     return n < list.length ? _slice(list, n) : [];
 }));

--- a/src/dropWhile.js
+++ b/src/dropWhile.js
@@ -1,11 +1,16 @@
 var _curry2 = require('./internal/_curry2');
+var _dispatchable = require('./internal/_dispatchable');
 var _slice = require('./internal/_slice');
+var _xdropWhile = require('./internal/_xdropWhile');
 
 
 /**
  * Returns a new list containing the last `n` elements of a given list, passing each value
  * to the supplied predicate function, skipping elements while the predicate function returns
  * `true`. The predicate function is passed one argument: *(value)*.
+ *
+ * Acts as a transducer if a transformer is given in list position.
+ * @see R.transduce
  *
  * @func
  * @memberOf R
@@ -22,8 +27,8 @@ var _slice = require('./internal/_slice');
  *
  *      R.dropWhile(lteTwo, [1, 2, 3, 4]); //=> [3, 4]
  */
-module.exports = _curry2(function dropWhile(pred, list) {
+module.exports = _curry2(_dispatchable('dropWhile', _xdropWhile, function dropWhile(pred, list) {
     var idx = -1, len = list.length;
     while (++idx < len && pred(list[idx])) {}
     return _slice(list, idx);
-});
+}));

--- a/src/filter.js
+++ b/src/filter.js
@@ -1,6 +1,7 @@
-var _checkForMethod = require('./internal/_checkForMethod');
 var _curry2 = require('./internal/_curry2');
+var _dispatchable = require('./internal/_dispatchable');
 var _filter = require('./internal/_filter');
+var _xfilter = require('./internal/_xfilter');
 
 
 /**
@@ -10,6 +11,9 @@ var _filter = require('./internal/_filter');
  * Note that `R.filter` does not skip deleted or unassigned indices, unlike the native
  * `Array.prototype.filter` method. For more details on this behavior, see:
  * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter#Description
+ *
+ * Acts as a transducer if a transformer is given in list position.
+ * @see R.transduce
  *
  * @func
  * @memberOf R
@@ -25,4 +29,4 @@ var _filter = require('./internal/_filter');
  *      };
  *      R.filter(isEven, [1, 2, 3, 4]); //=> [2, 4]
  */
-module.exports = _curry2(_checkForMethod('filter', _filter));
+module.exports = _curry2(_dispatchable('filter', _xfilter, _filter));

--- a/src/find.js
+++ b/src/find.js
@@ -1,9 +1,14 @@
 var _curry2 = require('./internal/_curry2');
+var _dispatchable = require('./internal/_dispatchable');
+var _xfind = require('./internal/_xfind');
 
 
 /**
  * Returns the first element of the list which matches the predicate, or `undefined` if no
  * element matches.
+ *
+ * Acts as a transducer if a transformer is given in list position.
+ * @see R.transduce
  *
  * @func
  * @memberOf R
@@ -19,7 +24,7 @@ var _curry2 = require('./internal/_curry2');
  *      R.find(R.propEq('a', 2))(xs); //=> {a: 2}
  *      R.find(R.propEq('a', 4))(xs); //=> undefined
  */
-module.exports = _curry2(function find(fn, list) {
+module.exports = _curry2(_dispatchable('find', _xfind, function find(fn, list) {
     var idx = -1;
     var len = list.length;
     while (++idx < len) {
@@ -27,4 +32,4 @@ module.exports = _curry2(function find(fn, list) {
             return list[idx];
         }
     }
-});
+}));

--- a/src/findIndex.js
+++ b/src/findIndex.js
@@ -1,9 +1,14 @@
 var _curry2 = require('./internal/_curry2');
+var _dispatchable = require('./internal/_dispatchable');
+var _xfindIndex = require('./internal/_xfindIndex');
 
 
 /**
  * Returns the index of the first element of the list which matches the predicate, or `-1`
  * if no element matches.
+ *
+ * Acts as a transducer if a transformer is given in list position.
+ * @see R.transduce
  *
  * @func
  * @memberOf R
@@ -19,7 +24,7 @@ var _curry2 = require('./internal/_curry2');
  *      R.findIndex(R.propEq('a', 2))(xs); //=> 1
  *      R.findIndex(R.propEq('a', 4))(xs); //=> -1
  */
-module.exports = _curry2(function findIndex(fn, list) {
+module.exports = _curry2(_dispatchable('findIndex', _xfindIndex, function findIndex(fn, list) {
     var idx = -1;
     var len = list.length;
     while (++idx < len) {
@@ -28,4 +33,4 @@ module.exports = _curry2(function findIndex(fn, list) {
         }
     }
     return -1;
-});
+}));

--- a/src/findLast.js
+++ b/src/findLast.js
@@ -1,9 +1,14 @@
 var _curry2 = require('./internal/_curry2');
+var _dispatchable = require('./internal/_dispatchable');
+var _xfindLast = require('./internal/_xfindLast');
 
 
 /**
  * Returns the last element of the list which matches the predicate, or `undefined` if no
  * element matches.
+ *
+ * Acts as a transducer if a transformer is given in list position.
+ * @see R.transduce
  *
  * @func
  * @memberOf R
@@ -19,11 +24,11 @@ var _curry2 = require('./internal/_curry2');
  *      R.findLast(R.propEq('a', 1))(xs); //=> {a: 1, b: 1}
  *      R.findLast(R.propEq('a', 4))(xs); //=> undefined
  */
-module.exports = _curry2(function findLast(fn, list) {
+module.exports = _curry2(_dispatchable('findLast', _xfindLast, function findLast(fn, list) {
     var idx = list.length;
     while (idx--) {
         if (fn(list[idx])) {
             return list[idx];
         }
     }
-});
+}));

--- a/src/findLastIndex.js
+++ b/src/findLastIndex.js
@@ -1,9 +1,14 @@
 var _curry2 = require('./internal/_curry2');
+var _dispatchable = require('./internal/_dispatchable');
+var _xfindLastIndex = require('./internal/_xfindLastIndex');
 
 
 /**
  * Returns the index of the last element of the list which matches the predicate, or
  * `-1` if no element matches.
+ *
+ * Acts as a transducer if a transformer is given in list position.
+ * @see R.transduce
  *
  * @func
  * @memberOf R
@@ -19,7 +24,7 @@ var _curry2 = require('./internal/_curry2');
  *      R.findLastIndex(R.propEq('a', 1))(xs); //=> 1
  *      R.findLastIndex(R.propEq('a', 4))(xs); //=> -1
  */
-module.exports = _curry2(function findLastIndex(fn, list) {
+module.exports = _curry2(_dispatchable('findLastIndex', _xfindLastIndex, function findLastIndex(fn, list) {
     var idx = list.length;
     while (idx--) {
         if (fn(list[idx])) {
@@ -27,4 +32,4 @@ module.exports = _curry2(function findLastIndex(fn, list) {
         }
     }
     return -1;
-});
+}));

--- a/src/groupBy.js
+++ b/src/groupBy.js
@@ -1,11 +1,16 @@
 var _append = require('./internal/_append');
 var _curry2 = require('./internal/_curry2');
+var _dispatchable = require('./internal/_dispatchable');
 var _reduce = require('./internal/_reduce');
+var _xgroupBy = require('./internal/_xgroupBy');
 
 
 /**
  * Splits a list into sub-lists stored in an object, based on the result of calling a String-returning function
  * on each element, and grouping the results according to values returned.
+ *
+ * Acts as a transducer if a transformer is given in list position.
+ * @see R.transduce
  *
  * @func
  * @memberOf R
@@ -36,10 +41,10 @@ var _reduce = require('./internal/_reduce');
  *     //   'F': [{name: 'Eddy', score: 58}]
  *     // }
  */
-module.exports = _curry2(function groupBy(fn, list) {
+module.exports = _curry2(_dispatchable('groupBy', _xgroupBy, function groupBy(fn, list) {
     return _reduce(function(acc, elt) {
         var key = fn(elt);
         acc[key] = _append(elt, acc[key] || (acc[key] = []));
         return acc;
     }, {}, list);
-});
+}));

--- a/src/internal/_appendTo.js
+++ b/src/internal/_appendTo.js
@@ -1,0 +1,6 @@
+var _concat = require('./_concat');
+
+
+module.exports = function _appendTo(acc, x) {
+    return _concat(acc, [x]);
+};

--- a/src/internal/_arrayReduce.js
+++ b/src/internal/_arrayReduce.js
@@ -1,0 +1,11 @@
+module.exports = function _arrayReduce(xf, acc, list) {
+    var idx = -1, len = list.length;
+    while (++idx < len) {
+        acc = xf.step(acc, list[idx]);
+        if (acc && acc.__transducers_reduced__) {
+            acc = acc.value;
+            break;
+        }
+    }
+    return xf.result(acc);
+};

--- a/src/internal/_dispatchable.js
+++ b/src/internal/_dispatchable.js
@@ -1,0 +1,39 @@
+var _isArray = require('./_isArray');
+var _isTransformer = require('./_isTransformer');
+var _slice = require('./_slice');
+
+
+/**
+ * Returns a function that dispatches with different strategies based on the
+ * object in list position (last argument). If it is an array, executes [fn].
+ * Otherwise, if it has a  function with [methodname], it will execute that
+ * function (functor case). Otherwise, if it is a transformer, uses transducer
+ * [xf] to return a new transformer (transducer case). Otherwise, it will
+ * default to executing [fn].
+ *
+ * @private
+ * @param {String} methodname property to check for a custom implementation
+ * @param {Function} xf transducer to initialize if object is transformer
+ * @param {Function} fn default ramda implementation
+ * @return {Function} A function that dispatches on object in list position
+ */
+module.exports = function _dispatchable(methodname, xf, fn) {
+    return function() {
+        var length = arguments.length;
+        if (length === 0) {
+            return fn();
+        }
+        var obj = arguments[length - 1];
+        if (!_isArray(obj)) {
+          var args = _slice(arguments, 0, length - 1);
+          if (typeof obj[methodname] === 'function') {
+              return obj[methodname].apply(obj, args);
+          }
+          if (_isTransformer(obj)) {
+              var transducer = xf.apply(null, args);
+              return transducer(obj);
+          }
+        }
+        return fn.apply(this, arguments);
+    };
+};

--- a/src/internal/_isIterable.js
+++ b/src/internal/_isIterable.js
@@ -1,0 +1,6 @@
+var _symIterator = require('./_symIterator');
+
+
+module.exports = function _isIterable(x) {
+    return (x[_symIterator] != null) || (typeof x.next === 'function');
+};

--- a/src/internal/_isTransformer.js
+++ b/src/internal/_isTransformer.js
@@ -1,0 +1,7 @@
+var _symTransformer = require('./_symTransformer');
+
+
+module.exports = function _isTransformer(obj) {
+    return (obj[_symTransformer] != null) ||
+        (typeof obj.step === 'function' && typeof obj.result === 'function');
+};

--- a/src/internal/_iterableReduce.js
+++ b/src/internal/_iterableReduce.js
@@ -1,0 +1,18 @@
+var _symIterator = require('./_symIterator');
+
+
+module.exports = function _iterableReduce(xf, acc, iter) {
+    if (iter[_symIterator]) {
+        iter = iter[_symIterator]();
+    }
+    var step = iter.next();
+    while (!step.done) {
+        acc = xf.step(acc, step.value);
+        if (acc && acc.__transducers_reduced__) {
+            acc = acc.value;
+            break;
+        }
+        step = iter.next();
+    }
+    return xf.result(acc);
+};

--- a/src/internal/_reduce.js
+++ b/src/internal/_reduce.js
@@ -1,7 +1,19 @@
+var _arrayReduce = require('./_arrayReduce');
+var _isIterable = require('./_isIterable');
+var _iterableReduce = require('./_iterableReduce');
+var _xwrap = require('./_xwrap');
+var isArrayLike = require('../isArrayLike');
+
+
 module.exports = function _reduce(fn, acc, list) {
-    var idx = -1, len = list.length;
-    while (++idx < len) {
-        acc = fn(acc, list[idx]);
+    if (typeof fn === 'function') {
+        fn = _xwrap(fn);
     }
-    return acc;
+    if (isArrayLike(list)) {
+        return _arrayReduce(fn, acc, list);
+    }
+    if (_isIterable(list)) {
+        return _iterableReduce(fn, acc, list);
+    }
+    throw new TypeError('reduce: list must be array or iterable');
 };

--- a/src/internal/_reduced.js
+++ b/src/internal/_reduced.js
@@ -1,0 +1,3 @@
+module.exports = function(x) {
+    return x && x.__transducers_reduced__ ? x : {value: x, __transducers_reduced__: true};
+};

--- a/src/internal/_stepCat.js
+++ b/src/internal/_stepCat.js
@@ -1,0 +1,54 @@
+var _add = require('./_add');
+var _appendTo = require('./_appendTo');
+var _isTransformer = require('./_isTransformer');
+var _symTransformer = require('./_symTransformer');
+var isArrayLike = require('../isArrayLike');
+var merge = require('../merge');
+
+
+module.exports = (function() {
+  var _result = function(result) { return result; };
+  var _stepCatArray = {
+       init: Array,
+       step: _appendTo,
+       result: _result
+  };
+  var _stepCatString = {
+      init: String,
+      step: _add,
+      result: _result
+  };
+  var _stepCatObject = {
+      init: Object,
+      step: function(result, input) {
+          var key;
+          var vals;
+          var stepObj = {};
+          if (isArrayLike(input)) {
+              key = input[0];
+              vals = input[1];
+              stepObj[key] = vals;
+          } else {
+              stepObj = input;
+          }
+          return merge(result, stepObj);
+      },
+      result: _result
+  };
+
+  return function _stepCat(obj) {
+      if (_isTransformer(obj)) {
+          return obj[_symTransformer] || obj;
+      }
+      if (isArrayLike(obj)) {
+          return _stepCatArray;
+      }
+      if (typeof obj === 'string') {
+          return _stepCatString;
+      }
+      if (typeof obj === 'object') {
+          return _stepCatObject;
+      }
+      throw new Error('Cannot create transformer for ' + obj);
+  };
+})();

--- a/src/internal/_symIterator.js
+++ b/src/internal/_symIterator.js
@@ -1,0 +1,1 @@
+module.exports = (typeof Symbol !== 'undefined') ? Symbol.iterator : '@@iterator';

--- a/src/internal/_symTransformer.js
+++ b/src/internal/_symTransformer.js
@@ -1,0 +1,1 @@
+module.exports = (typeof Symbol !== 'undefined') ? Symbol('transformer') : '@@transformer';

--- a/src/internal/_xall.js
+++ b/src/internal/_xall.js
@@ -1,0 +1,29 @@
+var _curry2 = require('./_curry2');
+var _reduced = require('./_reduced');
+
+
+module.exports = (function() {
+    function XAll(f, xf) {
+        this.xf = xf;
+        this.f = f;
+        this.all = true;
+    }
+    XAll.prototype.init = function() {
+        return this.xf.init();
+    };
+    XAll.prototype.result = function(result) {
+        if (this.all) {
+          result = this.xf.step(result, true);
+        }
+        return this.xf.result(result);
+    };
+    XAll.prototype.step = function(result, input) {
+        if (!this.f(input)) {
+            this.all = false;
+            result = _reduced(this.xf.step(result, false));
+        }
+        return result;
+    };
+
+    return _curry2(function _xall(f, xf) { return new XAll(f, xf); });
+})();

--- a/src/internal/_xany.js
+++ b/src/internal/_xany.js
@@ -1,0 +1,29 @@
+var _curry2 = require('./_curry2');
+var _reduced = require('./_reduced');
+
+
+module.exports = (function() {
+    function XAny(f, xf) {
+        this.xf = xf;
+        this.f = f;
+        this.any = false;
+    }
+    XAny.prototype.init = function() {
+        return this.xf.init();
+    };
+    XAny.prototype.result = function(result) {
+        if (!this.any) {
+            result = this.xf.step(result, false);
+        }
+        return this.xf.result(result);
+    };
+    XAny.prototype.step = function(result, input) {
+        if (this.f(input)) {
+          this.any = true;
+          result = _reduced(this.xf.step(result, true));
+        }
+        return result;
+    };
+
+    return _curry2(function _xany(f, xf) { return new XAny(f, xf); });
+})();

--- a/src/internal/_xdrop.js
+++ b/src/internal/_xdrop.js
@@ -1,0 +1,24 @@
+var _curry2 = require('./_curry2');
+
+
+module.exports = (function() {
+    function XDrop(n, xf) {
+        this.xf = xf;
+        this.n = n;
+    }
+    XDrop.prototype.init = function() {
+        return this.xf.init();
+    };
+    XDrop.prototype.result = function(result) {
+        return this.xf.result(result);
+    };
+    XDrop.prototype.step = function(result, input) {
+      if (this.n > 0) {
+          this.n -= 1;
+          return result;
+      }
+      return this.xf.step(result, input);
+    };
+
+    return _curry2(function _xdrop(n, xf) { return new XDrop(n, xf); });
+})();

--- a/src/internal/_xdropWhile.js
+++ b/src/internal/_xdropWhile.js
@@ -1,0 +1,26 @@
+var _curry2 = require('./_curry2');
+
+
+module.exports = (function() {
+    function XDropWhile(f, xf) {
+        this.xf = xf;
+        this.f = f;
+    }
+    XDropWhile.prototype.init = function() {
+        return this.xf.init();
+    };
+    XDropWhile.prototype.result = function(result) {
+        return this.xf.result(result);
+    };
+    XDropWhile.prototype.step = function(result, input) {
+        if (this.f) {
+            if (this.f(input)) {
+                return result;
+            }
+            this.f = null;
+        }
+        return this.xf.step(result, input);
+    };
+
+    return _curry2(function _xdropWhile(f, xf) { return new XDropWhile(f, xf); });
+})();

--- a/src/internal/_xfilter.js
+++ b/src/internal/_xfilter.js
@@ -1,0 +1,20 @@
+var _curry2 = require('./_curry2');
+
+
+module.exports = (function() {
+    function XFilter(f, xf) {
+        this.xf = xf;
+        this.f = f;
+    }
+    XFilter.prototype.init = function() {
+        return this.xf.init();
+    };
+    XFilter.prototype.result = function(result) {
+        return this.xf.result(result);
+    };
+    XFilter.prototype.step = function(result, input) {
+        return this.f(input) ? this.xf.step(result, input) : result;
+    };
+
+    return _curry2(function _xfilter(f, xf) { return new XFilter(f, xf); });
+})();

--- a/src/internal/_xfind.js
+++ b/src/internal/_xfind.js
@@ -1,0 +1,29 @@
+var _curry2 = require('./_curry2');
+var _reduced = require('./_reduced');
+
+
+module.exports = (function() {
+    function XFind(f, xf) {
+        this.xf = xf;
+        this.f = f;
+        this.found = false;
+    }
+    XFind.prototype.init = function() {
+        return this.xf.init();
+    };
+    XFind.prototype.result = function(result) {
+        if (!this.found) {
+            result = this.xf.step(result, void 0);
+        }
+        return this.xf.result(result);
+    };
+    XFind.prototype.step = function(result, input) {
+        if (this.f(input)) {
+            this.found = true;
+            result = _reduced(this.xf.step(result, input));
+        }
+        return result;
+    };
+
+    return _curry2(function _xfind(f, xf) { return new XFind(f, xf); });
+})();

--- a/src/internal/_xfindIndex.js
+++ b/src/internal/_xfindIndex.js
@@ -1,0 +1,31 @@
+var _curry2 = require('./_curry2');
+var _reduced = require('./_reduced');
+
+
+module.exports = (function() {
+    function XFindIndex(f, xf) {
+        this.xf = xf;
+        this.f = f;
+        this.idx = -1;
+        this.found = false;
+    }
+    XFindIndex.prototype.init = function() {
+        return this.xf.init();
+    };
+    XFindIndex.prototype.result = function(result) {
+        if (!this.found) {
+            result = this.xf.step(result, -1);
+        }
+        return this.xf.result(result);
+    };
+    XFindIndex.prototype.step = function(result, input) {
+        this.idx += 1;
+        if (this.f(input)) {
+            this.found = true;
+            result = _reduced(this.xf.step(result, this.idx));
+        }
+        return result;
+    };
+
+    return _curry2(function _xfindIndex(f, xf) { return new XFindIndex(f, xf); });
+})();

--- a/src/internal/_xfindLast.js
+++ b/src/internal/_xfindLast.js
@@ -1,0 +1,23 @@
+var _curry2 = require('./_curry2');
+
+
+module.exports = (function() {
+    function XFindLast(f, xf) {
+        this.xf = xf;
+        this.f = f;
+    }
+    XFindLast.prototype.init = function() {
+        return this.xf.init();
+    };
+    XFindLast.prototype.result = function(result) {
+        return this.xf.result(this.xf.step(result, this.last));
+    };
+    XFindLast.prototype.step = function(result, input) {
+        if (this.f(input)) {
+            this.last = input;
+        }
+        return result;
+    };
+
+    return _curry2(function _xfindLast(f, xf) { return new XFindLast(f, xf); });
+})();

--- a/src/internal/_xfindLastIndex.js
+++ b/src/internal/_xfindLastIndex.js
@@ -1,0 +1,26 @@
+var _curry2 = require('./_curry2');
+
+
+module.exports = (function() {
+    function XFindLastIndex(f, xf) {
+        this.xf = xf;
+        this.f = f;
+        this.idx = -1;
+        this.lastIdx = -1;
+    }
+    XFindLastIndex.prototype.init = function() {
+        return this.xf.init();
+    };
+    XFindLastIndex.prototype.result = function(result) {
+        return this.xf.result(this.xf.step(result, this.lastIdx));
+    };
+    XFindLastIndex.prototype.step = function(result, input) {
+        this.idx += 1;
+        if (this.f(input)) {
+            this.lastIdx = this.idx;
+        }
+        return result;
+    };
+
+    return _curry2(function _xfindLastIndex(f, xf) { return new XFindLastIndex(f, xf); });
+})();

--- a/src/internal/_xgroupBy.js
+++ b/src/internal/_xgroupBy.js
@@ -1,0 +1,36 @@
+var _append = require('./_append');
+var _curry2 = require('./_curry2');
+var _has = require('./_has');
+
+
+module.exports = (function() {
+    function XGroupBy(f, xf) {
+        this.xf = xf;
+        this.f = f;
+        this.inputs = {};
+    }
+    XGroupBy.prototype.init = function() {
+        return this.xf.init();
+    };
+    XGroupBy.prototype.result = function(result) {
+        var key;
+        for (key in this.inputs) {
+            if (_has(key, this.inputs)) {
+                result = this.xf.step(result, this.inputs[key]);
+                if (result.__transducers_reduced__) {
+                     result = result.value;
+                     break;
+                }
+            }
+        }
+        return this.xf.result(result);
+    };
+    XGroupBy.prototype.step = function(result, input) {
+        var key = this.f(input);
+        this.inputs[key] = this.inputs[key] || [key, []];
+        this.inputs[key][1] = _append(input, this.inputs[key][1]);
+        return result;
+    };
+
+    return _curry2(function _xgroupBy(f, xf) { return new XGroupBy(f, xf); });
+})();

--- a/src/internal/_xmap.js
+++ b/src/internal/_xmap.js
@@ -1,0 +1,20 @@
+var _curry2 = require('./_curry2');
+
+
+module.exports = (function() {
+    function XMap(f, xf) {
+        this.xf = xf;
+        this.f = f;
+    }
+    XMap.prototype.init = function() {
+        return this.xf.init();
+    };
+    XMap.prototype.result = function(result) {
+        return this.xf.result(result);
+    };
+    XMap.prototype.step = function(result, input) {
+        return this.xf.step(result, this.f(input));
+    };
+
+    return _curry2(function _xmap(f, xf) { return new XMap(f, xf); });
+})();

--- a/src/internal/_xtake.js
+++ b/src/internal/_xtake.js
@@ -1,0 +1,22 @@
+var _curry2 = require('./_curry2');
+var _reduced = require('./_reduced');
+
+
+module.exports = (function() {
+    function XTake(n, xf) {
+        this.xf = xf;
+        this.n = n;
+    }
+    XTake.prototype.init = function() {
+        return this.xf.init();
+    };
+    XTake.prototype.result = function(result) {
+        return this.xf.result(result);
+    };
+    XTake.prototype.step = function(result, input) {
+      this.n -= 1;
+      return this.n >= 0 ? this.xf.step(result, input) : _reduced(result);
+    };
+
+    return _curry2(function _xtake(n, xf) { return new XTake(n, xf); });
+})();

--- a/src/internal/_xtakeWhile.js
+++ b/src/internal/_xtakeWhile.js
@@ -1,0 +1,21 @@
+var _curry2 = require('./_curry2');
+var _reduced = require('./_reduced');
+
+
+module.exports = (function() {
+    function XTakeWhile(f, xf) {
+        this.xf = xf;
+        this.f = f;
+    }
+    XTakeWhile.prototype.init = function() {
+        return this.xf.init();
+    };
+    XTakeWhile.prototype.result = function(result) {
+        return this.xf.result(result);
+    };
+    XTakeWhile.prototype.step = function(result, input) {
+      return this.f(input) ? this.xf.step(result, input) : _reduced(result);
+    };
+
+    return _curry2(function _xtakeWhile(f, xf) { return new XTakeWhile(f, xf); });
+})();

--- a/src/internal/_xwrap.js
+++ b/src/internal/_xwrap.js
@@ -1,0 +1,14 @@
+module.exports = (function() {
+    function XWrap(fn) {
+        this.f = fn;
+    }
+    XWrap.prototype.init = function() {
+        throw new Error('init not implemented on XWrap');
+    };
+    XWrap.prototype.result = function(acc) { return acc; };
+    XWrap.prototype.step = function(acc, x) {
+        return this.f(acc, x);
+    };
+
+    return function _xwrap(fn) { return new XWrap(fn); };
+}());

--- a/src/into.js
+++ b/src/into.js
@@ -1,0 +1,44 @@
+var _curry3 = require('./internal/_curry3');
+var _isTransformer = require('./internal/_isTransformer');
+var _reduce = require('./internal/_reduce');
+var _stepCat = require('./internal/_stepCat');
+
+
+/**
+ * Transforms the items of the list with the transducer and appends the transformed items to
+ * the accumulator using an appropriate iterator function based on the accumulator type.
+ *
+ * The accumulator can be an array, string, object or a transformer. Iterated items will
+ * be appended to arrays and concatenated to strings. Objects will be merged directly or 2-item
+ * arrays will be merged as key, value pairs.
+ *
+ * The accumulator can also be a transformer object that provides a 2-arity reducing iterator
+ * function, step, 0-arity initial value function, init, and 1-arity result extraction function
+ * result. The step function is used as the iterator function in reduce. The result function is
+ * used to convert the final accumulator into the return type and in most cases is R.identity.
+ * The init function is used to provide the initial accumulator.
+ *
+ * The iteration is performed with R.reduce after initializing the transducer.
+ *
+ * @func
+ * @memberOf R
+ * @category List
+ * @sig a -> (b -> b) -> [c] -> a
+ * @param {*} acc The initial accumulator value.
+ * @param {Function} xf The transducer function. Receives a transformer and returns a transformer.
+ * @param {Array} list The list to iterate over.
+ * @return {*} The final, accumulated value.
+ * @example
+ *
+ *      var numbers = [1, 2, 3, 4];
+ *      var transducer = R.compose(R.map(R.add(1)), R.take(2));
+ *
+ *      R.into([], transducer, numbers); //=> [2, 3]
+ *
+ *      var intoArray = R.into([]);
+ *      intoArray(transducer, numbers); //=> [2, 3]
+ */
+module.exports = _curry3(function into(acc, xf, list) {
+    return _isTransformer(acc) ? _reduce(xf(acc), acc.init(), list)
+                               : _reduce(xf(_stepCat(acc)), acc, list);
+});

--- a/src/map.js
+++ b/src/map.js
@@ -1,6 +1,7 @@
-var _checkForMethod = require('./internal/_checkForMethod');
 var _curry2 = require('./internal/_curry2');
+var _dispatchable = require('./internal/_dispatchable');
 var _map = require('./internal/_map');
+var _xmap = require('./internal/_xmap');
 
 
 /**
@@ -10,6 +11,9 @@ var _map = require('./internal/_map');
  * Note: `R.map` does not skip deleted or unassigned indices (sparse arrays), unlike the
  * native `Array.prototype.map` method. For more details on this behavior, see:
  * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map#Description
+ *
+ * Acts as a transducer if a transformer is given in list position.
+ * @see R.transduce
  *
  * @func
  * @memberOf R
@@ -26,4 +30,4 @@ var _map = require('./internal/_map');
  *
  *      R.map(double, [1, 2, 3]); //=> [2, 4, 6]
  */
-module.exports = _curry2(_checkForMethod('map', _map));
+module.exports = _curry2(_dispatchable('map', _xmap, _map));

--- a/src/take.js
+++ b/src/take.js
@@ -1,11 +1,15 @@
-var _checkForMethod = require('./internal/_checkForMethod');
 var _curry2 = require('./internal/_curry2');
+var _dispatchable = require('./internal/_dispatchable');
 var _slice = require('./internal/_slice');
+var _xtake = require('./internal/_xtake');
 
 
 /**
  * Returns a new list containing the first `n` elements of the given list.  If
  * `n > * list.length`, returns a list of `list.length` elements.
+ *
+ * Acts as a transducer if a transformer is given in list position.
+ * @see R.transduce
  *
  * @func
  * @memberOf R
@@ -15,6 +19,6 @@ var _slice = require('./internal/_slice');
  * @param {Array} list The array to query.
  * @return {Array} A new array containing the first elements of `list`.
  */
-module.exports = _curry2(_checkForMethod('take', function(n, list) {
+module.exports = _curry2(_dispatchable('take', _xtake, function take(n, list) {
     return _slice(list, 0, Math.min(n, list.length));
 }));

--- a/src/takeWhile.js
+++ b/src/takeWhile.js
@@ -1,6 +1,7 @@
-var _checkForMethod = require('./internal/_checkForMethod');
 var _curry2 = require('./internal/_curry2');
+var _dispatchable = require('./internal/_dispatchable');
 var _slice = require('./internal/_slice');
+var _xtakeWhile = require('./internal/_xtakeWhile');
 
 
 /**
@@ -8,6 +9,9 @@ var _slice = require('./internal/_slice');
  * to the supplied predicate function, and terminating when the predicate function returns
  * `false`. Excludes the element that caused the predicate function to fail. The predicate
  * function is passed one argument: *(value)*.
+ *
+ * Acts as a transducer if a transformer is given in list position.
+ * @see R.transduce
  *
  * @func
  * @memberOf R
@@ -24,7 +28,7 @@ var _slice = require('./internal/_slice');
  *
  *      R.takeWhile(isNotFour, [1, 2, 3, 4]); //=> [1, 2, 3]
  */
-module.exports = _curry2(_checkForMethod('takeWhile', function(fn, list) {
+module.exports = _curry2(_dispatchable('takeWhile', _xtakeWhile, function takeWhile(fn, list) {
     var idx = -1, len = list.length;
     while (++idx < len && fn(list[idx])) {}
     return _slice(list, 0, idx);

--- a/src/transduce.js
+++ b/src/transduce.js
@@ -1,0 +1,49 @@
+var _reduce = require('./internal/_reduce');
+var _xwrap = require('./internal/_xwrap');
+var curryN = require('./curryN');
+
+
+/**
+ * Initializes a transducer using supplied iterator function. Returns a single item by
+ * iterating through the list, successively calling the transformed iterator function and
+ * passing it an accumulator value and the current value from the array, and then passing
+ * the result to the next call.
+ *
+ * The iterator function receives two values: *(acc, value)*. It will be wrapped as a
+ * transformer to initialize the transducer. A transformer can be passed directly in place
+ * of an iterator function.
+ *
+ * A transducer is a function that accepts a transformer and returns a transformer and can
+ * be composed directly.
+ *
+ * A transformer is an an object that provides a 2-arity reducing iterator function, step,
+ * 0-arity initial value function, init, and 1-arity result extraction function, result.
+ * The step function is used as the iterator function in reduce. The result function is used
+ * to convert the final accumulator into the return type and in most cases is R.identity.
+ * The init function can be used to provide an initial accumulator, but is ignored by transduce.
+ *
+ * The iteration is performed with R.reduce after initializing the transducer.
+ *
+ * @func
+ * @memberOf R
+ * @category List
+ * @sig (c -> c) -> (a,b -> a) -> a -> [b] -> a
+ * @param {Function} xf The transducer function. Receives a transformer and returns a transformer.
+ * @param {Function} fn The iterator function. Receives two values, the accumulator and the
+ *        current element from the array. Wrapped as transformer, if necessary, and used to
+ *        initialize the transducer
+ * @param {*} acc The initial accumulator value.
+ * @param {Array} list The list to iterate over.
+ * @see R.into
+ * @return {*} The final, accumulated value.
+ * @example
+ *
+ *      var numbers = [1, 2, 3, 4];
+ *      var transducer = R.compose(R.map(R.add(1)), R.take(2));
+ *
+ *      R.transduce(transducer, R.appendTo, [], numbers); //=> [2, 3]
+ */
+module.exports = curryN(4, function(xf, fn, acc, list) {
+    return (typeof fn === 'function') ? _reduce(xf(_xwrap(fn)), acc, list)
+                                      : _reduce(xf(fn), acc, list);
+});

--- a/test/all.js
+++ b/test/all.js
@@ -1,4 +1,5 @@
 var assert = require('assert');
+var listXf = require('./helpers/listXf');
 
 var R = require('..');
 
@@ -6,9 +7,12 @@ var R = require('..');
 describe('all', function() {
     var even = function(n) {return n % 2 === 0;};
     var T = function() {return true;};
+    var isFalse = function(x) { return x === false; };
+    var intoArray = R.into([]);
 
     it('returns true if all elements satisfy the predicate', function() {
         assert.strictEqual(R.all(even, [2, 4, 6, 8, 10, 12]), true);
+        assert(R.all(isFalse, [false, false, false]));
     });
 
     it('returns false if any element fails to satisfy the predicate', function() {
@@ -17,6 +21,19 @@ describe('all', function() {
 
     it('returns true for an empty list', function() {
         assert.strictEqual(R.all(T, []), true);
+    });
+
+    it('returns true into array if all elements satisfy the predicate', function() {
+        assert.deepEqual(intoArray(R.all(even), [2, 4, 6, 8, 10, 12]), [true]);
+        assert.deepEqual(intoArray(R.all(isFalse), [false, false, false]), [true]);
+    });
+
+    it('returns false into array if any element fails to satisfy the predicate', function() {
+        assert.deepEqual(intoArray(R.all(even), [2, 4, 6, 8, 9, 10]), [false]);
+    });
+
+    it('returns true into array for an empty list', function() {
+        assert.deepEqual(intoArray(R.all(T), []), [true]);
     });
 
     it('short-circuits on first false value', function() {
@@ -33,6 +50,14 @@ describe('all', function() {
         function hasA(o) { return o.x.indexOf('a') > -1; }
         assert.strictEqual(R.all(len3, xs), false);
         assert.strictEqual(R.all(hasA, xs), true);
+    });
+
+    it('dispatches when given a transformer in list position', function() {
+        assert.deepEqual(R.all(even, listXf), {
+            all: true,
+            f: even,
+            xf: listXf
+        });
     });
 
     it('is automatically curried', function() {

--- a/test/any.js
+++ b/test/any.js
@@ -1,4 +1,5 @@
 var assert = require('assert');
+var listXf = require('./helpers/listXf');
 
 var R = require('..');
 
@@ -6,6 +7,7 @@ var R = require('..');
 describe('any', function() {
     var odd = function(n) {return n % 2 === 1;};
     var T = function() {return true;};
+    var intoArray = R.into([]);
 
     it('returns true if any element satisfies the predicate', function() {
         assert.strictEqual(R.any(odd, [2, 4, 6, 8, 10, 11, 12]), true);
@@ -13,6 +15,14 @@ describe('any', function() {
 
     it('returns false if all elements fails to satisfy the predicate', function() {
         assert.strictEqual(R.any(odd, [2, 4, 6, 8, 10, 12]), false);
+    });
+
+    it('returns true into array if any element satisfies the predicate', function() {
+        assert.deepEqual(intoArray(R.any(odd), [2, 4, 6, 8, 10, 11, 12]), [true]);
+    });
+
+    it('returns false if all elements fails to satisfy the predicate', function() {
+        assert.deepEqual(intoArray(R.any(odd), [2, 4, 6, 8, 10, 12]), [false]);
     });
 
     it('works with more complex objects', function() {
@@ -34,12 +44,24 @@ describe('any', function() {
         assert.strictEqual(R.any(T, []), false);
     });
 
+    it('returns false into array for an empty list', function() {
+        assert.deepEqual(intoArray(R.any(T), []), [false]);
+    });
+
     it('short-circuits on first true value', function() {
         var count = 0;
         var test = function(n) {count++; return odd(n);};
         var result = R.any(test, [2, 4, 6, 7, 8, 10]);
         assert(result);
         assert.strictEqual(count, 4);
+    });
+
+    it('dispatches when given a transformer in list position', function() {
+        assert.deepEqual(R.any(odd, listXf), {
+            any: false,
+            f: odd,
+            xf: listXf
+        });
     });
 
     it('is automatically curried', function() {

--- a/test/find.js
+++ b/test/find.js
@@ -11,6 +11,7 @@ describe('find', function() {
     var gt100 = function(x) { return x > 100; };
     var isStr = function(x) { return typeof x === 'string'; };
     var xGt100 = function(o) { return o && o.x > 100; };
+    var intoArray = R.into([]);
 
     it('returns the first element that satisfies the predicate', function() {
         assert.strictEqual(R.find(even, a), 10);
@@ -19,12 +20,27 @@ describe('find', function() {
         assert.strictEqual(R.find(xGt100, a), obj2);
     });
 
+    it('transduces the first element that satisfies the predicate into an array', function() {
+        assert.deepEqual(intoArray(R.find(even), a), [10]);
+        assert.deepEqual(intoArray(R.find(gt100), a), [200]);
+        assert.deepEqual(intoArray(R.find(isStr), a), ['cow']);
+        assert.deepEqual(intoArray(R.find(xGt100), a), [obj2]);
+    });
+
     it('returns `undefined` when no element satisfies the predicate', function() {
         assert.strictEqual(R.find(even, ['zing']), undefined);
     });
 
+    it('returns `undefined` in array when no element satisfies the predicate into an array', function() {
+        assert.deepEqual(intoArray(R.find(even), ['zing']), [undefined]);
+    });
+
     it('returns `undefined` when given an empty list', function() {
         assert.strictEqual(R.find(even, []), undefined);
+    });
+
+    it('returns `undefined` into an array when given an empty list', function() {
+        assert.deepEqual(intoArray(R.find(even), []), [undefined]);
     });
 
     it('is curried', function() {

--- a/test/findIndex.js
+++ b/test/findIndex.js
@@ -11,6 +11,7 @@ describe('findIndex', function() {
     var gt100 = function(x) { return x > 100; };
     var isStr = function(x) { return typeof x === 'string'; };
     var xGt100 = function(o) { return o && o.x > 100; };
+    var intoArray = R.into([]);
 
     it('returns the index of the first element that satisfies the predicate', function() {
         assert.strictEqual(R.findIndex(even, a), 1);
@@ -19,9 +20,20 @@ describe('findIndex', function() {
         assert.strictEqual(R.findIndex(xGt100, a), 10);
     });
 
+    it('returns the index of the first element that satisfies the predicate into an array', function() {
+        assert.deepEqual(intoArray(R.findIndex(even), a), [1]);
+        assert.deepEqual(intoArray(R.findIndex(gt100), a), [8]);
+        assert.deepEqual(intoArray(R.findIndex(isStr), a), [3]);
+        assert.deepEqual(intoArray(R.findIndex(xGt100), a), [10]);
+    });
+
     it('returns -1 when no element satisfies the predicate', function() {
         assert.strictEqual(R.findIndex(even, ['zing']), -1);
         assert.strictEqual(R.findIndex(even, []), -1);
+    });
+
+    it('returns -1 in array when no element satisfies the predicate into an array', function() {
+        assert.deepEqual(intoArray(R.findIndex(even), ['zing']), [-1]);
     });
 
     it('is curried', function() {

--- a/test/findLast.js
+++ b/test/findLast.js
@@ -11,6 +11,7 @@ describe('findLast', function() {
     var gt100 = function(x) { return x > 100; };
     var isStr = function(x) { return typeof x === 'string'; };
     var xGt100 = function(o) { return o && o.x > 100; };
+    var intoArray = R.into([]);
 
     it('returns the index of the last element that satisfies the predicate', function() {
         assert.strictEqual(R.findLast(even, a), 0);
@@ -19,8 +20,19 @@ describe('findLast', function() {
         assert.strictEqual(R.findLast(xGt100, a), obj2);
     });
 
+    it('returns the index of the last element that satisfies the predicate into an array', function() {
+        assert.deepEqual(intoArray(R.findLast(even), a), [0]);
+        assert.deepEqual(intoArray(R.findLast(gt100), a), [300]);
+        assert.deepEqual(intoArray(R.findLast(isStr), a), ['cow']);
+        assert.deepEqual(intoArray(R.findLast(xGt100), a), [obj2]);
+    });
+
     it('returns `undefined` when no element satisfies the predicate', function() {
-        assert.strictEqual(R.findLast(even, 'zing'), undefined);
+        assert.strictEqual(R.findLast(even, ['zing']), undefined);
+    });
+
+    it('returns `undefined` into an array when no element satisfies the predicate', function() {
+        assert.deepEqual(intoArray(R.findLast(even), ['zing']), [undefined]);
     });
 
     it('works when the first element matches', function() {

--- a/test/findLastIndex.js
+++ b/test/findLastIndex.js
@@ -11,6 +11,7 @@ describe('findLastIndex', function() {
     var gt100 = function(x) { return x > 100; };
     var isStr = function(x) { return typeof x === 'string'; };
     var xGt100 = function(o) { return o && o.x > 100; };
+    var intoArray = R.into([]);
 
     it('returns the index of the last element that satisfies the predicate', function() {
         assert.strictEqual(R.findLastIndex(even, a), 15);
@@ -20,7 +21,18 @@ describe('findLastIndex', function() {
     });
 
     it('returns -1 when no element satisfies the predicate', function() {
-        assert.strictEqual(R.findLastIndex(even, 'zing'), -1);
+        assert.strictEqual(R.findLastIndex(even, ['zing']), -1);
+    });
+
+    it('returns the index of the last element into an array that satisfies the predicate', function() {
+        assert.deepEqual(intoArray(R.findLastIndex(even), a), [15]);
+        assert.deepEqual(intoArray(R.findLastIndex(gt100), a), [9]);
+        assert.deepEqual(intoArray(R.findLastIndex(isStr), a), [3]);
+        assert.deepEqual(intoArray(R.findLastIndex(xGt100), a), [10]);
+    });
+
+    it('returns -1 into an array when no element satisfies the predicate', function() {
+        assert.deepEqual(intoArray(R.findLastIndex(even), ['zing']), [-1]);
     });
 
     it('works when the first element matches', function() {

--- a/test/groupBy.js
+++ b/test/groupBy.js
@@ -1,6 +1,7 @@
 var assert = require('assert');
 
 var R = require('..');
+var _isTransformer = require('../src/internal/_isTransformer');
 
 
 describe('groupBy', function() {
@@ -48,5 +49,15 @@ describe('groupBy', function() {
 
     it('returns an empty object if given an empty array', function() {
         assert.deepEqual(R.groupBy(R.prop('x'), []), {});
+    });
+
+    it('dispatches on transformer objects in list position', function() {
+        var byType = R.prop('type');
+        var xf = {
+            init: function() { return {}; },
+            result: function(x) { return x; },
+            step: R.merge
+        };
+        assert(_isTransformer(R.groupBy(byType, xf)));
     });
 });

--- a/test/helpers/listXf.js
+++ b/test/helpers/listXf.js
@@ -1,0 +1,5 @@
+module.exports = {
+    init: function() { return []; },
+    step: function(acc, x) { return acc.concat([x]); },
+    result: function(x) { return x; }
+};

--- a/test/into.js
+++ b/test/into.js
@@ -1,0 +1,50 @@
+var assert = require('assert');
+
+var R = require('..');
+
+
+describe('into', function() {
+    var add = R.add;
+    var isOdd = function(b) {return b % 2 === 1;};
+    var addXf = {
+        step: add,
+        init: R.always(0),
+        result: R.I
+    };
+
+    it('transduces into arrays', function() {
+        assert.deepEqual(R.into([], R.map(add(1)), [1, 2, 3, 4]), [2, 3, 4, 5]);
+        assert.deepEqual(R.into([], R.filter(isOdd), [1, 2, 3, 4]), [1, 3]);
+        assert.deepEqual(R.into([], R.compose(R.map(add(1)), R.take(2)), [1, 2, 3, 4]), [2, 3]);
+    });
+
+    it('transduces into strings', function() {
+        assert.deepEqual(R.into('', R.map(add(1)), [1, 2, 3, 4]), '2345');
+        assert.deepEqual(R.into('', R.filter(isOdd), [1, 2, 3, 4]), '13');
+        assert.deepEqual(R.into('', R.compose(R.map(add(1)), R.take(2)), [1, 2, 3, 4]), '23');
+    });
+
+    it('transduces into objects', function() {
+        assert.deepEqual(R.into({}, R.identity, [['a', 1], ['b', 2]]), {a: 1, b: 2});
+        assert.deepEqual(R.into({}, R.identity, [{a: 1}, {b: 2, c: 3}]), {a: 1, b: 2, c: 3});
+    });
+
+    it('is automatically curried', function() {
+        var intoArray = R.into([]);
+        var add2 = R.map(add(2));
+        var result = intoArray(add2);
+        assert.deepEqual(result([1, 2, 3, 4]), [3, 4, 5, 6]);
+    });
+
+    it('allows custom transformer', function() {
+        var intoSum = R.into(addXf);
+        var add2 = R.map(add(2));
+        var result = intoSum(add2);
+        assert.deepEqual(result([1, 2, 3, 4]), 18);
+    });
+
+    it('correctly reports the arity of curried versions', function() {
+        var sum = R.into([], R.map(add));
+        assert.strictEqual(sum.length, 1);
+    });
+});

--- a/test/map.js
+++ b/test/map.js
@@ -1,4 +1,5 @@
 var assert = require('assert');
+var listXf = require('./helpers/listXf');
 
 var R = require('..');
 
@@ -6,9 +7,41 @@ var R = require('..');
 describe('map', function() {
     var times2 = function(x) {return x * 2;};
     var add1 = function(x) {return x + 1;};
+    var dec = function(x) { return x - 1; };
+    var intoArray = R.into([]);
 
     it('maps simple functions over arrays', function() {
         assert.deepEqual(R.map(times2, [1, 2, 3, 4]), [2, 4, 6, 8]);
+    });
+
+    it('maps simple functions into arrays', function() {
+        assert.deepEqual(intoArray(R.map(times2), [1, 2, 3, 4]), [2, 4, 6, 8]);
+    });
+
+    it('dispatches to objects that implement `map`', function() {
+        var obj = {x: 100, map: function(f) { return f(this.x); }};
+        assert.strictEqual(R.map(add1, obj), 101);
+    });
+
+    it('dispatches to transformer objects', function() {
+        assert.deepEqual(R.map(add1, listXf), {
+            f: add1,
+            xf: listXf
+        });
+    });
+
+    it('composes', function() {
+        var mdouble = R.map(times2);
+        var mdec = R.map(dec);
+        assert.deepEqual(mdec(mdouble([10, 20, 30])), [19, 39, 59]);
+    });
+
+    it('can compose transducer-style', function() {
+        var mdouble = R.map(times2);
+        var mdec = R.map(dec);
+        var xcomp = mdec(mdouble(listXf));
+        assert.deepEqual(xcomp.xf, {xf: listXf, f: times2});
+        assert.strictEqual(xcomp.f, dec);
     });
 
     it('is automatically curried', function() {

--- a/test/transduce.js
+++ b/test/transduce.js
@@ -1,0 +1,82 @@
+var assert = require('assert');
+
+var R = require('..');
+
+
+describe('transduce', function() {
+    var add = R.add;
+    var mult = function(a, b) {return a * b;};
+    var isOdd = function(b) {return b % 2 === 1;};
+    var addxf = {
+        step: function(acc, x) { return acc + x; },
+        init: function() { return 0; },
+        result: function(x) { return x; }
+    };
+
+    var listxf = {
+        step: function(acc, x) { return acc.concat([x]); },
+        init: function() { return []; },
+        result: function(x) { return x; }
+    };
+
+    var multxf = {
+        step: function(acc, x) { return acc * x; },
+        init: function() { return 1; },
+        result: function(x) { return x; }
+    };
+
+    var toxf = function(fn) {
+        return function(xf) {
+            return {
+                f: fn,
+                step: xf.step,
+                result: xf.result,
+                xf: xf
+            };
+        };
+    };
+
+    it('transduces into arrays', function() {
+        assert.deepEqual(R.transduce(R.map(add(1)), R.appendTo, [], [1, 2, 3, 4]), [2, 3, 4, 5]);
+        assert.deepEqual(R.transduce(R.filter(isOdd), R.appendTo, [],  [1, 2, 3, 4]), [1, 3]);
+        assert.deepEqual(R.transduce(R.compose(R.map(add(1)), R.take(2)), R.appendTo, [],  [1, 2, 3, 4]), [2, 3]);
+    });
+
+    it('transduces into strings', function() {
+        assert.deepEqual(R.transduce(R.map(add(1)), add, '', [1, 2, 3, 4]), '2345');
+        assert.deepEqual(R.transduce(R.filter(isOdd), add, '', [1, 2, 3, 4]), '13');
+        assert.deepEqual(R.transduce(R.compose(R.map(add(1)), R.take(2)), add, '', [1, 2, 3, 4]), '23');
+    });
+
+    it('transduces into objects', function() {
+        assert.deepEqual(R.transduce(R.map(R.identity), R.merge, {}, [{a: 1}, {b: 2, c: 3}]), {a: 1, b: 2, c: 3});
+    });
+
+    it('folds transformer objects over a collection with the supplied accumulator', function() {
+        assert.strictEqual(R.transduce(toxf(add), addxf, 0, [1, 2, 3, 4]), 10);
+        assert.strictEqual(R.transduce(toxf(mult), multxf, 1, [1, 2, 3, 4]), 24);
+        assert.deepEqual(R.transduce(toxf(R.concat), listxf, [0], [1, 2, 3, 4]), [0, 1, 2, 3, 4]);
+        assert.strictEqual(R.transduce(toxf(add), add, 0, [1, 2, 3, 4]), 10);
+        assert.strictEqual(R.transduce(toxf(mult), mult, 1, [1, 2, 3, 4]), 24);
+    });
+
+    it('returns the accumulator for an empty collection', function() {
+        assert.strictEqual(R.transduce(toxf(add), addxf, 0, []), 0);
+        assert.strictEqual(R.transduce(toxf(mult), multxf, 1, []), 1);
+        assert.deepEqual(R.transduce(toxf(R.concat), listxf, [], []), []);
+    });
+
+    it('is automatically curried', function() {
+        var addOrCat1 = R.transduce(toxf(add));
+        var addOrCat2 = addOrCat1(addxf);
+        var sum = addOrCat2(0);
+        var cat = addOrCat2('');
+        assert.strictEqual(sum([1, 2, 3, 4]), 10);
+        assert.strictEqual(cat(['1', '2', '3', '4']), '1234');
+    });
+
+    it('correctly reports the arity of curried versions', function() {
+        var sum = R.transduce(toxf(add), addxf, 0);
+        assert.strictEqual(sum.length, 1);
+    });
+});


### PR DESCRIPTION
- Squashed from buzzedecafe:transduce
- Rebased to master
- Discussed in ramduce
- Credits to @buzzdecafe and @kedashoe

Squashed Commits:
- we have a map transducer
- Apply all arguments to transducer as function.
- Use switch case dispatch for transducer function
- port @kedashoe and @kevinbeaty changes
- Fix build and tests.
- _appendXf as single expression and fix require order for bulid
- foldl uses _xwrap for use with functions
- _dispatchable accepts function for use in _groupBy
- _isIterable uses _symIterator
- Fix filter/map to use _dispatchable appropriately
- Curry _xany, _xfilter, _xmap for use with _dispatchable
- Fix idx lint warning in _arrayReduce
- Remove no longer supported transformer dispatch test
- Transducers for take, takeWhile, drop, dropWhile
- get tests working again
- transduce tests
- improve map test coverage
- Add into
- all and any working
- Add find, findLast, findIndex and findLastIndex transducers
- Step default value in any/all
- stepLast no longer requires initial value since transducers always step single value
- Allow null/undefined accumulators when checking reduced
- groupBy transducer