### PR TITLE
simplify implementation of R.omit

### DIFF
--- a/dist/ramda.js
+++ b/dist/ramda.js
@@ -2414,6 +2414,30 @@
     });
 
     /**
+     * Returns a partial copy of an object omitting the keys specified.
+     *
+     * @func
+     * @memberOf R
+     * @category Object
+     * @sig [String] -> {String: *} -> {String: *}
+     * @param {Array} names an array of String property names to omit from the new object
+     * @param {Object} obj The object to copy from
+     * @return {Object} A new object with properties from `names` not on it.
+     * @example
+     *
+     *      R.omit(['a', 'd'], {a: 1, b: 2, c: 3, d: 4}); //=> {b: 2, c: 3}
+     */
+    var omit = _curry2(function omit(names, obj) {
+        var result = {};
+        for (var prop in obj) {
+            if (_indexOf(names, prop) < 0) {
+                result[prop] = obj[prop];
+            }
+        }
+        return result;
+    });
+
+    /**
      * Accepts a function `fn` and returns a function that guards invocation of `fn` such that
      * `fn` can only ever be called once, no matter how many times the returned function is
      * invoked.
@@ -4623,26 +4647,6 @@
      *      R.min([7, 3, 9, 2, 4, 9, 3]); //=> 2
      */
     var min = _createMaxMin(_lt, Infinity);
-
-    /**
-     * Returns a partial copy of an object omitting the keys specified.
-     *
-     * @func
-     * @memberOf R
-     * @category Object
-     * @sig [k] -> {k: v} -> {k: v}
-     * @param {Array} names an array of String property names to omit from the new object
-     * @param {Object} obj The object to copy from
-     * @return {Object} A new object with properties from `names` not on it.
-     * @example
-     *
-     *      R.omit(['a', 'd'], {a: 1, b: 2, c: 3, d: 4}); //=> {b: 2, c: 3}
-     */
-    var omit = _curry2(function omit(names, obj) {
-        return _pickBy(function (val, key) {
-            return !_contains(key, names);
-        }, obj);
-    });
 
     /**
      * Accepts as its arguments a function and any number of values and returns a function that,

--- a/src/omit.js
+++ b/src/omit.js
@@ -1,6 +1,5 @@
-var _contains = require('./internal/_contains');
 var _curry2 = require('./internal/_curry2');
-var _pickBy = require('./internal/_pickBy');
+var _indexOf = require('./internal/_indexOf');
 
 
 /**
@@ -9,7 +8,7 @@ var _pickBy = require('./internal/_pickBy');
  * @func
  * @memberOf R
  * @category Object
- * @sig [k] -> {k: v} -> {k: v}
+ * @sig [String] -> {String: *} -> {String: *}
  * @param {Array} names an array of String property names to omit from the new object
  * @param {Object} obj The object to copy from
  * @return {Object} A new object with properties from `names` not on it.
@@ -18,7 +17,11 @@ var _pickBy = require('./internal/_pickBy');
  *      R.omit(['a', 'd'], {a: 1, b: 2, c: 3, d: 4}); //=> {b: 2, c: 3}
  */
 module.exports = _curry2(function omit(names, obj) {
-    return _pickBy(function(val, key) {
-        return !_contains(key, names);
-    }, obj);
+    var result = {};
+    for (var prop in obj) {
+        if (_indexOf(names, prop) < 0) {
+            result[prop] = obj[prop];
+        }
+    }
+    return result;
 });


### PR DESCRIPTION
This implementation is simpler in the terms of the number of direct and indirect internal dependencies. If we're to promote the use case outlined in #829 we should avoid defining functions in terms of other functions where practical. I realize this is the antithesis of functional programming!
