### PR TITLE
deprecate R.I

### DIFF
--- a/dist/ramda.js
+++ b/dist/ramda.js
@@ -3524,6 +3524,7 @@
     var F = always(false);
 
     /**
+     * @deprecated since v0.11.0
      * @func
      * @memberOf R
      * @category Function

--- a/src/I.js
+++ b/src/I.js
@@ -2,6 +2,7 @@ var identity = require('./identity');
 
 
 /**
+ * @deprecated since v0.11.0
  * @func
  * @memberOf R
  * @category Function


### PR DESCRIPTION
As discussed in #859. We were 2–1 in favour of `R.identity`; this pull request deprecates `R.I`. Those who'll miss `R.I` can console themselves by defining an :alien:: `var I = R.identity;`.
