### PR TITLE
add R.none

### DIFF
--- a/src/internal/_not.js
+++ b/src/internal/_not.js
@@ -1,0 +1,3 @@
+module.exports = function _not(f) {
+    return function() {return !f.apply(this, arguments);};
+};

--- a/src/none.js
+++ b/src/none.js
@@ -1,0 +1,24 @@
+var _any = require('./internal/_any');
+var _curry2 = require('./internal/_curry2');
+var _dispatchable = require('./internal/_dispatchable');
+var _not = require('./internal/_not');
+var _xany = require('./internal/_xany');
+
+
+/**
+ * Returns `true` if no elements of the list match the predicate,
+ * `false` otherwise.
+ *
+ * @func
+ * @memberOf R
+ * @category List
+ * @sig (a -> Boolean) -> [a] -> Boolean
+ * @param {Function} fn The predicate function.
+ * @param {Array} list The array to consider.
+ * @return {Boolean} `true` if the predicate is not satisfied by every element, `false` otherwise.
+ * @example
+ *
+ *      R.none(isNaN, [1, 2, 3]); //=> true
+ *      R.none(isNaN, [1, 2, 3, NaN]); //=> false
+ */
+module.exports = _curry2(_not(_dispatchable('any', _xany, _any)));

--- a/src/not.js
+++ b/src/not.js
@@ -1,4 +1,5 @@
 var _curry1 = require('./internal/_curry1');
+var _not = require('./internal/_not');
 
 
 /**
@@ -18,6 +19,4 @@ var _curry1 = require('./internal/_curry1');
  *      f(11); //=> false
  *      f(9); //=> true
  */
-module.exports = _curry1(function not(f) {
-    return function() {return !f.apply(this, arguments);};
-});
+module.exports = _curry1(_not);

--- a/test/none.js
+++ b/test/none.js
@@ -1,0 +1,33 @@
+var assert = require('assert');
+
+var R = require('..');
+
+
+describe('none', function() {
+    var even = function(n) {return n % 2 === 0;};
+    var T = function() {return true;};
+
+    it('returns true if no elements satisfy the predicate', function() {
+        assert.strictEqual(R.none(even, [1, 3, 5, 7, 9, 11]), true);
+    });
+
+    it('returns false if any element satisfies the predicate', function() {
+        assert.strictEqual(R.none(even, [1, 3, 5, 7, 8, 11]), false);
+    });
+
+    it('returns true for an empty list', function() {
+        assert.strictEqual(R.none(T, []), true);
+    });
+
+    it('works with more complex objects', function() {
+        var xs = [{x: 'abcd'}, {x: 'adef'}, {x: 'fghiajk'}];
+        function len3(o) { return o.x.length === 3; }
+        function hasA(o) { return o.x.indexOf('a') >= 0; }
+        assert.strictEqual(R.none(len3, xs), true);
+        assert.strictEqual(R.none(hasA, xs), false);
+    });
+
+    it('is automatically curried', function() {
+        assert.strictEqual(R.none(even)([1, 3, 5, 6, 7, 9]), false);
+    });
+});


### PR DESCRIPTION


I keep missing a function named `R.none`, which would be the counterpart of [`R.all`](http://ramdajs.com/docs/#all). It's easy to accomplish the same thing by doing `R.all(R.not(fn))` but that's not very readable.

In some occasions I've found myself doing things like:

    var foo = R.map(parseInt, ['1', '2', 'sfa']);
    var noneAreNaN = R.all(R.not(isNaN));
    if (noneAreNaN(foo)) {
      // Do something
    }

And I would like to be able to do this:

    var foo = R.map(parseInt, ['1', '2', 'sfa']);
    if (R.none(isNaN)(foo)) {
      // Do something
    }

