### PR TITLE
use `xs[xs.length] = x` rather than `xs.push(x)`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@
     `scripts/build --complete` to a temporary file, then rename the file.
 
 5.  Run `make test lint`, (or `grunt test`) and address any errors. Preferably,
-    fix commits in place using `git rebase` or `git commit --amend` to make the 
+    fix commits in place using `git rebase` or `git commit --amend` to make the
     changes easier to review and to keep the history tidy.
 
 6.  Push to your fork:
@@ -28,3 +28,11 @@
         $ git push origin <branch>
 
 7.  Open a pull request.
+
+### Conventions
+
+  - Do not use `Array.prototype.push`. Use `xs[idx] = x` or `xs[xs.length] = x`
+    rather than `xs.push(x)`. See [#890][1] for links to related pull requests.
+
+
+[1]: https://github.com/ramda/ramda/issues/890

--- a/dist/ramda.js
+++ b/dist/ramda.js
@@ -90,11 +90,11 @@
         var result = [];
         idx = -1;
         while (++idx < len1) {
-            result.push(set1[idx]);
+            result[result.length] = set1[idx];
         }
         idx = -1;
         while (++idx < len2) {
-            result.push(set2[idx]);
+            result[result.length] = set2[idx];
         }
         return result;
     };
@@ -270,7 +270,7 @@
         var idx = -1, len = list.length, result = [];
         while (++idx < len) {
             if (fn(list[idx])) {
-                result.push(list[idx]);
+                result[result.length] = list[idx];
             }
         }
         return result;
@@ -280,7 +280,7 @@
         var idx = -1, len = list.length, result = [];
         while (++idx < len) {
             if (fn(list[idx], idx, list)) {
-                result.push(list[idx]);
+                result[result.length] = list[idx];
             }
         }
         return result;
@@ -413,7 +413,7 @@
     var _map = function _map(fn, list) {
         var idx = -1, len = list.length, result = [];
         while (++idx < len) {
-            result.push(fn(list[idx]));
+            result[idx] = fn(list[idx]);
         }
         return result;
     };
@@ -557,7 +557,7 @@
         default:
             var length = Math.max(0, to - from), list = [], idx = -1;
             while (++idx < length) {
-                list.push(args[from + idx]);
+                list[idx] = args[from + idx];
             }
             return list;
         }
@@ -1026,7 +1026,7 @@
                     var idx = -1;
                     while (++idx < n) {
                         var val = initialArgs[idx];
-                        combinedArgs.push(val === __ ? currentArgs.shift() : val);
+                        combinedArgs[idx] = val === __ ? currentArgs.shift() : val;
                     }
                     return fn.apply(this, combinedArgs.concat(currentArgs));
                 });
@@ -1101,7 +1101,7 @@
         var containsPred = containsWith(pred);
         while (++idx < firstLen) {
             if (!containsPred(first[idx], second) && !containsPred(first[idx], out)) {
-                out.push(first[idx]);
+                out[idx] = first[idx];
             }
         }
         return out;
@@ -1810,7 +1810,7 @@
     var keysIn = _curry1(function keysIn(obj) {
         var prop, ks = [];
         for (prop in obj) {
-            ks.push(prop);
+            ks[ks.length] = prop;
         }
         return ks;
     });
@@ -2012,7 +2012,7 @@
         var idx = -1, len = list.length, result = [], tuple = [acc];
         while (++idx < len) {
             tuple = fn(tuple[0], list[idx]);
-            result.push(tuple[1]);
+            result[idx] = tuple[1];
         }
         return [
             tuple[0],
@@ -2088,7 +2088,7 @@
     var mapIndexed = _curry2(function mapIndexed(fn, list) {
         var idx = -1, len = list.length, result = [];
         while (++idx < len) {
-            result.push(fn(list[idx], idx, list));
+            result[idx] = fn(list[idx], idx, list);
         }
         return result;
     });
@@ -2567,7 +2567,8 @@
      */
     var partition = _curry2(function partition(pred, list) {
         return _reduce(function (acc, elt) {
-            acc[pred(elt) ? 0 : 1].push(elt);
+            var xs = acc[pred(elt) ? 0 : 1];
+            xs[xs.length] = elt;
             return acc;
         }, [
             [],
@@ -2802,7 +2803,7 @@
     var props = _curry2(function props(ps, obj) {
         var len = ps.length, out = [], idx = -1;
         while (++idx < len) {
-            out.push(obj[ps[idx]]);
+            out[idx] = obj[ps[idx]];
         }
         return out;
     });
@@ -2829,7 +2830,7 @@
         }
         var idx = 0, result = [];
         while (from < to) {
-            result.push(from++);
+            result[idx] = from++;
             idx += 1;
         }
         return result;
@@ -3087,11 +3088,10 @@
      *      var factorials = R.scan(R.multiply, 1, numbers); //=> [1, 1, 2, 6, 24]
      */
     var scan = _curry3(function scan(fn, acc, list) {
-        var idx = 0, len = list.length + 1, result = [];
-        result.push(acc);
+        var idx = 0, len = list.length + 1, result = [acc];
         while (++idx < len) {
             acc = fn(acc, list[idx - 1]);
-            result.push(acc);
+            result[idx] = acc;
         }
         return result;
     });
@@ -3423,7 +3423,7 @@
         var pair = fn(seed);
         var result = [];
         while (pair && pair.length) {
-            result.push(pair[0]);
+            result[result.length] = pair[0];
             pair = fn(pair[1]);
         }
         return result;
@@ -3455,7 +3455,7 @@
         while (++idx < len) {
             item = list[idx];
             if (!_containsWith(pred, item, result)) {
-                result.push(item);
+                result[result.length] = item;
             }
         }
         return result;
@@ -3483,7 +3483,7 @@
     var valuesIn = _curry1(function valuesIn(obj) {
         var prop, vs = [];
         for (prop in obj) {
-            vs.push(obj[prop]);
+            vs[vs.length] = obj[prop];
         }
         return vs;
     });
@@ -3547,10 +3547,10 @@
         while (++idx < ilen) {
             j = -1;
             while (++j < jlen) {
-                result.push([
+                result[result.length] = [
                     a[idx],
                     b[j]
-                ]);
+                ];
             }
         }
         return result;
@@ -3578,10 +3578,10 @@
         var idx = -1;
         var len = Math.min(a.length, b.length);
         while (++idx < len) {
-            rv.push([
+            rv[idx] = [
                 a[idx],
                 b[idx]
-            ]);
+            ];
         }
         return rv;
     });
@@ -3633,7 +3633,7 @@
     var zipWith = _curry3(function zipWith(fn, a, b) {
         var rv = [], idx = -1, len = Math.min(a.length, b.length);
         while (++idx < len) {
-            rv.push(fn(a[idx], b[idx]));
+            rv[idx] = fn(a[idx], b[idx]);
         }
         return rv;
     });
@@ -3709,8 +3709,8 @@
                     return refTo[idx];
                 }
             }
-            refFrom.push(value);
-            refTo.push(copiedValue);
+            refFrom[idx + 1] = value;
+            refTo[idx + 1] = copiedValue;
             for (var key in value) {
                 copiedValue[key] = _baseCopy(value[key], refFrom, refTo);
             }
@@ -3888,10 +3888,10 @@
                     j = -1;
                     jlen = value.length;
                     while (++j < jlen) {
-                        result.push(value[j]);
+                        result[result.length] = value[j];
                     }
                 } else {
-                    result.push(list[idx]);
+                    result[result.length] = list[idx];
                 }
             }
             return result;
@@ -4214,7 +4214,7 @@
         var firstLen = first.length;
         while (++idx < firstLen) {
             if (!_contains(first[idx], second) && !_contains(first[idx], out)) {
-                out.push(first[idx]);
+                out[out.length] = first[idx];
             }
         }
         return out;
@@ -4517,7 +4517,7 @@
         var results = [], idx = -1;
         while (++idx < list1.length) {
             if (_containsWith(pred, list1[idx], list2)) {
-                results.push(list1[idx]);
+                results[results.length] = list1[idx];
             }
         }
         return uniqWith(pred, results);
@@ -4613,7 +4613,7 @@
             var prop, ks = [], nIdx;
             for (prop in obj) {
                 if (_has(prop, obj)) {
-                    ks.push(prop);
+                    ks[ks.length] = prop;
                 }
             }
             if (hasEnumBug) {
@@ -4621,7 +4621,7 @@
                 while (nIdx--) {
                     prop = nonEnumerableProps[nIdx];
                     if (_has(prop, obj) && !_contains(prop, ks)) {
-                        ks.push(prop);
+                        ks[ks.length] = prop;
                     }
                 }
             }
@@ -5284,7 +5284,7 @@
         while (++idx < len) {
             item = list[idx];
             if (!_contains(item, result)) {
-                result.push(item);
+                result[result.length] = item;
             }
         }
         return result;
@@ -5378,7 +5378,7 @@
         return curry(arity(tlen, function () {
             var args = [], idx = -1;
             while (++idx < tlen) {
-                args.push(transformers[idx](arguments[idx]));
+                args[idx] = transformers[idx](arguments[idx]);
             }
             return fn.apply(this, args.concat(_slice(arguments, tlen)));
         }));
@@ -5405,7 +5405,7 @@
         var vals = [];
         var idx = -1;
         while (++idx < len) {
-            vals.push(obj[props[idx]]);
+            vals[idx] = obj[props[idx]];
         }
         return vals;
     });
@@ -5483,8 +5483,8 @@
                     return stackB[idx] === b;
                 }
             }
-            stackA.push(a);
-            stackB.push(b);
+            stackA[stackA.length] = a;
+            stackB[stackB.length] = b;
             idx = keysA.length;
             while (idx--) {
                 var key = keysA[idx];
@@ -5970,10 +5970,8 @@
         while (++idx < len) {
             var key = props[idx];
             var val = obj[key];
-            if (!_has(val, out)) {
-                out[val] = [];
-            }
-            out[val].push(key);
+            var list = _has(val, out) ? out[val] : out[val] = [];
+            list[list.length] = key;
         }
         return out;
     });

--- a/src/curryN.js
+++ b/src/curryN.js
@@ -67,7 +67,7 @@ module.exports = _curry2(function curryN(length, fn) {
                 var idx = -1;
                 while (++idx < n) {
                     var val = initialArgs[idx];
-                    combinedArgs.push(val === __ ? currentArgs.shift() : val);
+                    combinedArgs[idx] = (val === __ ? currentArgs.shift() : val);
                 }
                 return fn.apply(this, combinedArgs.concat(currentArgs));
             });

--- a/src/difference.js
+++ b/src/difference.js
@@ -24,7 +24,7 @@ module.exports = _curry2(function difference(first, second) {
     var firstLen = first.length;
     while (++idx < firstLen) {
         if (!_contains(first[idx], second) && !_contains(first[idx], out)) {
-            out.push(first[idx]);
+            out[out.length] = first[idx];
         }
     }
     return out;

--- a/src/differenceWith.js
+++ b/src/differenceWith.js
@@ -31,7 +31,7 @@ module.exports = _curry3(function differenceWith(pred, first, second) {
     var containsPred = containsWith(pred);
     while (++idx < firstLen) {
         if (!containsPred(first[idx], second) && !containsPred(first[idx], out)) {
-            out.push(first[idx]);
+            out[idx] = first[idx];
         }
     }
     return out;

--- a/src/internal/_baseCopy.js
+++ b/src/internal/_baseCopy.js
@@ -19,8 +19,8 @@ module.exports = function _baseCopy(value, refFrom, refTo) {
                 return refTo[idx];
             }
         }
-        refFrom.push(value);
-        refTo.push(copiedValue);
+        refFrom[idx + 1] = value;
+        refTo[idx + 1] = copiedValue;
         for (var key in value) {
             copiedValue[key] = _baseCopy(value[key], refFrom, refTo);
         }

--- a/src/internal/_concat.js
+++ b/src/internal/_concat.js
@@ -19,11 +19,11 @@ module.exports = function _concat(set1, set2) {
 
     idx = -1;
     while (++idx < len1) {
-        result.push(set1[idx]);
+        result[result.length] = set1[idx];
     }
     idx = -1;
     while (++idx < len2) {
-        result.push(set2[idx]);
+        result[result.length] = set2[idx];
     }
     return result;
 };

--- a/src/internal/_eqDeep.js
+++ b/src/internal/_eqDeep.js
@@ -42,8 +42,8 @@ module.exports = function _eqDeep(a, b, stackA, stackB) {
             }
         }
 
-        stackA.push(a);
-        stackB.push(b);
+        stackA[stackA.length] = a;
+        stackB[stackB.length] = b;
         idx = keysA.length;
         while (idx--) {
             var key = keysA[idx];

--- a/src/internal/_filter.js
+++ b/src/internal/_filter.js
@@ -2,7 +2,7 @@ module.exports = function _filter(fn, list) {
     var idx = -1, len = list.length, result = [];
     while (++idx < len) {
         if (fn(list[idx])) {
-            result.push(list[idx]);
+            result[result.length] = list[idx];
         }
     }
     return result;

--- a/src/internal/_filterIndexed.js
+++ b/src/internal/_filterIndexed.js
@@ -2,7 +2,7 @@ module.exports = function _filterIndexed(fn, list) {
     var idx = -1, len = list.length, result = [];
     while (++idx < len) {
         if (fn(list[idx], idx, list)) {
-            result.push(list[idx]);
+            result[result.length] = list[idx];
         }
     }
     return result;

--- a/src/internal/_makeFlat.js
+++ b/src/internal/_makeFlat.js
@@ -16,10 +16,10 @@ module.exports = function _makeFlat(recursive) {
                 j = -1;
                 jlen = value.length;
                 while (++j < jlen) {
-                    result.push(value[j]);
+                    result[result.length] = value[j];
                 }
             } else {
-                result.push(list[idx]);
+                result[result.length] = list[idx];
             }
         }
         return result;

--- a/src/internal/_map.js
+++ b/src/internal/_map.js
@@ -1,7 +1,7 @@
 module.exports = function _map(fn, list) {
     var idx = -1, len = list.length, result = [];
     while (++idx < len) {
-        result.push(fn(list[idx]));
+        result[idx] = fn(list[idx]);
     }
     return result;
 };

--- a/src/internal/_slice.js
+++ b/src/internal/_slice.js
@@ -22,7 +22,7 @@ module.exports = function _slice(args, from, to) {
         default:
             var length = Math.max(0, to - from), list = [], idx = -1;
             while (++idx < length) {
-                list.push(args[from + idx]);
+                list[idx] = args[from + idx];
             }
             return list;
     }

--- a/src/intersectionWith.js
+++ b/src/intersectionWith.js
@@ -44,7 +44,7 @@ module.exports = _curry3(function intersectionWith(pred, list1, list2) {
     var results = [], idx = -1;
     while (++idx < list1.length) {
         if (_containsWith(pred, list1[idx], list2)) {
-            results.push(list1[idx]);
+            results[results.length] = list1[idx];
         }
     }
     return uniqWith(pred, results);

--- a/src/invert.js
+++ b/src/invert.js
@@ -35,11 +35,8 @@ module.exports = _curry1(function invert(obj) {
     while (++idx < len) {
         var key = props[idx];
         var val = obj[key];
-
-        if (!_has(val, out)) {
-            out[val] = [];
-        }
-        out[val].push(key);
+        var list = _has(val, out) ? out[val] : (out[val] = []);
+        list[list.length] = key;
     }
     return out;
 });

--- a/src/keys.js
+++ b/src/keys.js
@@ -35,7 +35,7 @@ module.exports = (function() {
         var prop, ks = [], nIdx;
         for (prop in obj) {
             if (_has(prop, obj)) {
-                ks.push(prop);
+                ks[ks.length] = prop;
             }
         }
         if (hasEnumBug) {
@@ -43,7 +43,7 @@ module.exports = (function() {
             while (nIdx--) {
                 prop = nonEnumerableProps[nIdx];
                 if (_has(prop, obj) && !_contains(prop, ks)) {
-                    ks.push(prop);
+                    ks[ks.length] = prop;
                 }
             }
         }

--- a/src/keysIn.js
+++ b/src/keysIn.js
@@ -23,7 +23,7 @@ var _curry1 = require('./internal/_curry1');
 module.exports = _curry1(function keysIn(obj) {
     var prop, ks = [];
     for (prop in obj) {
-        ks.push(prop);
+        ks[ks.length] = prop;
     }
     return ks;
 });

--- a/src/mapAccum.js
+++ b/src/mapAccum.js
@@ -29,7 +29,7 @@ module.exports = _curry3(function mapAccum(fn, acc, list) {
     var idx = -1, len = list.length, result = [], tuple = [acc];
     while (++idx < len) {
         tuple = fn(tuple[0], list[idx]);
-        result.push(tuple[1]);
+        result[idx] = tuple[1];
     }
     return [tuple[0], result];
 });

--- a/src/mapIndexed.js
+++ b/src/mapIndexed.js
@@ -30,7 +30,7 @@ var _curry2 = require('./internal/_curry2');
 module.exports = _curry2(function mapIndexed(fn, list) {
     var idx = -1, len = list.length, result = [];
     while (++idx < len) {
-        result.push(fn(list[idx], idx, list));
+        result[idx] = fn(list[idx], idx, list);
     }
     return result;
 });

--- a/src/partition.js
+++ b/src/partition.js
@@ -21,7 +21,8 @@ var _reduce = require('./internal/_reduce');
  */
 module.exports = _curry2(function partition(pred, list) {
     return _reduce(function(acc, elt) {
-        acc[pred(elt) ? 0 : 1].push(elt);
+        var xs = acc[pred(elt) ? 0 : 1];
+        xs[xs.length] = elt;
         return acc;
     }, [[], []], list);
 });

--- a/src/props.js
+++ b/src/props.js
@@ -25,7 +25,7 @@ module.exports = _curry2(function props(ps, obj) {
         idx = -1;
 
     while (++idx < len) {
-        out.push(obj[ps[idx]]);
+        out[idx] = obj[ps[idx]];
     }
 
     return out;

--- a/src/range.js
+++ b/src/range.js
@@ -23,7 +23,7 @@ module.exports = _curry2(function range(from, to) {
     }
     var idx = 0, result = [];
     while (from < to) {
-        result.push(from++);
+        result[idx] = from++;
         idx += 1;
     }
     return result;

--- a/src/scan.js
+++ b/src/scan.js
@@ -19,11 +19,10 @@ var _curry3 = require('./internal/_curry3');
  *      var factorials = R.scan(R.multiply, 1, numbers); //=> [1, 1, 2, 6, 24]
  */
 module.exports = _curry3(function scan(fn, acc, list) {
-    var idx = 0, len = list.length + 1, result = [];
-    result.push(acc);
+    var idx = 0, len = list.length + 1, result = [acc];
     while (++idx < len) {
         acc = fn(acc, list[idx - 1]);
-        result.push(acc);
+        result[idx] = acc;
     }
     return result;
 });

--- a/src/unfold.js
+++ b/src/unfold.js
@@ -27,7 +27,7 @@ module.exports = _curry2(function unfold(fn, seed) {
     var pair = fn(seed);
     var result = [];
     while (pair && pair.length) {
-        result.push(pair[0]);
+        result[result.length] = pair[0];
         pair = fn(pair[1]);
     }
     return result;

--- a/src/uniq.js
+++ b/src/uniq.js
@@ -25,7 +25,7 @@ module.exports = _curry1(function uniq(list) {
     while (++idx < len) {
         item = list[idx];
         if (!_contains(item, result)) {
-            result.push(item);
+            result[result.length] = item;
         }
     }
     return result;

--- a/src/uniqWith.js
+++ b/src/uniqWith.js
@@ -28,7 +28,7 @@ module.exports = _curry2(function uniqWith(pred, list) {
     while (++idx < len) {
         item = list[idx];
         if (!_containsWith(pred, item, result)) {
-            result.push(item);
+            result[result.length] = item;
         }
     }
     return result;

--- a/src/useWith.js
+++ b/src/useWith.js
@@ -73,7 +73,7 @@ module.exports = curry(function useWith(fn /*, transformers */) {
     return curry(arity(tlen, function() {
         var args = [], idx = -1;
         while (++idx < tlen) {
-            args.push(transformers[idx](arguments[idx]));
+            args[idx] = transformers[idx](arguments[idx]);
         }
         return fn.apply(this, args.concat(_slice(arguments, tlen)));
     }));

--- a/src/values.js
+++ b/src/values.js
@@ -23,7 +23,7 @@ module.exports = _curry1(function values(obj) {
     var vals = [];
     var idx = -1;
     while (++idx < len) {
-        vals.push(obj[props[idx]]);
+        vals[idx] = obj[props[idx]];
     }
     return vals;
 });

--- a/src/valuesIn.js
+++ b/src/valuesIn.js
@@ -23,7 +23,7 @@ var _curry1 = require('./internal/_curry1');
 module.exports = _curry1(function valuesIn(obj) {
     var prop, vs = [];
     for (prop in obj) {
-        vs.push(obj[prop]);
+        vs[vs.length] = obj[prop];
     }
     return vs;
 });

--- a/src/xprod.js
+++ b/src/xprod.js
@@ -26,7 +26,7 @@ module.exports = _curry2(function xprod(a, b) { // = xprodWith(prepend); (takes 
     while (++idx < ilen) {
         j = -1;
         while (++j < jlen) {
-            result.push([a[idx], b[j]]);
+            result[result.length] = [a[idx], b[j]];
         }
     }
     return result;

--- a/src/zip.js
+++ b/src/zip.js
@@ -23,7 +23,7 @@ module.exports = _curry2(function zip(a, b) {
     var idx = -1;
     var len = Math.min(a.length, b.length);
     while (++idx < len) {
-        rv.push([a[idx], b[idx]]);
+        rv[idx] = [a[idx], b[idx]];
     }
     return rv;
 });

--- a/src/zipWith.js
+++ b/src/zipWith.js
@@ -26,7 +26,7 @@ var _curry3 = require('./internal/_curry3');
 module.exports = _curry3(function zipWith(fn, a, b) {
     var rv = [], idx = -1, len = Math.min(a.length, b.length);
     while (++idx < len) {
-        rv.push(fn(a[idx], b[idx]));
+        rv[idx] = fn(a[idx], b[idx]);
     }
     return rv;
 });


### PR DESCRIPTION
Closes #890

This pull request:

  - reverts #887;
  - replaces the handful of uses of `Array.prototype.push` which predated #887; and
  - adds a note to a new "Conventions" section of __CONTRIBUTING.md__.

Before:

```
~/github.com/ramda/ramda (master)
$ grunt bench
Running "benchmark:all" (benchmark) task

Running suite concat [lib/bench/concat.bench.js]...
>> _(s1).concat(s2) x 1,368,969 ops/sec ±3.22% (95 runs sampled)
>> concat(s1, s2) x 403,106 ops/sec ±7.09% (90 runs sampled)
>> concat(s1)(s2) x 426,277 ops/sec ±1.84% (94 runs sampled)
>> concatS1(s2) x 453,114 ops/sec ±0.48% (97 runs sampled)
Fastest test is _(s1).concat(s2) at 3.0x faster than concatS1(s2)

Running suite curry [lib/bench/curry.bench.js]...
>> _x4(100) x 13,037,423 ops/sec ±1.59% (95 runs sampled)
>> mult4(100) x 1,241,952 ops/sec ±1.48% (94 runs sampled)
>> manual(100) x 61,685,048 ops/sec ±1.60% (91 runs sampled)
Fastest test is manual(100) at 4.7x faster than _x4(100)

Running suite forEach [lib/bench/each.bench.js]...
>> _.each(nums, x2) x 415,982 ops/sec ±0.61% (99 runs sampled)
>> forEach(x2, nums) x 423,948 ops/sec ±0.71% (98 runs sampled)
>> forEach(x2)(nums) x 414,706 ops/sec ±0.57% (97 runs sampled)
Fastest test is forEach(x2, nums) at 1.02x faster than forEach(x2)(nums) and _.each(nums, x2)

Running suite filter where [lib/bench/filter-where.bench.js]...
>> _.filter(objs, {x: []}) x 115,878 ops/sec ±1.68% (98 runs sampled)
>> filter(where({x: isEmpty}), objs) x 77,985 ops/sec ±2.07% (94 runs sampled)
>> filter(where({x: isEmpty}))(objs) x 66,790 ops/sec ±6.04% (88 runs sampled)
>> filterEmptyX(objs) x 69,758 ops/sec ±2.92% (89 runs sampled)
>> _.filter(objs, {y: false}) x 920,353 ops/sec ±2.36% (91 runs sampled)
>> filter(where({y: false}), objs) x 69,271 ops/sec ±0.53% (98 runs sampled)
>> filter(where({y: false}))(objs) x 56,283 ops/sec ±3.37% (82 runs sampled)
>> filterFalseY(objs) x 81,667 ops/sec ±2.71% (95 runs sampled)
Fastest test is _.filter(objs, {y: false}) at 7.9x faster than _.filter(objs, {x: []})

Running suite filter [lib/bench/filter.bench.js]...
>> _.filter(nums, isEven) x 2,613,794 ops/sec ±0.47% (98 runs sampled)
>> filter(isEven, nums) x 564,926 ops/sec ±2.36% (85 runs sampled)
>> filter(isEven)(nums) x 457,530 ops/sec ±10.90% (77 runs sampled)
>> filterEven(nums) x 606,480 ops/sec ±2.32% (93 runs sampled)
Fastest test is _.filter(nums, isEven) at 4.3x faster than filterEven(nums)

Running suite find where [lib/bench/find-where.bench.js]...
>> _.find(objs, {x: []}) x 625,614 ops/sec ±1.79% (95 runs sampled)
>> find(where({x: isEmpty}), objs) x 202,359 ops/sec ±3.36% (86 runs sampled)
>> find(where({x: isEmpty}))(objs) x 246,246 ops/sec ±0.75% (91 runs sampled)
>> findEmptyX(objs) x 274,585 ops/sec ±0.55% (101 runs sampled)
>> _.find(objs, {y: false}) x 1,232,320 ops/sec ±2.66% (90 runs sampled)
>> find(where({y: false}), objs) x 227,554 ops/sec ±0.78% (92 runs sampled)
>> find(where({y: false}))(objs) x 202,823 ops/sec ±4.57% (87 runs sampled)
>> findFalseY(objs) x 195,202 ops/sec ±5.49% (76 runs sampled)
Fastest test is _.find(objs, {y: false}) at 1.97x faster than _.find(objs, {x: []})

Running suite find [lib/bench/find.bench.js]...
>> _.find(nums, isZero) x 5,952,412 ops/sec ±2.32% (88 runs sampled)
>> find(isZero, nums) x 9,722,953 ops/sec ±2.37% (89 runs sampled)
>> find(isZero)(nums) x 5,128,579 ops/sec ±7.35% (73 runs sampled)
>> findZero(nums) x 10,596,381 ops/sec ±3.06% (90 runs sampled)
Fastest test is findZero(nums) at 1.09x faster than find(isZero, nums)

Running suite findIndex where [lib/bench/findIndex-where.bench.js]...
>> _.findIndex(objs, {x: []}) x 549,893 ops/sec ±5.52% (83 runs sampled)
>> findIndex(where({x: isEmpty}), objs) x 229,476 ops/sec ±3.21% (89 runs sampled)
>> findIndex(where({x: isEmpty}))(objs) x 196,259 ops/sec ±4.86% (78 runs sampled)
>> findIndexEmptyX(objs) x 189,437 ops/sec ±12.95% (68 runs sampled)
>> _.findIndex(objs, {y: false}) x 1,145,725 ops/sec ±5.89% (84 runs sampled)
>> findIndex(where({y: false}), objs) x 196,104 ops/sec ±6.59% (83 runs sampled)
>> findIndex(where({y: false}))(objs) x 215,852 ops/sec ±4.13% (90 runs sampled)
>> findIndexFalseY(objs) x 243,758 ops/sec ±0.53% (97 runs sampled)
Fastest test is _.findIndex(objs, {y: false}) at 2.1x faster than _.findIndex(objs, {x: []})

Running suite findIndex [lib/bench/findIndex.bench.js]...
>> _.findIndex(nums, isZero) x 6,575,388 ops/sec ±0.46% (98 runs sampled)
>> findIndex(isZero, nums) x 11,027,587 ops/sec ±1.10% (97 runs sampled)
>> findIndex(isZero)(nums) x 6,063,651 ops/sec ±2.68% (92 runs sampled)
>> findIndexZero(nums) x 11,222,322 ops/sec ±2.21% (91 runs sampled)
Fastest test is findIndexZero(nums) at 1.02x faster than findIndex(isZero, nums)

Running suite indexOf [lib/bench/indexof.bench.js]...
>> _.indexOf x 19,635,066 ops/sec ±6.54% (74 runs sampled)
>> indexOf(sq, nums) x 14,489,096 ops/sec ±7.96% (77 runs sampled)
>> indexOf(sq)(nums) x 7,415,894 ops/sec ±3.14% (83 runs sampled)
>> idxOf23(nums) x 20,006,247 ops/sec ±1.38% (94 runs sampled)
Fastest test is idxOf23(nums) at 1.02x faster than _.indexOf

Running suite isSet [lib/bench/isset.bench.js]...
>> isSet(unsortedBag) x 17,000,501 ops/sec ±2.13% (91 runs sampled)
>> isSet(unsortedSet) x 5,283,432 ops/sec ±2.04% (95 runs sampled)
>> isSet(sortedBag) x 16,638,628 ops/sec ±1.83% (89 runs sampled)
>> isSet(sortedSet) x 5,271,099 ops/sec ±1.22% (95 runs sampled)
Fastest test is isSet(unsortedBag) at 1.02x faster than isSet(sortedBag)

Running suite map [lib/bench/map.bench.js]...
>> _.map x 4,084,769 ops/sec ±1.86% (93 runs sampled)
>> map(sq, nums) x 377,451 ops/sec ±2.18% (91 runs sampled)
>> map(sq)(nums) x 391,288 ops/sec ±1.17% (93 runs sampled)
>> mapSq(nums) x 402,405 ops/sec ±1.37% (95 runs sampled)
Fastest test is _.map at 10.2x faster than mapSq(nums)

Running suite maxBy [lib/bench/maxWith.bench.js]...
>> _.max x 117,517 ops/sec ±2.05% (91 runs sampled)
>> maxBy(computer, nums) x 262,155 ops/sec ±1.57% (96 runs sampled)
>> maxBy(computer)(vals) x 264,003 ops/sec ±0.81% (98 runs sampled)
>> maxVal(vals) x 274,450 ops/sec ±0.41% (101 runs sampled)
Fastest test is maxVal(vals) at 1.05x faster than maxBy(computer, nums) and maxBy(computer)(vals)

Running suite reduce [lib/bench/reduce.bench.js]...
>> _.reduce(nums, add, 0) x 3,767,838 ops/sec ±5.60% (88 runs sampled)
>> reduce(add, 0, nums) x 6,703,083 ops/sec ±1.90% (92 runs sampled)
>> reduce(add, 0)(nums) x 4,315,366 ops/sec ±4.64% (79 runs sampled)
>> reduceAdd(nums) x 7,777,166 ops/sec ±1.92% (93 runs sampled)
Fastest test is reduceAdd(nums) at 1.16x faster than reduce(add, 0, nums)
```

After:

```
11:27 ~/github.com/ramda/ramda (push)
$ grunt bench
Running "benchmark:all" (benchmark) task

Running suite concat [lib/bench/concat.bench.js]...
>> _(s1).concat(s2) x 1,386,591 ops/sec ±1.80% (94 runs sampled)
>> concat(s1, s2) x 3,448,162 ops/sec ±1.23% (94 runs sampled)
>> concat(s1)(s2) x 2,671,543 ops/sec ±2.38% (89 runs sampled)
>> concatS1(s2) x 3,107,912 ops/sec ±3.64% (85 runs sampled)
Fastest test is concat(s1, s2) at 1.11x faster than concatS1(s2)

Running suite curry [lib/bench/curry.bench.js]...
>> _x4(100) x 11,149,670 ops/sec ±4.63% (87 runs sampled)
>> mult4(100) x 1,800,595 ops/sec ±5.01% (85 runs sampled)
>> manual(100) x 52,777,090 ops/sec ±2.21% (84 runs sampled)
Fastest test is manual(100) at 4.7x faster than _x4(100)

Running suite forEach [lib/bench/each.bench.js]...
>> _.each(nums, x2) x 402,820 ops/sec ±0.80% (95 runs sampled)
>> forEach(x2, nums) x 350,622 ops/sec ±4.57% (84 runs sampled)
>> forEach(x2)(nums) x 383,634 ops/sec ±2.77% (92 runs sampled)
Fastest test is _.each(nums, x2) at 1.15x faster than forEach(x2, nums) and forEach(x2)(nums)

Running suite filter where [lib/bench/filter-where.bench.js]...
>> _.filter(objs, {x: []}) x 90,490 ops/sec ±6.53% (80 runs sampled)
>> filter(where({x: isEmpty}), objs) x 85,409 ops/sec ±4.21% (85 runs sampled)
>> filter(where({x: isEmpty}))(objs) x 86,835 ops/sec ±5.87% (94 runs sampled)
>> filterEmptyX(objs) x 79,729 ops/sec ±3.95% (78 runs sampled)
>> _.filter(objs, {y: false}) x 768,583 ops/sec ±9.11% (76 runs sampled)
>> filter(where({y: false}), objs) x 55,069 ops/sec ±15.28% (71 runs sampled)
>> filter(where({y: false}))(objs) x 68,521 ops/sec ±4.07% (85 runs sampled)
>> filterFalseY(objs) x 81,487 ops/sec ±2.22% (95 runs sampled)
Fastest test is _.filter(objs, {y: false}) at 8.5x faster than _.filter(objs, {x: []})

Running suite filter [lib/bench/filter.bench.js]...
>> _.filter(nums, isEven) x 2,640,032 ops/sec ±1.37% (96 runs sampled)
>> filter(isEven, nums) x 2,533,728 ops/sec ±0.71% (98 runs sampled)
>> filter(isEven)(nums) x 1,795,904 ops/sec ±3.16% (86 runs sampled)
>> filterEven(nums) x 2,299,163 ops/sec ±3.05% (87 runs sampled)
Fastest test is _.filter(nums, isEven) at 1.04x faster than filter(isEven, nums)

Running suite find where [lib/bench/find-where.bench.js]...
>> _.find(objs, {x: []}) x 619,718 ops/sec ±1.85% (89 runs sampled)
>> find(where({x: isEmpty}), objs) x 292,321 ops/sec ±0.95% (93 runs sampled)
>> find(where({x: isEmpty}))(objs) x 268,966 ops/sec ±1.88% (93 runs sampled)
>> findEmptyX(objs) x 324,765 ops/sec ±0.91% (95 runs sampled)
>> _.find(objs, {y: false}) x 1,312,225 ops/sec ±0.51% (98 runs sampled)
>> find(where({y: false}), objs) x 253,730 ops/sec ±1.16% (94 runs sampled)
>> find(where({y: false}))(objs) x 241,227 ops/sec ±0.90% (93 runs sampled)
>> findFalseY(objs) x 262,049 ops/sec ±0.83% (96 runs sampled)
Fastest test is _.find(objs, {y: false}) at 2.1x faster than _.find(objs, {x: []})

Running suite find [lib/bench/find.bench.js]...
>> _.find(nums, isZero) x 5,681,946 ops/sec ±1.76% (87 runs sampled)
>> find(isZero, nums) x 9,029,246 ops/sec ±3.81% (90 runs sampled)
>> find(isZero)(nums) x 6,025,048 ops/sec ±1.33% (91 runs sampled)
>> findZero(nums) x 11,267,172 ops/sec ±1.27% (94 runs sampled)
Fastest test is findZero(nums) at 1.25x faster than find(isZero, nums)

Running suite findIndex where [lib/bench/findIndex-where.bench.js]...
>> _.findIndex(objs, {x: []}) x 421,490 ops/sec ±9.78% (67 runs sampled)
>> findIndex(where({x: isEmpty}), objs) x 260,069 ops/sec ±9.11% (92 runs sampled)
>> findIndex(where({x: isEmpty}))(objs) x 274,760 ops/sec ±1.27% (94 runs sampled)
>> findIndexEmptyX(objs) x 310,609 ops/sec ±1.50% (92 runs sampled)
>> _.findIndex(objs, {y: false}) x 1,081,033 ops/sec ±6.49% (81 runs sampled)
>> findIndex(where({y: false}), objs) x 235,401 ops/sec ±6.55% (90 runs sampled)
>> findIndex(where({y: false}))(objs) x 206,008 ops/sec ±5.96% (83 runs sampled)
>> findIndexFalseY(objs) x 231,775 ops/sec ±4.05% (86 runs sampled)
Fastest test is _.findIndex(objs, {y: false}) at 2.6x faster than _.findIndex(objs, {x: []})

Running suite findIndex [lib/bench/findIndex.bench.js]...
>> _.findIndex(nums, isZero) x 6,454,087 ops/sec ±0.64% (96 runs sampled)
>> findIndex(isZero, nums) x 10,386,156 ops/sec ±1.29% (93 runs sampled)
>> findIndex(isZero)(nums) x 6,086,126 ops/sec ±2.25% (93 runs sampled)
>> findIndexZero(nums) x 11,608,603 ops/sec ±1.06% (94 runs sampled)
Fastest test is findIndexZero(nums) at 1.12x faster than findIndex(isZero, nums)

Running suite indexOf [lib/bench/indexof.bench.js]...
>> _.indexOf x 25,862,557 ops/sec ±0.95% (93 runs sampled)
>> indexOf(sq, nums) x 19,114,500 ops/sec ±0.98% (98 runs sampled)
>> indexOf(sq)(nums) x 7,476,330 ops/sec ±2.51% (76 runs sampled)
>> idxOf23(nums) x 21,108,074 ops/sec ±0.45% (96 runs sampled)
Fastest test is _.indexOf at 1.23x faster than idxOf23(nums)

Running suite isSet [lib/bench/isset.bench.js]...
>> isSet(unsortedBag) x 17,319,852 ops/sec ±1.17% (94 runs sampled)
>> isSet(unsortedSet) x 5,414,832 ops/sec ±0.97% (93 runs sampled)
commit 52f32cf8f2e8aee6a6ae3202290d8848822d92d4
>> isSet(sortedBag) x 18,292,157 ops/sec ±0.67% (98 runs sampled)
>> isSet(sortedSet) x 5,401,572 ops/sec ±1.10% (94 runs sampled)
Fastest test is isSet(sortedBag) at 1.06x faster than isSet(unsortedBag)

Running suite map [lib/bench/map.bench.js]...
>> _.map x 4,261,501 ops/sec ±1.00% (96 runs sampled)
>> map(sq, nums) x 2,439,993 ops/sec ±1.27% (97 runs sampled)
>> map(sq)(nums) x 1,841,576 ops/sec ±1.88% (92 runs sampled)
>> mapSq(nums) x 2,440,210 ops/sec ±1.19% (95 runs sampled)
commit 52f32cf8f2e8aee6a6ae3202290d8848822d92d4
Fastest test is _.map at 1.75x faster than map(sq, nums) and mapSq(nums)

Running suite maxBy [lib/bench/maxWith.bench.js]...
>> _.max x 145,845 ops/sec ±0.88% (97 runs sampled)
>> maxBy(computer, nums) x 267,226 ops/sec ±1.16% (99 runs sampled)
>> maxBy(computer)(vals) x 266,891 ops/sec ±1.14% (95 runs sampled)
>> maxVal(vals) x 280,475 ops/sec ±0.95% (98 runs sampled)
Fastest test is maxVal(vals) at 1.05x faster than maxBy(computer)(vals) and maxBy(computer, nums)

Running suite reduce [lib/bench/reduce.bench.js]...
>> _.reduce(nums, add, 0) x 4,372,079 ops/sec ±0.40% (100 runs sampled)
>> reduce(add, 0, nums) x 7,233,313 ops/sec ±0.65% (99 runs sampled)
>> reduce(add, 0)(nums) x 4,847,441 ops/sec ±0.65% (88 runs sampled)
>> reduceAdd(nums) x 8,287,915 ops/sec ±0.68% (96 runs sampled)
Fastest test is reduceAdd(nums) at 1.15x faster than reduce(add, 0, nums)
```

The fact that `map'` is capable of six times as many operations per second as `map` is surprising.
