### PR TITLE
add R.test

### DIFF
--- a/src/internal/_cloneRegExp.js
+++ b/src/internal/_cloneRegExp.js
@@ -1,0 +1,7 @@
+module.exports = function _cloneRegExp(pattern) {
+    return new RegExp(pattern.source, (pattern.global     ? 'g' : '') +
+                                      (pattern.ignoreCase ? 'i' : '') +
+                                      (pattern.multiline  ? 'm' : '') +
+                                      (pattern.sticky     ? 'y' : '') +
+                                      (pattern.unicode    ? 'u' : ''));
+};

--- a/src/test.js
+++ b/src/test.js
@@ -1,0 +1,22 @@
+var _cloneRegExp = require('./internal/_cloneRegExp');
+var _curry2 = require('./internal/_curry2');
+
+
+/**
+ * Determines whether a given string matches a given regular expression.
+ *
+ * @func
+ * @memberOf R
+ * @category String
+ * @sig RegExp -> String -> Boolean
+ * @param {RegExp} pattern
+ * @param {String} str
+ * @return {Boolean}
+ * @example
+ *
+ *      R.test(/^x/, 'xyz'); //=> true
+ *      R.test(/^y/, 'xyz'); //=> false
+ */
+module.exports = _curry2(function test(pattern, str) {
+    return _cloneRegExp(pattern).test(str);
+});

--- a/test/test.js
+++ b/test/test.js
@@ -1,0 +1,22 @@
+var assert = require('assert');
+
+var R = require('..');
+
+
+describe('test', function() {
+    it('returns true if string matches pattern', function() {
+        assert.strictEqual(R.test(/^x/, 'xyz'), true);
+    });
+
+    it('returns false if string does not match pattern', function() {
+        assert.strictEqual(R.test(/^y/, 'xyz'), false);
+    });
+
+    it('is referentially transparent', function() {
+        var pattern = /x/g;
+        assert.strictEqual(pattern.lastIndex, 0);
+        assert.strictEqual(R.test(pattern, 'xyz'), true);
+        assert.strictEqual(pattern.lastIndex, 0);
+        assert.strictEqual(R.test(pattern, 'xyz'), true);
+    });
+});


### PR DESCRIPTION
I find myself defining this function quite frequently. It's a nice companion to `R.match`.

Note that `RegExp.prototype.test` is not referentially transparent:

```javascript
> var pattern = /x/g
undefined
> pattern.lastIndex
0
> pattern.test('xyz')
true
> pattern.lastIndex
1
> pattern.test('xyz')
false
```

It's thus necessary to invoke the method on a clone of `pattern`.

The implementation of `_cloneRegExp` comes from purescript/purescript-strings#6.

We should also use `_cloneRegExp` in `clone`, but I've leave that for a separate pull request.
