### PR TITLE
clarify `always` documentation

### DIFF
--- a/src/always.js
+++ b/src/always.js
@@ -2,7 +2,8 @@ var _curry1 = require('./internal/_curry1');
 
 
 /**
- * Returns a function that always returns the given value.
+ * Returns a function that always returns the given value. Note that for non-primitives the value
+ * returned is a reference to the original value.
  *
  * @func
  * @memberOf R


### PR DESCRIPTION
`always` doesn't internally clone non-primitives like objects so this might
be good to note.

Discussion in gitter:

https://gitter.im/ramda/ramda?at=55001e958233c93368d0a1e8