### PR TITLE
support cloning of RegExp objects in R.clone

### DIFF
--- a/src/internal/_baseCopy.js
+++ b/src/internal/_baseCopy.js
@@ -1,3 +1,4 @@
+var _cloneRegExp = require('./_cloneRegExp');
 var type = require('../type');
 
 
@@ -30,6 +31,7 @@ module.exports = function _baseCopy(value, refFrom, refTo) {
         case 'Object':  return copy({});
         case 'Array':   return copy([]);
         case 'Date':    return new Date(value);
+        case 'RegExp':  return _cloneRegExp(value);
         default:        return value;
     }
 };

--- a/test/clone.js
+++ b/test/clone.js
@@ -117,8 +117,8 @@ describe('deep `clone` functions', function() {
     });
 });
 
-describe('deep clone Dates', function() {
-    it('clone date', function() {
+describe('built-in types', function() {
+    it('clones Date object', function() {
         var date = new Date(2014, 10, 14, 23, 59, 59, 999);
 
         var clone = R.clone(date);
@@ -127,6 +127,18 @@ describe('deep clone Dates', function() {
         assert.deepEqual(clone.toString(), new Date(2014, 10, 14, 23, 59, 59, 999).toString());
 
         assert.strictEqual(clone.getDay(), 5); // friday
+    });
+
+    it('clones RegExp object', function() {
+        R.forEach(function(pattern) {
+            var clone = R.clone(pattern);
+            assert.notStrictEqual(clone, pattern);
+            assert.strictEqual(clone.constructor, RegExp);
+            assert.strictEqual(clone.source, pattern.source);
+            assert.strictEqual(clone.global, pattern.global);
+            assert.strictEqual(clone.ignoreCase, pattern.ignoreCase);
+            assert.strictEqual(clone.multiline, pattern.multiline);
+        }, [/x/, /x/g, /x/i, /x/m, /x/gi, /x/gm, /x/im, /x/gim]);
     });
 });
 


### PR DESCRIPTION
As suggested in #901
