### PR TITLE
rename R.func

### DIFF
--- a/src/func.js
+++ b/src/func.js
@@ -7,6 +7,7 @@ var curry = require('./curry');
  * after `fn` and `obj` are passed in to `fn`. If no additional arguments are passed to `func`,
  * `fn` is invoked with no arguments.
  *
+ * @deprecated since v0.12.0
  * @func
  * @memberOf R
  * @category Object
@@ -14,6 +15,7 @@ var curry = require('./curry');
  * @param {String} funcName The name of the property mapped to the function to invoke
  * @param {Object} obj The object
  * @return {*} The value of invoking `obj.fn`.
+ * @see R.invoke
  * @example
  *
  *      R.func('add', R, 1, 2); //=> 3

--- a/src/invoke.js
+++ b/src/invoke.js
@@ -1,0 +1,24 @@
+var _slice = require('./internal/_slice');
+var curry = require('./curry');
+
+
+/**
+ * Returns the result of invoking `obj[methodName]` with the zero or more
+ * positional arguments following `methodName` and `obj`.
+ *
+ * @func
+ * @memberOf R
+ * @category Object
+ * @sig String -> Object -> *
+ * @param {String} methodName
+ * @param {Object} obj
+ * @return {*}
+ * @example
+ *
+ *      R.invoke('add', R, 1, 2); //=> 3
+ *
+ *      R.invoke('f', {f: function() { return 'f called'; }}); //=> 'f called'
+ */
+module.exports = curry(function invoke(methodName, obj) {
+    return obj[methodName].apply(obj, _slice(arguments, 2));
+});

--- a/test/invoke.js
+++ b/test/invoke.js
@@ -1,0 +1,46 @@
+var assert = require('assert');
+
+var R = require('..');
+
+
+describe('invoke', function() {
+    it('returns a function that applies the appropriate function to the supplied object', function() {
+        var fred = {first: 'Fred', last: 'Flintstone', getName: function() {
+            return this.first + ' ' + this.last;
+        }};
+        var barney = {first: 'Barney', last: 'Rubble', getName: function() {
+            return this.first + ' ' + this.last;
+        }};
+        var gName = R.invoke('getName');
+        assert.strictEqual(typeof gName, 'function');
+        assert.strictEqual(gName(fred), 'Fred Flintstone');
+        assert.strictEqual(gName(barney), 'Barney Rubble');
+    });
+
+    it('passes arguments appropriately when not curried', function() {
+        assert.strictEqual(R.invoke('add', R, 3, 6), 9);
+    });
+
+    it('invokes the function with no arguments when no extra params are supplied', function() {
+        var obj = {f: function() { return 'called f'; }};
+        assert.strictEqual(R.invoke('f', obj), 'called f');
+    });
+
+    it('applies additional arguments to the function', function() {
+        var Point = function(x, y) {
+            this.x = x;
+            this.y = y;
+        };
+        Point.prototype.moveBy = function(dx, dy) {
+            this.x += dx;
+            this.y += dy;
+        };
+        var p1 = new Point(10, 20);
+
+
+        var moveBy = R.invoke('moveBy');
+        moveBy(p1, 5, 7);
+        assert.strictEqual(p1.x, 15);
+        assert.strictEqual(p1.y, 27);
+    });
+});


### PR DESCRIPTION
Closes #905

I did not make `R.func` an :alien: for `R.invoke` as I'd like to propose a change to `R.invoke` in a subsequent pull request and we'll want to preserve the current `R.func` behaviour until we remove that function.
