### PR TITLE
(WIP) Meta implementation

### DIFF
--- a/src/arity.js
+++ b/src/arity.js
@@ -6,6 +6,7 @@ var _curry2 = require('./internal/_curry2');
  * parameters. Unlike `nAry`, which passes only `n` arguments to the wrapped function,
  * functions produced by `arity` will pass all provided arguments to the wrapped function.
  *
+ * @deprecated since v0.12.0
  * @func
  * @memberOf R
  * @sig (Number, (* -> *)) -> (* -> *)

--- a/src/bind.js
+++ b/src/bind.js
@@ -1,5 +1,5 @@
 var _curry2 = require('./internal/_curry2');
-var arity = require('./arity');
+var _meta = require('./internal/_meta');
 
 
 /**
@@ -17,7 +17,7 @@ var arity = require('./arity');
  * @return {Function} A function that will execute in the context of `thisObj`.
  */
 module.exports = _curry2(function bind(fn, thisObj) {
-    return arity(fn.length, function() {
+    return _meta.set(function() {
         return fn.apply(thisObj, arguments);
-    });
+    }, fn);
 });

--- a/src/construct.js
+++ b/src/construct.js
@@ -1,4 +1,5 @@
 var _curry1 = require('./internal/_curry1');
+var _meta = require('./internal/_meta');
 var constructN = require('./constructN');
 
 
@@ -27,5 +28,5 @@ var constructN = require('./constructN');
  *      R.map(R.construct(Widget), allConfigs); // a list of Widgets
  */
 module.exports = _curry1(function construct(Fn) {
-    return constructN(Fn.length, Fn);
+    return constructN(_meta.arity(Fn), Fn);
 });

--- a/src/curry.js
+++ b/src/curry.js
@@ -1,4 +1,5 @@
 var _curry1 = require('./internal/_curry1');
+var _meta = require('./internal/_meta');
 var curryN = require('./curryN');
 
 
@@ -45,5 +46,5 @@ var curryN = require('./curryN');
  *      g(4); //=> 10
  */
 module.exports = _curry1(function curry(fn) {
-    return curryN(fn.length, fn);
+    return curryN(_meta.arity(fn), fn);
 });

--- a/src/curryN.js
+++ b/src/curryN.js
@@ -1,7 +1,7 @@
 var __ = require('./__');
 var _curry2 = require('./internal/_curry2');
+var _meta = require('./internal/_meta');
 var _slice = require('./internal/_slice');
-var arity = require('./arity');
 
 
 /**
@@ -48,7 +48,7 @@ var arity = require('./arity');
  *      g(4); //=> 10
  */
 module.exports = _curry2(function curryN(length, fn) {
-    return arity(length, function() {
+    return _meta.set(function() {
         var n = arguments.length;
         var shortfall = length - n;
         var idx = n;
@@ -72,5 +72,5 @@ module.exports = _curry2(function curryN(length, fn) {
                 return fn.apply(this, combinedArgs.concat(currentArgs));
             });
         }
-    });
+    }, fn, length);
 });

--- a/src/internal/_compose.js
+++ b/src/internal/_compose.js
@@ -1,3 +1,5 @@
+var _meta = require('./_meta');
+
 /**
  * Basic, right-associative composition function. Accepts two functions and returns the
  * composite function; this composite function represents the operation `var h = f(g(x))`,
@@ -21,7 +23,7 @@
  *      squareThenDouble(5); //≅ double(square(5)) => 50
  */
 module.exports = function _compose(f, g) {
-    return function() {
+    return _meta.set(function() {
         return f.call(this, g.apply(this, arguments));
-    };
+    }, g);
 };

--- a/src/internal/_composeP.js
+++ b/src/internal/_composeP.js
@@ -1,5 +1,5 @@
 var _isThenable = require('./_isThenable');
-
+var _meta = require('./_meta');
 
 /**
  * A right-associative two-argument composition function like `_compose`
@@ -25,7 +25,7 @@ var _isThenable = require('./_isThenable');
  *          });
  */
 module.exports = function _composeP(f, g) {
-    return function() {
+    return _meta.set(function() {
         var context = this;
         var value = g.apply(this, arguments);
         if (_isThenable(value)) {
@@ -35,5 +35,5 @@ module.exports = function _composeP(f, g) {
         } else {
             return f.call(this, value);
         }
-    };
+    }, g);
 };

--- a/src/internal/_createComposer.js
+++ b/src/internal/_createComposer.js
@@ -1,6 +1,3 @@
-var arity = require('../arity');
-
-
 /*
  * Returns a function that makes a multi-argument version of compose from
  * either _compose or _composeP.
@@ -9,10 +6,9 @@ module.exports = function _createComposer(composeFunction) {
     return function() {
         var idx = arguments.length - 1;
         var fn = arguments[idx];
-        var length = fn.length;
         while (idx--) {
             fn = composeFunction(arguments[idx], fn);
         }
-        return arity(length, fn);
+        return fn;
     };
 };

--- a/src/internal/_createPartialApplicator.js
+++ b/src/internal/_createPartialApplicator.js
@@ -1,12 +1,12 @@
+var _meta = require('./_meta');
 var _slice = require('./_slice');
-var arity = require('../arity');
 
 
 module.exports = function _createPartialApplicator(concat) {
     return function(fn) {
         var args = _slice(arguments, 1);
-        return arity(Math.max(0, fn.length - args.length), function() {
+        return _meta.set(function() {
             return fn.apply(this, concat(args, arguments));
-        });
+        }, fn, Math.max(0, _meta.arity(fn) - args.length));
     };
 };

--- a/src/internal/_meta.js
+++ b/src/internal/_meta.js
@@ -1,0 +1,32 @@
+module.exports = (function() {
+    // Should we use a Symbol or let users have free access to metadata
+    // which could be useful for extensions.
+    var metaSymbol = typeof Symbol === 'function' ? Symbol('metadata') : '@@metadata';
+
+    return {
+        set: function(wrapper, child, arity) {
+            wrapper[metaSymbol] = {
+                arity: arity != null ? arity : child.length,
+                name: child.name,
+                wrapped: child
+            };
+            return wrapper;
+        },
+        get: function(wrapper) {
+            return wrapper[metaSymbol];
+        },
+        arity: function(wrapper) {
+            return wrapper[metaSymbol] ?
+                    wrapper[metaSymbol].arity :
+                    wrapper.length;
+        },
+        // Find the original source of the wrapped function
+        // (for debugging)
+        source: function(wrapper) {
+            while (wrapper[metaSymbol]) {
+                wrapper = wrapper[metaSymbol].child;
+            }
+            return wrapper;
+        }
+    };
+})();

--- a/src/internal/_predicateWrap.js
+++ b/src/internal/_predicateWrap.js
@@ -1,7 +1,7 @@
-var _pluck = require('./_pluck');
+var _meta = require('./_meta');
 var _slice = require('./_slice');
-var arity = require('../arity');
-var max = require('../max');
+var maxBy = require('../maxBy');
+var prop = require('../prop');
 
 
 /**
@@ -23,6 +23,6 @@ module.exports = function _predicateWrap(predPicker) {
             // Call function immediately if given arguments
             predIterator.apply(null, _slice(arguments, 1)) :
             // Return a function which will call the predicates with the provided arguments
-            arity(max(_pluck('length', preds)), predIterator);
+            _meta.set(predIterator, maxBy(prop('length'), preds));
     };
 };

--- a/src/lift.js
+++ b/src/lift.js
@@ -1,4 +1,5 @@
 var _curry1 = require('./internal/_curry1');
+var _meta = require('./internal/_meta');
 var liftN = require('./liftN');
 
 
@@ -26,5 +27,5 @@ var liftN = require('./liftN');
  *     madd5([1,2], [3], [4, 5], [6], [7, 8]); //=> [21, 22, 22, 23, 22, 23, 23, 24]
  */
 module.exports = _curry1(function lift(fn) {
-    return liftN(fn.length, fn);
+    return liftN(_meta.arity(fn), fn);
 });

--- a/src/nAry.js
+++ b/src/nAry.js
@@ -5,6 +5,7 @@ var _curry2 = require('./internal/_curry2');
  * Wraps a function of any arity (including nullary) in a function that accepts exactly `n`
  * parameters. Any extraneous parameters will not be passed to the supplied function.
  *
+ * @deprecated since v0.12.0
  * @func
  * @memberOf R
  * @category Function

--- a/src/useWith.js
+++ b/src/useWith.js
@@ -1,5 +1,5 @@
+var _meta = require('./internal/_meta');
 var _slice = require('./internal/_slice');
-var arity = require('./arity');
 var curry = require('./curry');
 
 
@@ -70,11 +70,11 @@ var curry = require('./curry');
 module.exports = curry(function useWith(fn /*, transformers */) {
     var transformers = _slice(arguments, 1);
     var tlen = transformers.length;
-    return curry(arity(tlen, function() {
+    return curry(_meta.set(function() {
         var args = [], idx = -1;
         while (++idx < tlen) {
             args[idx] = transformers[idx](arguments[idx]);
         }
         return fn.apply(this, args.concat(_slice(arguments, tlen)));
-    }));
+    }, fn, tlen));
 });

--- a/src/wrap.js
+++ b/src/wrap.js
@@ -1,6 +1,7 @@
 var _concat = require('./internal/_concat');
 var _curry2 = require('./internal/_curry2');
-var curryN = require('./curryN');
+var _meta = require('./internal/_meta');
+var curry = require('./curry');
 
 
 /**
@@ -30,7 +31,7 @@ var curryN = require('./curryN');
  *
  */
 module.exports = _curry2(function wrap(fn, wrapper) {
-    return curryN(fn.length, function() {
+    return curry(_meta.set(function() {
         return wrapper.apply(this, _concat([fn], arguments));
-    });
+    }, fn));
 });


### PR DESCRIPTION
For discussion before this goes any further

Currently the obvious 15 tests fail.

This implements all the internal methods that rely on the `arity` of a function through metadata. It also tracks the source function and name of a function.

An obvious extension of this is to do native unwrapping (for example doing currying and partial and other decorators in a single method as lodash does [big benefit!])

The main motivation of this is (for me) is a) a big perf benefit by avoiding arity and b) enables us to later implement `restParams` which will be a substantial improvement in several places in the code base (it didn't make sense to implement this through arity). Overall this enables a couple follow up optimizations

Points of interest:

- Should it be added to an object publicly   or use a symbol
- What should be included
- Should repl stuff be added

Benchmarks to follow (in case its not obvious the benefit): http://jsperf.com/ramda-currying-cost/4
