### PR TITLE
remove deedpoll

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,3 @@
-DEEDPOLL = node_modules/.bin/deedpoll \
-	--rename arr:list \
-	--rename array:list \
-	--rename ctor:Ctor \
-	--rename fnArity:length \
-	--rename i:idx \
-	--rename index:idx
 MOCHA = node_modules/.bin/mocha
 UGLIFY = node_modules/.bin/uglifyjs
 XYZ = node_modules/.bin/xyz --repo git@github.com:ramda/ramda.git --script scripts/prepublish
@@ -30,7 +23,6 @@ clean:
 
 .PHONY: lint
 lint:
-	@$(DEEDPOLL) -- $(SRC)
 
 
 .PHONY: release-major release-minor release-patch

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "acorn": "0.9.x",
     "benchmark": "~1.0.0",
     "commander": "2.5.x",
-    "deedpoll": "0.2.x",
     "dox": "latest",
     "envvar": "1.x.x",
     "escodegen": "1.4.x",


### PR DESCRIPTION
I'm now of the opinion that deedpoll needn't be part of the linting process, though I imagine I'll continue to use it from time to time to keep this project's identifiers consistent.
