### PR TITLE
Remove _symTransformer until official spec is worked out.

### DIFF
--- a/src/internal/_isTransformer.js
+++ b/src/internal/_isTransformer.js
@@ -1,7 +1,3 @@
-var _symTransformer = require('./_symTransformer');
-
-
 module.exports = function _isTransformer(obj) {
-    return (obj[_symTransformer] != null) ||
-        (typeof obj.step === 'function' && typeof obj.result === 'function');
+    return typeof obj.step === 'function' && typeof obj.result === 'function';
 };

--- a/src/internal/_stepCat.js
+++ b/src/internal/_stepCat.js
@@ -3,7 +3,6 @@ var _appendTo = require('./_appendTo');
 var _createMapEntry = require('./_createMapEntry');
 var _identity = require('./_identity');
 var _isTransformer = require('./_isTransformer');
-var _symTransformer = require('./_symTransformer');
 var isArrayLike = require('../isArrayLike');
 var merge = require('../merge');
 
@@ -32,7 +31,7 @@ module.exports = (function() {
 
     return function _stepCat(obj) {
         if (_isTransformer(obj)) {
-            return obj[_symTransformer] || obj;
+            return obj;
         }
         if (isArrayLike(obj)) {
             return _stepCatArray;

--- a/src/internal/_symTransformer.js
+++ b/src/internal/_symTransformer.js
@@ -1,1 +1,0 @@
-module.exports = (typeof Symbol !== 'undefined') ? Symbol('transformer') : '@@transformer';


### PR DESCRIPTION
Prompted by cognitect-labs/transducers-js#20 from @tgriesser, removing
the internal transformer symbol until issues are worked out. This symbol
is currently only supported in jlongster/transducers.js and
interoperability is questionable as (Symbol('transformer') !==
Symbol('transformer')).

This feature was not documented, nor do the tests depend on it, and
only effects an undocumented feature of into. Better to remove it now
until details are worked out.  If an "official spec" is agreed upon,
I will open a new PR.