### PR TITLE
remove short-circuiting tests for R.any and R.all

### DIFF
--- a/test/all.js
+++ b/test/all.js
@@ -36,14 +36,6 @@ describe('all', function() {
         assert.deepEqual(intoArray(R.all(T), []), [true]);
     });
 
-    it('short-circuits on first false value', function() {
-        var count = 0;
-        var test = function(n) {count++; return even(n);};
-        var result = R.all(test, [2, 4, 6, 7, 8, 10]);
-        assert(!result);
-        assert.strictEqual(count, 4);
-    });
-
     it('works with more complex objects', function() {
         var xs = [{x: 'abc'}, {x: 'ade'}, {x: 'fghiajk'}];
         function len3(o) { return o.x.length === 3; }

--- a/test/any.js
+++ b/test/any.js
@@ -48,14 +48,6 @@ describe('any', function() {
         assert.deepEqual(intoArray(R.any(T), []), [false]);
     });
 
-    it('short-circuits on first true value', function() {
-        var count = 0;
-        var test = function(n) {count++; return odd(n);};
-        var result = R.any(test, [2, 4, 6, 7, 8, 10]);
-        assert(result);
-        assert.strictEqual(count, 4);
-    });
-
     it('dispatches when given a transformer in list position', function() {
         assert.deepEqual(R.any(odd, listXf), {
             any: false,


### PR DESCRIPTION
This was discussed in #881. These tests assert left-to-right enumeration order, but nothing in the definitions of these functions requires a particular enumeration order. Rather than *test* for a specific implementation, let's consider short-circuiting part of the *specification* for each of these functions.
