### PR TITLE
Fix typo in pathEq docs

### DIFF
--- a/src/pathEq.js
+++ b/src/pathEq.js
@@ -3,9 +3,8 @@ var _path = require('./internal/_path');
 
 
 /**
- * Determines whether a nested path on an object, seperated by periods,
- * has a specific value according to strict equality ('==='). Most
- * likely used to filter a list:
+ * Determines whether a nested path on an object has a specific value
+ * according to strict equality ('==='). Most likely used to filter a list:
  *
  * @func
  * @memberOf R


### PR DESCRIPTION
`R.pathEq` now accepts a list rather than a period delimited string.