### PR TITLE
Functor method dispatch on reduce.

### DIFF
--- a/src/internal/_reduce.js
+++ b/src/internal/_reduce.js
@@ -1,4 +1,5 @@
 var _xwrap = require('./_xwrap');
+var bind = require('../bind');
 var isArrayLike = require('../isArrayLike');
 
 
@@ -28,6 +29,10 @@ module.exports = (function() {
         return xf.result(acc);
     }
 
+    function _methodReduce(xf, acc, obj) {
+        return xf.result(obj.reduce(bind(xf.step, xf), acc));
+    }
+
     var symIterator = (typeof Symbol !== 'undefined') ? Symbol.iterator : '@@iterator';
     return function _reduce(fn, acc, list) {
         if (typeof fn === 'function') {
@@ -35,6 +40,9 @@ module.exports = (function() {
         }
         if (isArrayLike(list)) {
             return _arrayReduce(fn, acc, list);
+        }
+        if (typeof list.reduce === 'function') {
+            return _methodReduce(fn, acc, list);
         }
         if (list[symIterator] != null) {
             return _iterableReduce(fn, acc, list[symIterator]());

--- a/src/transduce.js
+++ b/src/transduce.js
@@ -44,6 +44,5 @@ var curryN = require('./curryN');
  *      R.transduce(transducer, R.flip(R.append), [], numbers); //=> [2, 3]
  */
 module.exports = curryN(4, function(xf, fn, acc, list) {
-    return (typeof fn === 'function') ? _reduce(xf(_xwrap(fn)), acc, list)
-                                      : _reduce(xf(fn), acc, list);
+    return _reduce(xf(typeof fn === 'function' ? _xwrap(fn) : fn), acc, list);
 });

--- a/test/into.js
+++ b/test/into.js
@@ -1,4 +1,5 @@
 var assert = require('assert');
+var lodash = require('lodash');
 
 var R = require('..');
 
@@ -27,6 +28,12 @@ describe('into', function() {
     it('transduces into objects', function() {
         assert.deepEqual(R.into({}, R.identity, [['a', 1], ['b', 2]]), {a: 1, b: 2});
         assert.deepEqual(R.into({}, R.identity, [{a: 1}, {b: 2, c: 3}]), {a: 1, b: 2, c: 3});
+    });
+
+    it('dispatches to objects that implement `reduce`', function() {
+        var obj = {x: [1, 2, 3], reduce: function(f, acc) { return lodash.reduce(this.x, f, acc); }};
+        assert.deepEqual(R.into([], R.map(add(1)), obj), [2, 3, 4]);
+        assert.deepEqual(R.into([], R.filter(isOdd), obj), [1, 3]);
     });
 
     it('is automatically curried', function() {

--- a/test/reduce.js
+++ b/test/reduce.js
@@ -1,4 +1,5 @@
 var assert = require('assert');
+var lodash = require('lodash');
 
 var R = require('..');
 
@@ -10,6 +11,12 @@ describe('reduce', function() {
     it('folds simple functions over arrays with the supplied accumulator', function() {
         assert.strictEqual(R.reduce(add, 0, [1, 2, 3, 4]), 10);
         assert.strictEqual(R.reduce(mult, 1, [1, 2, 3, 4]), 24);
+    });
+
+    it('dispatches to objects that implement `reduce`', function() {
+        var obj = {x: [1, 2, 3], reduce: function(f, acc) { return lodash.reduce(this.x, f, acc); }};
+        assert.strictEqual(R.reduce(add, 0, obj), 6);
+        assert.strictEqual(R.reduce(add, 10, obj), 16);
     });
 
     it('returns the accumulator for an empty array', function() {

--- a/test/transduce.js
+++ b/test/transduce.js
@@ -1,4 +1,5 @@
 var assert = require('assert');
+var lodash = require('lodash');
 
 var R = require('..');
 
@@ -58,6 +59,12 @@ describe('transduce', function() {
         assert.deepEqual(R.transduce(toxf(R.concat), listxf, [0], [1, 2, 3, 4]), [0, 1, 2, 3, 4]);
         assert.strictEqual(R.transduce(toxf(add), add, 0, [1, 2, 3, 4]), 10);
         assert.strictEqual(R.transduce(toxf(mult), mult, 1, [1, 2, 3, 4]), 24);
+    });
+
+    it('dispatches to objects that implement `reduce`', function() {
+        var obj = {x: [1, 2, 3], reduce: function(f, acc) { return lodash.reduce(this.x, f, acc); }};
+        assert.strictEqual(R.transduce(R.map(add(1)), add, 0, obj), 9);
+        assert.strictEqual(R.transduce(R.map(add(1)), add, 10, obj), 19);
     });
 
     it('returns the accumulator for an empty collection', function() {


### PR DESCRIPTION
`into` and `transduce` also allow dispatch on `reduce`. This
behavior is similar to Clojure with `IReduceInit` dispatching
and allows chaining applications of transducers with `eduction`.
Also allows using `into` and `transduce` with any object that
has a `reduce` method.