### PR TITLE
make R.invoke a fixed-arity function

### DIFF
--- a/src/invoke.js
+++ b/src/invoke.js
@@ -1,24 +1,25 @@
-var _slice = require('./internal/_slice');
 var curry = require('./curry');
 
 
 /**
- * Returns the result of invoking `obj[methodName]` with the zero or more
- * positional arguments following `methodName` and `obj`.
+ * Returns the result of applying `obj[methodName]` to `args`.
  *
  * @func
  * @memberOf R
  * @category Object
- * @sig String -> Object -> *
+ * @sig String -> Object -> [*] -> *
  * @param {String} methodName
  * @param {Object} obj
+ * @param {Array} args
  * @return {*}
  * @example
  *
- *      R.invoke('add', R, 1, 2); //=> 3
+ *      //  toBinary :: Number -> String
+ *      var toBinary = R.invoke('toString', R.__, [2])
  *
- *      R.invoke('f', {f: function() { return 'f called'; }}); //=> 'f called'
+ *      toBinary(42); //=> '101010'
+ *      toBinary(63); //=> '111111'
  */
-module.exports = curry(function invoke(methodName, obj) {
-    return obj[methodName].apply(obj, _slice(arguments, 2));
+module.exports = curry(function invoke(methodName, obj, args) {
+    return obj[methodName].apply(obj, args);
 });

--- a/test/invoke.js
+++ b/test/invoke.js
@@ -13,17 +13,17 @@ describe('invoke', function() {
         }};
         var gName = R.invoke('getName');
         assert.strictEqual(typeof gName, 'function');
-        assert.strictEqual(gName(fred), 'Fred Flintstone');
-        assert.strictEqual(gName(barney), 'Barney Rubble');
+        assert.strictEqual(gName(fred, []), 'Fred Flintstone');
+        assert.strictEqual(gName(barney, []), 'Barney Rubble');
     });
 
     it('passes arguments appropriately when not curried', function() {
-        assert.strictEqual(R.invoke('add', R, 3, 6), 9);
+        assert.strictEqual(R.invoke('add', R, [3, 6]), 9);
     });
 
     it('invokes the function with no arguments when no extra params are supplied', function() {
         var obj = {f: function() { return 'called f'; }};
-        assert.strictEqual(R.invoke('f', obj), 'called f');
+        assert.strictEqual(R.invoke('f', obj, []), 'called f');
     });
 
     it('applies additional arguments to the function', function() {
@@ -39,7 +39,7 @@ describe('invoke', function() {
 
 
         var moveBy = R.invoke('moveBy');
-        moveBy(p1, 5, 7);
+        moveBy(p1, [5, 7]);
         assert.strictEqual(p1.x, 15);
         assert.strictEqual(p1.y, 27);
     });


### PR DESCRIPTION
I take exception to this expression:

```javascript
R.invoke('substring', 'Ramda', 1, 4)
```

We're providing three things: a method name, an object, and zero or more arguments (two in this case). Though we're providing three things, we're providing *four* arguments to `R.invoke`. The expression would be clearer if the arguments we wish to provide to `'Ramda'.substring` were grouped:

```javascript
R.invoke('substring', 'Ramda', [1, 4])
```

This would make the function easier to describe:

<p><del>Returns the result of invoking <code>obj[methodName]</code> with the zero or more positional arguments following <code>methodName</code> and <code>obj</code>.</del></p>

<p><ins>Returns the result of applying <code>obj[methodName]</code> to <code>args</code>.</ins></p>

It would also simplify the function's `@sig`. Perhaps most significantly, it would mean we could partially apply any combination of arguments. For example:

```javascript
//  toBinary :: Number -> String
var toBinary = R.invoke('toString', R.__, [2])

toBinary(42);  // => '101010'
toBinary(63);  // => '111111'
```

I can also imagine contexts in which partially applying the first and second arguments is useful.

This is not a breaking change since `R.invoke` was added in #906 and we have not published since that pull request was merged.
