### PR TITLE
anti-sauce

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,15 +3,7 @@ node_js:
 - '0.10'
 - '0.12'
 - 'io.js'
-env:
-  global:
-  - secure: dgshxCQaY6olKOZnD+BT8R1Vp8uJhwCIUlSnoFji1m+7KIy3zwbbgi/2jkf/SWBCxzlpzDBWUuWbaMJOrJHWfjUaX3JfUY+2gbAPunrofD+42+brfo506rIxr20yaoomsnLxXFLgleLW5FuaezP6KP4lW5IOlWZXOEv0vTvoxQk=
-  - secure: RdTqvihsZTytLsHWjhdRiA3W0dIhM1dDW07ow0wbzWb7OMZSnZUKEBm0bMME1ndpt5V0T1iqeNuhCZ7BDwTAKa8+kKoJ+kxjSHzgdTAKa0IRglq/FMJT/kjJ7uYyxX1HPD7q1Y3PzAhM77fXnEE3DzjpgpXUIXplkDIE+A0R3pA=
-  - secure: TJ1ZGwnQa7xuPyLQf2GFX5zFzjsiJhZMFFGEYSaMiNauln1mm7x8v0K7eof8nNxObbFCZK/oyV9MPYgIquoCSgwnu7PwgRSKpeuatiwFLnhTvVpuNrXu2nDm9zCaoR4E3yxtg78g8kU5CioVCVKzQucTRKg8i4HXMQfp3GAj4NM=
 before_script:
 - npm install -g grunt-cli
 script:
 - make test lint
-after_success:
-- grunt bench
-- grunt sauce

--- a/README.md
+++ b/README.md
@@ -191,8 +191,6 @@ link provided in your browser and you will see the results in your terminal.
 If you have _PhantomJS_ installed, you can run `testem -l phantomjs` to run the
 tests completely headlessly.
 
-![ramda on sauce labs](https://saucelabs.com/browser-matrix/ramda.svg)
-
 
 
 


### PR DESCRIPTION
sauce labs is running after each platform build and if it errors -- not *fails* -- on any one, the whole build gets marked as errored. I propose running sauce either pre-publish or at regular intervals. 