### PR TITLE
avoid recursing once more than necessary in XTake.prototype.step

### DIFF
--- a/src/internal/_xtake.js
+++ b/src/internal/_xtake.js
@@ -15,7 +15,8 @@ module.exports = (function() {
     };
     XTake.prototype.step = function(result, input) {
         this.n -= 1;
-        return this.n >= 0 ? this.xf.step(result, input) : _reduced(result);
+        return this.n === 0 ? _reduced(this.xf.step(result, input))
+                            : this.xf.step(result, input);
     };
 
     return _curry2(function _xtake(n, xf) { return new XTake(n, xf); });


### PR DESCRIPTION
Fixes #921

We need to decide how to include tests involving ES6 features such as generators. Suggestions as to other ways to write a regression test for #921 much appreciated.
