### PR TITLE
add R.toString

### DIFF
--- a/src/internal/_quote.js
+++ b/src/internal/_quote.js
@@ -1,0 +1,3 @@
+module.exports = function _quote(s) {
+  return '"' + s.replace(/"/g, '\\"') + '"';
+};

--- a/src/internal/_toISOString.js
+++ b/src/internal/_toISOString.js
@@ -1,0 +1,22 @@
+/**
+ * Polyfill from <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString>.
+ */
+module.exports = (function() {
+  var pad = function pad(n) { return (n < 10 ? '0' : '') + n; };
+
+  return typeof Date.prototype.toISOString === 'function' ?
+    function _toISOString(d) {
+      return d.toISOString();
+    } :
+    function _toISOString(d) {
+      return (
+        d.getUTCFullYear() + '-' +
+        pad(d.getUTCMonth() + 1) + '-' +
+        pad(d.getUTCDate()) + 'T' +
+        pad(d.getUTCHours()) + ':' +
+        pad(d.getUTCMinutes()) + ':' +
+        pad(d.getUTCSeconds()) + '.' +
+        (d.getUTCMilliseconds() / 1000).toFixed(3).slice(2, 5) + 'Z'
+      );
+    };
+}());

--- a/src/internal/_toString.js
+++ b/src/internal/_toString.js
@@ -1,0 +1,37 @@
+var _indexOf = require('./_indexOf');
+var _map = require('./_map');
+var _quote = require('./_quote');
+var _toISOString = require('./_toISOString');
+var keys = require('../keys');
+
+
+module.exports = function _toString(x, seen) {
+  var recur = function recur(y) {
+    var xs = seen.concat([x]);
+    return _indexOf(xs, y) >= 0 ? '<Circular>' : _toString(y, xs);
+  };
+
+  switch (Object.prototype.toString.call(x)) {
+    case '[object Arguments]':
+      return '(function() { return arguments; }(' + _map(recur, x).join(', ') + '))';
+    case '[object Array]':
+      return '[' + _map(recur, x).join(', ') + ']';
+    case '[object Boolean]':
+      return typeof x === 'object' ? 'new Boolean(' + recur(x.valueOf()) + ')' : x.toString();
+    case '[object Date]':
+      return 'new Date(' + _quote(_toISOString(x)) + ')';
+    case '[object Null]':
+      return 'null';
+    case '[object Number]':
+      return typeof x === 'object' ? 'new Number(' + recur(x.valueOf()) + ')' : 1 / x === -Infinity ? '-0' : x.toString(10);
+    case '[object String]':
+      return typeof x === 'object' ? 'new String(' + recur(x.valueOf()) + ')' : _quote(x);
+    case '[object Undefined]':
+      return 'undefined';
+    default:
+      return (typeof x.constructor === 'function' && x.constructor.name !== 'Object' &&
+              typeof x.toString === 'function' && x.toString() !== '[object Object]') ?
+             x.toString() :  // Function, RegExp, user-defined types
+             '{' + _map(function(k) { return _quote(k) + ': ' + recur(x[k]); }, keys(x).sort()).join(', ') + '}';
+  }
+};

--- a/src/toString.js
+++ b/src/toString.js
@@ -1,0 +1,40 @@
+var _curry1 = require('./internal/_curry1');
+var _toString = require('./internal/_toString');
+
+
+/**
+ * Returns the string representation of the given value. `eval`'ing the output
+ * should result in a value equivalent to the input value. Many of the built-in
+ * `toString` methods do not satisfy this requirement.
+ *
+ * If the given value is an `[object Object]` with a `toString` method other
+ * than `Object.prototype.toString`, this method is invoked with no arguments
+ * to produce the return value. This means user-defined constructor functions
+ * can provide a suitable `toString` method. For example:
+ *
+ *     function Point(x, y) {
+ *       this.x = x;
+ *       this.y = y;
+ *     }
+ *
+ *     Point.prototype.toString = function() {
+ *       return 'new Point(' + this.x + ', ' + this.y + ')';
+ *     };
+ *
+ *     R.toString(new Point(1, 2)); //=> 'new Point(1, 2)'
+ *
+ * @func
+ * @memberOf R
+ * @category String
+ * @sig * -> String
+ * @param {*} val
+ * @return {String}
+ * @example
+ *
+ *      R.toString(42); //=> '42'
+ *      R.toString('abc'); //=> '"abc"'
+ *      R.toString([1, 2, 3]); //=> '[1, 2, 3]'
+ *      R.toString({foo: 1, bar: 2, baz: 3}); //=> '{"bar": 2, "baz": 3, "foo": 1}'
+ *      R.toString(new Date('2001-02-03T04:05:06Z')); //=> 'new Date("2001-02-03T04:05:06.000Z")'
+ */
+module.exports = _curry1(function toString(val) { return _toString(val, []); });


### PR DESCRIPTION
Closes #875

I'm very excited about this function! I've written similar functions several times but never with such a clear goal in mind:

> `eval`'ing the output should result in a value equivalent to the input value.

Without this it wouldn't have been clear what to return for `-0`, `new Boolean(true)`, and many other values.

The implementation is straightforward, which also pleases me. :)
