### PR TITLE
refer to partial in bind docs

### DIFF
--- a/src/bind.js
+++ b/src/bind.js
@@ -11,6 +11,7 @@ var arity = require('./arity');
  * @memberOf R
  * @category Function
  * @category Object
+ * @see R.partial
  * @sig (* -> *) -> {*} -> (* -> *)
  * @param {Function} fn The function to bind to context
  * @param {Object} thisObj The context to bind `fn` to


### PR DESCRIPTION
It says

> Note: R.bind does not provide the additional argument-binding capabilities of Function.prototype.bind.

but doesn't tell you where to go.