### PR TITLE
change mapObj category to object

### DIFF
--- a/src/mapObj.js
+++ b/src/mapObj.js
@@ -10,7 +10,7 @@ var keys = require('./keys');
  *
  * @func
  * @memberOf R
- * @category List
+ * @category Object
  * @sig (v -> v) -> {k: v} -> {k: v}
  * @param {Function} fn A function called for each property in `obj`. Its return value will
  * become a new property on the return object.


### PR DESCRIPTION
I don't if this was intentional, but mapObj is in the List category. I think it belongs in the Object category. If there is strong opposition, then feel free to close the request. 

I apologize if I didn't build some auxiliary files. `make` told me `'dist/ramda.js' is up to date.`