### PR TITLE
Add separate documentation for R.__

### DIFF
--- a/lib/doc/jsdoc-template/publish.js
+++ b/lib/doc/jsdoc-template/publish.js
@@ -104,7 +104,7 @@ function publish(data, opts) {
     data = helper.prune(data);
     var fullData = data()
         .order('name, version, since')
-        .filter({kind: 'function'})
+        .filter({kind: ['function', 'constant']})
         .get()
         .filter(nonPrivateAccess)
         .map(simplifyData);

--- a/src/__.js
+++ b/src/__.js
@@ -1,1 +1,25 @@
+/**
+ * A special placeholder value used to specify "gaps" within curried functions,
+ * allowing partial application of any combination of arguments,
+ * regardless of their positions.
+ *
+ * If `g` is a curried ternary function and `_` is `R.__`, the following are equivalent:
+ *
+ *   - `g(1, 2, 3)`
+ *   - `g(_, 2, 3)(1)`
+ *   - `g(_, _, 3)(1)(2)`
+ *   - `g(_, _, 3)(1, 2)`
+ *   - `g(_, 2, _)(1, 3)`
+ *   - `g(_, 2)(1)(3)`
+ *   - `g(_, 2)(1, 3)`
+ *   - `g(_, 2)(_, 3)(1)`
+ *
+ * @constant
+ * @memberOf R
+ * @category Function
+ * @example
+ *
+ *      var greet = R.replace('{name}', R.__, 'Hello, {name}!');
+ *      greet('Alice'); //=> 'Hello, Alice!'
+ */
 module.exports = {ramda: 'placeholder'};


### PR DESCRIPTION
Addressing #835.

One question I had - would it be worthwhile to remove the mostly identical sections within the docs for `R.curry` and `R.curryN`?

Also slightly unsure about the `@constant` tag.