### PR TITLE
replace erroneous occurrences of R.nix with R.not

### DIFF
--- a/lib/doc/jsdoc-template/publish.js
+++ b/lib/doc/jsdoc-template/publish.js
@@ -73,7 +73,7 @@ function embedData(d) {
 
 var nonPrivateAccess = R.pipe(
     R.prop('access'),
-    R.nix(R.eq('private'))
+    R.not(R.eq('private'))
 );
 
 // For embedding a JSON blob with documentation data inside the HTML.

--- a/test/test.examplesRunner.js
+++ b/test/test.examplesRunner.js
@@ -164,7 +164,7 @@ var ramda_source = String(fs.readFileSync('./dist/ramda.js'));
 var ramda_dox = dox.parseComments(ramda_source);
 
 // get our examples
-var examples = R.filter(R.nix(R.eq(false)), R.mapIndexed(getExampleFromDox, ramda_dox));
+var examples = R.filter(R.not(R.eq(false)), R.mapIndexed(getExampleFromDox, ramda_dox));
 
 // prepare our source code to inject examples
 var source_for_compliation = splitAt(ramda_source, '/* TEST_ENTRY_POINT */');


### PR DESCRIPTION
These files `require('ramda')` as in the dev dependency `ramda@0.11.0` specified in __package.json__. They were mistakenly updated in #902.
