### PR TITLE
Type signature fix for groupBy

### DIFF
--- a/src/groupBy.js
+++ b/src/groupBy.js
@@ -15,7 +15,7 @@ var _xgroupBy = require('./internal/_xgroupBy');
  * @func
  * @memberOf R
  * @category List
- * @sig (a -> s) -> [a] -> {s: [a]}
+ * @sig (a -> String) -> [a] -> {String: [a]}
  * @param {Function} fn Function :: a -> String
  * @param {Array} list The array to group
  * @return {Object} An object with the output of `fn` for keys, mapped to arrays of elements

--- a/src/groupBy.js
+++ b/src/groupBy.js
@@ -15,7 +15,7 @@ var _xgroupBy = require('./internal/_xgroupBy');
  * @func
  * @memberOf R
  * @category List
- * @sig (a -> s) -> [a] -> {s: a}
+ * @sig (a -> s) -> [a] -> {s: [a]}
  * @param {Function} fn Function :: a -> String
  * @param {Array} list The array to group
  * @return {Object} An object with the output of `fn` for keys, mapped to arrays of elements


### PR DESCRIPTION
`groupBy` returns an object where the values are arrays, the type signature in the docs should then be 

    (a -> s) -> [a] -> {s: [a]}`