### PR TITLE
accept negative offsets in R.substring{,From,To}

### DIFF
--- a/src/substring.js
+++ b/src/substring.js
@@ -1,20 +1,21 @@
-var invoker = require('./invoker');
+var slice = require('./slice');
 
 
 /**
- * returns a subset of a string between one index and another.
+ * Returns a string containing the characters of `str` from `fromIndex`
+ * (inclusive) to `toIndex` (exclusive).
  *
  * @func
  * @memberOf R
  * @category String
  * @sig Number -> Number -> String -> String
- * @param {Number} indexA An integer between 0 and the length of the string.
- * @param {Number} indexB An integer between 0 and the length of the string.
- * @param {String} str The string to extract from
- * @return {String} The extracted substring.
- * @see R.invoker
+ * @param {Number} fromIndex The start index (inclusive).
+ * @param {Number} toIndex The end index (exclusive).
+ * @param {String} str The string to slice.
+ * @return {String}
+ * @see R.slice
  * @example
  *
  *      R.substring(2, 5, 'abcdefghijklm'); //=> 'cde'
  */
-module.exports = invoker(2, 'substring');
+module.exports = slice;

--- a/src/substringFrom.js
+++ b/src/substringFrom.js
@@ -1,19 +1,21 @@
-var flip = require('./flip');
+var __ = require('./__');
 var substring = require('./substring');
 
 
 /**
- * The trailing substring of a String starting with the nth character:
+ * Returns a string containing the characters of `str` from `fromIndex`
+ * (inclusive) to the end of `str`.
  *
  * @func
  * @memberOf R
  * @category String
  * @sig Number -> String -> String
- * @param {Number} indexA An integer between 0 and the length of the string.
- * @param {String} str The string to extract from
- * @return {String} The extracted substring.
+ * @param {Number} fromIndex
+ * @param {String} str
+ * @return {String}
  * @example
  *
- *      R.substringFrom(8, 'abcdefghijklm'); //=> 'ijklm'
+ *      R.substringFrom(3, 'Ramda'); //=> 'da'
+ *      R.substringFrom(-2, 'Ramda'); //=> 'da'
  */
-module.exports = flip(substring)(void 0);
+module.exports = substring(__, Infinity);

--- a/src/substringTo.js
+++ b/src/substringTo.js
@@ -2,17 +2,18 @@ var substring = require('./substring');
 
 
 /**
- * The leading substring of a String ending before the nth character:
+ * Returns a string containing the first `toIndex` characters of `str`.
  *
  * @func
  * @memberOf R
  * @category String
  * @sig Number -> String -> String
- * @param {Number} indexA An integer between 0 and the length of the string.
- * @param {String} str The string to extract from
- * @return {String} The extracted substring.
+ * @param {Number} toIndex
+ * @param {String} str
+ * @return {String}
  * @example
  *
- *      R.substringTo(8, 'abcdefghijklm'); //=> 'abcdefgh'
+ *      R.substringTo(3, 'Ramda'); //=> 'Ram'
+ *      R.substringTo(-2, 'Ramda'); //=> 'Ram'
  */
 module.exports = substring(0);

--- a/test/substring.js
+++ b/test/substring.js
@@ -8,6 +8,12 @@ describe('substring', function() {
         assert.strictEqual(R.substring(2, 5, 'abcdefghijklm'), 'cde');
     });
 
+    it('accepts negative offsets', function() {
+        assert.strictEqual(R.substring(0, -2, 'Ramda'), 'Ram');
+        assert.strictEqual(R.substring(-4, 3, 'Ramda'), 'am');
+        assert.strictEqual(R.substring(-4, -2, 'Ramda'), 'am');
+    });
+
     it('is automatically curried', function() {
         var from2 = R.substring(2);
         assert.strictEqual(from2(5, 'abcdefghijklm'), 'cde');

--- a/test/substringFrom.js
+++ b/test/substringFrom.js
@@ -8,6 +8,10 @@ describe('substringFrom', function() {
         assert.strictEqual(R.substringFrom(8, 'abcdefghijklm'), 'ijklm');
     });
 
+    it('accepts negative offsets', function() {
+        assert.strictEqual(R.substringFrom(-2, 'Ramda'), 'da');
+    });
+
     it('is automatically curried', function() {
         var after8 = R.substringFrom(8);
         assert.strictEqual(after8('abcdefghijklm'), 'ijklm');

--- a/test/substringTo.js
+++ b/test/substringTo.js
@@ -8,6 +8,10 @@ describe('substringTo', function() {
         assert.strictEqual(R.substringTo(8, 'abcdefghijklm'), 'abcdefgh');
     });
 
+    it('accepts negative offsets', function() {
+        assert.strictEqual(R.substringTo(-2, 'Ramda'), 'Ram');
+    });
+
     it('is automatically curried', function() {
         var through8 = R.substringTo(8);
         assert.strictEqual(through8('abcdefghijklm'), 'abcdefgh');


### PR DESCRIPTION
It's slightly embarrassing that despite the existence of three substring functions, taking the last N characters of a string currently requires `R.slice` (which does not officially support strings). This pull request rectifies the situation by making `R.substring` an :alien: for `R.slice`.
