### PR TITLE
docs: fix indent

### DIFF
--- a/lib/doc/jsdoc-template/publish.js
+++ b/lib/doc/jsdoc-template/publish.js
@@ -20,7 +20,7 @@ var unprefix = R.pipe(
 
 var trimCode = R.pipe(
     R.split(/\n/),
-    R.map(R.trim),
+    R.map(R.replace(/^[ ]{5}/, '')),
     R.join('\n')
 );
 


### PR DESCRIPTION
Closes #715

5 is a magic number for the amount of indent ramda has in its examples

```
 @example

      R.F(); //=> false
 └─5─┘
```

[before](https://cloud.githubusercontent.com/assets/11027/6765625/86039db8-cff1-11e4-8e9d-db2fa36030b6.png)
[after](https://cloud.githubusercontent.com/assets/11027/6765624/8421d6ae-cff1-11e4-8f38-93654c4e0fe6.png)
