### PR TITLE
replace occurrences of assert(...) and assert.ok(...)

### DIFF
--- a/test/all.js
+++ b/test/all.js
@@ -12,7 +12,7 @@ describe('all', function() {
 
   it('returns true if all elements satisfy the predicate', function() {
     assert.strictEqual(R.all(even, [2, 4, 6, 8, 10, 12]), true);
-    assert(R.all(isFalse, [false, false, false]));
+    assert.strictEqual(R.all(isFalse, [false, false, false]), true);
   });
 
   it('returns false if any element fails to satisfy the predicate', function() {
@@ -55,6 +55,6 @@ describe('all', function() {
   it('is automatically curried', function() {
     var count = 0;
     var test = function(n) {count += 1; return even(n);};
-    assert(R.all(test)([2, 4, 6, 7, 8, 10]) === false);
+    assert.strictEqual(R.all(test)([2, 4, 6, 7, 8, 10]), false);
   });
 });

--- a/test/any.js
+++ b/test/any.js
@@ -59,6 +59,6 @@ describe('any', function() {
   it('is automatically curried', function() {
     var count = 0;
     var test = function(n) {count += 1; return odd(n);};
-    assert(R.any(test)([2, 4, 6, 7, 8, 10]) === true);
+    assert.strictEqual(R.any(test)([2, 4, 6, 7, 8, 10]), true);
   });
 });

--- a/test/bind.js
+++ b/test/bind.js
@@ -23,7 +23,7 @@ describe('bind', function() {
   };
 
   it('returns a function', function() {
-    assert(typeof R.bind(add, Foo) === 'function');
+    assert.strictEqual(typeof R.bind(add, Foo), 'function');
   });
 
   it('returns a function bound to the specified context object', function() {
@@ -38,8 +38,8 @@ describe('bind', function() {
 
   it('works with built-in types', function() {
     var abc = R.bind(String.prototype.toLowerCase, 'ABCDEFG');
-    assert(typeof abc === 'function');
-    assert(abc() === 'abcdefg');
+    assert.strictEqual(typeof abc, 'function');
+    assert.strictEqual(abc(), 'abcdefg');
   });
 
   it('works with user-defined types', function() {
@@ -59,8 +59,8 @@ describe('bind', function() {
       return this.x + 1;
     }
     var incPojso = R.bind(incThis, pojso);
-    assert(typeof incPojso === 'function');
-    assert(incPojso() === 101);
+    assert.strictEqual(typeof incPojso, 'function');
+    assert.strictEqual(incPojso(), 101);
   });
 
   it('does not interefere with existing object methods', function() {
@@ -75,7 +75,7 @@ describe('bind', function() {
 
   it('is curried', function() {
     var f = new Foo(1);
-    assert(R.bind(add)(f)(10) === 11);
+    assert.strictEqual(R.bind(add)(f)(10), 11);
   });
 
   it('preserves arity', function() {

--- a/test/clone.js
+++ b/test/clone.js
@@ -45,11 +45,11 @@ describe('deep clone objects', function() {
     var z = {b: y};
     x.c = z;
     var clone = R.clone(x);
-    assert.ok(x !== clone);
-    assert.ok(x.c !== clone.c);
-    assert.ok(x.c.b !== clone.c.b);
-    assert.ok(x.c.b.a !== clone.c.b.a);
-    assert.ok(x.c.b.a.c !== clone.c.b.a.c);
+    assert.notStrictEqual(x, clone);
+    assert.notStrictEqual(x.c, clone.c);
+    assert.notStrictEqual(x.c.b, clone.c.b);
+    assert.notStrictEqual(x.c.b.a, clone.c.b.a);
+    assert.notStrictEqual(x.c.b.a.c, clone.c.b.a.c);
     assert.deepEqual(R.keys(clone), R.keys(x));
     assert.deepEqual(R.keys(clone.c), R.keys(x.c));
     assert.deepEqual(R.keys(clone.c.b), R.keys(x.c.b));
@@ -77,7 +77,7 @@ describe('deep clone objects', function() {
     var clone = R.clone(obj);
     assert.strictEqual(clone.get(), 10);
 
-    assert.ok(obj !== clone);
+    assert.notStrictEqual(obj, clone);
 
     obj.set(11);
     assert.strictEqual(obj.get(), 11);
@@ -97,9 +97,9 @@ describe('deep clone arrays', function() {
     var list = [1, [1, 2, 3], [[[5]]]];
     var clone = R.clone(list);
 
-    assert.ok(list !== clone);
-    assert.ok(list[2] !== clone[2]);
-    assert.ok(list[2][0] !== clone[2][0]);
+    assert.notStrictEqual(list, clone);
+    assert.notStrictEqual(list[2], clone[2]);
+    assert.notStrictEqual(list[2][0], clone[2][0]);
 
     assert.deepEqual(clone, [1, [1, 2, 3], [[[5]]]]);
   });
@@ -113,7 +113,7 @@ describe('deep `clone` functions', function() {
     var clone = R.clone(list);
 
     assert.strictEqual(clone[0].a(10), 20);
-    assert.ok(list[0].a === clone[0].a);
+    assert.strictEqual(list[0].a, clone[0].a);
   });
 });
 
@@ -123,7 +123,7 @@ describe('built-in types', function() {
 
     var clone = R.clone(date);
 
-    assert.ok(date !== clone);
+    assert.notStrictEqual(date, clone);
     assert.deepEqual(clone.toString(), new Date(2014, 10, 14, 23, 59, 59, 999).toString());
 
     assert.strictEqual(clone.getDay(), 5); // friday
@@ -162,10 +162,10 @@ describe('deep clone deep nested mixed objects', function() {
     var list = [{b: obj}, {b: obj}];
     var clone = R.clone(list);
 
-    assert.ok(list[0].b === list[1].b);
-    assert.ok(clone[0].b === clone[1].b);
-    assert.ok(clone[0].b !== list[0].b);
-    assert.ok(clone[1].b !== list[1].b);
+    assert.strictEqual(list[0].b, list[1].b);
+    assert.strictEqual(clone[0].b, clone[1].b);
+    assert.notStrictEqual(clone[0].b, list[0].b);
+    assert.notStrictEqual(clone[1].b, list[1].b);
 
     assert.deepEqual(clone[0].b, {a:1});
     assert.deepEqual(clone[1].b, {a:1});

--- a/test/commute.js
+++ b/test/commute.js
@@ -22,7 +22,7 @@ describe('commute', function() {
 
   it('is curried', function() {
     var cmtArr = R.commute(R.of);
-    assert(typeof cmtArr === 'function');
+    assert.strictEqual(typeof cmtArr, 'function');
     assert.deepEqual(cmtArr(as), [[1, 3], [1, 4]]);
     assert.deepEqual(cmtArr(bs), [[1, 3], [2, 3]]);
     assert.deepEqual(cmtArr(cs), [[1, 3], [2, 3], [1, 4], [2, 4]]);

--- a/test/commuteMap.js
+++ b/test/commuteMap.js
@@ -23,10 +23,10 @@ describe('commuteMap', function() {
 
   it('is curried', function() {
     var cmtPlus10 = R.commuteMap(plus10map);
-    assert(typeof cmtPlus10 === 'function');
+    assert.strictEqual(typeof cmtPlus10, 'function');
 
     var cmtmArr = cmtPlus10(R.of);
-    assert(typeof cmtmArr === 'function');
+    assert.strictEqual(typeof cmtmArr, 'function');
     assert.deepEqual(cmtmArr(as), [[11, 13], [11, 14]]);
     assert.deepEqual(cmtmArr(bs), [[11, 13], [12, 13]]);
     assert.deepEqual(cmtmArr(cs), [[11, 13], [12, 13], [11, 14], [12, 14]]);

--- a/test/construct.js
+++ b/test/construct.js
@@ -10,27 +10,27 @@ describe('construct', function() {
   it('turns a constructor function into one that can be called without `new`', function() {
     var rect = R.construct(Rectangle);
     var r1 = rect(3, 4);
-    assert(r1 instanceof Rectangle);
+    assert.strictEqual(r1.constructor, Rectangle);
     assert.strictEqual(r1.width, 3);
     assert.strictEqual(r1.area(), 12);
 
     var regex = R.construct(RegExp);
     var word = regex('word', 'gi');
-    assert(word instanceof RegExp);
+    assert.strictEqual(word.constructor, RegExp);
     assert.strictEqual(word.source, 'word');
     assert.strictEqual(word.global, true);
   });
 
   it('can be used to create Date object', function() {
     var date = R.construct(Date)(1984, 3, 26, 0, 0, 0, 0);
-    assert(date instanceof Date);
+    assert.strictEqual(date.constructor, Date);
     assert.strictEqual(date.getFullYear(), 1984);
   });
 
   it('supports constructors with no arguments', function() {
     function Foo() {}
     var foo = R.construct(Foo)();
-    assert(foo instanceof Foo);
+    assert.strictEqual(foo.constructor, Foo);
   });
 
   it('does not support constructor with greater than ten arguments', function() {
@@ -49,7 +49,7 @@ describe('construct', function() {
     var rect = R.construct(Rectangle);
     var rect3 = rect(3);
     var r1 = rect3(4);
-    assert(r1 instanceof Rectangle);
+    assert.strictEqual(r1.constructor, Rectangle);
     assert.strictEqual(r1.width, 3);
     assert.strictEqual(r1.height, 4);
     assert.strictEqual(r1.area(), 12);
@@ -57,7 +57,7 @@ describe('construct', function() {
     var regex = R.construct(RegExp);
     var word = regex('word');
     var complete = word('gi');
-    assert(complete instanceof RegExp);
+    assert.strictEqual(complete.constructor, RegExp);
     assert.strictEqual(complete.source, 'word');
     assert.strictEqual(complete.global, true);
   });

--- a/test/constructN.js
+++ b/test/constructN.js
@@ -13,27 +13,27 @@ describe('constructN', function() {
   it('turns a constructor function into a function with n arguments', function() {
     var circle = R.constructN(2, Circle);
     var c1 = circle(1, 'red');
-    assert(c1 instanceof Circle);
+    assert.strictEqual(c1.constructor, Circle);
     assert.strictEqual(c1.r, 1);
     assert.strictEqual(c1.area(), Math.PI);
     assert.deepEqual(c1.colors, ['red']);
 
     var regex = R.constructN(1, RegExp);
     var pattern = regex('[a-z]');
-    assert(pattern instanceof RegExp);
+    assert.strictEqual(pattern.constructor, RegExp);
     assert.strictEqual(pattern.source, '[a-z]');
   });
 
   it('can be used to create Date object', function() {
     var date = R.constructN(3, Date)(1984, 3, 26);
-    assert(date instanceof Date);
+    assert.strictEqual(date.constructor, Date);
     assert.strictEqual(date.getFullYear(), 1984);
   });
 
   it('supports constructors with no arguments', function() {
     function Foo() {}
     var foo = R.constructN(0, Foo)();
-    assert(foo instanceof Foo);
+    assert.strictEqual(foo.constructor, Foo);
   });
 
   it('does not support constructor with greater than ten arguments', function() {
@@ -51,10 +51,10 @@ describe('constructN', function() {
   it('is curried', function() {
     function G(a, b, c) { this.a = a; this.b = b; this.c = c; }
     var construct2 = R.constructN(2);
-    assert(typeof construct2 === 'function');
+    assert.strictEqual(typeof construct2, 'function');
     var g2 = construct2(G);
-    assert(typeof g2 === 'function');
-    assert(g2('a', 'b') instanceof G);
-    assert(g2('a')('b') instanceof G);
+    assert.strictEqual(typeof g2, 'function');
+    assert.strictEqual(g2('a', 'b').constructor, G);
+    assert.strictEqual(g2('a')('b').constructor, G);
   });
 });

--- a/test/containsWith.js
+++ b/test/containsWith.js
@@ -9,12 +9,12 @@ describe('containsWith', function() {
   var eqA = function(r, s) { return r.a === s.a; };
 
   it('determines if an element is the list based on the predicate', function() {
-    assert(R.containsWith(eqA, {a: 3}, So));
+    assert.strictEqual(R.containsWith(eqA, {a: 3}, So), true);
     assert.strictEqual(R.containsWith(eqA, {a: 3000}, So), false);
   });
   it('is curried', function() {
     assert.strictEqual(typeof R.containsWith(eqA), 'function');
     assert.strictEqual(typeof R.containsWith(eqA)({a: 3}), 'function');
-    assert(R.containsWith(eqA)({a: 3})(Ro));
+    assert.strictEqual(R.containsWith(eqA)({a: 3})(Ro), true);
   });
 });

--- a/test/difference.js
+++ b/test/difference.js
@@ -36,7 +36,7 @@ describe('difference', function() {
   });
 
   it('is curried', function() {
-    assert(typeof R.difference([1, 2, 3]) === 'function');
+    assert.strictEqual(typeof R.difference([1, 2, 3]), 'function');
     assert.deepEqual(R.difference([1, 2, 3])([1, 3]), [2]);
   });
 });

--- a/test/groupBy.js
+++ b/test/groupBy.js
@@ -58,6 +58,6 @@ describe('groupBy', function() {
       result: function(x) { return x; },
       step: R.merge
     };
-    assert(_isTransformer(R.groupBy(byType, xf)));
+    assert.strictEqual(_isTransformer(R.groupBy(byType, xf)), true);
   });
 });

--- a/test/gt.js
+++ b/test/gt.js
@@ -5,24 +5,24 @@ var R = require('..');
 
 describe('gt', function() {
   it('reports whether one item is less than another', function() {
-    assert(!R.gt(3, 5));
-    assert(R.gt(6, 4));
-    assert(!R.gt(7.0, 7.0));
-    assert(!R.gt('abc', 'xyz'));
-    assert(R.gt('abcd', 'abc'));
+    assert.strictEqual(R.gt(3, 5), false);
+    assert.strictEqual(R.gt(6, 4), true);
+    assert.strictEqual(R.gt(7.0, 7.0), false);
+    assert.strictEqual(R.gt('abc', 'xyz'), false);
+    assert.strictEqual(R.gt('abcd', 'abc'), true);
   });
 
   it('is curried', function() {
     var lt20 = R.gt(20);
-    assert(lt20(10));
-    assert(!lt20(20));
-    assert(!lt20(25));
+    assert.strictEqual(lt20(10), true);
+    assert.strictEqual(lt20(20), false);
+    assert.strictEqual(lt20(25), false);
   });
 
   it('behaves right curried when passed `R.__` for its first argument', function() {
     var gt20 = R.gt(R.__, 20);
-    assert(!gt20(10));
-    assert(!gt20(20));
-    assert(gt20(25));
+    assert.strictEqual(gt20(10), false);
+    assert.strictEqual(gt20(20), false);
+    assert.strictEqual(gt20(25), true);
   });
 });

--- a/test/gte.js
+++ b/test/gte.js
@@ -5,24 +5,24 @@ var R = require('..');
 
 describe('gte', function() {
   it('reports whether one item is less than another', function() {
-    assert(!R.gte(3, 5));
-    assert(R.gte(6, 4));
-    assert(R.gte(7.0, 7.0));
-    assert(!R.gte('abc', 'xyz'));
-    assert(R.gte('abcd', 'abc'));
+    assert.strictEqual(R.gte(3, 5), false);
+    assert.strictEqual(R.gte(6, 4), true);
+    assert.strictEqual(R.gte(7.0, 7.0), true);
+    assert.strictEqual(R.gte('abc', 'xyz'), false);
+    assert.strictEqual(R.gte('abcd', 'abc'), true);
   });
 
   it('is curried', function() {
     var lte20 = R.gte(20);
-    assert(lte20(10));
-    assert(lte20(20));
-    assert(!lte20(25));
+    assert.strictEqual(lte20(10), true);
+    assert.strictEqual(lte20(20), true);
+    assert.strictEqual(lte20(25), false);
   });
 
   it('behaves right curried when passed `R.__` for its first argument', function() {
     var gte20 = R.gte(R.__, 20);
-    assert(!gte20(10));
-    assert(gte20(20));
-    assert(gte20(25));
+    assert.strictEqual(gte20(10), false);
+    assert.strictEqual(gte20(20), true);
+    assert.strictEqual(gte20(25), true);
   });
 });

--- a/test/invert.js
+++ b/test/invert.js
@@ -9,7 +9,7 @@ describe('invert', function() {
 
     var inverted = R.invert([0]);
     var keys = R.keys(inverted);
-    assert(R.is(Array, inverted[keys.pop()]));
+    assert.strictEqual(R.is(Array, inverted[keys.pop()]), true);
   });
 
   it('returns an empty object when applied to a primitive', function() {
@@ -31,9 +31,9 @@ describe('invert', function() {
     assert.deepEqual(R.invert(['a', 'b', 'a']), {a:['0', '2'], b:['1']});
 
     var inverted = R.invert({x:'a', y:'b', z:'a', _id:'a'});
-    assert(R.indexOf('x', inverted.a)   > -1);
-    assert(R.indexOf('z', inverted.a)   > -1);
-    assert(R.indexOf('_id', inverted.a) > -1);
+    assert.strictEqual(R.indexOf('x', inverted.a) >= 0, true);
+    assert.strictEqual(R.indexOf('z', inverted.a) >= 0, true);
+    assert.strictEqual(R.indexOf('_id', inverted.a) >= 0, true);
     assert.deepEqual(inverted.b, ['y']);
   });
 

--- a/test/is.js
+++ b/test/is.js
@@ -75,7 +75,7 @@ describe('is', function() {
   });
 
   it('is curried', function() {
-    assert(typeof R.is(String) === 'function');
-    assert(R.is(String)('s'));
+    assert.strictEqual(typeof R.is(String), 'function');
+    assert.strictEqual(R.is(String)('s'), true);
   });
 });

--- a/test/isArrayLike.js
+++ b/test/isArrayLike.js
@@ -5,18 +5,18 @@ var R = require('..');
 
 describe('isArrayLike', function() {
   it('is true for Arrays', function() {
-    assert(R.isArrayLike([]));
-    assert(R.isArrayLike([1, 2, 3, 4]));
-    assert(R.isArrayLike([null]));
+    assert.strictEqual(R.isArrayLike([]), true);
+    assert.strictEqual(R.isArrayLike([1, 2, 3, 4]), true);
+    assert.strictEqual(R.isArrayLike([null]), true);
   });
 
   it('is true for arguments', function() {
     function test() {
       return R.isArrayLike(arguments);
     }
-    assert(test());
-    assert(test(1, 2, 3));
-    assert(test(null));
+    assert.strictEqual(test(), true);
+    assert.strictEqual(test(1, 2, 3), true);
+    assert.strictEqual(test(null), true);
   });
 
   it('is false for Strings', function() {
@@ -31,12 +31,12 @@ describe('isArrayLike', function() {
     var obj4 = {0: 'zero', 1: 'one', length: 2};
     var obj5 = {0: 'zero', length: 2};
     var obj6 = {1: 'one', length: 2};
-    assert(R.isArrayLike(obj1));
-    assert(R.isArrayLike(obj2));
-    assert(R.isArrayLike(obj3));
-    assert(R.isArrayLike(obj4));
-    assert(!R.isArrayLike(obj5));
-    assert(!R.isArrayLike(obj6));
+    assert.strictEqual(R.isArrayLike(obj1), true);
+    assert.strictEqual(R.isArrayLike(obj2), true);
+    assert.strictEqual(R.isArrayLike(obj3), true);
+    assert.strictEqual(R.isArrayLike(obj4), true);
+    assert.strictEqual(R.isArrayLike(obj5), false);
+    assert.strictEqual(R.isArrayLike(obj6), false);
   });
 
   it('is false for everything else', function() {

--- a/test/length.js
+++ b/test/length.js
@@ -26,18 +26,18 @@ describe('length', function() {
 
   it('returns NaN for value of unexpected type', function() {
     function isNaN_(x) { return x !== x; }
-    assert(isNaN_(R.length(0)));
-    assert(isNaN_(R.length({})));
-    assert(isNaN_(R.length(null)));
-    assert(isNaN_(R.length(undefined)));
+    assert.strictEqual(isNaN_(R.length(0)), true);
+    assert.strictEqual(isNaN_(R.length({})), true);
+    assert.strictEqual(isNaN_(R.length(null)), true);
+    assert.strictEqual(isNaN_(R.length(undefined)), true);
   });
 
   it('returns NaN for length property of unexpected type', function() {
     function isNaN_(x) { return x !== x; }
-    assert(isNaN_(R.length({length: ''})));
-    assert(isNaN_(R.length({length: '1.23'})));
-    assert(isNaN_(R.length({length: null})));
-    assert(isNaN_(R.length({length: undefined})));
-    assert(isNaN_(R.length({})));
+    assert.strictEqual(isNaN_(R.length({length: ''})), true);
+    assert.strictEqual(isNaN_(R.length({length: '1.23'})), true);
+    assert.strictEqual(isNaN_(R.length({length: null})), true);
+    assert.strictEqual(isNaN_(R.length({length: undefined})), true);
+    assert.strictEqual(isNaN_(R.length({})), true);
   });
 });

--- a/test/lens.js
+++ b/test/lens.js
@@ -27,9 +27,9 @@ describe('lens', function() {
   var phraseLens = R.lens(getPhrase, setPhrase);
 
   it('returns a function with `set` and `map` properties', function() {
-    assert(typeof phraseLens === 'function');
-    assert(typeof phraseLens.set === 'function');
-    assert(typeof phraseLens.map === 'function');
+    assert.strictEqual(typeof phraseLens, 'function');
+    assert.strictEqual(typeof phraseLens.set, 'function');
+    assert.strictEqual(typeof phraseLens.map, 'function');
   });
 
   it('retrieves values from inside an object as defined by the `getter` function', function() {
@@ -77,8 +77,8 @@ describe('lens', function() {
     };
     var x2 = function(x) { return x * 2; };
     var partial = R.lens(get1);
-    assert(typeof partial === 'function');
-    assert(typeof partial(set1) === 'function');
+    assert.strictEqual(typeof partial, 'function');
+    assert.strictEqual(typeof partial(set1), 'function');
     assert.deepEqual(partial(set1)(['zeroth', 'first', 'second']), 'first');
     assert.deepEqual(partial(set1)([10, 20, 30]), 20);
     assert.deepEqual(partial(set1).set('zoom', [10, 20, 30]), [10, 'zoom', 30]);

--- a/test/lensOn.js
+++ b/test/lensOn.js
@@ -36,9 +36,9 @@ describe('lensOn', function() {
     var x2 = function(x) { return x * 2; };
     var partial1 = R.lensOn(getX);
     var partial2 = partial1(setX);
-    assert(typeof partial1 === 'function');
-    assert(typeof partial2 === 'function');
-    assert(typeof partial2({x: 1}) === 'function');
+    assert.strictEqual(typeof partial1, 'function');
+    assert.strictEqual(typeof partial2, 'function');
+    assert.strictEqual(typeof partial2({x: 1}), 'function');
     assert.deepEqual(partial2({x: 'cow'}).set('moo'), {x: 'moo'});
     assert.deepEqual(partial2({x: 100}).map(x2), {x: 200});
   });

--- a/test/lift.js
+++ b/test/lift.js
@@ -23,7 +23,7 @@ var madd5 = R.lift(add5);
 describe('lift', function() {
 
   it('returns a function if called with just a function', function() {
-    assert(typeof R.lift(R.add) === 'function');
+    assert.strictEqual(typeof R.lift(R.add), 'function');
   });
 
   it('produces a cross-product of array values', function() {

--- a/test/liftN.js
+++ b/test/liftN.js
@@ -21,7 +21,7 @@ describe('liftN', function() {
   var addN5 = R.liftN(5, addN);
 
   it('returns a function', function() {
-    assert(typeof R.liftN(3, add3) === 'function');
+    assert.strictEqual(typeof R.liftN(3, add3), 'function');
   });
 
   it('limits a variadic function to the specified arity', function() {
@@ -42,7 +42,7 @@ describe('liftN', function() {
 
   it('is curried', function() {
     var f4 = R.liftN(4);
-    assert(typeof f4 === 'function');
+    assert.strictEqual(typeof f4, 'function');
     assert.deepEqual(f4(addN)([1], [2], [3], [4, 5]), [10, 11]);
   });
 

--- a/test/lt.js
+++ b/test/lt.js
@@ -5,24 +5,24 @@ var R = require('..');
 
 describe('lt', function() {
   it('reports whether one item is less than another', function() {
-    assert(R.lt(3, 5));
-    assert(!R.lt(6, 4));
-    assert(!R.lt(7.0, 7.0));
-    assert(R.lt('abc', 'xyz'));
-    assert(!R.lt('abcd', 'abc'));
+    assert.strictEqual(R.lt(3, 5), true);
+    assert.strictEqual(R.lt(6, 4), false);
+    assert.strictEqual(R.lt(7.0, 7.0), false);
+    assert.strictEqual(R.lt('abc', 'xyz'), true);
+    assert.strictEqual(R.lt('abcd', 'abc'), false);
   });
 
   it('is curried', function() {
     var gt5 = R.lt(5);
-    assert(gt5(10));
-    assert(!gt5(5));
-    assert(!gt5(3));
+    assert.strictEqual(gt5(10), true);
+    assert.strictEqual(gt5(5), false);
+    assert.strictEqual(gt5(3), false);
   });
 
   it('behaves right curried when passed `R.__` for its first argument', function() {
     var lt5 = R.lt(R.__, 5);
-    assert(!lt5(10));
-    assert(!lt5(5));
-    assert(lt5(3));
+    assert.strictEqual(lt5(10), false);
+    assert.strictEqual(lt5(5), false);
+    assert.strictEqual(lt5(3), true);
   });
 });

--- a/test/lte.js
+++ b/test/lte.js
@@ -5,24 +5,24 @@ var R = require('..');
 
 describe('lte', function() {
   it('reports whether one item is less than another', function() {
-    assert(R.lte(3, 5));
-    assert(!R.lte(6, 4));
-    assert(R.lte(7.0, 7.0));
-    assert(R.lte('abc', 'xyz'));
-    assert(!R.lte('abcd', 'abc'));
+    assert.strictEqual(R.lte(3, 5), true);
+    assert.strictEqual(R.lte(6, 4), false);
+    assert.strictEqual(R.lte(7.0, 7.0), true);
+    assert.strictEqual(R.lte('abc', 'xyz'), true);
+    assert.strictEqual(R.lte('abcd', 'abc'), false);
   });
 
   it('is curried', function() {
     var gte20 = R.lte(20);
-    assert(!gte20(10));
-    assert(gte20(20));
-    assert(gte20(25));
+    assert.strictEqual(gte20(10), false);
+    assert.strictEqual(gte20(20), true);
+    assert.strictEqual(gte20(25), true);
   });
 
   it('behaves right curried when passed `R.__` for its first argument', function() {
     var upTo20 = R.lte(R.__, 20);
-    assert(upTo20(10));
-    assert(upTo20(20));
-    assert(!upTo20(25));
+    assert.strictEqual(upTo20(10), true);
+    assert.strictEqual(upTo20(20), true);
+    assert.strictEqual(upTo20(25), false);
   });
 });

--- a/test/nAry.js
+++ b/test/nAry.js
@@ -27,10 +27,10 @@ describe('nAry', function() {
 
     var undefs = fn();
     var ns = R.repeat(undefined, 10);
-    assert(undefs.length === ns.length);
+    assert.strictEqual(undefs.length, ns.length);
     var idx = undefs.length;
     while (--idx) {
-      assert(undefs[idx] === ns[idx]);
+      assert.strictEqual(undefs[idx], ns[idx]);
     }
   });
 

--- a/test/replace.js
+++ b/test/replace.js
@@ -14,8 +14,8 @@ describe('replace', function() {
   });
 
   it('is curried up to 3 arguments', function() {
-    assert(R.replace(null) instanceof Function);
-    assert(R.replace(null, null) instanceof Function);
+    assert.strictEqual(R.replace(null).constructor, Function);
+    assert.strictEqual(R.replace(null, null).constructor, Function);
 
     var replaceSemicolon = R.replace(';');
     var removeSemicolon = replaceSemicolon('');

--- a/test/takeWhile.js
+++ b/test/takeWhile.js
@@ -9,7 +9,7 @@ describe('takeWhile', function() {
   });
 
   it('starts at the right arg and acknowledges undefined', function() {
-    assert.deepEqual(R.takeWhile(function() { assert.ok(false); }, []), []);
+    assert.deepEqual(R.takeWhile(function() { assert(false); }, []), []);
     assert.deepEqual(R.takeWhile(function(x) {return x !== void 0;}, [1, 3, void 0, 5, 7]), [1, 3]);
   });
 

--- a/test/union.js
+++ b/test/union.js
@@ -13,7 +13,7 @@ describe('union', function() {
   });
 
   it('is curried', function() {
-    assert(typeof R.union(M) === 'function');
+    assert.strictEqual(typeof R.union(M), 'function');
     assert.deepEqual(R.union(M)(N), [1, 2, 3, 4, 5, 6]);
   });
 

--- a/test/valuesIn.js
+++ b/test/valuesIn.js
@@ -12,22 +12,22 @@ describe('valuesIn', function() {
 
   it("returns an array of the given object's values", function() {
     var vs = R.valuesIn(obj);
-    assert(vs.length === 6);
-    assert(R.indexOf(100, vs) > -1);
-    assert(R.indexOf('D', vs) > -1);
-    assert(R.indexOf(null, vs) > -1);
-    assert(R.indexOf(undefined, vs) > -1);
-    assert(R.indexOf(obj.b, vs) > -1);
-    assert(R.indexOf(obj.c, vs) > -1);
+    assert.strictEqual(vs.length, 6);
+    assert.strictEqual(R.indexOf(100, vs) >= 0, true);
+    assert.strictEqual(R.indexOf('D', vs) >= 0, true);
+    assert.strictEqual(R.indexOf(null, vs) >= 0, true);
+    assert.strictEqual(R.indexOf(undefined, vs) >= 0, true);
+    assert.strictEqual(R.indexOf(obj.b, vs) >= 0, true);
+    assert.strictEqual(R.indexOf(obj.c, vs) >= 0, true);
   });
 
   it("includes the given object's prototype properties", function() {
     var vs = R.valuesIn(cobj);
-    assert(vs.length === 4);
-    assert(R.indexOf(100, vs) > -1);
-    assert(R.indexOf(200, vs) > -1);
-    assert(R.indexOf(cobj.x, vs) > -1);
-    assert(R.indexOf('y', vs) > -1);
+    assert.strictEqual(vs.length, 4);
+    assert.strictEqual(R.indexOf(100, vs) >= 0, true);
+    assert.strictEqual(R.indexOf(200, vs) >= 0, true);
+    assert.strictEqual(R.indexOf(cobj.x, vs) >= 0, true);
+    assert.strictEqual(R.indexOf('y', vs) >= 0, true);
   });
 
   it('works for primitives', function() {


### PR DESCRIPTION
`assert` and its :alien: `assert.ok` are problematic for two reasons:

  - They're imprecise. Consider this buggy `isOdd` function:

    ```javascript
    var isOdd = function(n) { return n % 2; };

    assert(isOdd(7));
    assert.strictEqual(isOdd(7), true);  // AssertionError: 1 === true
    ```

  - They don't provide useful feedback in case of failure:

    ```javascript
    assert(2 + 2, 5);  // AssertionError: false == true
    assert.strictEqual(2 + 2, 5);  // AssertionError: 4 === 5
    ```
