### PR TITLE
add R.isNaN

### DIFF
--- a/src/isNaN.js
+++ b/src/isNaN.js
@@ -1,0 +1,23 @@
+var _curry1 = require('./internal/_curry1');
+
+
+/**
+ * Returns `true` if the input value is `NaN`.
+ *
+ * Equivalent to ES6's [`Number.isNaN`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isNaN).
+ *
+ * @func
+ * @memberOf R
+ * @category Math
+ * @sig * -> Boolean
+ * @param {*} x
+ * @return {Boolean}
+ * @example
+ *
+ *     R.isNaN(NaN);        //=> true
+ *     R.isNaN(undefined);  //=> false
+ *     R.isNaN({});         //=> false
+ */
+module.exports = _curry1(function isNaN(x) {
+  return typeof x === 'number' && x !== x;
+});

--- a/src/none.js
+++ b/src/none.js
@@ -18,7 +18,7 @@ var _xany = require('./internal/_xany');
  * @return {Boolean} `true` if the predicate is not satisfied by every element, `false` otherwise.
  * @example
  *
- *      R.none(isNaN, [1, 2, 3]); //=> true
- *      R.none(isNaN, [1, 2, 3, NaN]); //=> false
+ *      R.none(R.isNaN, [1, 2, 3]); //=> true
+ *      R.none(R.isNaN, [1, 2, 3, NaN]); //=> false
  */
 module.exports = _curry2(_complement(_dispatchable('any', _xany, _any)));

--- a/test/isNaN.js
+++ b/test/isNaN.js
@@ -1,0 +1,28 @@
+var assert = require('assert');
+
+var R = require('..');
+
+
+describe('isNaN', function() {
+
+  it('returns true for `NaN`', function() {
+    assert.strictEqual(R.isNaN(NaN), true);
+
+    assert.strictEqual(isNaN(NaN), true);
+  });
+
+  it('returns false for `new Number(NaN)`', function() {
+    /* jshint -W053 */
+    assert.strictEqual(R.isNaN(new Number(NaN)), false);
+    /* jshint +W053 */
+  });
+
+  it('returns false for any other value', function() {
+    assert.strictEqual(R.isNaN(void 0), false);
+    assert.strictEqual(R.isNaN({}), false);
+
+    assert.strictEqual(isNaN(void 0), true);
+    assert.strictEqual(isNaN({}), true);
+  });
+
+});

--- a/test/length.js
+++ b/test/length.js
@@ -25,19 +25,17 @@ describe('length', function() {
   });
 
   it('returns NaN for value of unexpected type', function() {
-    function isNaN_(x) { return x !== x; }
-    assert.strictEqual(isNaN_(R.length(0)), true);
-    assert.strictEqual(isNaN_(R.length({})), true);
-    assert.strictEqual(isNaN_(R.length(null)), true);
-    assert.strictEqual(isNaN_(R.length(undefined)), true);
+    assert.strictEqual(R.isNaN(R.length(0)), true);
+    assert.strictEqual(R.isNaN(R.length({})), true);
+    assert.strictEqual(R.isNaN(R.length(null)), true);
+    assert.strictEqual(R.isNaN(R.length(undefined)), true);
   });
 
   it('returns NaN for length property of unexpected type', function() {
-    function isNaN_(x) { return x !== x; }
-    assert.strictEqual(isNaN_(R.length({length: ''})), true);
-    assert.strictEqual(isNaN_(R.length({length: '1.23'})), true);
-    assert.strictEqual(isNaN_(R.length({length: null})), true);
-    assert.strictEqual(isNaN_(R.length({length: undefined})), true);
-    assert.strictEqual(isNaN_(R.length({})), true);
+    assert.strictEqual(R.isNaN(R.length({length: ''})), true);
+    assert.strictEqual(R.isNaN(R.length({length: '1.23'})), true);
+    assert.strictEqual(R.isNaN(R.length({length: null})), true);
+    assert.strictEqual(R.isNaN(R.length({length: undefined})), true);
+    assert.strictEqual(R.isNaN(R.length({})), true);
   });
 });

--- a/test/mathMod.js
+++ b/test/mathMod.js
@@ -19,10 +19,10 @@ describe('mathMod', function() {
 
   it('computes the true modulo function', function() {
     assert.strictEqual(R.mathMod(-17, 5), 3);
-    assert.strictEqual(isNaN(R.mathMod(17, -5)), true);
-    assert.strictEqual(isNaN(R.mathMod(17, 0)), true);
-    assert.strictEqual(isNaN(R.mathMod(17.2, 5)), true);
-    assert.strictEqual(isNaN(R.mathMod(17, 5.5)), true);
+    assert.strictEqual(R.isNaN(R.mathMod(17, -5)), true);
+    assert.strictEqual(R.isNaN(R.mathMod(17, 0)), true);
+    assert.strictEqual(R.isNaN(R.mathMod(17.2, 5)), true);
+    assert.strictEqual(R.isNaN(R.mathMod(17, 5.5)), true);
   });
 
   it('is curried', function() {


### PR DESCRIPTION
Useful given the questionable semantics of [`isNaN`][1].


[1]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/isNaN
