### PR TITLE
Adds lensIndex, lensProp, composeL & pipeL

### DIFF
--- a/src/composeL.js
+++ b/src/composeL.js
@@ -1,0 +1,37 @@
+var _composeL = require('./internal/_composeL');
+
+/**
+ * Creates a new lens that allows getting and setting values of nested properties, by
+ * following each given lens in succession.
+ *
+ * Note that `composeL` is a right-associative function, which means the lenses provided
+ * will be invoked in order from right to left.
+ *
+ * @func
+ * @memberOf R
+ * @category Function
+ * @see R.lens
+ * @sig ((y -> z), (x -> y), ..., (b -> c), (a -> b)) -> (a -> z)
+ * @param {...Function} lenses A variable number of lenses.
+ * @return {Function} A new lens which represents the result of calling each of the
+ *         input `lenses`, passing the result of each getter/setter as the source
+ *         to the next, from right to left.
+ * @example
+ *
+ *      var headLens = R.lensIndex(0);
+ *      var secondLens = R.lensIndex(1);
+ *      var xLens = R.lensProp('x');
+ *      var secondOfXOfHeadLens = R.composeL(secondLens, xLens, headLens);
+ *
+ *      var source = [{x: [0, 1], y: [2, 3]}, {x: [4, 5], y: [6, 7]}];
+ *      secondOfXOfHeadLens(source); //=> 1
+ *      secondOfXOfHeadLens.set(123, source); //=> [{x: [0, 123], y: [2, 3]}, {x: [4, 5], y: [6, 7]}]
+ */
+module.exports = function() {
+  var idx = arguments.length - 1;
+  var fn = arguments[idx];
+  while (--idx >= 0) {
+    fn = _composeL(arguments[idx], fn);
+  }
+  return fn;
+};

--- a/src/internal/_composeL.js
+++ b/src/internal/_composeL.js
@@ -1,0 +1,9 @@
+var _compose = require('./_compose');
+var lens = require('../lens');
+
+module.exports = function _composeL(innerLens, outerLens) {
+  return lens(_compose(innerLens, outerLens), function(x, source) {
+    var newInnerValue = innerLens.set(x, outerLens(source));
+    return outerLens.set(newInnerValue, source);
+  });
+};

--- a/src/lensIndex.js
+++ b/src/lensIndex.js
@@ -1,0 +1,27 @@
+var _slice = require('./internal/_slice');
+var lens = require('./lens');
+var nth = require('./nth');
+
+/**
+ * Creates a lens that will focus on index `n` of the source array.
+ *
+ * @func
+ * @memberOf R
+ * @category List
+ * @see R.lens
+ * @sig Number -> (a -> b)
+ * @param {Number} n The index of the array that the returned lens will focus on.
+ * @return {Function} the returned function has `set` and `map` properties that are
+ *         also curried functions.
+ * @example
+ *
+ *     var headLens = R.lensIndex(0);
+ *     headLens([10, 20, 30, 40]); //=> 10
+ *     headLens.set('mu', [10, 20, 30, 40]); //=> ['mu', 20, 30, 40]
+ *     headLens.map(function(x) { return x + 1; }, [10, 20, 30, 40]); //=> [11, 20, 30, 40]
+ */
+module.exports = function lensIndex(n) {
+  return lens(nth(n), function(x, xs) {
+    return _slice(xs, 0, n).concat([x], _slice(xs, n + 1));
+  });
+};

--- a/src/lensProp.js
+++ b/src/lensProp.js
@@ -1,0 +1,29 @@
+var assoc = require('./assoc');
+var lens = require('./lens');
+var prop = require('./prop');
+
+/**
+ * Creates a lens that will focus on property `k` of the source object.
+ *
+ * @func
+ * @memberOf R
+ * @category Object
+ * @see R.lens
+ * @sig String -> (a -> b)
+ * @param {String} k A string that represents a property to focus on.
+ * @return {Function} the returned function has `set` and `map` properties that are
+ *         also curried functions.
+ * @example
+ *
+ *     var phraseLens = R.lensProp('phrase');
+ *     var obj1 = { phrase: 'Absolute filth . . . and I LOVED it!'};
+ *     var obj2 = { phrase: "What's all this, then?"};
+ *     phraseLens(obj1); // => 'Absolute filth . . . and I LOVED it!'
+ *     phraseLens(obj2); // => "What's all this, then?"
+ *     phraseLens.set('Ooh Betty', obj1); //=> { phrase: 'Ooh Betty'}
+ *     phraseLens.map(R.toUpper, obj2); //=> { phrase: "WHAT'S ALL THIS, THEN?"}
+ */
+module.exports = function(k) {
+  return lens(prop(k), assoc(k));
+};
+

--- a/src/pipeL.js
+++ b/src/pipeL.js
@@ -1,0 +1,34 @@
+var apply = require('./apply');
+var compose = require('./compose');
+var composeL = require('./composeL');
+var reverse = require('./reverse');
+var unapply = require('./unapply');
+
+/**
+ * Creates a new lens that allows getting and setting values of nested properties, by
+ * following each given lens in succession.
+ *
+ * `pipeL` is the mirror version of `composeL`. `pipeL` is left-associative, which means that
+ * each of the functions provided is executed in order from left to right.
+ *
+ * @func
+ * @memberOf R
+ * @category Function
+ * @see R.lens
+ * @sig ((a -> b), (b -> c), ..., (x -> y), (y -> z)) -> (a -> z)
+ * @param {...Function} lenses A variable number of lenses.
+ * @return {Function} A new lens which represents the result of calling each of the
+ *         input `lenses`, passing the result of each getter/setter as the source
+ *         to the next, from right to left.
+ * @example
+ *
+ *      var headLens = R.lensIndex(0);
+ *      var secondLens = R.lensIndex(1);
+ *      var xLens = R.lensProp('x');
+ *      var headThenXThenSecondLens = R.pipeL(headLens, xLens, secondLens);
+ *
+ *      var source = [{x: [0, 1], y: [2, 3]}, {x: [4, 5], y: [6, 7]}];
+ *      headThenXThenSecondLens(source); //=> 1
+ *      headThenXThenSecondLens.set(123, source); //=> [{x: [0, 123], y: [2, 3]}, {x: [4, 5], y: [6, 7]}]
+ */
+module.exports = compose(apply(composeL), unapply(reverse));

--- a/test/composeL.js
+++ b/test/composeL.js
@@ -1,0 +1,65 @@
+var assert = require('assert');
+
+var R = require('..');
+
+describe('composeL', function() {
+
+  var identityLens = R.lens(R.identity, R.identity);
+  var headLens = R.lensIndex(0);
+  var secondLens = R.lensIndex(1);
+  var xLens = R.lensProp('x');
+
+  var headOfXLens = R.composeL(headLens, xLens);
+  var xOfHeadLens = R.composeL(xLens, headLens);
+  var secondOfXOfHeadLens = R.composeL(secondLens, xLens, headLens);
+
+  var objWithList = {x: [1, 2, 3]};
+  var listOfObjs = [{x: 4}, {x: 5}, {x: 6}];
+
+  it('composes gets from right to left', function() {
+    assert.strictEqual(headOfXLens(objWithList), 1);
+    assert.strictEqual(xOfHeadLens(listOfObjs), 4);
+  });
+
+  it('composes sets from right to left', function() {
+    assert.deepEqual(headOfXLens.set(10, objWithList), {x: [10, 2, 3]});
+    assert.deepEqual(xOfHeadLens.set(10, listOfObjs), [{x: 10}, {x: 5}, {x: 6}]);
+  });
+
+  it('does not mutate the source when setting', function() {
+    assert.deepEqual(headOfXLens.set(10, objWithList), {x: [10, 2, 3]});
+    assert.deepEqual(objWithList, {x: [1, 2, 3]});
+  });
+
+  it('can compose multiple lenses', function() {
+    var source = [{x: [0, 1], y: [2, 3]}, {x: [4, 5], y: [6, 7]}];
+    assert.strictEqual(secondOfXOfHeadLens(source), 1);
+    assert.deepEqual(secondOfXOfHeadLens.set(8, source), [{x: [0, 8], y: [2, 3]}, {x: [4, 5], y: [6, 7]}]);
+    assert.deepEqual(source, [{x: [0, 1], y: [2, 3]}, {x: [4, 5], y: [6, 7]}]);
+  });
+
+  it('satisfies left identity', function() {
+    var xIdentityLens = R.composeL(xLens, identityLens);
+    assert.deepEqual(xIdentityLens(objWithList), xLens(objWithList));
+    assert.deepEqual(xIdentityLens.set(1, objWithList), xLens.set(1, objWithList));
+  });
+
+  it('satisfies right identity', function() {
+    var identityXLens = R.composeL(identityLens, xLens);
+    assert.deepEqual(identityXLens(objWithList), xLens(objWithList));
+    assert.deepEqual(identityXLens.set(1, objWithList), xLens.set(1, objWithList));
+  });
+
+  it('satisfies associativity', function() {
+    var source = [{x: [0, 1], y: [2, 3]}, {x: [4, 5], y: [6, 7]}];
+    var l1 = R.composeL(secondLens, R.composeL(xLens, headLens));
+    var l2 = R.composeL(R.composeL(secondLens, xLens), headLens);
+
+    assert.strictEqual(l1(source), 1);
+    assert.deepEqual(l1.set(8, source), [{x: [0, 8], y: [2, 3]}, {x: [4, 5], y: [6, 7]}]);
+
+    assert.strictEqual(l2(source), 1);
+    assert.deepEqual(l2.set(8, source), [{x: [0, 8], y: [2, 3]}, {x: [4, 5], y: [6, 7]}]);
+  });
+
+});

--- a/test/lensIndex.js
+++ b/test/lensIndex.js
@@ -1,0 +1,45 @@
+var assert = require('assert');
+
+var R = require('..');
+
+
+describe('lensIndex', function() {
+
+  var headOf = R.lensIndex(0);
+
+  it('retrieves the nth value from an array as defined by the `n` parameter', function() {
+    assert.strictEqual(headOf([10, 20, 30, 40]), 10);
+    assert.strictEqual(headOf(['a', 'b', 'c', 'd']), 'a');
+  });
+
+  it('"sets" a value a position `n`, returning a new array', function() {
+    assert.deepEqual(headOf.set('cow', [1, 2, 3, 4]), ['cow', 2, 3, 4]);
+  });
+
+  it('the setter should not mutate the object', function() {
+    var xs = [1, 2, 3, 4];
+    assert.deepEqual(headOf.set(10, xs), [10, 2, 3, 4]);
+    assert.deepEqual(xs, [1, 2, 3, 4]);
+  });
+
+  it('maps an index from getter to setter', function() {
+    function plus10(x) { return x + 10; }
+    assert.deepEqual(headOf.map(plus10, [-9, 2, 3]), [1, 2, 3]);
+  });
+
+  it('the modifier should not mutate the object', function() {
+    var xs = ['a', 'b', 'c'];
+    function uc(s) { return s.toUpperCase(); }
+    assert.deepEqual(headOf.map(uc, xs), ['A', 'b', 'c']);
+    assert.deepEqual(xs, ['a', 'b', 'c']);
+  });
+
+  it('curries map and set and modifies with composed lens', function() {
+    var headPlus3 = R.compose(headOf.map(R.add(1)), headOf.map(R.add(2)));
+    assert.deepEqual(headPlus3([-2, 2, 3]), [1, 2, 3]);
+    var set0Plus1 = R.compose(headOf.map(R.add(1)), headOf.set(0));
+    assert.deepEqual(set0Plus1([-2, 2, 3]), [1, 2, 3]);
+    var mapHeadPlus3 = R.map(headPlus3);
+    assert.deepEqual(mapHeadPlus3([[-2, 2, 3], [-1, 2, 3]]), [[1, 2, 3], [2, 2, 3]]);
+  });
+});

--- a/test/lensProp.js
+++ b/test/lensProp.js
@@ -1,0 +1,42 @@
+var assert = require('assert');
+
+var R = require('..');
+
+
+describe('lensProp', function() {
+
+  var phraseLens = R.lensProp('catchphrase');
+  var xLens = R.lensProp('x');
+  var obj = {x: 100, y: 200, catchphrase: 'zing!'};
+  function uc(s) { return s.toUpperCase(); }
+
+  it('retrieves values from inside an object as defined by the `k` parameter', function() {
+    assert.strictEqual(phraseLens(obj), 'zing!');
+  });
+
+  it('"sets" properties on an object and return the new object', function() {
+    assert.deepEqual(phraseLens.set('cow', obj), {x: 100, y: 200, catchphrase: 'cow'});
+  });
+
+  it('the setter should not mutate the object', function() {
+    assert.deepEqual(phraseLens.set('kapow!', obj), {x: 100, y: 200, catchphrase: 'kapow!'});
+    assert.deepEqual(obj, {x: 100, y: 200, catchphrase: 'zing!'});
+  });
+
+  it('maps a property from getter to setter', function() {
+    assert.deepEqual(phraseLens.map(uc, obj), {x: 100, y: 200, catchphrase: 'ZING!'});
+  });
+
+  it('the modifier should not mutate the object', function() {
+    var obj = {x: 100, y: 200, catchphrase: 'zing!'};
+    assert.deepEqual(phraseLens.map(uc, obj), {x: 100, y: 200, catchphrase: 'ZING!'});
+    assert.deepEqual(obj, {x: 100, y: 200, catchphrase: 'zing!'});
+  });
+
+  it('curries map and set and modifies with composed lens', function() {
+    var xPlus3 = R.compose(xLens.map(R.add(1)), xLens.map(R.add(2)));
+    assert.deepEqual(xPlus3(obj), {x: 103, y: 200, catchphrase: 'zing!'});
+    var set0Plus1 = R.compose(xLens.map(R.add(1)), xLens.set(0));
+    assert.deepEqual(set0Plus1(obj), {x: 1, y: 200, catchphrase: 'zing!'});
+  });
+});

--- a/test/pipeL.js
+++ b/test/pipeL.js
@@ -1,0 +1,39 @@
+var assert = require('assert');
+
+var R = require('..');
+
+describe('pipeL', function() {
+
+  var headLens = R.lensIndex(0);
+  var xLens = R.lensProp('x');
+
+  var headThenXLens = R.pipeL(headLens, xLens);
+  var xThenHeadLens = R.pipeL(xLens, headLens);
+  var headXHeadLens = R.pipeL(headLens, xLens, headLens);
+
+  var objWithList = {x: [1, 2, 3]};
+  var listOfObjs = [{x: 4}, {x: 5}, {x: 6}];
+
+  it('composes gets from left to right', function() {
+    assert.strictEqual(xThenHeadLens(objWithList), 1);
+    assert.strictEqual(headThenXLens(listOfObjs), 4);
+  });
+
+  it('composes sets from left to right', function() {
+    assert.deepEqual(xThenHeadLens.set(10, objWithList), {x: [10, 2, 3]});
+    assert.deepEqual(headThenXLens.set(10, listOfObjs), [{x: 10}, {x: 5}, {x: 6}]);
+  });
+
+  it('does not mutate the source when setting', function() {
+    assert.deepEqual(xThenHeadLens.set(10, objWithList), {x: [10, 2, 3]});
+    assert.deepEqual(objWithList, {x: [1, 2, 3]});
+  });
+
+  it('can compose multiple lenses', function() {
+    var source = [{x: [0, 1], y: [2, 3]}, {x: [4, 5], y: [6, 7]}];
+    assert.strictEqual(headXHeadLens(source), 0);
+    assert.deepEqual(headXHeadLens.set(8, source), [{x: [8, 1], y: [2, 3]}, {x: [4, 5], y: [6, 7]}]);
+    assert.deepEqual(source, [{x: [0, 1], y: [2, 3]}, {x: [4, 5], y: [6, 7]}]);
+  });
+
+});


### PR DESCRIPTION
This change introduces 2 new helpers for generating lenses,
`lensIndex` and `lensProp`, where `lensIndex` is used to
create a new lens with a focus on an array index, while
`lensProp` is used to create a new lens with a focus on an
object property.

```js
var phraseLens = R.lensProp('phrase');
var obj1 = { phrase: 'Absolute filth . . . and I LOVED it!'};
phraseLens(obj1); // => 'Absolute filth . . . and I LOVED it!'
phraseLens.set('Ooh Betty', obj1); //=> { phrase: 'Ooh Betty'}

var headLens = R.lensIndex(0);
headLens([10, 20, 30, 40]); //=> 10
headLens.set('mu', [10, 20, 30, 40]); //=> ['mu', 20, 30, 40]
```

This change also introduces `composeL` and `pipeL` which
are used to compose lenses together, resulting in a new lens
which can be used to access and update nested properties
of a target object.

```js
var headLens = R.lensIndex(0);
var secondLens = R.lensIndex(1);
var xLens = R.lensProp('x');
var secondOfXOfHeadLens = R.composeL(secondLens, xLens, headLens);

var source = [{x: [0, 1], y: [2, 3]}, {x: [4, 5], y: [6, 7]}];
secondOfXOfHeadLens(source); //=> 1
secondOfXOfHeadLens.set(123, source); //=> [{x: [0, 123], y: [2, 3]}, {x: [4, 5], y: [6, 7]}]
```