### PR TITLE
Adds `adjust` and `update`

### DIFF
--- a/src/adjust.js
+++ b/src/adjust.js
@@ -1,0 +1,34 @@
+var _concat = require('./internal/_concat');
+var _curry3 = require('./internal/_curry3');
+
+/**
+ * Applies a function to the value at the given index of an array,
+ * returning a new copy of the array with the element at the given
+ * index replaced with the result of the function application.
+ *
+ * @func
+ * @memberOf R
+ * @category List
+ * @sig (a -> a) -> Number -> [a] -> [a]
+ * @param {Function} fn The function to apply.
+ * @param {Number} idx The index.
+ * @param {Array|Arguments} list An array-like object whose value
+ *        at the supplied index will be replaced.
+ * @return {Array} A copy of the supplied array-like object with
+ *         the element at index `idx` replaced with the value
+ *         returned by applying `fn` to the existing element.
+ * @example
+ *
+ *      R.adjust(R.add(10), 1, [0, 1, 2]);     //=> [0, 11, 2]
+ *      R.adjust(R.add(10))(1)([0, 1, 2]);     //=> [0, 11, 2]
+ */
+module.exports = _curry3(function(fn, idx, list) {
+  if (idx >= list.length || idx < -list.length) {
+    return list;
+  }
+  var start = idx < 0 ? list.length : 0;
+  var _idx = start + idx;
+  var _list = _concat(list);
+  _list[_idx] = fn(list[_idx]);
+  return _list;
+});

--- a/src/update.js
+++ b/src/update.js
@@ -1,0 +1,24 @@
+var _curry3 = require('./internal/_curry3');
+var adjust = require('./adjust');
+var always = require('./always');
+
+/**
+ * Returns a new copy of the array with the element at the
+ * provided index replaced with the given value.
+ *
+ * @func
+ * @memberOf R
+ * @category List
+ * @sig Number -> a -> [a] -> [a]
+ * @param {Number} idx The index to update.
+ * @param {*} x The value to exist at the given index of the returned array.
+ * @param {Array|Arguments} list The source array-like object to be updated.
+ * @return {Array} A copy of `list` with the value at index `idx` replaced with `x`.
+ * @example
+ *
+ *      R.update(1, 11, [0, 1, 2]);     //=> [0, 11, 2]
+ *      R.update(1)(11)([0, 1, 2]);     //=> [0, 11, 2]
+ */
+module.exports = _curry3(function(idx, x, list) {
+  return adjust(always(x), idx, list);
+});

--- a/test/adjust.js
+++ b/test/adjust.js
@@ -1,0 +1,36 @@
+var assert = require('assert');
+
+var R = require('..');
+
+describe('adjust', function() {
+  it('applies the given function to the value at the given index of the supplied array', function() {
+    assert.deepEqual(R.adjust(R.add(1), 2, [0, 1, 2, 3]), [0, 1, 3, 3]);
+  });
+
+  it('offsets negative indexes from the end of the array', function() {
+    assert.deepEqual(R.adjust(R.add(1), -3, [0, 1, 2, 3]), [0, 2, 2, 3]);
+  });
+
+  it('returns the original array if the supplied index is out of bounds', function() {
+    var list = [0, 1, 2, 3];
+    assert.deepEqual(R.adjust(R.add(1), 4, list), list);
+    assert.deepEqual(R.adjust(R.add(1), -5, list), list);
+  });
+
+  it('does not mutate the original array', function() {
+    var list = [0, 1, 2, 3];
+    assert.deepEqual(R.adjust(R.add(1), 2, list), [0, 1, 3, 3]);
+    assert.deepEqual(list, [0, 1, 2, 3]);
+  });
+
+  it('curries the arguments', function() {
+    assert.deepEqual(R.adjust(R.add(1))(2)([0, 1, 2, 3]), [0, 1, 3, 3]);
+  });
+
+  it('accepts an array-like object', function() {
+    function args() {
+      return arguments;
+    }
+    assert.deepEqual(R.adjust(R.add(1), 2, args(0, 1, 2, 3)), [0, 1, 3, 3]);
+  });
+});

--- a/test/update.js
+++ b/test/update.js
@@ -1,0 +1,36 @@
+var assert = require('assert');
+
+var R = require('..');
+
+describe('update', function() {
+  it('updates the value at the given index of the supplied array', function() {
+    assert.deepEqual(R.update(2, 4, [0, 1, 2, 3]), [0, 1, 4, 3]);
+  });
+
+  it('offsets negative indexes from the end of the array', function() {
+    assert.deepEqual(R.update(-3, 4, [0, 1, 2, 3]), [0, 4, 2, 3]);
+  });
+
+  it('returns the original array if the supplied index is out of bounds', function() {
+    var list = [0, 1, 2, 3];
+    assert.deepEqual(R.update(4, 4, list), list);
+    assert.deepEqual(R.update(-5, 4, list), list);
+  });
+
+  it('does not mutate the original array', function() {
+    var list = [0, 1, 2, 3];
+    assert.deepEqual(R.update(2, 4, list), [0, 1, 4, 3]);
+    assert.deepEqual(list, [0, 1, 2, 3]);
+  });
+
+  it('curries the arguments', function() {
+    assert.deepEqual(R.update(2)(4)([0, 1, 2, 3]), [0, 1, 4, 3]);
+  });
+
+  it('accepts an array-like object', function() {
+    function args() {
+      return arguments;
+    }
+    assert.deepEqual(R.update(2, 4, args(0, 1, 2, 3)), [0, 1, 4, 3]);
+  });
+});


### PR DESCRIPTION
**This is a proposal / stawman for #773**

This change introduces 2 new list functions `adjust` and `update`, providing the ability to modify values at a given index of a list. `adjust` applies a given function to replace the value, while `update` is the specialised form, updating the array with a new explicit value.

```js
R.adjust(R.add(10))(1)([0, 1, 2]);  //=> [0, 11, 2]
R.update(1)(11)([0, 1, 2]);         //=> [0, 11, 2]
```