### PR TITLE
add R.mean and R.median

### DIFF
--- a/src/mean.js
+++ b/src/mean.js
@@ -1,0 +1,21 @@
+var _curry1 = require('./internal/_curry1');
+var sum = require('./sum');
+
+
+/**
+ * Returns the mean of the given list of numbers.
+ *
+ * @func
+ * @memberOf R
+ * @category Math
+ * @sig [Number] -> Number
+ * @param {Array} list
+ * @return {Number}
+ * @example
+ *
+ *      R.mean([2, 7, 9]); //=> 6
+ *      R.mean([]); //=> NaN
+ */
+module.exports = _curry1(function mean(list) {
+  return sum(list) / list.length;
+});

--- a/src/median.js
+++ b/src/median.js
@@ -1,0 +1,31 @@
+var _curry1 = require('./internal/_curry1');
+var _slice = require('./internal/_slice');
+var mean = require('./mean');
+
+
+/**
+ * Returns the median of the given list of numbers.
+ *
+ * @func
+ * @memberOf R
+ * @category Math
+ * @sig [Number] -> Number
+ * @param {Array} list
+ * @return {Number}
+ * @example
+ *
+ *      R.median([2, 9, 7]); //=> 7
+ *      R.median([7, 2, 10, 9]); //=> 8
+ *      R.median([]); //=> NaN
+ */
+module.exports = _curry1(function median(list) {
+  var len = list.length;
+  if (len === 0) {
+    return NaN;
+  }
+  var width = 2 - len % 2;
+  var idx = (len - width) / 2;
+  return mean(_slice(list).sort(function(a, b) {
+    return a < b ? -1 : a > b ? 1 : 0;
+  }).slice(idx, idx + width));
+});

--- a/test/mean.js
+++ b/test/mean.js
@@ -1,0 +1,23 @@
+var assert = require('assert');
+
+var R = require('..');
+
+
+describe('mean', function() {
+
+  it('returns mean of a nonempty list', function() {
+    assert.strictEqual(R.mean([2]), 2);
+    assert.strictEqual(R.mean([2, 7]), 4.5);
+    assert.strictEqual(R.mean([2, 7, 9]), 6);
+    assert.strictEqual(R.mean([2, 7, 9, 10]), 7);
+  });
+
+  it('returns NaN for an empty list', function() {
+    assert.strictEqual(R.isNaN(R.mean([])), true);
+  });
+
+  it('handles array-like object', function() {
+    assert.strictEqual(R.mean((function() { return arguments; }(1, 2, 3))), 2);
+  });
+
+});

--- a/test/median.js
+++ b/test/median.js
@@ -1,0 +1,26 @@
+var assert = require('assert');
+
+var R = require('..');
+
+
+describe('median', function() {
+
+  it('returns middle value of an odd-length list', function() {
+    assert.strictEqual(R.median([2]), 2);
+    assert.strictEqual(R.median([2, 9, 7]), 7);
+  });
+
+  it('returns mean of two middle values of a nonempty even-length list', function() {
+    assert.strictEqual(R.median([7, 2]), 4.5);
+    assert.strictEqual(R.median([7, 2, 10, 9]), 8);
+  });
+
+  it('returns NaN for an empty list', function() {
+    assert.strictEqual(R.isNaN(R.median([])), true);
+  });
+
+  it('handles array-like object', function() {
+    assert.strictEqual(R.median((function() { return arguments; }(1, 2, 3))), 2);
+  });
+
+});


### PR DESCRIPTION
I'd also like to add a [mode][1] function, but since it should work with values other than numbers it's more of a cousin than a sibling of `R.mean` and `R.median`. I'll open a separate pull request for that function if and when this pull request is merged.


[1]: http://en.wikipedia.org/wiki/Mode_%28statistics%29
