### PR TITLE
Path should return entire object for empty path

### DIFF
--- a/src/internal/_path.js
+++ b/src/internal/_path.js
@@ -14,7 +14,7 @@
  *      _path(['a', 'b'], {a: {b: 2}}); //=> 2
  */
 module.exports = function _path(paths, obj) {
-  if (obj == null || paths.length === 0) {
+  if (obj == null) {
     return;
   } else {
     var val = obj;

--- a/test/path.js
+++ b/test/path.js
@@ -22,7 +22,7 @@ describe('path', function() {
       j: ['J']
     };
     assert.strictEqual(R.path(['a', 'b', 'c'], obj), 100);
-    assert.strictEqual(R.path([], obj), undefined);
+    assert.strictEqual(R.path([], obj), obj);
     assert.strictEqual(R.path(['a', 'e', 'f', '1'], obj), 101);
     assert.strictEqual(R.path(['j', '0'], obj), 'J');
     assert.strictEqual(R.path(['j', '1'], obj), undefined);

--- a/test/pathEq.js
+++ b/test/pathEq.js
@@ -29,7 +29,7 @@ describe('pathEq', function() {
 
   it('accepts empty path', function() {
     assert.strictEqual(R.pathEq([], 42, {a: 1, b: 2}), false);
-    assert.strictEqual(R.pathEq([], undefined, {a: 1, b: 2}), true);
+    assert.strictEqual(R.pathEq([], obj, obj), true);
   });
 
 });


### PR DESCRIPTION
Today `_.path([], someObj)` returns `undefined`. This seems inconsistent to me. If you take zero steps down, you're still at the top.

This modifies the internal `_path` function so that `_.path([], obj)` returns the passed in object and so that `_.pathEq([], obj, obj) === true`.

This PR simply removes a special case in the code. This, I think, goes to show that the current behavior is inconsistent, i.e. it is not how a user would guess the function would be working.

If the current behavior was implemented with a good reason I'm sorry for this PR :)