### PR TITLE
Simplify anyPass and allPass for common use case

### DIFF
--- a/src/internal/_isTransformer.js
+++ b/src/internal/_isTransformer.js
@@ -1,3 +1,3 @@
 module.exports = function _isTransformer(obj) {
-  return typeof obj.step === 'function' && typeof obj.result === 'function';
+  return typeof obj['@@transducer/step'] === 'function';
 };

--- a/src/internal/_reduce.js
+++ b/src/internal/_reduce.js
@@ -7,30 +7,30 @@ module.exports = (function() {
   function _arrayReduce(xf, acc, list) {
     var idx = -1, len = list.length;
     while (++idx < len) {
-      acc = xf.step(acc, list[idx]);
-      if (acc && acc.__transducers_reduced__) {
-        acc = acc.value;
+      acc = xf['@@transducer/step'](acc, list[idx]);
+      if (acc && acc['@@transducer/reduced']) {
+        acc = acc['@@transducer/value'];
         break;
       }
     }
-    return xf.result(acc);
+    return xf['@@transducer/result'](acc);
   }
 
   function _iterableReduce(xf, acc, iter) {
     var step = iter.next();
     while (!step.done) {
-      acc = xf.step(acc, step.value);
-      if (acc && acc.__transducers_reduced__) {
-        acc = acc.value;
+      acc = xf['@@transducer/step'](acc, step.value);
+      if (acc && acc['@@transducer/reduced']) {
+        acc = acc['@@transducer/value'];
         break;
       }
       step = iter.next();
     }
-    return xf.result(acc);
+    return xf['@@transducer/result'](acc);
   }
 
   function _methodReduce(xf, acc, obj) {
-    return xf.result(obj.reduce(bind(xf.step, xf), acc));
+    return xf['@@transducer/result'](obj.reduce(bind(xf['@@transducer/step'], xf), acc));
   }
 
   var symIterator = (typeof Symbol !== 'undefined') ? Symbol.iterator : '@@iterator';

--- a/src/internal/_reduced.js
+++ b/src/internal/_reduced.js
@@ -1,3 +1,7 @@
 module.exports = function(x) {
-  return x && x.__transducers_reduced__ ? x : {value: x, __transducers_reduced__: true};
+  return x && x['@@transducer/reduced'] ? x :
+    {
+      '@@transducer/value': x,
+      '@@transducer/reduced': true
+    };
 };

--- a/src/internal/_stepCat.js
+++ b/src/internal/_stepCat.js
@@ -9,24 +9,24 @@ var merge = require('../merge');
 
 module.exports = (function() {
   var _stepCatArray = {
-    init: Array,
-    step: function(xs, x) { return _concat(xs, [x]); },
-    result: _identity
+    '@@transducer/init': Array,
+    '@@transducer/step': function(xs, x) { return _concat(xs, [x]); },
+    '@@transducer/result': _identity
   };
   var _stepCatString = {
-    init: String,
-    step: _add,
-    result: _identity
+    '@@transducer/init': String,
+    '@@transducer/step': _add,
+    '@@transducer/result': _identity
   };
   var _stepCatObject = {
-    init: Object,
-    step: function(result, input) {
+    '@@transducer/init': Object,
+    '@@transducer/step': function(result, input) {
       return merge(
         result,
         isArrayLike(input) ? _createMapEntry(input[0], input[1]) : input
       );
     },
-    result: _identity
+    '@@transducer/result': _identity
   };
 
   return function _stepCat(obj) {

--- a/src/internal/_xall.js
+++ b/src/internal/_xall.js
@@ -8,19 +8,19 @@ module.exports = (function() {
     this.f = f;
     this.all = true;
   }
-  XAll.prototype.init = function() {
-    return this.xf.init();
+  XAll.prototype['@@transducer/init'] = function() {
+    return this.xf['@@transducer/init']();
   };
-  XAll.prototype.result = function(result) {
+  XAll.prototype['@@transducer/result'] = function(result) {
     if (this.all) {
-      result = this.xf.step(result, true);
+      result = this.xf['@@transducer/step'](result, true);
     }
-    return this.xf.result(result);
+    return this.xf['@@transducer/result'](result);
   };
-  XAll.prototype.step = function(result, input) {
+  XAll.prototype['@@transducer/step'] = function(result, input) {
     if (!this.f(input)) {
       this.all = false;
-      result = _reduced(this.xf.step(result, false));
+      result = _reduced(this.xf['@@transducer/step'](result, false));
     }
     return result;
   };

--- a/src/internal/_xany.js
+++ b/src/internal/_xany.js
@@ -8,19 +8,19 @@ module.exports = (function() {
     this.f = f;
     this.any = false;
   }
-  XAny.prototype.init = function() {
-    return this.xf.init();
+  XAny.prototype['@@transducer/init'] = function() {
+    return this.xf['@@transducer/init']();
   };
-  XAny.prototype.result = function(result) {
+  XAny.prototype['@@transducer/result'] = function(result) {
     if (!this.any) {
-      result = this.xf.step(result, false);
+      result = this.xf['@@transducer/step'](result, false);
     }
-    return this.xf.result(result);
+    return this.xf['@@transducer/result'](result);
   };
-  XAny.prototype.step = function(result, input) {
+  XAny.prototype['@@transducer/step'] = function(result, input) {
     if (this.f(input)) {
       this.any = true;
-      result = _reduced(this.xf.step(result, true));
+      result = _reduced(this.xf['@@transducer/step'](result, true));
     }
     return result;
   };

--- a/src/internal/_xdrop.js
+++ b/src/internal/_xdrop.js
@@ -6,18 +6,18 @@ module.exports = (function() {
     this.xf = xf;
     this.n = n;
   }
-  XDrop.prototype.init = function() {
-    return this.xf.init();
+  XDrop.prototype['@@transducer/init'] = function() {
+    return this.xf['@@transducer/init']();
   };
-  XDrop.prototype.result = function(result) {
-    return this.xf.result(result);
+  XDrop.prototype['@@transducer/result'] = function(result) {
+    return this.xf['@@transducer/result'](result);
   };
   XDrop.prototype.step = function(result, input) {
     if (this.n > 0) {
       this.n -= 1;
       return result;
     }
-    return this.xf.step(result, input);
+    return this.xf['@@transducer/step'](result, input);
   };
 
   return _curry2(function _xdrop(n, xf) { return new XDrop(n, xf); });

--- a/src/internal/_xdropWhile.js
+++ b/src/internal/_xdropWhile.js
@@ -6,20 +6,20 @@ module.exports = (function() {
     this.xf = xf;
     this.f = f;
   }
-  XDropWhile.prototype.init = function() {
-    return this.xf.init();
+  XDropWhile.prototype['@@transducer/init'] = function() {
+    return this.xf['@@transducer/init']();
   };
   XDropWhile.prototype.result = function(result) {
-    return this.xf.result(result);
+    return this.xf['@@transducer/result'](result);
   };
-  XDropWhile.prototype.step = function(result, input) {
+  XDropWhile.prototype['@@transducer/step'] = function(result, input) {
     if (this.f) {
       if (this.f(input)) {
         return result;
       }
       this.f = null;
     }
-    return this.xf.step(result, input);
+    return this.xf['@@transducer/step'](result, input);
   };
 
   return _curry2(function _xdropWhile(f, xf) { return new XDropWhile(f, xf); });

--- a/src/internal/_xfilter.js
+++ b/src/internal/_xfilter.js
@@ -6,14 +6,14 @@ module.exports = (function() {
     this.xf = xf;
     this.f = f;
   }
-  XFilter.prototype.init = function() {
-    return this.xf.init();
+  XFilter.prototype['@@transducer/init'] = function() {
+    return this.xf['@@transducer/init']();
   };
-  XFilter.prototype.result = function(result) {
-    return this.xf.result(result);
+  XFilter.prototype['@@transducer/result'] = function(result) {
+    return this.xf['@@transducer/result'](result);
   };
-  XFilter.prototype.step = function(result, input) {
-    return this.f(input) ? this.xf.step(result, input) : result;
+  XFilter.prototype['@@transducer/step'] = function(result, input) {
+    return this.f(input) ? this.xf['@@transducer/step'](result, input) : result;
   };
 
   return _curry2(function _xfilter(f, xf) { return new XFilter(f, xf); });

--- a/src/internal/_xfind.js
+++ b/src/internal/_xfind.js
@@ -8,19 +8,19 @@ module.exports = (function() {
     this.f = f;
     this.found = false;
   }
-  XFind.prototype.init = function() {
+  XFind.prototype['@@transducer/init'] = function() {
     return this.xf.init();
   };
-  XFind.prototype.result = function(result) {
+  XFind.prototype['@@transducer/result'] = function(result) {
     if (!this.found) {
-      result = this.xf.step(result, void 0);
+      result = this.xf['@@transducer/step'](result, void 0);
     }
-    return this.xf.result(result);
+    return this.xf['@@transducer/result'](result);
   };
-  XFind.prototype.step = function(result, input) {
+  XFind.prototype['@@transducer/step'] = function(result, input) {
     if (this.f(input)) {
       this.found = true;
-      result = _reduced(this.xf.step(result, input));
+      result = _reduced(this.xf['@@transducer/step'](result, input));
     }
     return result;
   };

--- a/src/internal/_xfindIndex.js
+++ b/src/internal/_xfindIndex.js
@@ -9,20 +9,20 @@ module.exports = (function() {
     this.idx = -1;
     this.found = false;
   }
-  XFindIndex.prototype.init = function() {
-    return this.xf.init();
+  XFindIndex.prototype['@@transducer/init'] = function() {
+    return this.xf['@@transducer/init']();
   };
-  XFindIndex.prototype.result = function(result) {
+  XFindIndex.prototype['@@transducer/result'] = function(result) {
     if (!this.found) {
-      result = this.xf.step(result, -1);
+      result = this.xf['@@transducer/step'](result, -1);
     }
-    return this.xf.result(result);
+    return this.xf['@@transducer/result'](result);
   };
-  XFindIndex.prototype.step = function(result, input) {
+  XFindIndex.prototype['@@transducer/step'] = function(result, input) {
     this.idx += 1;
     if (this.f(input)) {
       this.found = true;
-      result = _reduced(this.xf.step(result, this.idx));
+      result = _reduced(this.xf['@@transducer/step'](result, this.idx));
     }
     return result;
   };

--- a/src/internal/_xfindLast.js
+++ b/src/internal/_xfindLast.js
@@ -6,13 +6,13 @@ module.exports = (function() {
     this.xf = xf;
     this.f = f;
   }
-  XFindLast.prototype.init = function() {
-    return this.xf.init();
+  XFindLast.prototype['@@transducer/init'] = function() {
+    return this.xf['@@transducer/init']();
   };
-  XFindLast.prototype.result = function(result) {
-    return this.xf.result(this.xf.step(result, this.last));
+  XFindLast.prototype['@@transducer/result'] = function(result) {
+    return this.xf['@@transducer/result'](this.xf['@@transducer/step'](result, this.last));
   };
-  XFindLast.prototype.step = function(result, input) {
+  XFindLast.prototype['@@transducer/step'] = function(result, input) {
     if (this.f(input)) {
       this.last = input;
     }

--- a/src/internal/_xfindLastIndex.js
+++ b/src/internal/_xfindLastIndex.js
@@ -8,13 +8,13 @@ module.exports = (function() {
     this.idx = -1;
     this.lastIdx = -1;
   }
-  XFindLastIndex.prototype.init = function() {
-    return this.xf.init();
+  XFindLastIndex.prototype['@@transducer/init'] = function() {
+    return this.xf['@@transducer/init']();
   };
-  XFindLastIndex.prototype.result = function(result) {
-    return this.xf.result(this.xf.step(result, this.lastIdx));
+  XFindLastIndex.prototype['@@transducer/result'] = function(result) {
+    return this.xf['@@transducer/result'](this.xf['@@transducer/step'](result, this.lastIdx));
   };
-  XFindLastIndex.prototype.step = function(result, input) {
+  XFindLastIndex.prototype['@@transducer/step'] = function(result, input) {
     this.idx += 1;
     if (this.f(input)) {
       this.lastIdx = this.idx;

--- a/src/internal/_xgroupBy.js
+++ b/src/internal/_xgroupBy.js
@@ -9,23 +9,23 @@ module.exports = (function() {
     this.f = f;
     this.inputs = {};
   }
-  XGroupBy.prototype.init = function() {
-    return this.xf.init();
+  XGroupBy.prototype['@@transducer/init'] = function() {
+    return this.xf['@@transducer/init']();
   };
-  XGroupBy.prototype.result = function(result) {
+  XGroupBy.prototype['@@transducer/result'] = function(result) {
     var key;
     for (key in this.inputs) {
       if (_has(key, this.inputs)) {
-        result = this.xf.step(result, this.inputs[key]);
-        if (result.__transducers_reduced__) {
-          result = result.value;
+        result = this.xf['@@transducer/step'](result, this.inputs[key]);
+        if (result['@@transducer/reduced']) {
+          result = result['@@transducer/value'];
           break;
         }
       }
     }
-    return this.xf.result(result);
+    return this.xf['@@transducer/result'](result);
   };
-  XGroupBy.prototype.step = function(result, input) {
+  XGroupBy.prototype['@@transducer/step'] = function(result, input) {
     var key = this.f(input);
     this.inputs[key] = this.inputs[key] || [key, []];
     this.inputs[key][1] = _append(input, this.inputs[key][1]);

--- a/src/internal/_xmap.js
+++ b/src/internal/_xmap.js
@@ -6,14 +6,14 @@ module.exports = (function() {
     this.xf = xf;
     this.f = f;
   }
-  XMap.prototype.init = function() {
-    return this.xf.init();
+  XMap.prototype['@@transducer/init'] = function() {
+    return this.xf['@@transducer/init']();
   };
-  XMap.prototype.result = function(result) {
-    return this.xf.result(result);
+  XMap.prototype['@@transducer/result'] = function(result) {
+    return this.xf['@@transducer/result'](result);
   };
-  XMap.prototype.step = function(result, input) {
-    return this.xf.step(result, this.f(input));
+  XMap.prototype['@@transducer/step'] = function(result, input) {
+    return this.xf['@@transducer/step'](result, this.f(input));
   };
 
   return _curry2(function _xmap(f, xf) { return new XMap(f, xf); });

--- a/src/internal/_xtake.js
+++ b/src/internal/_xtake.js
@@ -7,16 +7,16 @@ module.exports = (function() {
     this.xf = xf;
     this.n = n;
   }
-  XTake.prototype.init = function() {
-    return this.xf.init();
+  XTake.prototype['@@transducer/init'] = function() {
+    return this.xf['@@transducer/init']();
   };
-  XTake.prototype.result = function(result) {
-    return this.xf.result(result);
+  XTake.prototype['@@transducer/result'] = function(result) {
+    return this.xf['@@transducer/result'](result);
   };
-  XTake.prototype.step = function(result, input) {
+  XTake.prototype['@@transducer/step'] = function(result, input) {
     this.n -= 1;
-    return this.n === 0 ? _reduced(this.xf.step(result, input))
-                        : this.xf.step(result, input);
+    return this.n === 0 ? _reduced(this.xf['@@transducer/step'](result, input))
+                        : this.xf['@@transducer/step'](result, input);
   };
 
   return _curry2(function _xtake(n, xf) { return new XTake(n, xf); });

--- a/src/internal/_xtakeWhile.js
+++ b/src/internal/_xtakeWhile.js
@@ -7,14 +7,14 @@ module.exports = (function() {
     this.xf = xf;
     this.f = f;
   }
-  XTakeWhile.prototype.init = function() {
-    return this.xf.init();
+  XTakeWhile.prototype['@@transducer/init'] = function() {
+    return this.xf['@@transducer/init']();
   };
-  XTakeWhile.prototype.result = function(result) {
-    return this.xf.result(result);
+  XTakeWhile.prototype['@@transducer/result'] = function(result) {
+    return this.xf['@@transducer/result'](result);
   };
-  XTakeWhile.prototype.step = function(result, input) {
-    return this.f(input) ? this.xf.step(result, input) : _reduced(result);
+  XTakeWhile.prototype['@@transducer/step'] = function(result, input) {
+    return this.f(input) ? this.xf['@@transducer/step'](result, input) : _reduced(result);
   };
 
   return _curry2(function _xtakeWhile(f, xf) { return new XTakeWhile(f, xf); });

--- a/src/internal/_xwrap.js
+++ b/src/internal/_xwrap.js
@@ -2,11 +2,11 @@ module.exports = (function() {
   function XWrap(fn) {
     this.f = fn;
   }
-  XWrap.prototype.init = function() {
+  XWrap.prototype['@@transducer/init'] = function() {
     throw new Error('init not implemented on XWrap');
   };
-  XWrap.prototype.result = function(acc) { return acc; };
-  XWrap.prototype.step = function(acc, x) {
+  XWrap.prototype['@@transducer/result'] = function(acc) { return acc; };
+  XWrap.prototype['@@transducer/step'] = function(acc, x) {
     return this.f(acc, x);
   };
 

--- a/src/into.js
+++ b/src/into.js
@@ -39,6 +39,6 @@ var _stepCat = require('./internal/_stepCat');
  *      intoArray(transducer, numbers); //=> [2, 3]
  */
 module.exports = _curry3(function into(acc, xf, list) {
-  return _isTransformer(acc) ? _reduce(xf(acc), acc.init(), list)
+  return _isTransformer(acc) ? _reduce(xf(acc), acc['@@transducer/init'](), list)
                              : _reduce(xf(_stepCat(acc)), acc, list);
 });

--- a/test/groupBy.js
+++ b/test/groupBy.js
@@ -54,9 +54,9 @@ describe('groupBy', function() {
   it('dispatches on transformer objects in list position', function() {
     var byType = R.prop('type');
     var xf = {
-      init: function() { return {}; },
-      result: function(x) { return x; },
-      step: R.merge
+      '@@transducer/init': function() { return {}; },
+      '@@transducer/result': function(x) { return x; },
+      '@@transducer/step': R.merge
     };
     assert.strictEqual(_isTransformer(R.groupBy(byType, xf)), true);
   });

--- a/test/helpers/listXf.js
+++ b/test/helpers/listXf.js
@@ -1,5 +1,5 @@
 module.exports = {
-    init: function() { return []; },
-    step: function(acc, x) { return acc.concat([x]); },
-    result: function(x) { return x; }
+  '@@transducer/init': function() { return []; },
+  '@@transducer/step': function(acc, x) { return acc.concat([x]); },
+  '@@transducer/result': function(x) { return x; }
 };

--- a/test/into.js
+++ b/test/into.js
@@ -8,9 +8,9 @@ describe('into', function() {
   var add = R.add;
   var isOdd = function(b) {return b % 2 === 1;};
   var addXf = {
-    step: add,
-    init: R.always(0),
-    result: R.identity
+    '@@transducer/step': add,
+    '@@transducer/init': R.always(0),
+    '@@transducer/result': R.identity
   };
 
   it('transduces into arrays', function() {

--- a/test/transduce.js
+++ b/test/transduce.js
@@ -9,29 +9,29 @@ describe('transduce', function() {
   var mult = function(a, b) {return a * b;};
   var isOdd = function(b) {return b % 2 === 1;};
   var addxf = {
-    step: function(acc, x) { return acc + x; },
-    init: function() { return 0; },
-    result: function(x) { return x; }
+    '@@transducer/step': function(acc, x) { return acc + x; },
+    '@@transducer/init': function() { return 0; },
+    '@@transducer/result': function(x) { return x; }
   };
 
   var listxf = {
-    step: function(acc, x) { return acc.concat([x]); },
-    init: function() { return []; },
-    result: function(x) { return x; }
+    '@@transducer/step': function(acc, x) { return acc.concat([x]); },
+    '@@transducer/init': function() { return []; },
+    '@@transducer/result': function(x) { return x; }
   };
 
   var multxf = {
-    step: function(acc, x) { return acc * x; },
-    init: function() { return 1; },
-    result: function(x) { return x; }
+    '@@transducer/step': function(acc, x) { return acc * x; },
+    '@@transducer/init': function() { return 1; },
+    '@@transducer/result': function(x) { return x; }
   };
 
   var toxf = function(fn) {
     return function(xf) {
       return {
         f: fn,
-        step: xf.step,
-        result: xf.result,
+        '@@transducer/step': xf['@@transducer/step'],
+        '@@transducer/result': xf['@@transducer/result'],
         xf: xf
       };
     };


### PR DESCRIPTION
The current implementation of `allPass` and `anyPass` seems a bit odd to me. They support predicates taking a variable amount of arguments.

There is a test case where the predicates are all of different arity? I don't see this making sense since all the predicates are passed the same arguments.

I can't think of any use case where a list of predicates would all take more than one argument, all be of the same arity and all make sense to the same set of arguments?

Furthermore `allPass` and `anyPass` are variadic. So even though their arity is 1 I can do stuff like this: `R.allPass([gt10, even], 11);`. As far as I can see this is undocumented.

This commit does the following: Change `allPass` and `anyPass` into functions taking two arguments that behaves exactly like `allPass` and `anyPass` does today when the predicates takes one argument. But, they don't support anything else.

This has the advantage that support for `R.allPass([gt10, even], 11)` can be supported without relying on variadic behavior. The implementation is also vastly simplified.

I realize that I should have opened an issue before creating this pull request in case there actually is a realistic use case for the removed functionality.