### PR TITLE
`adjust` and `assoc` now returns the same instance if the value does not change

### DIFF
--- a/src/adjust.js
+++ b/src/adjust.js
@@ -1,5 +1,7 @@
 var _concat = require('./internal/_concat');
 var _curry3 = require('./internal/_curry3');
+var _eq = require('./internal/_eq');
+
 
 /**
  * Applies a function to the value at the given index of an array,
@@ -23,12 +25,21 @@ var _curry3 = require('./internal/_curry3');
  *      R.adjust(R.add(10))(1)([0, 1, 2]);     //=> [0, 11, 2]
  */
 module.exports = _curry3(function(fn, idx, list) {
+  var oldVal, newVal, _idx, _list;
+
   if (idx >= list.length || idx < -list.length) {
     return list;
   }
-  var start = idx < 0 ? list.length : 0;
-  var _idx = start + idx;
-  var _list = _concat(list);
-  _list[_idx] = fn(list[_idx]);
-  return _list;
+
+  _idx = idx < 0 ? idx + list.length : idx;
+  oldVal = list[_idx];
+  newVal = fn(oldVal);
+
+  if (_eq(oldVal, newVal)) {
+    return list;
+  } else {
+    _list = _concat(list);
+    _list[_idx] = fn(list[_idx]);
+    return _list;
+  }
 });

--- a/src/internal/_assoc.js
+++ b/src/internal/_assoc.js
@@ -1,4 +1,10 @@
+var _eq = require('./_eq');
+
+
 module.exports = function _assoc(prop, val, obj) {
+  if (_eq(obj[prop], val)) {
+    return obj;
+  }
   var result = {};
   for (var p in obj) {
     result[p] = obj[p];


### PR DESCRIPTION
This prevents an unnecessary clone of the array and allows users to perform strict equality checks of the resulting array to easily determine whether the values of the array have changed.