### PR TITLE
Add R.dropRepeats and R.dropRepeatsWith

### DIFF
--- a/src/dropRepeats.js
+++ b/src/dropRepeats.js
@@ -1,0 +1,24 @@
+var _curry1 = require('./internal/_curry1');
+var _dispatchable = require('./internal/_dispatchable');
+var _eq = require('./internal/_eq');
+var _xdropRepeatsWith = require('./internal/_xdropRepeatsWith');
+var dropRepeatsWith = require('./dropRepeatsWith');
+
+
+/**
+ * Returns a new list without any consecutively repeating elements.
+ *
+ * Acts as a transducer if a transformer is given in list position.
+ * @see R.transduce
+ *
+ * @func
+ * @memberOf R
+ * @category List
+ * @sig [a] -> [a]
+ * @param {Array} list The array to consider.
+ * @return {Array} `list` without repeating elements.
+ * @example
+ *
+ *     R.dropRepeats([1, 1, 1, 2, 3, 4, 4, 2, 2]); //=> [1, 2, 3, 4, 2]
+ */
+module.exports = _curry1(_dispatchable('dropRepeats', _xdropRepeatsWith(_eq), dropRepeatsWith(_eq)));

--- a/src/dropRepeatsWith.js
+++ b/src/dropRepeatsWith.js
@@ -1,0 +1,42 @@
+var _curry2 = require('./internal/_curry2');
+var _dispatchable = require('./internal/_dispatchable');
+var _xdropRepeatsWith = require('./internal/_xdropRepeatsWith');
+var last = require('./last');
+
+
+/**
+ * Returns a new list without any consecutively repeating elements. Equality is
+ * determined by applying the supplied predicate two consecutive elements.
+ * The first element in a series of equal element is the one being preserved.
+ *
+ * Acts as a transducer if a transformer is given in list position.
+ * @see R.transduce
+ *
+ * @func
+ * @memberOf R
+ * @category List
+ * @sig (a, a -> Boolean) -> [a] -> [a]
+ * @param {Function} pred A predicate used to test whether two items are equal.
+ * @param {Array} list The array to consider.
+ * @return {Array} `list` without repeating elements.
+ * @example
+ *
+ *      function lengthEq(x, y) { return Math.abs(x) === Math.abs(y); };
+ *      var l = [1, -1, 1, 3, 4, -4, -4, -5, 5, 3, 3];
+ *      R.dropRepeatsWith(lengthEq, l); //=> [1, 3, 4, -5, 3]
+ */
+module.exports = _curry2(_dispatchable('dropRepeatsWith', _xdropRepeatsWith, function dropRepeatsWith(pred, list) {
+  var result = [];
+  var idx = 0;
+  var len = list.length;
+  if (len !== 0) {
+    result[0] = list[0];
+    while (++idx < len) {
+      if (!pred(last(result), list[idx])) {
+        result[result.length] = list[idx];
+      }
+    }
+  }
+  return result;
+}));
+

--- a/src/internal/_xdropRepeatsWith.js
+++ b/src/internal/_xdropRepeatsWith.js
@@ -1,0 +1,29 @@
+var _curry2 = require('./_curry2');
+
+
+module.exports = (function() {
+  function XDropRepeatsWith(pred, xf) {
+    this.xf = xf;
+    this.pred = pred;
+    this.lastValue = undefined;
+    this.seenFirstValue = false;
+  }
+  XDropRepeatsWith.prototype['@@transducer/init'] = function() {
+    return this.xf['@@transducer/init']();
+  };
+  XDropRepeatsWith.prototype['@@transducer/result'] = function(result) {
+    return this.xf['@@transducer/result'](result);
+  };
+  XDropRepeatsWith.prototype['@@transducer/step'] = function(result, input) {
+    var sameAsLast = false;
+    if (!this.seenFirstValue) {
+      this.seenFirstValue = true;
+    } else if (this.pred(this.lastValue, input)) {
+      sameAsLast = true;
+    }
+    this.lastValue = input;
+    return sameAsLast ? result : this.xf['@@transducer/step'](result, input);
+  };
+
+  return _curry2(function _xdropRepeatsWith(pred, xf) { return new XDropRepeatsWith(pred, xf); });
+})();

--- a/test/dropRepeats.js
+++ b/test/dropRepeats.js
@@ -1,0 +1,22 @@
+var assert = require('assert');
+
+var R = require('..');
+
+
+describe('dropRepeats', function() {
+  var objs = [1, 2, 3, 4, 5, 3, 2];
+  var objs2 = [1, 2, 2, 2, 3, 4, 4, 5, 5, 3, 2, 2];
+
+  it('removes repeated elements', function() {
+    assert.deepEqual(R.dropRepeats(objs2), objs);
+    assert.deepEqual(R.dropRepeats(objs), objs);
+  });
+
+  it('returns an empty array for an empty array', function() {
+    assert.deepEqual(R.dropRepeats([]), []);
+  });
+
+  it('can act as a transducer', function() {
+    assert.deepEqual(R.into([], R.dropRepeats, objs2), objs);
+  });
+});

--- a/test/dropRepeatsWith.js
+++ b/test/dropRepeatsWith.js
@@ -1,0 +1,41 @@
+var assert = require('assert');
+
+var R = require('..');
+
+
+describe('dropRepeatsWith', function() {
+  var objs = [
+    {i: 1}, {i: 2}, {i: 3}, {i: 4}, {i: 5}, {i: 3}
+  ];
+  var objs2 = [
+    {i: 1}, {i: 1}, {i: 1}, {i: 2}, {i: 3},
+    {i: 3}, {i: 4}, {i: 4}, {i: 5}, {i: 3},
+  ];
+  var eqI = R.eqProps('i');
+
+  it('removes repeated elements based on predicate', function() {
+    assert.deepEqual(R.dropRepeatsWith(eqI, objs2), objs);
+    assert.deepEqual(R.dropRepeatsWith(eqI, objs), objs);
+  });
+
+  it('keeps elements from the left', function() {
+    assert.deepEqual(
+      R.dropRepeatsWith(eqI, [{i: 1, n: 1}, {i: 1, n: 2}, {i: 1, n: 3}, {i: 4, n: 1}, {i: 4, n: 2}]),
+      [{i: 1, n: 1}, {i: 4, n: 1}]
+    );
+  });
+
+  it('returns an empty array for an empty array', function() {
+    assert.deepEqual(R.dropRepeatsWith(eqI, []), []);
+  });
+
+  it('is curried', function() {
+    assert.strictEqual(typeof R.dropRepeatsWith(eqI), 'function');
+    assert.deepEqual(R.dropRepeatsWith(eqI)(objs), objs);
+    assert.deepEqual(R.dropRepeatsWith(eqI)(objs2), objs);
+  });
+
+  it('can act as a transducer', function() {
+    assert.deepEqual(R.into([], R.dropRepeatsWith(eqI), objs2), objs);
+  });
+});


### PR DESCRIPTION
This closes #1005.

I've tried to conform to the existing code patterns, but there a few things to note:

* I've added a test for the transducer version by using `R.into`. I could hardly find any tests for the existing transducer compatible functions. Maybe I've missed something.
* The non-transducer implementation is not based on the transducer implementation. This seems to be in line with the existing transducer compatible functions.
* The non-transducer implementation is meant to be performant and I've used `Array#push`. There is however no other Ramda function that uses push. Is there a reason for that? It is a fast way to build an array and it is supported by all browsers.
* The non-`With` version is simply based on the `With`-version. I couldn't find any other functions implemented on top of their `With` companion in this way but it seems logical so I did it anyway.

What do you think?