### PR TITLE
Document that reject is a transducer

### DIFF
--- a/src/reject.js
+++ b/src/reject.js
@@ -7,6 +7,9 @@ var filter = require('./filter');
  * Similar to `filter`, except that it keeps only values for which the given predicate
  * function returns falsy. The predicate function is passed one argument: *(value)*.
  *
+ * Acts as a transducer if a transformer is given in list position.
+ * @see R.transduce
+ *
  * @func
  * @memberOf R
  * @category List


### PR DESCRIPTION
`reject` is implemented on top of `filter` so it works as a transducer as well.