### PR TITLE
Don't clone in sort

### DIFF
--- a/src/sort.js
+++ b/src/sort.js
@@ -1,5 +1,5 @@
 var _curry2 = require('./internal/_curry2');
-var clone = require('./clone');
+var _slice = require('./internal/_slice');
 
 
 /**
@@ -20,5 +20,5 @@ var clone = require('./clone');
  *      R.sort(diff, [4,2,7,5]); //=> [2, 4, 5, 7]
  */
 module.exports = _curry2(function sort(comparator, list) {
-  return clone(list).sort(comparator);
+  return _slice(list).sort(comparator);
 });


### PR DESCRIPTION
Sort currently makes a clone (deep copy) of the list to sort. That is unnecessary and undocumented.

This PR changes `clone` to a `_slice` which is consistent with the rest of the code ([sortBy for instance](https://github.com/ramda/ramda/blob/master/src/sortBy.js#L37)).