### PR TITLE
Update _xfind to transducer protocol

### DIFF
--- a/src/internal/_xfind.js
+++ b/src/internal/_xfind.js
@@ -9,7 +9,7 @@ module.exports = (function() {
     this.found = false;
   }
   XFind.prototype['@@transducer/init'] = function() {
-    return this.xf.init();
+    return this.xf['@@transducer/init']();
   };
   XFind.prototype['@@transducer/result'] = function(result) {
     if (!this.found) {


### PR DESCRIPTION
Is seems like [this commit](https://github.com/ramda/ramda/commit/fd3c99b8ac0d07a16019e902663a6e1d27f8cfa6) missed this `init` function in `_xfind`.