### PR TITLE
Fix pathEq test

### DIFF
--- a/test/pathEq.js
+++ b/test/pathEq.js
@@ -34,8 +34,8 @@ describe('pathEq', function() {
 
   it('has Object.is semantics', function() {
     assert.strictEqual(R.pathEq(['value'], -0, {value: 0}), false);
-    assert.strictEqual(R.propEq(['value'], 0, {value: -0}), false);
-    assert.strictEqual(R.propEq(['value'], NaN, {value: NaN}), true);
+    assert.strictEqual(R.pathEq(['value'], 0, {value: -0}), false);
+    assert.strictEqual(R.pathEq(['value'], NaN, {value: NaN}), true);
   });
 
 });


### PR DESCRIPTION
Noticed this while playing around with the tests. Interesting that these tests only passed because `['value'].toString() === 'value'`, which means `({value: NaN})[['value']] === NaN`