### PR TITLE
docs/not: refer to `complement`

### DIFF
--- a/src/not.js
+++ b/src/not.js
@@ -11,6 +11,7 @@ var _curry1 = require('./internal/_curry1');
  * @sig * -> Boolean
  * @param {*} a any value
  * @return {Boolean} the logical inverse of passed argument.
+ * @see complement
  * @example
  *
  *      R.not(true); //=> false


### PR DESCRIPTION
before 0.12 `not` used to have behavior similar to `complement`