### PR TITLE
Implement uniq in terms of uniqWith

### DIFF
--- a/src/uniq.js
+++ b/src/uniq.js
@@ -1,5 +1,5 @@
-var _contains = require('./internal/_contains');
-var _curry1 = require('./internal/_curry1');
+var eq = require('./eq');
+var uniqWith = require('./uniqWith');
 
 
 /**
@@ -19,14 +19,4 @@ var _curry1 = require('./internal/_curry1');
  *      R.uniq([{}, {}]);     //=> [{}, {}]
  *      R.uniq([1, '1']);     //=> [1, '1']
  */
-module.exports = _curry1(function uniq(list) {
-  var idx = -1, len = list.length;
-  var result = [], item;
-  while (++idx < len) {
-    item = list[idx];
-    if (!_contains(item, result)) {
-      result[result.length] = item;
-    }
-  }
-  return result;
-});
+module.exports = uniqWith(eq);


### PR DESCRIPTION
Removes repetition.

With equivalent benefits this could easily be done for other functions with `*With` equivalents as well.