### PR TITLE
docs/filter: only filter categories with a full match

### DIFF
--- a/lib/doc/main.js
+++ b/lib/doc/main.js
@@ -19,7 +19,7 @@ function filterToc() {
 function filterElement(nameFilter, elem) {
   var name = elem.getAttribute('data-name');
   var category = elem.getAttribute('data-category');
-  var matches = strIn(nameFilter, name) || strIn(nameFilter, category);
+  var matches = strIn(nameFilter, name) || R.toLower(nameFilter) === R.toLower(category);
   elem.style.display = matches ? '' : 'none';
 }
 


### PR DESCRIPTION
i feel this filtering logic serves the majority of use cases better

before:

![screenshot 2015-04-16 21 07 55](https://cloud.githubusercontent.com/assets/11027/7187999/47981c2a-e47d-11e4-80e1-bf9f76fdad28.png)

after:

![screenshot 2015-04-16 21 07 31](https://cloud.githubusercontent.com/assets/11027/7188005/4bc8d438-e47d-11e4-841d-5d490e353af2.png)