### PR TITLE
use R.toString to generate cache keys in R.memoize

### DIFF
--- a/src/memoize.js
+++ b/src/memoize.js
@@ -1,6 +1,6 @@
 var _curry1 = require('./internal/_curry1');
 var _has = require('./internal/_has');
-var _map = require('./internal/_map');
+var toString = require('./toString');
 
 
 /**
@@ -8,9 +8,6 @@ var _map = require('./internal/_map');
  * argument set and returns the result. Subsequent calls to the memoized `fn` with the same
  * argument set will not result in an additional call to `fn`; instead, the cached result
  * for that set of arguments will be returned.
- *
- * Note that this version of `memoize` should not be applied to functions which
- * take objects as arguments.
  *
  * @func
  * @memberOf R
@@ -30,35 +27,13 @@ var _map = require('./internal/_map');
  *      factorial(5); //=> 120
  *      count; //=> 1
  */
-module.exports = (function() {
-  // Returns a string representation of the given value suitable for use as
-  // a property name.
-  //
-  // > repr(42)
-  // '42::[object Number]'
-  var repr = function(x) {
-    return x + '::' + Object.prototype.toString.call(x);
+module.exports = _curry1(function memoize(fn) {
+  var cache = {};
+  return function() {
+    var key = toString(arguments);
+    if (!_has(key, cache)) {
+      cache[key] = fn.apply(this, arguments);
+    }
+    return cache[key];
   };
-
-  // Serializes an array-like object. The approach is similar to that taken
-  // by [CANON](https://github.com/davidchambers/CANON), though it does not
-  // differentiate between objects at all (!) and, since it is not applied
-  // recursively, does not distinguish between [[42]] and [['42']].
-  //
-  // > serialize(['foo', 42])
-  // '2:{foo::[object String],42::[object Number]}'
-  var serialize = function(args) {
-    return args.length + ':{' + _map(repr, args).join(',') + '}';
-  };
-
-  return _curry1(function memoize(fn) {
-    var cache = {};
-    return function() {
-      var key = serialize(arguments);
-      if (!_has(key, cache)) {
-        cache[key] = fn.apply(this, arguments);
-      }
-      return cache[key];
-    };
-  });
-}());
+});

--- a/test/memoize.js
+++ b/test/memoize.js
@@ -67,8 +67,22 @@ describe('memoize', function() {
   });
 
   it('differentiates values with same string representation', function() {
-    var f = R.memoize(function(x) { return x; });
-    assert.strictEqual(f(42), 42);
-    assert.strictEqual(f('42'), '42');
+    var f = R.memoize(R.toString);
+    assert.strictEqual(f(42), '42');
+    assert.strictEqual(f('42'), '"42"');
+    assert.strictEqual(f([[42]]), '[[42]]');
+    assert.strictEqual(f([['42']]), '[["42"]]');
+  });
+
+  it('respects object equivalence', function() {
+    var count = 0;
+    var f = R.memoize(function(x) {
+      count += 1;
+      return R.toString(x);
+    });
+    assert.strictEqual(f({x: 1, y: 2}), '{"x": 1, "y": 2}');
+    assert.strictEqual(f({x: 1, y: 2}), '{"x": 1, "y": 2}');
+    assert.strictEqual(f({y: 2, x: 1}), '{"x": 1, "y": 2}');
+    assert.strictEqual(count, 1);
   });
 });


### PR DESCRIPTION
As mentioned in https://github.com/ramda/ramda/pull/924#issuecomment-88779624, using `R.toString` to generate cache keys makes `R.memoize` *much* more useful as it now works correctly for objects (!) and for dissimilar arrays which have the same string representation according to `Array.prototype.toString` (e.g. `[0]` and `['0']`).

The implementation is simpler as `repr` and `serialize` are no longer necessary.
