### PR TITLE
Adds reduceRightLazy

### DIFF
--- a/src/reduceRightLazy.js
+++ b/src/reduceRightLazy.js
@@ -1,0 +1,44 @@
+var _curry3 = require('./internal/_curry3');
+var _slice = require('./internal/_slice');
+
+
+/**
+ * Reduces a list by passing each element to the provided iterator
+ * function, along with a thunk (zero arity function) that evaluates
+ * to the accumulated result of reducing all elements to the right of
+ * the current element.
+ *
+ * This function operates in a similar manner to `R.reduceRight`, with
+ * the exception that the accumulated value is evaluated lazily, such
+ * that the iterator function must execute the thunk to get access to
+ * the value. If the iterator chooses to not evaluate the thunk, this
+ * function will short circuit and return the current value without
+ * iterating over the entire list.
+ *
+ * @func
+ * @memberOf R
+ * @category List
+ * @sig ((() -> b, a) -> b) -> b -> List[a] -> b
+ * @param {Function} fn The iterator function. Receives two values,
+ *        a thunk (zero arity function) that evaluates the accumulated
+ *        value and the current element from the array.
+ * @param {*} acc The initial accumulated value.
+ * @param {Array} list The list to reduce
+ * @return {*} The final accumulated value
+ * @see R.reduceRight
+ * @example
+ *
+ *      function exists(p, list) {
+ *        return R.reduceRightLazy(function(acc, a) {
+ *          return p(a) || acc();
+ *        }, false, list);
+ *      }
+ *
+ *      exists(R.eq(4), [2,4,6,8]); //=> true
+ */
+module.exports = _curry3(function reduceRightLazy(fn, acc, list) {
+  return list.length === 0 ? acc : fn(
+    function() { return reduceRightLazy(fn, acc, _slice(list, 1)); },
+    list[0]
+  );
+});

--- a/test/reduceRightLazy.js
+++ b/test/reduceRightLazy.js
@@ -1,0 +1,43 @@
+var assert = require('assert');
+
+var R = require('..');
+
+
+describe('reduceRightLazy', function() {
+  var plusThunk = function(a, b) { return a() + b; };
+
+  it('folds lists with right-associativity', function() {
+    assert.strictEqual(
+      R.reduceRightLazy(plusThunk, '', ['a', 'b', 'c', 'd']),
+      'dcba'
+    );
+  });
+
+  it('folds functions over arrays with the supplied accumulator', function() {
+    assert.strictEqual(R.reduceRightLazy(plusThunk, 0, [12, 4, 10, 6]), 32);
+  });
+
+  it('returns the accumulator for an empty array', function() {
+    assert.strictEqual(R.reduceRightLazy(plusThunk, 0, []), 0);
+  });
+
+  it('is curried', function() {
+    var sum = R.reduceRightLazy(plusThunk, 0);
+    assert.strictEqual(sum([12, 4, 10, 6]), 32);
+  });
+
+  it('correctly reports the arity of curried versions', function() {
+    var sum = R.reduceRightLazy(plusThunk, 0);
+    assert.strictEqual(sum.length, 1);
+  });
+
+  it('short-circuits when the accumulator thunk is not evaluated', function() {
+    var count = 0;
+    var found2 = R.reduceRightLazy(function(acc, a) {
+      count++;
+      return a === 2 || acc();
+    }, false, [1, 2, 3, 4]);
+    assert.strictEqual(count, 2);
+    assert.strictEqual(found2, true);
+  });
+});


### PR DESCRIPTION
Not sure if there is any interest for inclusion of this, or whether transducers should be promoted to cover this use case instead. (I'm not familiar enough with transducers yet to say one way or another)

This introduces `R.reduceRightLazy`, which is a slight variation of `R.reduceRight` whereby the accumulated value is evaluated lazily, allowing for short-circuiting to prevent iterating over the entire list.

e.g.
```js
function exists(p, list) {
  return R.reduceRightLazy(function(acc, a) {
    return p(a) || acc();
  }, false, list);
}
```
