### PR TITLE
Add `deepMerge`/`set`/`extend`/`mixin`

### DIFF
--- a/src/set.js
+++ b/src/set.js
@@ -1,0 +1,47 @@
+var _curry2 = require('./internal/_curry2');
+var _extend = require('./internal/_extend');
+var _has = require('./internal/_has');
+var _isArray = require('./internal/_isArray');
+var isEmpty = require('./isEmpty');
+var keys = require('./keys');
+
+
+/**
+ * Creates a new object with the values from `b` merged with the
+ * values in `a`. Only own enumerable properties are considered. This function
+ * recursively handles nested objects, but not arrays, with own enumerable
+ * properties. All non-primitive properties are copied by reference if
+ * possible. This function * will *not* mutate passed-in objects.
+ *
+ * @func
+ * @memberOf R
+ * @category Object
+ * @sig {k: v} -> {k: v} -> {k: v}
+ * @param {Object} a object with higher precedence in output
+ * @param {Object} b source object
+ * @return {Object} The merged object.
+ * @example
+ *
+ *      R.set({age: 40, {name: 'fred', age: 10});
+ *      //=> {'name': 'fred', 'age': 40}
+ *
+ *      R.set({parent: {age: 40}}, {name: 'fred', age: 10, parent: {age: 39}});
+ *      //=> {'name': 'fred', 'age': 10, {parent: {age: 40}}}
+ */
+module.exports = _curry2(function set(update, original) {
+  if (_isArray(update) || _isArray(original)) {
+    return update;
+  }
+  var updateKeys = keys(update);
+  var originalKeys = keys(original);
+  if (isEmpty(updateKeys) || isEmpty(originalKeys)) {
+    return update;
+  }
+  var result = _extend({}, original);
+  var key, idx = -1, length = updateKeys.length;
+  while (++idx < length) {
+    key = updateKeys[idx];
+    result[key] = _has(key, original) ? set(update[key], original[key]) : update[key];
+  }
+  return result;
+});

--- a/test/set.js
+++ b/test/set.js
@@ -1,0 +1,38 @@
+var assert = require('assert');
+
+var R = require('..');
+
+
+describe('set', function() {
+  it('handles flat object', function() {
+    var a = {w: 1, x: 2, y: 3, z: 4};
+    var b = R.set({y: 5}, a);
+    assert.deepEqual(b, {w: 1, x: 2, y: 5, z: 4});
+  });
+
+  it('add new properties to original object', function() {
+    var a = {w: 1, x: 2, y: 3};
+    var b = R.set({z: 4}, a);
+    assert.deepEqual(b, {w: 1, x: 2, y: 3, z: 4});
+  });
+
+  it('handles nested objects', function() {
+    var a = {w: 1, x: {a: 1, b: 2, c: 3}, z: 4};
+    var b = R.set({x: {a: 5}}, a);
+    assert.deepEqual(b, {w: 1, x: {a: 5, b: 2, c: 3}, z: 4});
+  });
+
+  it('swallow copies when possible', function() {
+    var a = {w: 1, x: {a: 1, b: 2, c: 3}, z: 4};
+    var b = R.set({z: 5}, a);
+    assert.strictEqual(a.x, b.x);
+    var c = R.set({x: {a: 5}}, a);
+    assert.notStrictEqual(a.x, c.x);
+  });
+
+  it('overrides arrays', function() {
+    var a = {w: 1, x: [1, 2, 3], z: 4};
+    var b = R.set({x: [4]}, a);
+    assert.deepEqual(b.x, [4]);
+  });
+});


### PR DESCRIPTION
This pull request adds a function that recursively combines two supplied objects into one. This has previously been discussed at #1073. This PR uses the name `set` as a non-final placeholder.

This implementation follows the rules I outlined in the above mentioned thread with a few changes based on the discussion. These rules leads to a very simple implementation and behavior that is IMO easy to understand:

1/ The function recurses into ~~arrays and~~ non-atomic objects. Non-atomic objects are objects that have keys in the eyes of `Object.keys` (i.e. they have own enumerable properties). It will for instance recurse into an object literal but not into a date object.
2/ Values from objects are always copied into a new plain object.
3/ ~~Value from arrays are copied into a new array. Sparse arrays are not handled.~~ Arrays are always copied by reference.

__Use cases__

As I've [mentioned](https://gitter.im/ramda/ramda?at=555229f11817239c37e4e6c4) I think the most interesting way to think about such a function is as [a way to set properties](https://gitter.im/ramda/ramda?at=5552359df853e7f14c2b84c5) on objects.

This way of thinking has changed my opinions on the implementation in two ways:

1. The overriding object should be first instead of last to be consistent with `assoc` and `assocPath`. `R.assoc('c', 3, {a: 1, b: 2})` matches `R.set({c: 3}, {a: 1, b: 2})`.
2. I now think of the returned object as "`b` with these changes from `a`" instead of "a brand new thing made up of `a` and `b`." With the first view I'd expect as little deep copying as possible but with the second view I'd expect everything to be deep copied. This PR implements the former.

I see this function as a more powerful and useful version of `assoc` and `deepAssoc`.

```javascript
// Compare this
var o = {a: {b: 1, c: 2, d: 3}};
var o2 = R.set({a: {b: 4, c: 5}}, 0);
// To this
var o3 = R.compose(
  R.assocPath(['a', 'b'], 4)
  R.assocPath(['a', 'c'], 5)
)(o);
```

I think this is a very welcome addition to Ramda. Currently Ramda has a lot of great functions for working with arrays without mutating them but it feels a bit weaker with regards to objects.

__About arrays__

@ivan-kleshnin had some [great reasons](https://github.com/ramda/ramda/issues/1073#issuecomment-100600208) why we should not (unlike Lodash) attempt to merge arrays.

While being able to do something like this is neat:

```javascript
var users = {
  'data': [{ 'user': 'barney' }, { 'user': 'fred' }]
};
var ages = {
  'data': [{ 'age': 36 }, { 'age': 40 }]
};
_.merge(users, ages);
// → { 'data': [{ 'user': 'barney', 'age': 36 }, { 'user': 'fred', 'age': 40 }] }
```

But the same behavior can also be a disaster:

```javascript
var users = {
  'data': [{ 'user': 'barney', 'age': 36 }, { 'user': 'fred', 'age': 40 }]
};
var anotherUser = {
  'data': [{ 'user': 'kim', 'age': 42 }] // new user, not an update
};
_.merge(users, anotherUser);
// → { 'data': [{ 'user': 'kim', 'age': 42 }, { 'user': 'fred', 'age': 40 }] }
// Barney disappeared :(
```

__About naming__

I really don't know what to call this thing. In my head the name `merge` implies merging two conceptually equal objects. Not applying a few changes to an existing object. On the other hand @joneshf seemed to have been thinking about `merge` like this all along. I really don't know.

But I definitely think that having both this function _and_ `merge` would be too much. I choose `set` as the name in this PR just because I had to call it something (and `set` might not be a bad name).

__Symmetry with `R.evolve`__

When/if this gets merged I think `R.evolve` should be made recursive in the same way as well. I think these two functions together provides a very solid experience for updating object without mutations.

Handling the before mentioned Lodash example is very easy and, importantly, free from bad surprises (the example below can be implemented with todays `evolve` and `merge` but this power does not extend to nested objects).

```javascript
var users = {
  'data': [{ 'user': 'barney' }, { 'user': 'fred' }]
};
var ages = {
  'data': [{ 'age': 36 }, { 'age': 40 }]
};
R.evolve({data: R.zipWith(R.set, ages.data)}, users);
// { 'data': [{ 'user': 'barney', 'age': 36 }, { 'user': 'fred', 'age': 40 }] }

var anotherUser = {
  'data': [{ 'user': 'kim', 'age': 42 }] // new user, not an update
};
R.evolve({data: R.concat(anotherUser.data)}, users);
// { 'data': [{ 'user': 'barney', 'age': 36 }, { 'user': 'fred', 'age': 40 }, { 'user': 'kim', 'age': 42 }] }
// Barney did not disappear :)
```

__Cycles__

This implementation does not detect cycles. I agrees with @ivan-kleshnin's [opinion on this](https://github.com/ramda/ramda/issues/1073#issuecomment-100601526). Also as far as I can think the only way to create data with cycles it with mutations (I could be wrong)? So not supporting them should be a minor issue. If there was a very simple way to detect cycles that would not be too inefficient I think adding it would be great though. But I can't think of one.

Consider this PR to be nothing but my current suggestion for an implementation. Everything is up for discussion :)