### PR TITLE
fix handling of `new Number(0)` in R.eq

### DIFF
--- a/src/internal/_eq.js
+++ b/src/internal/_eq.js
@@ -1,7 +1,11 @@
-module.exports = function _eq(a, b) {
-  if (a === 0) {
-    return 1 / a === 1 / b;
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is#Polyfill
+module.exports = function _eq(x, y) {
+  // SameValue algorithm
+  if (x === y) { // Steps 1-5, 7-10
+    // Steps 6.b-6.e: +0 != -0
+    return x !== 0 || 1 / x === 1 / y;
   } else {
-    return a === b || (a !== a && b !== b);
+    // Step 6.a: NaN == NaN
+    return x !== x;
   }
 };

--- a/test/eq.js
+++ b/test/eq.js
@@ -18,6 +18,12 @@ describe('eq', function() {
     assert.strictEqual(R.eq(-0, 0), false);
     assert.strictEqual(R.eq(0, -0), false);
     assert.strictEqual(R.eq(NaN, NaN), true);
+
+    /* jshint -W053 */
+    assert.strictEqual(R.eq(0, new Number(0)), false);
+    assert.strictEqual(R.eq(new Number(0), 0), false);
+    assert.strictEqual(R.eq(new Number(0), new Number(0)), false);
+    /* jshint +W053 */
   });
 
   it('is curried', function() {


### PR DESCRIPTION
Currently `R.eq(0, new Number(0))` evaluates true, which is incorrect.
