### PR TITLE
fix bug causing R.eq(NaN, x) to evaluate true for every x

### DIFF
--- a/src/internal/_eq.js
+++ b/src/internal/_eq.js
@@ -6,6 +6,6 @@ module.exports = function _eq(x, y) {
     return x !== 0 || 1 / x === 1 / y;
   } else {
     // Step 6.a: NaN == NaN
-    return x !== x;
+    return x !== x && y !== y;
   }
 };

--- a/test/eq.js
+++ b/test/eq.js
@@ -19,6 +19,9 @@ describe('eq', function() {
     assert.strictEqual(R.eq(0, -0), false);
     assert.strictEqual(R.eq(NaN, NaN), true);
 
+    assert.strictEqual(R.eq(NaN, 42), false);
+    assert.strictEqual(R.eq(42, NaN), false);
+
     /* jshint -W053 */
     assert.strictEqual(R.eq(0, new Number(0)), false);
     assert.strictEqual(R.eq(new Number(0), 0), false);


### PR DESCRIPTION
I've made the same change to the MDN [polyfill][1].


[1]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is#Polyfill
