### PR TITLE
avoid shift and concat in `curryN`

### DIFF
--- a/src/curryN.js
+++ b/src/curryN.js
@@ -65,11 +65,15 @@ module.exports = _curry2(function curryN(length, fn) {
         var currentArgs = _slice(arguments);
         var combinedArgs = [];
         var idx = -1;
+        var currentArgsIdx = 0;
         while (++idx < n) {
           var val = initialArgs[idx];
-          combinedArgs[idx] = (val === __ ? currentArgs.shift() : val);
+          combinedArgs[idx] = (val === __ ? currentArgs[currentArgsIdx++] : val);
         }
-        return fn.apply(this, combinedArgs.concat(currentArgs));
+        while (currentArgsIdx < currentArgs.length) {
+          combinedArgs[idx++] = currentArgs[currentArgsIdx++];
+        }
+        return fn.apply(this, combinedArgs);
       });
     }
   });


### PR DESCRIPTION
When `curryN` recieves placeholders it has to merge a list of arguments containing placeholders (named `initialArgs`) with a list of arguments without placeholders (named `currentArgs`). To do that it creates a new array named `combinedArgs`.

In the process it currently does two nasty things:

1/ Instead of simply looping over `currentArgs` it `shift`s over it.
2/ Instead of merging everything into `combinedArgs` it uses `Array.prototype.concat` to merge `combinedArgs` with the part of `currentArgs` that does not fill a placeholder in `initialArgs`. Thus both `combinedArgs and `initialArgs` is left for garbage collection and a brand new array is allocated and returned instead.

This PR solves both of these issues. My guesstimate is that this should improve performance.