### PR TITLE
replace R.curryN and R.nAry with R.curryMinMax

### DIFF
--- a/src/addIndex.js
+++ b/src/addIndex.js
@@ -2,7 +2,7 @@ var _concat = require('./internal/_concat');
 var _curry1 = require('./internal/_curry1');
 var _prepend = require('./internal/_prepend');
 var _slice = require('./internal/_slice');
-var curryN = require('./curryN');
+var curryMinMax = require('./curryMinMax');
 
 
 /**
@@ -28,7 +28,7 @@ var curryN = require('./curryN');
  *      //=> ['0-f', '1-o', '2-o', '3-b', '4-a', '5-r']
  */
 module.exports = _curry1(function(fn) {
-  return curryN(fn.length, function() {
+  return curryMinMax(fn.length, fn.length, function() {
     var idx = -1;
     var origFn = arguments[0];
     var list = arguments[arguments.length - 1];

--- a/src/allPass.js
+++ b/src/allPass.js
@@ -1,6 +1,6 @@
 var _all = require('./internal/_all');
 var _predicateWrap = require('./internal/_predicateWrap');
-var curry = require('./curry');
+var curryMinMax = require('./curryMinMax');
 
 
 /**
@@ -22,4 +22,4 @@ var curry = require('./curry');
  *      f(11); //=> false
  *      f(12); //=> true
  */
-module.exports = curry(_predicateWrap(_all));
+module.exports = curryMinMax(1, Infinity, _predicateWrap(_all));

--- a/src/anyPass.js
+++ b/src/anyPass.js
@@ -1,6 +1,6 @@
 var _any = require('./internal/_any');
 var _predicateWrap = require('./internal/_predicateWrap');
-var curry = require('./curry');
+var curryMinMax = require('./curryMinMax');
 
 
 /**
@@ -23,4 +23,4 @@ var curry = require('./curry');
  *      f(8); //=> true
  *      f(9); //=> false
  */
-module.exports = curry(_predicateWrap(_any));
+module.exports = curryMinMax(1, Infinity, _predicateWrap(_any));

--- a/src/arity.js
+++ b/src/arity.js
@@ -1,3 +1,4 @@
+var _arity = require('./internal/_arity');
 var _curry2 = require('./internal/_curry2');
 
 
@@ -28,19 +29,4 @@ var _curry2 = require('./internal/_curry2');
  *      // All arguments are passed through to the wrapped function
  *      takesOneArg(1, 2); //=> [1, 2]
  */
-module.exports = _curry2(function(n, fn) {
-  switch (n) {
-    case 0: return function() {return fn.apply(this, arguments);};
-    case 1: return function(a0) {void a0; return fn.apply(this, arguments);};
-    case 2: return function(a0, a1) {void a1; return fn.apply(this, arguments);};
-    case 3: return function(a0, a1, a2) {void a2; return fn.apply(this, arguments);};
-    case 4: return function(a0, a1, a2, a3) {void a3; return fn.apply(this, arguments);};
-    case 5: return function(a0, a1, a2, a3, a4) {void a4; return fn.apply(this, arguments);};
-    case 6: return function(a0, a1, a2, a3, a4, a5) {void a5; return fn.apply(this, arguments);};
-    case 7: return function(a0, a1, a2, a3, a4, a5, a6) {void a6; return fn.apply(this, arguments);};
-    case 8: return function(a0, a1, a2, a3, a4, a5, a6, a7) {void a7; return fn.apply(this, arguments);};
-    case 9: return function(a0, a1, a2, a3, a4, a5, a6, a7, a8) {void a8; return fn.apply(this, arguments);};
-    case 10: return function(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9) {void a9; return fn.apply(this, arguments);};
-    default: throw new Error('First argument to arity must be a non-negative integer no greater than ten');
-  }
-});
+module.exports = _curry2(_arity);

--- a/src/binary.js
+++ b/src/binary.js
@@ -13,6 +13,7 @@ var nAry = require('./nAry');
  * @param {Function} fn The function to wrap.
  * @return {Function} A new function wrapping `fn`. The new function is guaranteed to be of
  *         arity 2.
+ * @deprecated since v0.15.0
  * @example
  *
  *      var takesThreeArgs = function(a, b, c) {

--- a/src/bind.js
+++ b/src/bind.js
@@ -1,5 +1,5 @@
+var _arity = require('./internal/_arity');
 var _curry2 = require('./internal/_curry2');
-var arity = require('./arity');
 
 
 /**
@@ -18,7 +18,7 @@ var arity = require('./arity');
  * @return {Function} A function that will execute in the context of `thisObj`.
  */
 module.exports = _curry2(function bind(fn, thisObj) {
-  return arity(fn.length, function() {
+  return _arity(fn.length, function() {
     return fn.apply(thisObj, arguments);
   });
 });

--- a/src/call.js
+++ b/src/call.js
@@ -1,5 +1,5 @@
 var _slice = require('./internal/_slice');
-var curry = require('./curry');
+var curryMinMax = require('./curryMinMax');
 
 
 /**
@@ -27,6 +27,6 @@ var curry = require('./curry');
  *
  *      format({indent: 2, value: 'foo\nbar\nbaz\n'}); //=> '  foo\n  bar\n  baz\n'
  */
-module.exports = curry(function call(fn) {
+module.exports = curryMinMax(1, Infinity, function call(fn) {
   return fn.apply(this, _slice(arguments, 1));
 });

--- a/src/converge.js
+++ b/src/converge.js
@@ -1,6 +1,6 @@
 var _map = require('./internal/_map');
 var _slice = require('./internal/_slice');
-var curryN = require('./curryN');
+var curryMinMax = require('./curryMinMax');
 var max = require('./max');
 var pluck = require('./pluck');
 
@@ -31,9 +31,9 @@ var pluck = require('./pluck');
  *      var add3 = function(a, b, c) { return a + b + c; };
  *      R.converge(add3, multiply, add, subtract)(1, 2); //=> 4
  */
-module.exports = curryN(3, function(after) {
+module.exports = curryMinMax(3, Infinity, function(after) {
   var fns = _slice(arguments, 1);
-  return curryN(max(pluck('length', fns)), function() {
+  return curryMinMax(max(pluck('length', fns)), Infinity, function() {
     var args = arguments;
     var context = this;
     return after.apply(context, _map(function(fn) {

--- a/src/curry.js
+++ b/src/curry.js
@@ -1,5 +1,5 @@
 var _curry1 = require('./internal/_curry1');
-var curryN = require('./curryN');
+var curryMinMax = require('./curryMinMax');
 
 
 /**
@@ -32,7 +32,7 @@ var curryN = require('./curryN');
  * @sig (* -> a) -> (* -> a)
  * @param {Function} fn The function to curry.
  * @return {Function} A new, curried function.
- * @see R.curryN
+ * @see R.curryMinMax
  * @example
  *
  *      var addFourNumbers = function(a, b, c, d) {
@@ -45,5 +45,5 @@ var curryN = require('./curryN');
  *      g(4); //=> 10
  */
 module.exports = _curry1(function curry(fn) {
-  return curryN(fn.length, fn);
+  return curryMinMax(fn.length, fn.length, fn);
 });

--- a/src/flip.js
+++ b/src/flip.js
@@ -1,6 +1,6 @@
 var _curry1 = require('./internal/_curry1');
 var _slice = require('./internal/_slice');
-var curry = require('./curry');
+var curryMinMax = require('./curryMinMax');
 
 
 /**
@@ -24,7 +24,7 @@ var curry = require('./curry');
  *      R.flip(mergeThree)(1, 2, 3); //=> [2, 1, 3]
  */
 module.exports = _curry1(function flip(fn) {
-  return curry(function(a, b) {
+  return curryMinMax(2, Infinity, function(a, b) {
     var args = _slice(arguments);
     args[0] = b;
     args[1] = a;

--- a/src/ifElse.js
+++ b/src/ifElse.js
@@ -1,5 +1,5 @@
 var _curry3 = require('./internal/_curry3');
-var curryN = require('./curryN');
+var curryMinMax = require('./curryMinMax');
 
 
 /**
@@ -24,9 +24,8 @@ var curryN = require('./curryN');
  *      flattenArrays([[[10], 123], [8, [10]], "hello"]); //=> [[10, 123], [8, 10], "hello"]
  */
 module.exports = _curry3(function ifElse(condition, onTrue, onFalse) {
-  return curryN(Math.max(condition.length, onTrue.length, onFalse.length),
-    function _ifElse() {
-      return condition.apply(this, arguments) ? onTrue.apply(this, arguments) : onFalse.apply(this, arguments);
-    }
-  );
+  var n = Math.max(condition.length, onTrue.length, onFalse.length);
+  return curryMinMax(n, n, function _ifElse() {
+    return condition.apply(this, arguments) ? onTrue.apply(this, arguments) : onFalse.apply(this, arguments);
+  });
 });

--- a/src/internal/_arity.js
+++ b/src/internal/_arity.js
@@ -1,0 +1,16 @@
+module.exports = function(n, fn) {
+  switch (n) {
+    case 0: return function() {return fn.apply(this, arguments);};
+    case 1: return function(a0) {void a0; return fn.apply(this, arguments);};
+    case 2: return function(a0, a1) {void a1; return fn.apply(this, arguments);};
+    case 3: return function(a0, a1, a2) {void a2; return fn.apply(this, arguments);};
+    case 4: return function(a0, a1, a2, a3) {void a3; return fn.apply(this, arguments);};
+    case 5: return function(a0, a1, a2, a3, a4) {void a4; return fn.apply(this, arguments);};
+    case 6: return function(a0, a1, a2, a3, a4, a5) {void a5; return fn.apply(this, arguments);};
+    case 7: return function(a0, a1, a2, a3, a4, a5, a6) {void a6; return fn.apply(this, arguments);};
+    case 8: return function(a0, a1, a2, a3, a4, a5, a6, a7) {void a7; return fn.apply(this, arguments);};
+    case 9: return function(a0, a1, a2, a3, a4, a5, a6, a7, a8) {void a8; return fn.apply(this, arguments);};
+    case 10: return function(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9) {void a9; return fn.apply(this, arguments);};
+    default: throw new Error('First argument to arity must be a non-negative integer no greater than ten');
+  }
+};

--- a/src/internal/_createComposer.js
+++ b/src/internal/_createComposer.js
@@ -1,4 +1,4 @@
-var arity = require('../arity');
+var _arity = require('./_arity');
 
 
 /*
@@ -13,6 +13,6 @@ module.exports = function _createComposer(composeFunction) {
     while (--idx >= 0) {
       fn = composeFunction(arguments[idx], fn);
     }
-    return arity(length, fn);
+    return _arity(length, fn);
   };
 };

--- a/src/internal/_createPartialApplicator.js
+++ b/src/internal/_createPartialApplicator.js
@@ -1,11 +1,11 @@
+var _arity = require('./_arity');
 var _slice = require('./_slice');
-var arity = require('../arity');
 
 
 module.exports = function _createPartialApplicator(concat) {
   return function(fn) {
     var args = _slice(arguments, 1);
-    return arity(Math.max(0, fn.length - args.length), function() {
+    return _arity(Math.max(0, fn.length - args.length), function() {
       return fn.apply(this, concat(args, arguments));
     });
   };

--- a/src/internal/_predicateWrap.js
+++ b/src/internal/_predicateWrap.js
@@ -1,6 +1,6 @@
+var _arity = require('./_arity');
 var _pluck = require('./_pluck');
 var _slice = require('./_slice');
-var arity = require('../arity');
 var max = require('../max');
 
 
@@ -23,6 +23,6 @@ module.exports = function _predicateWrap(predPicker) {
       // Call function immediately if given arguments
       predIterator.apply(null, _slice(arguments, 1)) :
       // Return a function which will call the predicates with the provided arguments
-      arity(max(_pluck('length', preds)), predIterator);
+      _arity(max(_pluck('length', preds)), predIterator);
   };
 };

--- a/src/invoker.js
+++ b/src/invoker.js
@@ -1,6 +1,5 @@
 var _slice = require('./internal/_slice');
-var curry = require('./curry');
-var curryN = require('./curryN');
+var curryMinMax = require('./curryMinMax');
 
 
 /**
@@ -25,10 +24,10 @@ var curryN = require('./curryN');
  *      var sliceFrom6 = R.invoker(2, 'slice', 6);
  *      sliceFrom6(8, 'abcdefghijklm'); //=> 'gh'
  */
-module.exports = curry(function invoker(arity, method) {
+module.exports = curryMinMax(2, Infinity, function invoker(arity, method) {
   var initialArgs = _slice(arguments, 2);
   var len = arity - initialArgs.length;
-  return curryN(len + 1, function() {
+  return curryMinMax(len + 1, Infinity, function() {
     var target = arguments[len];
     var args = initialArgs.concat(_slice(arguments, 0, len));
     return target[method].apply(target, args);

--- a/src/liftN.js
+++ b/src/liftN.js
@@ -2,7 +2,7 @@ var _curry2 = require('./internal/_curry2');
 var _reduce = require('./internal/_reduce');
 var _slice = require('./internal/_slice');
 var ap = require('./ap');
-var curryN = require('./curryN');
+var curryMinMax = require('./curryMinMax');
 var map = require('./map');
 
 
@@ -19,14 +19,14 @@ var map = require('./map');
  * @return {Function} The function `fn` applicable to mappable objects.
  * @example
  *
- *      var madd3 = R.liftN(3, R.curryN(3, function() {
+ *      var madd3 = R.liftN(3, R.curryMinMax(3, function() {
  *        return R.reduce(R.add, 0, arguments);
  *      }));
  *      madd3([1,2,3], [1,2,3], [1]); //=> [3, 4, 5, 4, 5, 6, 5, 6, 7]
  */
 module.exports = _curry2(function liftN(arity, fn) {
-  var lifted = curryN(arity, fn);
-  return curryN(arity, function() {
+  var lifted = curryMinMax(arity, arity, fn);
+  return curryMinMax(arity, arity, function() {
     return _reduce(ap, map(lifted, arguments[0]), _slice(arguments, 1));
   });
 });

--- a/src/nAry.js
+++ b/src/nAry.js
@@ -13,6 +13,7 @@ var _curry2 = require('./internal/_curry2');
  * @param {Function} fn The function to wrap.
  * @return {Function} A new function wrapping `fn`. The new function is guaranteed to be of
  *         arity `n`.
+ * @deprecated since v0.15.0
  * @example
  *
  *      var takesTwoArgs = function(a, b) {

--- a/src/partial.js
+++ b/src/partial.js
@@ -1,6 +1,6 @@
 var _concat = require('./internal/_concat');
 var _createPartialApplicator = require('./internal/_createPartialApplicator');
-var curry = require('./curry');
+var curryMinMax = require('./curryMinMax');
 
 
 /**
@@ -29,4 +29,4 @@ var curry = require('./curry');
  *      var sayHelloToMs = R.partial(sayHello, 'Ms.');
  *      sayHelloToMs('Jane', 'Jones'); //=> 'Hello, Ms. Jane Jones!'
  */
-module.exports = curry(_createPartialApplicator(_concat));
+module.exports = curryMinMax(1, Infinity, _createPartialApplicator(_concat));

--- a/src/partialRight.js
+++ b/src/partialRight.js
@@ -1,6 +1,6 @@
 var _concat = require('./internal/_concat');
 var _createPartialApplicator = require('./internal/_createPartialApplicator');
-var curry = require('./curry');
+var curryMinMax = require('./curryMinMax');
 var flip = require('./flip');
 
 
@@ -29,4 +29,4 @@ var flip = require('./flip');
  *
  *      greetMsJaneJones('Hello'); //=> 'Hello, Ms. Jane Jones!'
  */
-module.exports = curry(_createPartialApplicator(flip(_concat)));
+module.exports = curryMinMax(1, Infinity, _createPartialApplicator(flip(_concat)));

--- a/src/transduce.js
+++ b/src/transduce.js
@@ -1,6 +1,6 @@
 var _reduce = require('./internal/_reduce');
 var _xwrap = require('./internal/_xwrap');
-var curryN = require('./curryN');
+var curry = require('./curry');
 
 
 /**
@@ -46,6 +46,6 @@ var curryN = require('./curryN');
  *
  *      R.transduce(transducer, R.flip(R.append), [], numbers); //=> [2, 3]
  */
-module.exports = curryN(4, function(xf, fn, acc, list) {
+module.exports = curry(function(xf, fn, acc, list) {
   return _reduce(xf(typeof fn === 'function' ? _xwrap(fn) : fn), acc, list);
 });

--- a/src/unary.js
+++ b/src/unary.js
@@ -13,6 +13,7 @@ var nAry = require('./nAry');
  * @param {Function} fn The function to wrap.
  * @return {Function} A new function wrapping `fn`. The new function is guaranteed to be of
  *         arity 1.
+ * @deprecated since v0.15.0
  * @example
  *
  *      var takesTwoArgs = function(a, b) {

--- a/src/uncurryN.js
+++ b/src/uncurryN.js
@@ -1,6 +1,6 @@
 var _curry2 = require('./internal/_curry2');
 var _slice = require('./internal/_slice');
-var curryN = require('./curryN');
+var curryMinMax = require('./curryMinMax');
 
 
 /**
@@ -26,11 +26,11 @@ var curryN = require('./curryN');
  *        };
  *      };
  *
- *      var uncurriedAddFour = R.uncurryN(4, addFour);
+ *      var uncurriedAddFour = R.uncurryMinMax(4, addFour);
  *      curriedAddFour(1, 2, 3, 4); //=> 10
  */
-module.exports = _curry2(function uncurryN(depth, fn) {
-  return curryN(depth, function() {
+module.exports = _curry2(function uncurryMinMax(depth, fn) {
+  return curryMinMax(depth, Infinity, function() {
     var currentDepth = 1;
     var value = fn;
     var idx = 0;

--- a/src/useWith.js
+++ b/src/useWith.js
@@ -1,6 +1,5 @@
 var _slice = require('./internal/_slice');
-var arity = require('./arity');
-var curry = require('./curry');
+var curryMinMax = require('./curryMinMax');
 
 
 /**
@@ -66,14 +65,14 @@ var curry = require('./curry');
  *      //≅ addAll(double(10), square(5), R.identity(100));
  *      addDoubleAndSquare(10, 5, 100); //=> 145
  */
-module.exports = curry(function useWith(fn /*, transformers */) {
+module.exports = curryMinMax(1, Infinity, function useWith(fn /*, transformers */) {
   var transformers = _slice(arguments, 1);
   var tlen = transformers.length;
-  return curry(arity(tlen, function() {
+  return curryMinMax(tlen, Infinity, function() {
     var args = [], idx = -1;
     while (++idx < tlen) {
       args[idx] = transformers[idx](arguments[idx]);
     }
     return fn.apply(this, args.concat(_slice(arguments, tlen)));
-  }));
+  });
 });

--- a/src/wrap.js
+++ b/src/wrap.js
@@ -1,6 +1,6 @@
 var _concat = require('./internal/_concat');
 var _curry2 = require('./internal/_curry2');
-var curryN = require('./curryN');
+var curryMinMax = require('./curryMinMax');
 
 
 /**
@@ -29,7 +29,7 @@ var curryN = require('./curryN');
  *      shortenedGreet("Robert"); //=> "Hello Rob"
  */
 module.exports = _curry2(function wrap(fn, wrapper) {
-  return curryN(fn.length, function() {
+  return curryMinMax(fn.length, fn.length, function() {
     return wrapper.apply(this, _concat([fn], arguments));
   });
 });

--- a/test/curry.js
+++ b/test/curry.js
@@ -76,7 +76,7 @@ describe('curry', function() {
     assert.deepEqual(g(_, _, _)(1, _, _)(_, _)(2, _)(_)(3), [1, 2, 3]);
   });
 
-  it('forwards extra arguments', function() {
+  it('throws if given too many arguments', function() {
     var f = function(a, b, c) {
       void c;
       return Array.prototype.slice.call(arguments);
@@ -84,9 +84,22 @@ describe('curry', function() {
     var g = R.curry(f);
 
     assert.deepEqual(g(1, 2, 3), [1, 2, 3]);
-    assert.deepEqual(g(1, 2, 3, 4), [1, 2, 3, 4]);
-    assert.deepEqual(g(1, 2)(3, 4), [1, 2, 3, 4]);
-    assert.deepEqual(g(1)(2, 3, 4), [1, 2, 3, 4]);
-    assert.deepEqual(g(1)(2)(3, 4), [1, 2, 3, 4]);
+
+    assert.throws(function() { g(1, 2, 3, 4); }, R.both(
+      R.propEq('constructor', Error),
+      R.propEq('message', 'Too many arguments (expected at most 3; received 4)')
+    ));
+    assert.throws(function() { g(1)(2, 3, 4); }, R.both(
+      R.propEq('constructor', Error),
+      R.propEq('message', 'Too many arguments (expected at most 2; received 3)')
+    ));
+    assert.throws(function() { g(1, 2)(3, 4); }, R.both(
+      R.propEq('constructor', Error),
+      R.propEq('message', 'Too many arguments (expected at most 1; received 2)')
+    ));
+    assert.throws(function() { g(1)(2)(3, 4); }, R.both(
+      R.propEq('constructor', Error),
+      R.propEq('message', 'Too many arguments (expected at most 1; received 2)')
+    ));
   });
 });

--- a/test/curryMinMax.js
+++ b/test/curryMinMax.js
@@ -1,0 +1,91 @@
+var assert = require('assert');
+
+var R = require('..');
+
+
+describe('curryMinMax', function() {
+  function source(a, b, c, d) {
+    void d;
+    return a * b * c;
+  }
+  it('accepts an arity', function() {
+    var curried = R.curryMinMax(3, 3, source);
+    assert.strictEqual(curried(1)(2)(3), 6);
+    assert.strictEqual(curried(1, 2)(3), 6);
+    assert.strictEqual(curried(1)(2, 3), 6);
+    assert.strictEqual(curried(1, 2, 3), 6);
+  });
+
+  it('can be partially applied', function() {
+    var curry3 = R.curryMinMax(3, 3);
+    var curried = curry3(source);
+    assert.strictEqual(curried.length, 3);
+    assert.strictEqual(curried(1)(2)(3), 6);
+    assert.strictEqual(curried(1, 2)(3), 6);
+    assert.strictEqual(curried(1)(2, 3), 6);
+    assert.strictEqual(curried(1, 2, 3), 6);
+  });
+
+  it('preserves context', function() {
+    var ctx = {x: 10};
+    var f = function(a, b) { return a + b * this.x; };
+    var g = R.curryMinMax(2, 2, f);
+
+    assert.strictEqual(g.call(ctx, 2, 4), 42);
+    assert.strictEqual(g.call(ctx, 2).call(ctx, 4), 42);
+  });
+
+  it('supports R.__ placeholder', function() {
+    var f = function() { return Array.prototype.slice.call(arguments); };
+    var g = R.curryMinMax(3, 3, f);
+    var _ = R.__;
+
+    assert.deepEqual(g(1)(2)(3), [1, 2, 3]);
+    assert.deepEqual(g(1)(2, 3), [1, 2, 3]);
+    assert.deepEqual(g(1, 2)(3), [1, 2, 3]);
+    assert.deepEqual(g(1, 2, 3), [1, 2, 3]);
+
+    assert.deepEqual(g(_, 2, 3)(1), [1, 2, 3]);
+    assert.deepEqual(g(1, _, 3)(2), [1, 2, 3]);
+    assert.deepEqual(g(1, 2, _)(3), [1, 2, 3]);
+
+    assert.deepEqual(g(1, _, _)(2)(3), [1, 2, 3]);
+    assert.deepEqual(g(_, 2, _)(1)(3), [1, 2, 3]);
+    assert.deepEqual(g(_, _, 3)(1)(2), [1, 2, 3]);
+
+    assert.deepEqual(g(1, _, _)(2, 3), [1, 2, 3]);
+    assert.deepEqual(g(_, 2, _)(1, 3), [1, 2, 3]);
+    assert.deepEqual(g(_, _, 3)(1, 2), [1, 2, 3]);
+
+    assert.deepEqual(g(1, _, _)(_, 3)(2), [1, 2, 3]);
+    assert.deepEqual(g(_, 2, _)(_, 3)(1), [1, 2, 3]);
+    assert.deepEqual(g(_, _, 3)(_, 2)(1), [1, 2, 3]);
+
+    assert.deepEqual(g(_, _, _)(_, _)(_)(1, 2, 3), [1, 2, 3]);
+    assert.deepEqual(g(_, _, _)(1, _, _)(_, _)(2, _)(_)(3), [1, 2, 3]);
+  });
+
+  it('forwards up to `max` arguments', function() {
+    var f = function() { return Array.prototype.slice.call(arguments); };
+    var g = R.curryMinMax(3, Infinity, f);
+    var h = R.curryMinMax(2, 3, f);
+
+    assert.deepEqual(g(1, 2, 3), [1, 2, 3]);
+    assert.deepEqual(g(1, 2, 3, 4), [1, 2, 3, 4]);
+    assert.deepEqual(g(1, 2)(3, 4), [1, 2, 3, 4]);
+    assert.deepEqual(g(1)(2, 3, 4), [1, 2, 3, 4]);
+    assert.deepEqual(g(1)(2)(3, 4), [1, 2, 3, 4]);
+
+    assert.deepEqual(h(1, 2), [1, 2]);
+    assert.deepEqual(h(1, 2, 3), [1, 2, 3]);
+
+    assert.throws(function() { h(1, 2, 3, 4); }, R.both(
+      R.propEq('constructor', Error),
+      R.propEq('message', 'Too many arguments (expected at most 3; received 4)')
+    ));
+    assert.throws(function() { h(1)(2, 3, 4); }, R.both(
+      R.propEq('constructor', Error),
+      R.propEq('message', 'Too many arguments (expected at most 2; received 3)')
+    ));
+  });
+});


### PR DESCRIPTION
As suggested in https://github.com/ramda/ramda/issues/1107#issuecomment-106011338

Should we deprecate `R.curryN` rather than removing it? It would be confusing to have both `R.curryN` and `R.curryMinMax` for one release, but perhaps it would make upgrades smoother for some users.

If we decide to merge this pull request, we should consider renaming `R.uncurryN`. `R.uncurry` may be a better name.
