### PR TITLE
Make `R.evolve` recursive/deep

### DIFF
--- a/src/evolve.js
+++ b/src/evolve.js
@@ -1,11 +1,12 @@
 var _curry2 = require('./internal/_curry2');
-var _extend = require('./internal/_extend');
-var mapObjIndexed = require('./mapObjIndexed');
 
 
 /**
- * Creates a new object by evolving a shallow copy of `object`, according to the
- * `transformation` functions.  All non-primitive properties are copied by reference.
+ * Creates a new object by recursively evolving a shallow copy of `object`, according to the
+ * `transformation` functions. All non-primitive properties are copied by reference.
+ *
+ * A `tranformation` function will not be invoked if its corresponding key does not exist in
+ * the evolved object.
  *
  * @func
  * @memberOf R
@@ -17,10 +18,22 @@ var mapObjIndexed = require('./mapObjIndexed');
  * @return {Object} The transformed object.
  * @example
  *
- *      R.evolve({ elapsed: R.add(1), remaining: R.add(-1) }, { name: 'Tomato', elapsed: 100, remaining: 1400 }); //=> { name: 'Tomato', elapsed: 101, remaining: 1399 }
+ *      var tomato  = {firstName: '  Tomato ', elapsed: 100, remaining: 1400};
+ *      var transformations = {
+ *        firstName: R.trim,
+ *        lastName: R.trim, // Will not get invoked.
+ *        data: {elapsed: R.add(1), remaining: R.add(-1)}
+ *      };
+ *      R.evolve(transformations, tomato); //=> {firstName: 'Tomato', data: {elapsed: 101, remaining: 1399}}
  */
 module.exports = _curry2(function evolve(transformations, object) {
-  return _extend(_extend({}, object), mapObjIndexed(function(fn, key) {
-    return fn(object[key]);
-  }, transformations));
+  var transformation, key, type, result = {};
+  for (key in object) {
+    transformation = transformations[key];
+    type = typeof transformation;
+    result[key] = type === 'function' ? transformation(object[key])
+                : type === 'object'   ? evolve(transformations[key], object[key])
+                                      : object[key];
+  }
+  return result;
 });

--- a/test/evolve.js
+++ b/test/evolve.js
@@ -11,18 +11,26 @@ describe('evolve', function() {
     assert.deepEqual(R.evolve(transf, object), expected);
   });
 
-  it('invokes function with undefined if object does not contain the key', function() {
-    var transf   = {wow: String};
-    var object   = {};
-    var expected = {wow: 'undefined'};
+  it('does not invoke function if object does not contain the key', function() {
+    var transf   = {n: R.add(1), m: R.add(1)};
+    var object   = {m: 3};
+    var expected = {m: 4};
     assert.deepEqual(R.evolve(transf, object), expected);
   });
 
   it('is not destructive', function() {
     var transf   = {elapsed: R.add(1), remaining: R.add(-1)};
     var object   = {name: 'Tomato', elapsed: 100, remaining: 1400};
+    var expected = {name: 'Tomato', elapsed: 100, remaining: 1400};
     R.evolve(transf, object);
-    assert.deepEqual(object, {name: 'Tomato', elapsed: 100, remaining: 1400});
+    assert.deepEqual(object, expected);
+  });
+
+  it('is recursive', function() {
+    var transf   = {nested: {second: R.add(-1), third: R.add(1)}};
+    var object   = {first: 1, nested: {second: 2, third: 3}};
+    var expected = {first: 1, nested: {second: 1, third: 4}};
+    assert.deepEqual(R.evolve(transf, object), expected);
   });
 
   it('is curried', function() {


### PR DESCRIPTION
This PR makes `R.evolve` recurse into nested objects if one is present in both the object to evolve and the object of transformation functions.

Short example:

```javascript
R.evolve({nested: {object: R.add(1)}}, {nested: {object: 1}}); //=> {nested: {object: 2}}
```

This PR also changes the behavior of `R.evolve` when a transformation function exists for a property that does not exist on the object to evolve. Currently the transformation function is invoked with `undefined` and a new key is created on the returned object. New behavior is simply to not invoke the transformation function. I've decided to do that for the following reasons:

1. `evolve` is a function for modifying properties. To me it seems unexpected that it in some cases will also add new properties. I.e. not only modify existing properties but also change the shape of the object.
2. Passing `undefined` to a function otherwise used to update an existing property will rarely result in something desirable. Most often it will give broken data or runtime errors.
`R.evolve({amount: R.add(1)}, {}); //=> {amount: NaN}`
`R.evolve({name: R.toUpper}, {}); //=> Throws "TypeError: n is undefined"`
The transformation function would pretty much have to special case on `undefined`.
3. It makes `evolve` much more useful when dealing with objects of different shapes. I can do stuff like `R.map(R.evolve({name: R.toUpper}), list)` even if some items in `list` does not have a `name` property.
4. Ramda has other functions if one wants to add new properties to an object (`R.set` can be used for things like supplying defaults).
4. As an added benefit it makes the implementation simpler and more efficient since we'll only have to loop over the object to transform and not over the object of functions.

This is a breaking change. But I'd say it's a very low risk one. The old behavior was undocumented and quite odd. I doubt that many people depends on it. This PR documents the new behavior both in the description of `evolve` and in the provided example. The recursiveness is of course documented as well.