### PR TITLE
R.uniq implementation to use Set if available

### DIFF
--- a/src/uniq.js
+++ b/src/uniq.js
@@ -1,3 +1,5 @@
+var _contains = require('./internal/_contains');
+var _curry1 = require('./internal/_curry1');
 var equals = require('./equals');
 var uniqWith = require('./uniqWith');
 
@@ -18,4 +20,39 @@ var uniqWith = require('./uniqWith');
  *      R.uniq([1, '1']);     //=> [1, '1']
  *      R.uniq([[42], [42]]); //=> [[42]]
  */
-module.exports = uniqWith(equals);
+module.exports = (function() {
+  /**
+   * Uses a native `Set` instance where possible for
+   * removing duplicate items. Items that implement
+   * the fantasy-land Setoid spec fallback to using
+   * `_contains` to support custom equality behaviour.
+   */
+  function uniq(list) {
+    /* global Set */
+    var item,
+        set = new Set(),
+        idx = -1,
+        len = list.length,
+        items = [],
+        uniqs = [];
+
+    while (++idx < len) {
+      item = list[idx];
+      // `_contains` is also used to differentiate between
+      // +0 and -0, as the native Set does not.
+      if (item === 0 || (item != null && typeof item.equals === 'function')) {
+        if (!_contains(item, items)) {
+          items.push(item);
+          uniqs.push(item);
+        }
+      } else {
+        if (set.size !== set.add(item).size) {
+          uniqs.push(item);
+        }
+      }
+    }
+    return uniqs;
+  }
+
+  return typeof Set !== 'function' ? uniqWith(equals) : _curry1(uniq);
+})();

--- a/test/uniq.js
+++ b/test/uniq.js
@@ -27,4 +27,8 @@ describe('uniq', function() {
     assert.strictEqual(R.uniq([NaN, NaN]).length, 1);
     assert.strictEqual(R.uniq([new Just([42]), new Just([42])]).length, 1);
   });
+
+  it('handles null and undefined elements', function() {
+    assert.deepEqual(R.uniq([void 0, null, void 0, null]), [void 0, null]);
+  });
 });


### PR DESCRIPTION
Implementation for https://github.com/ramda/ramda/issues/1077

Below is a simple benchmark (take with a grain of salt) of the time taken to run `R.uniq` 100 times, comparing master branch with the branch of this PR.

When called with `R.flatten(R.repeat([{}, 0, new Just(5)], size))` (many dupes):

branch | time (ms) for 1000 items | time (ms) for 10000 items
--------- | -------------- | ---------------
master | 700 | 7000
uniq-set | 600 | 5900

When called with `R.map(function (x) { return x(); }, R.repeat(function () { return {}; }, size))` (no dupes):

branch | time (ms) for 10000 items | time (ms) for 100000 items
--------- | -------------- | ---------------
master | 750 | 7500
uniq-set | 75 | 1700

ping @asaf-romano