### PR TITLE
put build instructions lost in CONTRIBUTING.md to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,12 @@ These script tags add the variable `ramda` on the browser's global scope.
 
 Or you can inject ramda into virtually any unsuspecting website using [the bookmarklet](BOOKMARKLET.md).
 
-### Partial Builds
+### Build
+
+* on Unix-based platforms, `npm run build` updates __dist/ramda.js__ and __dist/ramda.min.js__
+* on Windows, write the output of `scripts/build --complete` to a temporary file, then rename the temporary file __dist/ramda.js__.
+
+#### Partial Builds
 
 It is possible to build Ramda with a subset of the functionality to reduce its file size. Ramda's build system supports this with command line flags. For example if you're using `R.compose`, `R.reduce`, and `R.filter` you can create a partial build with:
 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "bench": "scripts/benchRunner",
     "browserify": "node_modules/browserify/bin/cmd.js test/*.js --outfile lib/test/bundle.js",
     "bookmarklet": "scripts/bookmarklet",
+    "build": "make && make dist/ramda.min.js",
     "clean": "rimraf dist",
     "jscs": "jscs scripts/bookmarklet scripts/build **/*.js **/**/*.js",
     "jshint": "jshint scripts/bookmarklet scripts/build **/*.js **/**/*.js",


### PR DESCRIPTION
In fresh master `mocha` throwed, `R.addIndex` was missing because __dist/ramda.js__ was outdated. So i was searching for info on updating the build and only could find it here: https://github.com/ramda/ramda/pull/899