### PR TITLE
deprecate R.invoker

### DIFF
--- a/src/invoker.js
+++ b/src/invoker.js
@@ -18,6 +18,7 @@ var curryN = require('./curryN');
  *        before the target object.
  * @param {Function} method Name of the method to call.
  * @return {Function} A new curried function.
+ * @deprecated since v0.15.0
  * @example
  *
  *      var sliceFrom = R.invoker(1, 'slice');


### PR DESCRIPTION
We needn't provide both [`R.invoke`][1] and [`R.invoker`][2]: these functions have similar roles (despite having very different types).


[1]: http://ramdajs.com/docs/#invoke
[2]: http://ramdajs.com/docs/#invoker
