### PR TITLE
Remove support for supplying initial arguments to `R.invoker`

### DIFF
--- a/src/invoker.js
+++ b/src/invoker.js
@@ -1,5 +1,5 @@
+var _curry2 = require('./internal/_curry2');
 var _slice = require('./internal/_slice');
-var curry = require('./curry');
 var curryN = require('./curryN');
 
 
@@ -7,14 +7,14 @@ var curryN = require('./curryN');
  * Turns a named method with a specified arity into a function
  * that can be called directly supplied with arguments and a target object.
  *
- * The returned function is curried and accepts `len + 1` parameters where
+ * The returned function is curried and accepts `arity + 1` parameters where
  * the final parameter is the target object.
  *
  * @func
  * @memberOf R
  * @category Function
- * @sig (Number, String) -> (a... -> c -> b)
- * @param {Number} len Number of arguments the returned function should take
+ * @sig Number -> String -> (a -> b -> ... -> n -> Object -> *)
+ * @param {Number} arity Number of arguments the returned function should take
  *        before the target object.
  * @param {Function} method Name of the method to call.
  * @return {Function} A new curried function.
@@ -22,15 +22,12 @@ var curryN = require('./curryN');
  *
  *      var sliceFrom = R.invoker(1, 'slice');
  *      sliceFrom(6, 'abcdefghijklm'); //=> 'ghijklm'
- *      var sliceFrom6 = R.invoker(2, 'slice', 6);
+ *      var sliceFrom6 = R.invoker(2, 'slice')(6);
  *      sliceFrom6(8, 'abcdefghijklm'); //=> 'gh'
  */
-module.exports = curry(function invoker(arity, method) {
-  var initialArgs = _slice(arguments, 2);
-  var len = arity - initialArgs.length;
-  return curryN(len + 1, function() {
-    var target = arguments[len];
-    var args = initialArgs.concat(_slice(arguments, 0, len));
-    return target[method].apply(target, args);
+module.exports = _curry2(function invoker(arity, method) {
+  return curryN(arity + 1, function() {
+    var target = arguments[arity];
+    return target[method].apply(target, _slice(arguments, 0, arity));
   });
 });

--- a/test/invoker.js
+++ b/test/invoker.js
@@ -19,12 +19,4 @@ describe('invoker', function() {
     assert.deepEqual(concat2(3, 4)([1, 2]), [1, 2, 3, 4]);
     assert.deepEqual(concat2(3)(4, [1, 2]), [1, 2, 3, 4]);
   });
-
-  it('returns a function with correct arity when additional parameters are given', function() {
-    assert.strictEqual(R.invoker(2, 'concat', 'foo').length, 2);
-  });
-
-  it('applies additional parameters to the method', function() {
-    assert.deepEqual(R.invoker(2, 'concat', 2)(3, [1]), [1, 2, 3]);
-  });
 });


### PR DESCRIPTION
This makes `R.invoker` invariant. Which simplifies the implementation and makes the signature comprehensive/correct.

This is a breaking change. But the feature was only half documented before and the upgrade path is straight forward: `R.invoker(2, 'slice', 6)` to `R.invoker(2, 'slice')(6)`.

I think the current behavior has it's benefits. But in the end I think it does more harm than good.