### PR TITLE
Deprecate `update`

### DIFF
--- a/src/update.js
+++ b/src/update.js
@@ -14,6 +14,7 @@ var always = require('./always');
  * @param {*} x The value to exist at the given index of the returned array.
  * @param {Array|Arguments} list The source array-like object to be updated.
  * @return {Array} A copy of `list` with the value at index `idx` replaced with `x`.
+ * @deprecated since v0.15.0
  * @example
  *
  *      R.update(1, 11, [0, 1, 2]);     //=> [0, 11, 2]


### PR DESCRIPTION
`R.update` is just `R.adjust` with an `R.always` on the first parameter. It seems quite unnecessary and [confusing](https://github.com/ramda/ramda/issues/1133#issuecomment-106910074).

I originally found `update` and didn't think there'd be another function this similar to it so I wrongly assumed only the more limited `update` existed. Probably because it seems to me like Ramda generally does not supply functions that are just an `always` away.