### PR TITLE
Simplify curryN

### DIFF
--- a/src/curryN.js
+++ b/src/curryN.js
@@ -1,5 +1,5 @@
 var _curry2 = require('./internal/_curry2');
-var _slice = require('./internal/_slice');
+var _curryN = require('./internal/_curryN');
 var arity = require('./arity');
 
 
@@ -47,43 +47,5 @@ var arity = require('./arity');
  *      g(4); //=> 10
  */
 module.exports = _curry2(function curryN(length, fn) {
-  return arity(length, function() {
-    var n = arguments.length;
-    var shortfall = length - n;
-    var idx = n - 1;
-    while (idx >= 0) {
-      if (arguments[idx] != null &&
-          arguments[idx]['@@functional/placeholder'] === true) {
-        shortfall += 1;
-      }
-      idx -= 1;
-    }
-    if (shortfall <= 0) {
-      return fn.apply(this, arguments);
-    } else {
-      var initialArgs = _slice(arguments);
-      return curryN(shortfall, function() {
-        var currentArgs = _slice(arguments);
-        var combinedArgs = [];
-        var idx = 0;
-        var currentArgsIdx = 0;
-        while (idx < n) {
-          var val = initialArgs[idx];
-          if (val != null && val['@@functional/placeholder'] === true) {
-            combinedArgs[idx] = currentArgs[currentArgsIdx];
-            currentArgsIdx += 1;
-          } else {
-            combinedArgs[idx] = val;
-          }
-          idx += 1;
-        }
-        while (currentArgsIdx < currentArgs.length) {
-          combinedArgs[idx] = currentArgs[currentArgsIdx];
-          idx += 1;
-          currentArgsIdx += 1;
-        }
-        return fn.apply(this, combinedArgs);
-      });
-    }
-  });
+  return arity(length, _curryN(length, [], fn));
 });

--- a/src/internal/_curryN.js
+++ b/src/internal/_curryN.js
@@ -1,0 +1,38 @@
+var arity = require('../arity');
+
+
+/**
+ * Internal curryN function.
+ *
+ * @private
+ * @category Function
+ * @param {Number} length The arity of the curried function.
+ * @return {array} An array of arguments received thus far.
+ * @param {Function} fn The function to curry.
+ */
+module.exports = function _curryN(length, received, fn) {
+  return function() {
+    var combined = [];
+    var argsIdx = 0;
+    var left = length;
+    var combinedIdx = 0;
+    while (combinedIdx < received.length || argsIdx < arguments.length) {
+      var result;
+      if (combinedIdx < received.length &&
+          (received[combinedIdx] == null ||
+           received[combinedIdx]['@@functional/placeholder'] !== true ||
+           argsIdx >= arguments.length)) {
+        result = received[combinedIdx];
+      } else {
+        result = arguments[argsIdx];
+        argsIdx += 1;
+      }
+      combined[combinedIdx] = result;
+      if (result == null || result['@@functional/placeholder'] !== true) {
+        left -= 1;
+      }
+      combinedIdx += 1;
+    }
+    return left <= 0 ? fn.apply(this, combined) : arity(left, _curryN(length, combined, fn));
+  };
+};


### PR DESCRIPTION
I've always felt that there was something off with `R.curryN` but my last stab at it resulted in only minor modifications.

This PR introduces an internal `_curryN` as a base for the external `curryN`. The internal function has a slightly different signature. The new internal function is half the size of the old `curryN` and completely avoids using `_slice`.

I've also used `for` loops just to provocate. I think the idea of always using `while` loops is silly. It's like always using `reduce` and forbidding `map`. And the kind of "consistency" that is achieved by doing so is just as harmful. Code becomes less expressive and harder to read and understand because you're using a more general construct when a more specific one would capture the desired control flow better. 

Here is the new `_curryN` written with while loops:

```javascript
module.exports = function _curryN(length, recieved, fn) {
  return function() {
    var combined = [];
    var combinedIdx = -1; // What! Minus one? But that's not really where we begin indexing
    var argsIdx = 0;
    var left = length;
    while (++combinedIdx < recieved.length) { // Stuffing increment and condition check into one statement :( :( :(
      var val = recieved[combinedIdx];
      combined[combinedIdx] = val === __ && argsIdx < arguments.length ? arguments[argsIdx++] : val;
      if (combined[combinedIdx] !== __) { --left; }
    }
    while (argsIdx < arguments.length) {
      combined[combinedIdx] = arguments[argsIdx];
      if (combined[combinedIdx] !== __) { --left; }
      combinedIdx++; argsIdx++; // Huh!? For-loops have a well defined location for such increments
    }
    return left <= 0 ? fn.apply(this, combined) : arity(left, _curryN(length, combined, fn));
  };
});
```

I will change this PR to use `while` loops if requested to do so :)