### PR TITLE
Improve the performance of curryN/curry

### DIFF
--- a/src/curryN.js
+++ b/src/curryN.js
@@ -1,4 +1,5 @@
 var _arity = require('./internal/_arity');
+var _curry1 = require('./internal/_curry1');
 var _curry2 = require('./internal/_curry2');
 var _curryN = require('./internal/_curryN');
 
@@ -47,5 +48,8 @@ var _curryN = require('./internal/_curryN');
  *      g(4); //=> 10
  */
 module.exports = _curry2(function curryN(length, fn) {
+  if (length === 1) {
+    return _curry1(fn);
+  }
   return _arity(length, _curryN(length, [], fn));
 });

--- a/src/internal/_curry1.js
+++ b/src/internal/_curry1.js
@@ -13,7 +13,7 @@ module.exports = function _curry1(fn) {
     } else if (a != null && a['@@functional/placeholder'] === true) {
       return f1;
     } else {
-      return fn(a);
+      return fn.apply(this, arguments);
     }
   };
 };


### PR DESCRIPTION
We can improve the performance of `curryN`/`curry` with `_curry1`. Let's look at the performance.

Before:

curry | Count | Hertz
-------|----------|---------
_x4(100) | 592421 | 9868550.23950353 
mult4(100) | 152955 | 2609371.9307046887
manual(100) | 4406550 | 76401537.32172365

After:

curry | Count | Hertz
-------|----------|---------
_x4(100) | 628122 | 11911507.368938653 
mult4(100) | 226094 | 4277420.856223587 
manual(100) | 4400142 | 82213774.10192372

Also, I try to use `_curry2` and `_curry3` to improve the performance. But I found that we have to modify `_curry2` and `curry3` in order to pass test case, and those modifications will slow down `_curry2` and `_curry3` a lot.

