### PR TITLE
Adds stderr logging to `scripts/build`

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -2,7 +2,6 @@
 
 'use strict';
 
-var assert = require('assert');
 var fs = require('fs');
 var path = require('path');
 
@@ -21,10 +20,20 @@ var template = fs.readFileSync(path.join(__dirname, 'template.js'),
 //  version :: String
 var version = require('../package.json').version;
 
-//  $pathEq = [String] -> a -> Object -> ()
-var $pathEq = R.curry(function(path, expected, obj) {
-  assert.strictEqual(R.path(path, obj), expected);
+//  logWithPrefix = String -> String -> ()
+var logWithPrefix = R.curry(function(prefix, message) {
+  process.stderr.write(prefix + message + '\n');
 });
+
+//  warn :: String -> ()
+var warn = logWithPrefix('\u001b[33m>>> WARNING: \u001b[39;49m');
+
+//  abort :: String -> !
+var abort = R.pipe(
+  logWithPrefix('\u001b[31m>>> ERROR: \u001b[39;49m'),
+  R.always(1),
+  process.exit
+);
 
 //  filenameToIdentifier :: String -> String
 var filenameToIdentifier = R.partialRight(path.basename, '.js');
@@ -43,6 +52,8 @@ var parse = R.memoize(function(filename) {
   return {
     ast: acorn.parse(fs.readFileSync(filename), {
       ranges: true,
+      locations: true,
+      sourceFile: filename,
       onComment: comments,
       onToken: tokens
     }),
@@ -50,6 +61,96 @@ var parse = R.memoize(function(filename) {
     tokens: tokens
   };
 });
+
+//  isModuleExportsExpr :: {*} -> Boolean
+var isModuleExportsExpr = R.allPass([
+  R.pathEq(['type'], 'ExpressionStatement'),
+  R.pathEq(['expression', 'type'], 'AssignmentExpression'),
+  R.pathEq(['expression', 'operator'], '='),
+  R.pathEq(['expression', 'left', 'type'], 'MemberExpression'),
+  R.pathEq(['expression', 'left', 'object', 'type'], 'Identifier'),
+  R.pathEq(['expression', 'left', 'object', 'name'], 'module'),
+  R.pathEq(['expression', 'left', 'property', 'type'], 'Identifier'),
+  R.pathEq(['expression', 'left', 'property', 'name'], 'exports')
+]);
+
+//  isRequireExpr :: {*} -> Boolean
+var isRequireExpr = R.allPass([
+  R.pathEq(['init', 'type'], 'CallExpression'),
+  R.pathEq(['init', 'callee', 'type'], 'Identifier'),
+  R.pathEq(['init', 'callee', 'name'], 'require'),
+  R.pathEq(['init', 'arguments', 'length'], 1),
+  R.pathEq(['init', 'arguments', '0', 'type'], 'Literal')
+]);
+
+//  warnIgnoredTopLevel :: {*} -> {*}
+var warnIgnoredTopLevel = R.tap(R.pipe(
+  R.chain(R.ifElse(R.propEq('type', 'VariableDeclaration'),
+                   R.prop('declarations'),
+                   R.of)),
+  R.reject(R.either(isModuleExportsExpr, isRequireExpr)),
+  R.map(function(ast) {
+    return 'Top-level declaration `' + ast.id.name +
+      '` ignored in ' + ast.loc.source + ':' + ast.loc.start.line;
+  }),
+  R.forEach(warn)
+));
+
+//  abortIfNotSorted :: List[{*}] -> List[{*}]
+var abortIfNotSorted = R.tap(R.cond([
+    R.complement(R.pipe(
+      R.pluck('id'),
+      R.pluck('name'),
+      R.converge(R.eqDeep, R.identity, R.sortBy(R.identity))
+    )),
+    R.pipe(
+      R.path(['0', 'loc', 'source']),
+      R.concat('Dependencies not declared in alphabetical order in '),
+      abort
+    )
+  ])
+);
+
+//  abortIfExportNotLast :: {*} -> {*}
+var abortIfExportNotLast = R.tap(R.cond([
+  R.complement(R.pipe(R.prop('body'), R.last, isModuleExportsExpr)),
+  R.pipe(
+    R.path(['loc', 'source']),
+    R.concat('module.exports not positioned last in '),
+    abort
+  )
+]));
+
+//  abortIfDifferentRequireVar :: {*} -> {*}
+var abortIfDifferentRequireVar = R.tap(R.forEach(R.cond([
+  R.converge(
+    R.complement(R.eq),
+    R.path(['id', 'name']),
+    R.pipe(
+      R.path(['init', 'arguments', '0', 'value']),
+      R.replace(/^[.][/]internal[/]/, './'),
+      R.replace(/^[.]{1,2}[/]/, ''),
+      R.replace(/[.]([a-z])/g, R.pipe(R.nthArg(1), R.toUpper))
+    )
+  ),
+  function(ast) {
+    abort('Dependency declared with different variable name: `' +
+      ast.id.name + '` & `' +
+      ast.init.arguments[0].value +
+      '` in ' + ast.loc.source
+    );
+  }
+])));
+
+//  abortIfEmptyBody :: {*} -> {*}
+var abortIfEmptyBody = R.tap(R.cond([
+  R.pipe(R.prop('body'), R.isEmpty),
+  R.pipe(
+    R.path(['loc', 'source']),
+    R.concat('Nothing parsable in '),
+    abort
+  )
+]));
 
 // dependenciesOf :: String -> [String]
 //
@@ -73,31 +174,14 @@ R.pipe(identifierToFilename,
        parse,
        R.prop('ast'),
        R.prop('body'),
-       R.takeWhile(R.where({type: 'VariableDeclaration', kind: 'var'})),
-       R.pluck('declarations'),
-       R.map(R.tap($pathEq(['length'], 1))),
+       warnIgnoredTopLevel,
+       R.takeWhile(R.both(R.propEq('type', 'VariableDeclaration'),
+                          R.pipe(R.prop('declarations'),
+                                 R.all(isRequireExpr)))),
+  R.pluck('declarations'),
        R.map(R.head),
-       R.map(R.tap($pathEq(['init', 'type'], 'CallExpression'))),
-       R.map(R.tap($pathEq(['init', 'callee', 'type'], 'Identifier'))),
-       R.map(R.tap($pathEq(['init', 'callee', 'name'], 'require'))),
-       R.map(R.tap($pathEq(['init', 'arguments', 'length'], 1))),
-       R.map(R.tap($pathEq(['init', 'arguments', '0', 'type'], 'Literal'))),
-       R.tap(R.pipe(R.pluck('id'),
-                    R.pluck('name'),
-                    R.converge(assert.deepEqual,
-                               R.identity,
-                               R.sortBy(R.identity)))),
-       R.map(R.tap(R.converge(assert.strictEqual,
-                              R.path(['id', 'name']),
-                              R.pipe(R.path(['init',
-                                             'arguments',
-                                             '0',
-                                             'value']),
-                                     R.replace(/^[.][/]internal[/]/, './'),
-                                     R.replace(/^[.]{1,2}[/]/, ''),
-                                     R.replace(/[.]([a-z])/g,
-                                               R.pipe(R.nthArg(1),
-                                                      R.toUpper)))))),
+       abortIfNotSorted,
+       abortIfDifferentRequireVar,
        R.map(R.path(['id', 'name'])));
 
 //  createDependencyGraph :: [String] -> StrMap [String]
@@ -131,16 +215,9 @@ var orderDependencies = function orderDependencies(graph) {
 var getModifiedSource = function getModifiedSource(identifier) {
   var obj = parse(identifierToFilename(identifier));
   escodegen.attachComments(obj.ast, obj.comments, obj.tokens);
-  assert.notStrictEqual(obj.ast.body.length, 0);
+  abortIfEmptyBody(obj.ast);
+  abortIfExportNotLast(obj.ast);
   var last = R.last(obj.ast.body);
-  $pathEq(['type'], 'ExpressionStatement', last);
-  $pathEq(['expression', 'type'], 'AssignmentExpression', last);
-  $pathEq(['expression', 'operator'], '=', last);
-  $pathEq(['expression', 'left', 'type'], 'MemberExpression', last);
-  $pathEq(['expression', 'left', 'object', 'type'], 'Identifier', last);
-  $pathEq(['expression', 'left', 'object', 'name'], 'module', last);
-  $pathEq(['expression', 'left', 'property', 'type'], 'Identifier', last);
-  $pathEq(['expression', 'left', 'property', 'name'], 'exports', last);
   var declarationAst = {
     type: 'VariableDeclaration',
     kind: 'var',


### PR DESCRIPTION
This change adds logging messages for some of the various error scenarios in the build script that were previously handled with `assert`s.

Some examples:
```
>>> ERROR: Dependency declared with different variable name: `equal` & `./equals` in /Users/Scott/build/ramda/src/uniq.js
```
```
>>> ERROR: Dependencies not declared in alphabetical order in /Users/Scott/build/ramda/src/uniq.js
```
```
>>> ERROR: module.exports not positioned last in /Users/Scott/build/ramda/src/uniq.js
```
```
>>> WARNING: Top-level declaration `foo` ignored in /Users/Scott/build/ramda/src/uniq.js:23
```

The logic of the build script itself should not have changed.
```
> git checkout build-logging && scripts/build --complete > build-logging.js
> git checkout master && scripts/build --complete > master.js
> diff master.js build-logging.js | wc -l
0
```