### PR TITLE
lint: replace uses of ++ and -- operators

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -6,6 +6,7 @@
     "Symbol": true
   },
   "newcap": false,
+  "plusplus": true,
   "predef": ["beforeEach", "console", "define", "describe", "it", "module", "process", "require"],
   "undef": true,
   "unused": true

--- a/lib/sauce/ie8-shim.js
+++ b/lib/sauce/ie8-shim.js
@@ -26,7 +26,7 @@ if (typeof document.getElementsByClassName !== 'function') {
     } else {
       var rightClass = new RegExp('(^| )' + className + '( |$)');
       seek = document.getElementsByTagName(tag);
-      for (i = 0; i < seek.length; i++) {
+      for (i = 0; i < seek.length; i += 1) {
         if (rightClass.test((node = seek[i]).className)) {
           result.push(seek[i]);
         }

--- a/src/addIndex.js
+++ b/src/addIndex.js
@@ -29,10 +29,14 @@ var curryN = require('./curryN');
  */
 module.exports = _curry1(function(fn) {
   return curryN(fn.length, function() {
-    var idx = -1;
+    var idx = 0;
     var origFn = arguments[0];
     var list = arguments[arguments.length - 1];
-    var indexedFn = function() {return origFn.apply(this, _concat(arguments, [++idx, list]));};
+    var indexedFn = function() {
+      var result = origFn.apply(this, _concat(arguments, [idx, list]));
+      idx += 1;
+      return result;
+    };
 
     return fn.apply(this, _prepend(indexedFn, _slice(arguments, 1)));
   });

--- a/src/aperture.js
+++ b/src/aperture.js
@@ -19,11 +19,12 @@ var _slice = require('./internal/_slice');
  *      R.aperture(7, [1, 2, 3, 4, 5]); //=> []
  */
 module.exports = _curry2(function aperture(n, list) {
-  var idx = -1;
+  var idx = 0;
   var limit = list.length - (n - 1);
   var acc = new Array(limit >= 0 ? limit : 0);
-  while (++idx < limit) {
+  while (idx < limit) {
     acc[idx] = _slice(list, idx, idx + n);
+    idx += 1;
   }
   return acc;
 });

--- a/src/composeL.js
+++ b/src/composeL.js
@@ -28,10 +28,11 @@ var _composeL = require('./internal/_composeL');
  *      secondOfXOfHeadLens.set(123, source); //=> [{x: [0, 123], y: [2, 3]}, {x: [4, 5], y: [6, 7]}]
  */
 module.exports = function() {
-  var idx = arguments.length - 1;
-  var fn = arguments[idx];
-  while (--idx >= 0) {
+  var fn = arguments[arguments.length - 1];
+  var idx = arguments.length - 2;
+  while (idx >= 0) {
     fn = _composeL(arguments[idx], fn);
+    idx -= 1;
   }
   return fn;
 };

--- a/src/cond.js
+++ b/src/cond.js
@@ -26,11 +26,12 @@
 module.exports = function cond() {
   var pairs = arguments;
   return function() {
-    var idx = -1;
-    while (++idx < pairs.length) {
+    var idx = 0;
+    while (idx < pairs.length) {
       if (pairs[idx][0].apply(this, arguments)) {
         return pairs[idx][1].apply(this, arguments);
       }
+      idx += 1;
     }
   };
 };

--- a/src/countBy.js
+++ b/src/countBy.js
@@ -26,10 +26,11 @@ var _has = require('./internal/_has');
 module.exports = _curry2(function countBy(fn, list) {
   var counts = {};
   var len = list.length;
-  var idx = -1;
-  while (++idx < len) {
+  var idx = 0;
+  while (idx < len) {
     var key = fn(list[idx]);
     counts[key] = (_has(key, counts) ? counts[key] : 0) + 1;
+    idx += 1;
   }
   return counts;
 });

--- a/src/curryN.js
+++ b/src/curryN.js
@@ -51,11 +51,12 @@ module.exports = _curry2(function curryN(length, fn) {
   return arity(length, function() {
     var n = arguments.length;
     var shortfall = length - n;
-    var idx = n;
-    while (--idx >= 0) {
+    var idx = n - 1;
+    while (idx >= 0) {
       if (arguments[idx] === __) {
         shortfall += 1;
       }
+      idx -= 1;
     }
     if (shortfall <= 0) {
       return fn.apply(this, arguments);
@@ -64,14 +65,22 @@ module.exports = _curry2(function curryN(length, fn) {
       return curryN(shortfall, function() {
         var currentArgs = _slice(arguments);
         var combinedArgs = [];
-        var idx = -1;
+        var idx = 0;
         var currentArgsIdx = 0;
-        while (++idx < n) {
+        while (idx < n) {
           var val = initialArgs[idx];
-          combinedArgs[idx] = (val === __ ? currentArgs[currentArgsIdx++] : val);
+          if (val === __) {
+            combinedArgs[idx] = currentArgs[currentArgsIdx];
+            currentArgsIdx += 1;
+          } else {
+            combinedArgs[idx] = val;
+          }
+          idx += 1;
         }
         while (currentArgsIdx < currentArgs.length) {
-          combinedArgs[idx++] = currentArgs[currentArgsIdx++];
+          combinedArgs[idx] = currentArgs[currentArgsIdx];
+          idx += 1;
+          currentArgsIdx += 1;
         }
         return fn.apply(this, combinedArgs);
       });

--- a/src/difference.js
+++ b/src/difference.js
@@ -20,12 +20,13 @@ var _curry2 = require('./internal/_curry2');
  */
 module.exports = _curry2(function difference(first, second) {
   var out = [];
-  var idx = -1;
+  var idx = 0;
   var firstLen = first.length;
-  while (++idx < firstLen) {
+  while (idx < firstLen) {
     if (!_contains(first[idx], second) && !_contains(first[idx], out)) {
       out[out.length] = first[idx];
     }
+    idx += 1;
   }
   return out;
 });

--- a/src/differenceWith.js
+++ b/src/differenceWith.js
@@ -25,13 +25,14 @@ var containsWith = require('./containsWith');
  */
 module.exports = _curry3(function differenceWith(pred, first, second) {
   var out = [];
-  var idx = -1;
+  var idx = 0;
   var firstLen = first.length;
   var containsPred = containsWith(pred);
-  while (++idx < firstLen) {
+  while (idx < firstLen) {
     if (!containsPred(first[idx], second) && !containsPred(first[idx], out)) {
       out[out.length] = first[idx];
     }
+    idx += 1;
   }
   return out;
 });

--- a/src/dropRepeatsWith.js
+++ b/src/dropRepeatsWith.js
@@ -27,14 +27,15 @@ var last = require('./last');
  */
 module.exports = _curry2(_dispatchable('dropRepeatsWith', _xdropRepeatsWith, function dropRepeatsWith(pred, list) {
   var result = [];
-  var idx = 0;
+  var idx = 1;
   var len = list.length;
   if (len !== 0) {
     result[0] = list[0];
-    while (++idx < len) {
+    while (idx < len) {
       if (!pred(last(result), list[idx])) {
         result[result.length] = list[idx];
       }
+      idx += 1;
     }
   }
   return result;

--- a/src/dropWhile.js
+++ b/src/dropWhile.js
@@ -28,7 +28,9 @@ var _xdropWhile = require('./internal/_xdropWhile');
  *      R.dropWhile(lteTwo, [1, 2, 3, 4, 3, 2, 1]); //=> [3, 4, 3, 2, 1]
  */
 module.exports = _curry2(_dispatchable('dropWhile', _xdropWhile, function dropWhile(pred, list) {
-  var idx = -1, len = list.length;
-  while (++idx < len && pred(list[idx])) {}
+  var idx = 0, len = list.length;
+  while (idx < len && pred(list[idx])) {
+    idx += 1;
+  }
   return _slice(list, idx);
 }));

--- a/src/find.js
+++ b/src/find.js
@@ -25,11 +25,12 @@ var _xfind = require('./internal/_xfind');
  *      R.find(R.propEq('a', 4))(xs); //=> undefined
  */
 module.exports = _curry2(_dispatchable('find', _xfind, function find(fn, list) {
-  var idx = -1;
+  var idx = 0;
   var len = list.length;
-  while (++idx < len) {
+  while (idx < len) {
     if (fn(list[idx])) {
       return list[idx];
     }
+    idx += 1;
   }
 }));

--- a/src/findIndex.js
+++ b/src/findIndex.js
@@ -25,12 +25,13 @@ var _xfindIndex = require('./internal/_xfindIndex');
  *      R.findIndex(R.propEq('a', 4))(xs); //=> -1
  */
 module.exports = _curry2(_dispatchable('findIndex', _xfindIndex, function findIndex(fn, list) {
-  var idx = -1;
+  var idx = 0;
   var len = list.length;
-  while (++idx < len) {
+  while (idx < len) {
     if (fn(list[idx])) {
       return idx;
     }
+    idx += 1;
   }
   return -1;
 }));

--- a/src/findLast.js
+++ b/src/findLast.js
@@ -25,10 +25,11 @@ var _xfindLast = require('./internal/_xfindLast');
  *      R.findLast(R.propEq('a', 4))(xs); //=> undefined
  */
 module.exports = _curry2(_dispatchable('findLast', _xfindLast, function findLast(fn, list) {
-  var idx = list.length;
-  while (--idx >= 0) {
+  var idx = list.length - 1;
+  while (idx >= 0) {
     if (fn(list[idx])) {
       return list[idx];
     }
+    idx -= 1;
   }
 }));

--- a/src/findLastIndex.js
+++ b/src/findLastIndex.js
@@ -25,11 +25,12 @@ var _xfindLastIndex = require('./internal/_xfindLastIndex');
  *      R.findLastIndex(R.propEq('a', 4))(xs); //=> -1
  */
 module.exports = _curry2(_dispatchable('findLastIndex', _xfindLastIndex, function findLastIndex(fn, list) {
-  var idx = list.length;
-  while (--idx >= 0) {
+  var idx = list.length - 1;
+  while (idx >= 0) {
     if (fn(list[idx])) {
       return idx;
     }
+    idx -= 1;
   }
   return -1;
 }));

--- a/src/forEachIndexed.js
+++ b/src/forEachIndexed.js
@@ -32,9 +32,10 @@ var _curry2 = require('./internal/_curry2');
  *      R.forEachIndexed(plusFive, [1, 2, 3]); //=> [6, 7, 8]
  */
 module.exports = _curry2(function forEachIndexed(fn, list) {
-  var idx = -1, len = list.length;
-  while (++idx < len) {
+  var idx = 0, len = list.length;
+  while (idx < len) {
     fn(list[idx], idx, list);
+    idx += 1;
   }
   // i can't bear not to return *something*
   return list;

--- a/src/fromPairs.js
+++ b/src/fromPairs.js
@@ -16,11 +16,12 @@ var _isArray = require('./internal/_isArray');
  *      R.fromPairs([['a', 1], ['b', 2],  ['c', 3]]); //=> {a: 1, b: 2, c: 3}
  */
 module.exports = _curry1(function fromPairs(pairs) {
-  var idx = -1, len = pairs.length, out = {};
-  while (++idx < len) {
+  var idx = 0, len = pairs.length, out = {};
+  while (idx < len) {
     if (_isArray(pairs[idx]) && pairs[idx].length) {
       out[pairs[idx][0]] = pairs[idx][1];
     }
+    idx += 1;
   }
   return out;
 });

--- a/src/internal/_all.js
+++ b/src/internal/_all.js
@@ -1,9 +1,10 @@
 module.exports = function _all(fn, list) {
-  var idx = -1;
-  while (++idx < list.length) {
+  var idx = 0;
+  while (idx < list.length) {
     if (!fn(list[idx])) {
       return false;
     }
+    idx += 1;
   }
   return true;
 };

--- a/src/internal/_any.js
+++ b/src/internal/_any.js
@@ -1,9 +1,10 @@
 module.exports = function _any(fn, list) {
-  var idx = -1;
-  while (++idx < list.length) {
+  var idx = 0;
+  while (idx < list.length) {
     if (fn(list[idx])) {
       return true;
     }
+    idx += 1;
   }
   return false;
 };

--- a/src/internal/_baseCopy.js
+++ b/src/internal/_baseCopy.js
@@ -14,11 +14,12 @@ var type = require('../type');
 module.exports = function _baseCopy(value, refFrom, refTo) {
   var copy = function copy(copiedValue) {
     var len = refFrom.length;
-    var idx = -1;
-    while (++idx < len) {
+    var idx = 0;
+    while (idx < len) {
       if (value === refFrom[idx]) {
         return refTo[idx];
       }
+      idx += 1;
     }
     refFrom[idx + 1] = value;
     refTo[idx + 1] = copiedValue;

--- a/src/internal/_concat.js
+++ b/src/internal/_concat.js
@@ -17,13 +17,15 @@ module.exports = function _concat(set1, set2) {
   var len2 = set2.length;
   var result = [];
 
-  idx = -1;
-  while (++idx < len1) {
+  idx = 0;
+  while (idx < len1) {
     result[result.length] = set1[idx];
+    idx += 1;
   }
-  idx = -1;
-  while (++idx < len2) {
+  idx = 0;
+  while (idx < len2) {
     result[result.length] = set2[idx];
+    idx += 1;
   }
   return result;
 };

--- a/src/internal/_containsWith.js
+++ b/src/internal/_containsWith.js
@@ -1,9 +1,10 @@
 module.exports = function _containsWith(pred, x, list) {
-  var idx = -1, len = list.length;
-  while (++idx < len) {
+  var idx = 0, len = list.length;
+  while (idx < len) {
     if (pred(x, list[idx])) {
       return true;
     }
+    idx += 1;
   }
   return false;
 };

--- a/src/internal/_createComposer.js
+++ b/src/internal/_createComposer.js
@@ -7,11 +7,12 @@ var arity = require('../arity');
  */
 module.exports = function _createComposer(composeFunction) {
   return function() {
-    var idx = arguments.length - 1;
-    var fn = arguments[idx];
+    var fn = arguments[arguments.length - 1];
     var length = fn.length;
-    while (--idx >= 0) {
+    var idx = arguments.length - 2;
+    while (idx >= 0) {
       fn = composeFunction(arguments[idx], fn);
+      idx -= 1;
     }
     return arity(length, fn);
   };

--- a/src/internal/_createMaxMin.js
+++ b/src/internal/_createMaxMin.js
@@ -14,12 +14,13 @@ var _curry1 = require('./_curry1');
  */
 module.exports = function _createMaxMin(comparator, initialVal) {
   return _curry1(function(list) {
-    var idx = -1, winner = initialVal, computed;
-    while (++idx < list.length) {
+    var idx = 0, winner = initialVal, computed;
+    while (idx < list.length) {
       computed = +list[idx];
       if (comparator(computed, winner)) {
         winner = computed;
       }
+      idx += 1;
     }
     return winner;
   });

--- a/src/internal/_createMaxMinBy.js
+++ b/src/internal/_createMaxMinBy.js
@@ -13,16 +13,17 @@ module.exports = function _createMaxMinBy(comparator) {
     if (!(list && list.length > 0)) {
       return;
     }
-    var idx = 0;
+    var idx = 1;
     var winner = list[idx];
     var computedWinner = valueComputer(winner);
     var computedCurrent;
-    while (++idx < list.length) {
+    while (idx < list.length) {
       computedCurrent = valueComputer(list[idx]);
       if (comparator(computedCurrent, computedWinner)) {
         computedWinner = computedCurrent;
         winner = list[idx];
       }
+      idx += 1;
     }
     return winner;
   };

--- a/src/internal/_equals.js
+++ b/src/internal/_equals.js
@@ -41,21 +41,23 @@ module.exports = function _eqDeep(a, b, stackA, stackB) {
       return false;
     }
 
-    var idx = stackA.length;
-    while (--idx >= 0) {
+    var idx = stackA.length - 1;
+    while (idx >= 0) {
       if (stackA[idx] === a) {
         return stackB[idx] === b;
       }
+      idx -= 1;
     }
 
     stackA[stackA.length] = a;
     stackB[stackB.length] = b;
-    idx = keysA.length;
-    while (--idx >= 0) {
+    idx = keysA.length - 1;
+    while (idx >= 0) {
       var key = keysA[idx];
       if (!_has(key, b) || !_eqDeep(b[key], a[key], stackA, stackB)) {
         return false;
       }
+      idx -= 1;
     }
     stackA.pop();
     stackB.pop();

--- a/src/internal/_extend.js
+++ b/src/internal/_extend.js
@@ -18,9 +18,10 @@ var keys = require('../keys');
  */
 module.exports = function _extend(destination, other) {
   var props = keys(other);
-  var idx = -1, length = props.length;
-  while (++idx < length) {
+  var idx = 0, length = props.length;
+  while (idx < length) {
     destination[props[idx]] = other[props[idx]];
+    idx += 1;
   }
   return destination;
 };

--- a/src/internal/_filter.js
+++ b/src/internal/_filter.js
@@ -1,9 +1,10 @@
 module.exports = function _filter(fn, list) {
-  var idx = -1, len = list.length, result = [];
-  while (++idx < len) {
+  var idx = 0, len = list.length, result = [];
+  while (idx < len) {
     if (fn(list[idx])) {
       result[result.length] = list[idx];
     }
+    idx += 1;
   }
   return result;
 };

--- a/src/internal/_filterIndexed.js
+++ b/src/internal/_filterIndexed.js
@@ -1,9 +1,10 @@
 module.exports = function _filterIndexed(fn, list) {
-  var idx = -1, len = list.length, result = [];
-  while (++idx < len) {
+  var idx = 0, len = list.length, result = [];
+  while (idx < len) {
     if (fn(list[idx], idx, list)) {
       result[result.length] = list[idx];
     }
+    idx += 1;
   }
   return result;
 };

--- a/src/internal/_forEach.js
+++ b/src/internal/_forEach.js
@@ -1,7 +1,8 @@
 module.exports = function _forEach(fn, list) {
-  var idx = -1, len = list.length;
-  while (++idx < len) {
+  var idx = 0, len = list.length;
+  while (idx < len) {
     fn(list[idx]);
+    idx += 1;
   }
   // i can't bear not to return *something*
   return list;

--- a/src/internal/_indexOf.js
+++ b/src/internal/_indexOf.js
@@ -10,7 +10,7 @@ module.exports = function _indexOf(list, item, from) {
     if (equals(list[idx], item)) {
       return idx;
     }
-    ++idx;
+    idx += 1;
   }
   return -1;
 };

--- a/src/internal/_lastIndexOf.js
+++ b/src/internal/_lastIndexOf.js
@@ -2,14 +2,17 @@ var equals = require('../equals');
 
 
 module.exports = function _lastIndexOf(list, item, from) {
-  var idx = list.length;
+  var idx;
   if (typeof from === 'number') {
-    idx = from < 0 ? idx + from + 1 : Math.min(idx, from + 1);
+    idx = from < 0 ? list.length + from : Math.min(list.length - 1, from);
+  } else {
+    idx = list.length - 1;
   }
-  while (--idx >= 0) {
+  while (idx >= 0) {
     if (equals(list[idx], item)) {
       return idx;
     }
+    idx -= 1;
   }
   return -1;
 };

--- a/src/internal/_makeFlat.js
+++ b/src/internal/_makeFlat.js
@@ -9,18 +9,20 @@ var isArrayLike = require('../isArrayLike');
  */
 module.exports = function _makeFlat(recursive) {
   return function flatt(list) {
-    var value, result = [], idx = -1, j, ilen = list.length, jlen;
-    while (++idx < ilen) {
+    var value, result = [], idx = 0, j, ilen = list.length, jlen;
+    while (idx < ilen) {
       if (isArrayLike(list[idx])) {
         value = recursive ? flatt(list[idx]) : list[idx];
-        j = -1;
+        j = 0;
         jlen = value.length;
-        while (++j < jlen) {
+        while (j < jlen) {
           result[result.length] = value[j];
+          j += 1;
         }
       } else {
         result[result.length] = list[idx];
       }
+      idx += 1;
     }
     return result;
   };

--- a/src/internal/_map.js
+++ b/src/internal/_map.js
@@ -1,7 +1,8 @@
 module.exports = function _map(fn, list) {
-  var idx = -1, len = list.length, result = [];
-  while (++idx < len) {
+  var idx = 0, len = list.length, result = [];
+  while (idx < len) {
     result[idx] = fn(list[idx]);
+    idx += 1;
   }
   return result;
 };

--- a/src/internal/_reduce.js
+++ b/src/internal/_reduce.js
@@ -5,13 +5,14 @@ var isArrayLike = require('../isArrayLike');
 
 module.exports = (function() {
   function _arrayReduce(xf, acc, list) {
-    var idx = -1, len = list.length;
-    while (++idx < len) {
+    var idx = 0, len = list.length;
+    while (idx < len) {
       acc = xf['@@transducer/step'](acc, list[idx]);
       if (acc && acc['@@transducer/reduced']) {
         acc = acc['@@transducer/value'];
         break;
       }
+      idx += 1;
     }
     return xf['@@transducer/result'](acc);
   }

--- a/src/internal/_slice.js
+++ b/src/internal/_slice.js
@@ -21,10 +21,11 @@ module.exports = function _slice(args, from, to) {
     case 2: return _slice(args, from, args.length);
     default:
       var list = [];
-      var idx = -1;
+      var idx = 0;
       var len = Math.max(0, Math.min(args.length, to) - from);
-      while (++idx < len) {
+      while (idx < len) {
         list[idx] = args[from + idx];
+        idx += 1;
       }
       return list;
   }

--- a/src/intersectionWith.js
+++ b/src/intersectionWith.js
@@ -41,11 +41,12 @@ var uniqWith = require('./uniqWith');
  *      //=> [{id: 456, name: 'Stephen Stills'}, {id: 177, name: 'Neil Young'}]
  */
 module.exports = _curry3(function intersectionWith(pred, list1, list2) {
-  var results = [], idx = -1;
-  while (++idx < list1.length) {
+  var results = [], idx = 0;
+  while (idx < list1.length) {
     if (_containsWith(pred, list1[idx], list2)) {
       results[results.length] = list1[idx];
     }
+    idx += 1;
   }
   return uniqWith(pred, results);
 });

--- a/src/intersperse.js
+++ b/src/intersperse.js
@@ -18,14 +18,15 @@ var _curry2 = require('./internal/_curry2');
  */
 module.exports = _curry2(_checkForMethod('intersperse', function intersperse(separator, list) {
   var out = [];
-  var idx = -1;
+  var idx = 0;
   var length = list.length;
-  while (++idx < length) {
+  while (idx < length) {
     if (idx === length - 1) {
       out.push(list[idx]);
     } else {
       out.push(list[idx], separator);
     }
+    idx += 1;
   }
   return out;
 }));

--- a/src/invert.js
+++ b/src/invert.js
@@ -28,14 +28,15 @@ var keys = require('./keys');
 module.exports = _curry1(function invert(obj) {
   var props = keys(obj);
   var len = props.length;
-  var idx = -1;
+  var idx = 0;
   var out = {};
 
-  while (++idx < len) {
+  while (idx < len) {
     var key = props[idx];
     var val = obj[key];
     var list = _has(val, out) ? out[val] : (out[val] = []);
     list[list.length] = key;
+    idx += 1;
   }
   return out;
 });

--- a/src/invertObj.js
+++ b/src/invertObj.js
@@ -29,12 +29,13 @@ var keys = require('./keys');
 module.exports = _curry1(function invertObj(obj) {
   var props = keys(obj);
   var len = props.length;
-  var idx = -1;
+  var idx = 0;
   var out = {};
 
-  while (++idx < len) {
+  while (idx < len) {
     var key = props[idx];
     out[obj[key]] = key;
+    idx += 1;
   }
   return out;
 });

--- a/src/isSet.js
+++ b/src/isSet.js
@@ -20,11 +20,12 @@ var _indexOf = require('./internal/_indexOf');
  */
 module.exports = _curry1(function isSet(list) {
   var len = list.length;
-  var idx = -1;
-  while (++idx < len) {
+  var idx = 0;
+  while (idx < len) {
     if (_indexOf(list, list[idx], idx + 1) >= 0) {
       return false;
     }
+    idx += 1;
   }
   return true;
 });

--- a/src/keys.js
+++ b/src/keys.js
@@ -25,11 +25,12 @@ module.exports = (function() {
                             'propertyIsEnumerable', 'hasOwnProperty', 'toLocaleString'];
 
   var contains = function contains(list, item) {
-    var idx = -1;
-    while (++idx < list.length) {
+    var idx = 0;
+    while (idx < list.length) {
       if (list[idx] === item) {
         return true;
       }
+      idx += 1;
     }
     return false;
   };
@@ -48,12 +49,13 @@ module.exports = (function() {
       }
     }
     if (hasEnumBug) {
-      nIdx = nonEnumerableProps.length;
-      while (--nIdx >= 0) {
+      nIdx = nonEnumerableProps.length - 1;
+      while (nIdx >= 0) {
         prop = nonEnumerableProps[nIdx];
         if (_has(prop, obj) && !contains(ks, prop)) {
           ks[ks.length] = prop;
         }
+        nIdx -= 1;
       }
     }
     return ks;

--- a/src/mapAccum.js
+++ b/src/mapAccum.js
@@ -27,10 +27,11 @@ var _curry3 = require('./internal/_curry3');
  *      R.mapAccum(append, 0, digits); //=> ['01234', ['01', '012', '0123', '01234']]
  */
 module.exports = _curry3(function mapAccum(fn, acc, list) {
-  var idx = -1, len = list.length, result = [], tuple = [acc];
-  while (++idx < len) {
+  var idx = 0, len = list.length, result = [], tuple = [acc];
+  while (idx < len) {
     tuple = fn(tuple[0], list[idx]);
     result[idx] = tuple[1];
+    idx += 1;
   }
   return [tuple[0], result];
 });

--- a/src/mapAccumRight.js
+++ b/src/mapAccumRight.js
@@ -30,10 +30,11 @@ var _curry3 = require('./internal/_curry3');
  *      R.mapAccumRight(append, 0, digits); //=> ['04321', ['04321', '0432', '043', '04']]
  */
 module.exports = _curry3(function mapAccumRight(fn, acc, list) {
-  var idx = list.length, result = [], tuple = [acc];
-  while (--idx >= 0) {
+  var idx = list.length - 1, result = [], tuple = [acc];
+  while (idx >= 0) {
     tuple = fn(tuple[0], list[idx]);
     result[idx] = tuple[1];
+    idx -= 1;
   }
   return [tuple[0], result];
 });

--- a/src/mapIndexed.js
+++ b/src/mapIndexed.js
@@ -30,9 +30,10 @@ var _curry2 = require('./internal/_curry2');
  *      R.mapIndexed(squareEnds, [8, 5, 3, 0, 9]); //=> [64, 5, 3, 0, 81]
  */
 module.exports = _curry2(function mapIndexed(fn, list) {
-  var idx = -1, len = list.length, result = [];
-  while (++idx < len) {
+  var idx = 0, len = list.length, result = [];
+  while (idx < len) {
     result[idx] = fn(list[idx], idx, list);
+    idx += 1;
   }
   return result;
 });

--- a/src/pick.js
+++ b/src/pick.js
@@ -19,11 +19,12 @@ var _curry2 = require('./internal/_curry2');
  */
 module.exports = _curry2(function pick(names, obj) {
   var result = {};
-  var idx = -1;
-  while (++idx < names.length) {
+  var idx = 0;
+  while (idx < names.length) {
     if (names[idx] in obj) {
       result[names[idx]] = obj[names[idx]];
     }
+    idx += 1;
   }
   return result;
 });

--- a/src/pickAll.js
+++ b/src/pickAll.js
@@ -19,11 +19,12 @@ var _curry2 = require('./internal/_curry2');
  */
 module.exports = _curry2(function pickAll(names, obj) {
   var result = {};
-  var idx = -1;
+  var idx = 0;
   var len = names.length;
-  while (++idx < len) {
+  while (idx < len) {
     var name = names[idx];
     result[name] = obj[name];
+    idx += 1;
   }
   return result;
 });

--- a/src/props.js
+++ b/src/props.js
@@ -22,10 +22,11 @@ var _curry2 = require('./internal/_curry2');
 module.exports = _curry2(function props(ps, obj) {
   var len = ps.length;
   var out = [];
-  var idx = -1;
+  var idx = 0;
 
-  while (++idx < len) {
+  while (idx < len) {
     out[idx] = obj[ps[idx]];
+    idx += 1;
   }
 
   return out;

--- a/src/reduceIndexed.js
+++ b/src/reduceIndexed.js
@@ -33,9 +33,10 @@ var _curry3 = require('./internal/_curry3');
  *      R.reduceIndexed(objectify, {}, letters); //=> { 'a': 0, 'b': 1, 'c': 2 }
  */
 module.exports = _curry3(function reduceIndexed(fn, acc, list) {
-  var idx = -1, len = list.length;
-  while (++idx < len) {
+  var idx = 0, len = list.length;
+  while (idx < len) {
     acc = fn(acc, list[idx], idx, list);
+    idx += 1;
   }
   return acc;
 });

--- a/src/reduceRight.js
+++ b/src/reduceRight.js
@@ -33,9 +33,10 @@ var _curry3 = require('./internal/_curry3');
  *      R.reduceRight(flattenPairs, [], pairs); //=> [ 'c', 3, 'b', 2, 'a', 1 ]
  */
 module.exports = _curry3(function reduceRight(fn, acc, list) {
-  var idx = list.length;
-  while (--idx >= 0) {
+  var idx = list.length - 1;
+  while (idx >= 0) {
     acc = fn(acc, list[idx]);
+    idx -= 1;
   }
   return acc;
 });

--- a/src/reduceRightIndexed.js
+++ b/src/reduceRightIndexed.js
@@ -34,9 +34,10 @@ var _curry3 = require('./internal/_curry3');
  *      R.reduceRightIndexed(objectify, {}, letters); //=> { 'c': 2, 'b': 1, 'a': 0 }
  */
 module.exports = _curry3(function reduceRightIndexed(fn, acc, list) {
-  var idx = list.length;
-  while (--idx >= 0) {
+  var idx = list.length - 1;
+  while (idx >= 0) {
     acc = fn(acc, list[idx], idx, list);
+    idx -= 1;
   }
   return acc;
 });

--- a/src/scan.js
+++ b/src/scan.js
@@ -19,10 +19,11 @@ var _curry3 = require('./internal/_curry3');
  *      var factorials = R.scan(R.multiply, 1, numbers); //=> [1, 1, 2, 6, 24]
  */
 module.exports = _curry3(function scan(fn, acc, list) {
-  var idx = 0, len = list.length + 1, result = [acc];
-  while (++idx < len) {
-    acc = fn(acc, list[idx - 1]);
-    result[idx] = acc;
+  var idx = 0, len = list.length, result = [acc];
+  while (idx < len) {
+    acc = fn(acc, list[idx]);
+    result[idx + 1] = acc;
+    idx += 1;
   }
   return result;
 });

--- a/src/set.js
+++ b/src/set.js
@@ -38,10 +38,11 @@ module.exports = _curry2(function set(update, original) {
     return update;
   }
   var result = _extend({}, original);
-  var key, idx = -1, length = updateKeys.length;
-  while (++idx < length) {
+  var key, idx = 0, length = updateKeys.length;
+  while (idx < length) {
     key = updateKeys[idx];
     result[key] = _has(key, original) ? set(update[key], original[key]) : update[key];
+    idx += 1;
   }
   return result;
 });

--- a/src/takeWhile.js
+++ b/src/takeWhile.js
@@ -29,7 +29,9 @@ var _xtakeWhile = require('./internal/_xtakeWhile');
  *      R.takeWhile(isNotFour, [1, 2, 3, 4]); //=> [1, 2, 3]
  */
 module.exports = _curry2(_dispatchable('takeWhile', _xtakeWhile, function takeWhile(fn, list) {
-  var idx = -1, len = list.length;
-  while (++idx < len && fn(list[idx])) {}
+  var idx = 0, len = list.length;
+  while (idx < len && fn(list[idx])) {
+    idx += 1;
+  }
   return _slice(list, 0, idx);
 }));

--- a/src/uniqWith.js
+++ b/src/uniqWith.js
@@ -23,13 +23,14 @@ var _curry2 = require('./internal/_curry2');
  *      R.uniqWith(strEq)(['1', 1, 1]);    //=> ['1']
  */
 module.exports = _curry2(function uniqWith(pred, list) {
-  var idx = -1, len = list.length;
+  var idx = 0, len = list.length;
   var result = [], item;
-  while (++idx < len) {
+  while (idx < len) {
     item = list[idx];
     if (!_containsWith(pred, item, result)) {
       result[result.length] = item;
     }
+    idx += 1;
   }
   return result;
 });

--- a/src/useWith.js
+++ b/src/useWith.js
@@ -70,9 +70,10 @@ module.exports = curry(function useWith(fn /*, transformers */) {
   var transformers = _slice(arguments, 1);
   var tlen = transformers.length;
   return curry(arity(tlen, function() {
-    var args = [], idx = -1;
-    while (++idx < tlen) {
+    var args = [], idx = 0;
+    while (idx < tlen) {
       args[idx] = transformers[idx](arguments[idx]);
+      idx += 1;
     }
     return fn.apply(this, args.concat(_slice(arguments, tlen)));
   }));

--- a/src/values.js
+++ b/src/values.js
@@ -21,9 +21,10 @@ module.exports = _curry1(function values(obj) {
   var props = keys(obj);
   var len = props.length;
   var vals = [];
-  var idx = -1;
-  while (++idx < len) {
+  var idx = 0;
+  while (idx < len) {
     vals[idx] = obj[props[idx]];
+    idx += 1;
   }
   return vals;
 });

--- a/src/xprod.js
+++ b/src/xprod.js
@@ -18,16 +18,18 @@ var _curry2 = require('./internal/_curry2');
  *      R.xprod([1, 2], ['a', 'b']); //=> [[1, 'a'], [1, 'b'], [2, 'a'], [2, 'b']]
  */
 module.exports = _curry2(function xprod(a, b) { // = xprodWith(prepend); (takes about 3 times as long...)
-  var idx = -1;
+  var idx = 0;
   var ilen = a.length;
   var j;
   var jlen = b.length;
   var result = [];
-  while (++idx < ilen) {
-    j = -1;
-    while (++j < jlen) {
+  while (idx < ilen) {
+    j = 0;
+    while (j < jlen) {
       result[result.length] = [a[idx], b[j]];
+      j += 1;
     }
+    idx += 1;
   }
   return result;
 });

--- a/src/zip.js
+++ b/src/zip.js
@@ -20,10 +20,11 @@ var _curry2 = require('./internal/_curry2');
  */
 module.exports = _curry2(function zip(a, b) {
   var rv = [];
-  var idx = -1;
+  var idx = 0;
   var len = Math.min(a.length, b.length);
-  while (++idx < len) {
+  while (idx < len) {
     rv[idx] = [a[idx], b[idx]];
+    idx += 1;
   }
   return rv;
 });

--- a/src/zipObj.js
+++ b/src/zipObj.js
@@ -16,9 +16,10 @@ var _curry2 = require('./internal/_curry2');
  *      R.zipObj(['a', 'b', 'c'], [1, 2, 3]); //=> {a: 1, b: 2, c: 3}
  */
 module.exports = _curry2(function zipObj(keys, values) {
-  var idx = -1, len = keys.length, out = {};
-  while (++idx < len) {
+  var idx = 0, len = keys.length, out = {};
+  while (idx < len) {
     out[keys[idx]] = values[idx];
+    idx += 1;
   }
   return out;
 });

--- a/src/zipWith.js
+++ b/src/zipWith.js
@@ -24,9 +24,10 @@ var _curry3 = require('./internal/_curry3');
  *      //=> [f(1, 'a'), f(2, 'b'), f(3, 'c')]
  */
 module.exports = _curry3(function zipWith(fn, a, b) {
-  var rv = [], idx = -1, len = Math.min(a.length, b.length);
-  while (++idx < len) {
+  var rv = [], idx = 0, len = Math.min(a.length, b.length);
+  while (idx < len) {
     rv[idx] = fn(a[idx], b[idx]);
+    idx += 1;
   }
   return rv;
 });

--- a/test/nAry.js
+++ b/test/nAry.js
@@ -28,9 +28,10 @@ describe('nAry', function() {
     var undefs = fn();
     var ns = R.repeat(undefined, 10);
     assert.strictEqual(undefs.length, ns.length);
-    var idx = undefs.length;
-    while (--idx) {
+    var idx = undefs.length - 1;
+    while (idx >= 0) {
       assert.strictEqual(undefs[idx], ns[idx]);
+      idx -= 1;
     }
   });
 

--- a/test/unapply.js
+++ b/test/unapply.js
@@ -33,18 +33,20 @@ describe('unapply', function() {
 
     f = Math.max;
     g = R.unapply(R.apply(f));
-    n = 0;
-    while (++n <= 100) {
+    n = 1;
+    while (n <= 100) {
       a = rand(); b = rand(); c = rand(); d = rand(); e = rand();
       assert.strictEqual(f(a, b, c, d, e), g(a, b, c, d, e));
+      n += 1;
     }
 
     f = function(xs) { return '[' + xs + ']'; };
     g = R.apply(R.unapply(f));
-    n = 0;
-    while (++n <= 100) {
+    n = 1;
+    while (n <= 100) {
       a = rand(); b = rand(); c = rand(); d = rand(); e = rand();
       assert.strictEqual(f([a, b, c, d, e]), g([a, b, c, d, e]));
+      n += 1;
     }
   });
 });

--- a/test/unfold.js
+++ b/test/unfold.js
@@ -12,7 +12,8 @@ describe('unfold', function() {
     var fib = function(n) {
       var count = 0;
       return function(pair) {
-        if (++count <= n) {
+        count += 1;
+        if (count <= n) {
           return [pair[0], [pair[1], pair[0] + pair[1]]];
         }
       };


### PR DESCRIPTION
I believe these operators should be avoided.

The existence of both prefix and postfix operators is a source of confusion. One might write `x++` when one means `++x`, or vice versa. Understanding code which uses both prefix and postfix forms requires more mental effort than understanding code which uses just one form.

Postfix `++` and postfix `--` are particularly tricky: they have side effects but are only useful in "expressions", since in "statements" the prefix forms may be used instead. Avoiding the postfix forms makes side effects more apparent.

Prefix `++` and prefix `--` are sugar for `+= 1` and `-= 1`, but promote unnecessarily tricky code (such as initializing a loop variable to `-1` rather than `0`). Banning these operators means there is only one way to increment a variable and only one way to decrement a variable.
