### PR TITLE
lift ban on use of Array.prototype.push

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,11 +23,3 @@
         $ git push origin <branch>
 
 7.  Open a pull request.
-
-### Conventions
-
-  - Do not use `Array.prototype.push`. Use `xs[idx] = x` or `xs[xs.length] = x`
-    rather than `xs.push(x)`. See [#890][1] for links to related pull requests.
-
-
-[1]: https://github.com/ramda/ramda/issues/890


### PR DESCRIPTION
As proposed in [#1050][1]


[1]: https://github.com/ramda/ramda/pull/1050/files#r32039355
