### PR TITLE
refactor R.curryN

### DIFF
--- a/src/curryN.js
+++ b/src/curryN.js
@@ -1,5 +1,4 @@
 var _curry2 = require('./internal/_curry2');
-var _slice = require('./internal/_slice');
 var arity = require('./arity');
 
 
@@ -48,42 +47,21 @@ var arity = require('./arity');
  */
 module.exports = _curry2(function curryN(length, fn) {
   return arity(length, function() {
-    var n = arguments.length;
-    var shortfall = length - n;
-    var idx = n - 1;
-    while (idx >= 0) {
-      if (arguments[idx] != null &&
-          arguments[idx]['@@functional/placeholder'] === true) {
+    var args = arguments;
+    var shortfall = length - args.length;
+    for (var idx = 0; idx < args.length; idx += 1) {
+      if (args[idx] != null && args[idx]['@@functional/placeholder'] === true) {
         shortfall += 1;
       }
-      idx -= 1;
     }
-    if (shortfall <= 0) {
-      return fn.apply(this, arguments);
-    } else {
-      var initialArgs = _slice(arguments);
-      return curryN(shortfall, function() {
-        var currentArgs = _slice(arguments);
-        var combinedArgs = [];
-        var idx = 0;
-        var currentArgsIdx = 0;
-        while (idx < n) {
-          var val = initialArgs[idx];
-          if (val != null && val['@@functional/placeholder'] === true) {
-            combinedArgs[idx] = currentArgs[currentArgsIdx];
-            currentArgsIdx += 1;
-          } else {
-            combinedArgs[idx] = val;
-          }
-          idx += 1;
-        }
-        while (currentArgsIdx < currentArgs.length) {
-          combinedArgs[idx] = currentArgs[currentArgsIdx];
-          idx += 1;
-          currentArgsIdx += 1;
-        }
-        return fn.apply(this, combinedArgs);
-      });
-    }
+    return shortfall <= 0 ? fn.apply(this, args) : curryN(shortfall, function() {
+      var ys = Array.prototype.slice.call(arguments);
+      var xs = [];
+      for (var idx = 0; idx < args.length; idx += 1) {
+        var x = args[idx];
+        xs.push(x != null && x['@@functional/placeholder'] === true ? ys.shift() : x);
+      }
+      return fn.apply(this, xs.concat(ys));
+    });
   });
 });


### PR DESCRIPTION
I realized while working on plaid/sanctuary#50 that `Array.prototype.shift` obviates the need for the awkward `currentArgsIdx` variable.

> Showing __1 changed file__ with __13 additions__ and __35 deletions__.

:smile:

I realize that compactness is not the end goal, but in this case the difference is significant: the function was 50 lines and is now 20 lines, making it significantly more approachable. I have MacVim configured to display 35 lines of code, so the function now easily fits on my screen.

I'll switch to `while` loops upon request. I first wanted to show just how compact this code can be.
