### PR TITLE
Add undefined as return value in docs where applicable

### DIFF
--- a/src/head.js
+++ b/src/head.js
@@ -8,11 +8,12 @@ var nth = require('./nth');
  * @func
  * @memberOf R
  * @category List
- * @sig [a] -> a
+ * @sig [a] -> a | Undefined
  * @param {Array} list The array to consider.
  * @return {*} The first element of the list, or `undefined` if the list is empty.
  * @example
  *
  *      R.head(['fi', 'fo', 'fum']); //=> 'fi'
+ *      R.head([]); //=> undefined
  */
 module.exports = nth(0);

--- a/src/last.js
+++ b/src/last.js
@@ -7,11 +7,12 @@ var nth = require('./nth');
  * @func
  * @memberOf R
  * @category List
- * @sig [a] -> a
+ * @sig [a] -> a | Undefined
  * @param {Array} list The array to consider.
  * @return {*} The last element of the list, or `undefined` if the list is empty.
  * @example
  *
  *      R.last(['fi', 'fo', 'fum']); //=> 'fum'
+ *      R.last([]); //=> undefined
  */
 module.exports = nth(-1);

--- a/src/nth.js
+++ b/src/nth.js
@@ -9,7 +9,7 @@ var _nth = require('./internal/_nth');
  * @func
  * @memberOf R
  * @category List
- * @sig Number -> [a] -> a
+ * @sig Number -> [a] -> a | Undefined
  * @param {Number} idx
  * @param {Array} list
  * @return {*} The nth element of the list.

--- a/src/path.js
+++ b/src/path.js
@@ -8,11 +8,12 @@ var _path = require('./internal/_path');
  * @func
  * @memberOf R
  * @category Object
- * @sig [String] -> {*} -> *
+ * @sig [String] -> {k: v} -> v | Undefined
  * @param {Array} path The path to use.
  * @return {*} The data at `path`.
  * @example
  *
  *      R.path(['a', 'b'], {a: {b: 2}}); //=> 2
+ *      R.path(['a', 'b'], {c: {b: 2}}); //=> undefined
  */
 module.exports = _curry2(_path);

--- a/src/prop.js
+++ b/src/prop.js
@@ -7,7 +7,7 @@ var _curry2 = require('./internal/_curry2');
  * @func
  * @memberOf R
  * @category Object
- * @sig s -> {s: a} -> a
+ * @sig s -> {s: a} -> a | Undefined
  * @param {String} p The property name
  * @param {Object} obj The object to query
  * @return {*} The value at `obj.p`.


### PR DESCRIPTION
This adds undefined as a possible return value in the docs for functions
that might return undefined. Examples has also been added showing how
the functions might return undefined.

This was previously done for `find` and `findLast` but the docs were not
consistent.