### PR TITLE
Change mapped variable in construct examples into an array

### DIFF
--- a/src/construct.js
+++ b/src/construct.js
@@ -21,9 +21,9 @@ var constructN = require('./constructN');
  *      Widget.prototype = {
  *        // ...
  *      };
- *      var allConfigs = {
+ *      var allConfigs = [
  *        // ...
- *      };
+ *      ];
  *      R.map(R.construct(Widget), allConfigs); // a list of Widgets
  */
 module.exports = _curry1(function construct(Fn) {

--- a/src/constructN.js
+++ b/src/constructN.js
@@ -25,9 +25,9 @@ var nAry = require('./nAry');
  *      Widget.prototype = {
  *        // ...
  *      };
- *      var allConfigs = {
+ *      var allConfigs = [
  *        // ...
- *      };
+ *      ];
  *      R.map(R.constructN(1, Widget), allConfigs); // a list of Widgets
  */
 module.exports = _curry2(function constructN(n, Fn) {


### PR DESCRIPTION
My assumption is that `allConfigs` should actually be an array, since that would be a more plausible object to map over.