### PR TITLE
deprecate R.substring

### DIFF
--- a/src/substring.js
+++ b/src/substring.js
@@ -14,6 +14,7 @@ var slice = require('./slice');
  * @param {String} str The string to slice.
  * @return {String}
  * @see R.slice
+ * @deprecated since v0.15.0
  * @example
  *
  *      R.substring(2, 5, 'abcdefghijklm'); //=> 'cde'


### PR DESCRIPTION
`R.slice` dispatches to `slice`, so `R.substring` should be deprecated just as `R.substringTo` and `R.substringFrom` were in #1159.
