### PR TITLE
bookmarklet: add missing handlebars dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "dox": "latest",
     "envvar": "1.x.x",
     "escodegen": "1.4.x",
+    "handlebars": "3.0.x",
     "js-yaml": "^3.2.5",
     "jscs": "1.13.x",
     "jshint": "2.7.x",

--- a/scripts/bookmarklet
+++ b/scripts/bookmarklet
@@ -2,10 +2,12 @@
 
 'use strict';
 
-var Handlebars      = require('handlebars');
-var UglifyJS        = require('uglify-js');
 var fs              = require('fs');
 var path            = require('path');
+
+var Handlebars      = require('handlebars');
+var UglifyJS        = require('uglify-js');
+
 var pkg             = require('../package.json');
 
 var markletTmplPath = path.join(__dirname, 'bookmarklet.tmpl.js');


### PR DESCRIPTION
I also used [PEP 8 import grouping][1] to make it clear which are third-party package imports.


[1]: https://www.python.org/dev/peps/pep-0008/#imports
