### PR TITLE
Implements `lensIndex` setter using `update`

### DIFF
--- a/src/lensIndex.js
+++ b/src/lensIndex.js
@@ -1,6 +1,8 @@
-var _slice = require('./internal/_slice');
+var _curry1 = require('./internal/_curry1');
 var lens = require('./lens');
 var nth = require('./nth');
+var update = require('./update');
+
 
 /**
  * Creates a lens that will focus on index `n` of the source array.
@@ -20,8 +22,6 @@ var nth = require('./nth');
  *     headLens.set('mu', [10, 20, 30, 40]); //=> ['mu', 20, 30, 40]
  *     headLens.map(function(x) { return x + 1; }, [10, 20, 30, 40]); //=> [11, 20, 30, 40]
  */
-module.exports = function lensIndex(n) {
-  return lens(nth(n), function(x, xs) {
-    return _slice(xs, 0, n).concat([x], _slice(xs, n + 1));
-  });
-};
+module.exports = _curry1(function lensIndex(n) {
+  return lens(nth(n), update(n));
+});

--- a/src/lensProp.js
+++ b/src/lensProp.js
@@ -1,6 +1,8 @@
+var _curry1 = require('./internal/_curry1');
 var assoc = require('./assoc');
 var lens = require('./lens');
 var prop = require('./prop');
+
 
 /**
  * Creates a lens that will focus on property `k` of the source object.
@@ -23,7 +25,6 @@ var prop = require('./prop');
  *     phraseLens.set('Ooh Betty', obj1); //=> { phrase: 'Ooh Betty'}
  *     phraseLens.map(R.toUpper, obj2); //=> { phrase: "WHAT'S ALL THIS, THEN?"}
  */
-module.exports = function(k) {
+module.exports = _curry1(function lensProp(k) {
   return lens(prop(k), assoc(k));
-};
-
+});


### PR DESCRIPTION
As per @jethrolarson's suggestion here: https://github.com/ramda/ramda/pull/971#issuecomment-111279241, `lensIndex` now uses `update` for its setter function, providing a nice symmetry with `lensProp`:

```js
function lensProp(k) {
  return lens(prop(k), assoc(k));
}
```
```js
function lensIndex(n) {
  return lens(nth(n), update(n));
}
```