### PR TITLE
Deprecate `eq` and `deepEq`

### DIFF
--- a/src/eq.js
+++ b/src/eq.js
@@ -1,0 +1,31 @@
+var _curry2 = require('./internal/_curry2');
+var _eq = require('./internal/_eq');
+
+
+/**
+ * Tests if two items are equal.  Equality is strict here, meaning reference equality for objects and
+ * non-coercing equality for primitives.
+ *
+ * Has `Object.is` semantics: `NaN` is considered equal to `NaN`; `0` and `-0`
+ * are not considered equal.
+ * @see R.identical
+ *
+ * @func
+ * @memberOf R
+ * @category Relation
+ * @sig a -> a -> Boolean
+ * @param {*} a
+ * @param {*} b
+ * @return {Boolean}
+ * @deprecated since v0.15.0
+ * @example
+ *
+ *      var o = {};
+ *      R.eq(o, o); //=> true
+ *      R.eq(o, {}); //=> false
+ *      R.eq(1, 1); //=> true
+ *      R.eq(1, '1'); //=> false
+ *      R.eq(0, -0); //=> false
+ *      R.eq(NaN, NaN); //=> true
+ */
+module.exports = _curry2(_eq);

--- a/src/eqDeep.js
+++ b/src/eqDeep.js
@@ -1,0 +1,31 @@
+var equals = require('./equals');
+
+
+/**
+ * Performs a deep test on whether two items are equal.
+ * Equality implies the two items are semmatically equivalent.
+ * Cyclic structures are handled as expected
+ * @see R.equals
+ *
+ * @func
+ * @memberOf R
+ * @category Relation
+ * @sig a -> b -> Boolean
+ * @param {*} a
+ * @param {*} b
+ * @return {Boolean}
+ * @deprecated since v0.15.0
+ * @example
+ *
+ *      var o = {};
+ *      R.eqDeep(o, o); //=> true
+ *      R.eqDeep(o, {}); //=> true
+ *      R.eqDeep(1, 1); //=> true
+ *      R.eqDeep(1, '1'); //=> false
+ *
+ *      var a = {}; a.v = a;
+ *      var b = {}; b.v = b;
+ *      R.eqDeep(a, b); //=> true
+ */
+
+module.exports = equals;

--- a/src/internal/_eq.js
+++ b/src/internal/_eq.js
@@ -1,0 +1,11 @@
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is#Polyfill
+module.exports = function _eq(x, y) {
+  // SameValue algorithm
+  if (x === y) { // Steps 1-5, 7-10
+    // Steps 6.b-6.e: +0 != -0
+    return x !== 0 || 1 / x === 1 / y;
+  } else {
+    // Step 6.a: NaN == NaN
+    return x !== x && y !== y;
+  }
+};

--- a/test/eq.js
+++ b/test/eq.js
@@ -1,0 +1,36 @@
+var assert = require('assert');
+
+var R = require('..');
+
+
+describe('eq', function() {
+  var a = [];
+  var b = a;
+  it('has Object.is semantics', function() {
+    assert.strictEqual(R.eq(100, 100), true);
+    assert.strictEqual(R.eq(100, '100'), false);
+    assert.strictEqual(R.eq('string', 'string'), true);
+    assert.strictEqual(R.eq([], []), false);
+    assert.strictEqual(R.eq(a, b), true);
+    assert.strictEqual(R.eq(undefined, undefined), true);
+    assert.strictEqual(R.eq(null, undefined), false);
+
+    assert.strictEqual(R.eq(-0, 0), false);
+    assert.strictEqual(R.eq(0, -0), false);
+    assert.strictEqual(R.eq(NaN, NaN), true);
+
+    assert.strictEqual(R.eq(NaN, 42), false);
+    assert.strictEqual(R.eq(42, NaN), false);
+
+    /* jshint -W053 */
+    assert.strictEqual(R.eq(0, new Number(0)), false);
+    assert.strictEqual(R.eq(new Number(0), 0), false);
+    assert.strictEqual(R.eq(new Number(0), new Number(0)), false);
+    /* jshint +W053 */
+  });
+
+  it('is curried', function() {
+    var isA = R.eq(a);
+    assert.strictEqual(isA([]), false);
+  });
+});

--- a/test/eqDeep.js
+++ b/test/eqDeep.js
@@ -1,0 +1,100 @@
+/* jshint typed: true */
+
+var assert = require('assert');
+
+var R = require('..');
+
+describe('eqDeep', function() {
+  var a = [];
+  var b = a;
+  it('tests for deep equality of its operands', function() {
+    assert.strictEqual(R.eqDeep(100, 100), true);
+    assert.strictEqual(R.eqDeep(100, '100'), false);
+    assert.strictEqual(R.eqDeep([], []), true);
+    assert.strictEqual(R.eqDeep(a, b), true);
+  });
+
+  it('handles objects', function() {
+    assert.strictEqual(R.eqDeep({}, {}), true);
+    assert.strictEqual(R.eqDeep({a:1, b:2}, {a:1, b:2}), true);
+    assert.strictEqual(R.eqDeep({a:2, b:3}, {b:3, a:2}), true);
+    assert.strictEqual(R.eqDeep({a:2, b:3}, {a:3, b:3}), false);
+    assert.strictEqual(R.eqDeep({a:2, b:3, c:1}, {a:2, b:3}), false);
+  });
+
+  var supportsSticky = false;
+  try { RegExp('', 'y'); supportsSticky = true; } catch (e) {}
+
+  var supportsUnicode = false;
+  try { RegExp('', 'u'); supportsUnicode = true; } catch (e) {}
+
+  it('handles regex', function() {
+    assert.strictEqual(R.eqDeep(/\s/, /\s/), true);
+    assert.strictEqual(R.eqDeep(/\s/, /\d/), false);
+    assert.strictEqual(R.eqDeep(/a/gi, /a/ig), true);
+    assert.strictEqual(R.eqDeep(/a/mgi, /a/img), true);
+    assert.strictEqual(R.eqDeep(/a/gi, /a/i), false);
+
+    if (supportsSticky) {
+      // assert.strictEqual(R.eqDeep(/\s/y, /\s/y), true);
+      // assert.strictEqual(R.eqDeep(/a/mygi, /a/imgy), true);
+    }
+
+    if (supportsUnicode) {
+      // assert.strictEqual(R.eqDeep(/\s/u, /\s/u), true);
+      // assert.strictEqual(R.eqDeep(/a/mugi, /a/imgu), true);
+    }
+  });
+
+  var listA = [1, 2, 3];
+  var listB = [1, 3, 2];
+  it('handles lists', function() {
+    assert.strictEqual(R.eqDeep([], {}), false);
+    assert.strictEqual(R.eqDeep(listA, listB), false);
+  });
+
+  var c = {}; c.v = c;
+  var d = {}; d.v = d;
+  var e = []; e.push(e);
+  var f = []; f.push(f);
+  var nestA = {a:[1, 2, {c:1}], b:1};
+  var nestB = {a:[1, 2, {c:1}], b:1};
+  var nestC = {a:[1, 2, {c:2}], b:1};
+  it('handles recursive data structures', function() {
+    assert.strictEqual(R.eqDeep(c, d), true);
+    assert.strictEqual(R.eqDeep(e, f), true);
+    assert.strictEqual(R.eqDeep(nestA, nestB), true);
+    assert.strictEqual(R.eqDeep(nestA, nestC), false);
+  });
+
+  var date1 = new Date(0);
+  var date2 = new Date(0);
+  var date3 = new Date(1);
+  var date4 = new Date(0);
+  date4.v = 'value';
+  it('handles dates', function() {
+    assert.strictEqual(R.eqDeep(date1, date2), true);
+    assert.strictEqual(R.eqDeep(date2, date3), false);
+    assert.strictEqual(R.eqDeep(date1, date4), false);
+  });
+
+  if (typeof ArrayBuffer !== 'undefined' && typeof Int8Array !== 'undefined') {
+    var typArr1 = new ArrayBuffer(10);
+    typArr1[0] = 1;
+    var typArr2 = new ArrayBuffer(10);
+    typArr2[0] = 1;
+    var typArr3 = new ArrayBuffer(10);
+    var intTypArr = new Int8Array(typArr1);
+    typArr3[0] = 0;
+    it('handles typed arrays', function() {
+      assert.strictEqual(R.eqDeep(typArr1, typArr2), true);
+      assert.strictEqual(R.eqDeep(typArr1, typArr3), false);
+      assert.strictEqual(R.eqDeep(typArr1, intTypArr), false);
+    });
+  }
+
+  it('is curried', function() {
+    var isA = R.eqDeep(a);
+    assert.strictEqual(isA([]), true);
+  });
+});


### PR DESCRIPTION
See comments by @TheLudd in #1186.

This commit deprecates `eq` and `eqDeep`. `eqDeep` is implemented as an alias to `equals`.