### PR TITLE
docs/merge: use monospace for variables

### DIFF
--- a/src/merge.js
+++ b/src/merge.js
@@ -3,8 +3,8 @@ var _extend = require('./internal/_extend');
 
 
 /**
- * Create a new object with the own properties of a
- * merged with the own properties of object b.
+ * Create a new object with the own properties of `a`
+ * merged with the own properties of object `b`.
  * This function will *not* mutate passed-in objects.
  *
  * @func


### PR DESCRIPTION
to improve readability,

![screen shot 2015-06-21 at 13 32 32](https://cloud.githubusercontent.com/assets/11027/8271342/6e1742e2-181a-11e5-8831-4468de194688.png)
