### PR TITLE
add R.splitEvery

### DIFF
--- a/src/splitEvery.js
+++ b/src/splitEvery.js
@@ -1,0 +1,31 @@
+var _curry2 = require('./internal/_curry2');
+var slice = require('./slice');
+
+
+/**
+ * Splits a collection into slices of the specified length.
+ *
+ * @func
+ * @memberOf R
+ * @category List
+ * @sig Number -> [a] -> [[a]]
+ * @sig Number -> String -> [String]
+ * @param {Number} n
+ * @param {Array} list
+ * @return {Array}
+ * @example
+ *
+ *      R.splitEvery(3, [1, 2, 3, 4, 5, 6, 7]); //=> [[1, 2, 3], [4, 5, 6], [7]]
+ *      R.splitEvery(3, 'foobarbaz'); //=> ['foo', 'bar', 'baz']
+ */
+module.exports = _curry2(function splitEvery(n, list) {
+  if (n <= 0) {
+    throw new Error('First argument to splitEvery must be a positive integer');
+  }
+  var result = [];
+  var idx = 0;
+  while (idx < list.length) {
+    result.push(slice(idx, idx += n, list));
+  }
+  return result;
+});

--- a/test/splitEvery.js
+++ b/test/splitEvery.js
@@ -1,0 +1,34 @@
+var assert = require('assert');
+
+var R = require('..');
+
+
+describe('splitEvery', function() {
+
+  it('splits a collection into slices of the specified length', function() {
+    assert.deepEqual(R.splitEvery(1, [1, 2, 3, 4]), [[1], [2], [3], [4]]);
+    assert.deepEqual(R.splitEvery(2, [1, 2, 3, 4]), [[1, 2], [3, 4]]);
+    assert.deepEqual(R.splitEvery(3, [1, 2, 3, 4]), [[1, 2, 3], [4]]);
+    assert.deepEqual(R.splitEvery(4, [1, 2, 3, 4]), [[1, 2, 3, 4]]);
+    assert.deepEqual(R.splitEvery(5, [1, 2, 3, 4]), [[1, 2, 3, 4]]);
+    assert.deepEqual(R.splitEvery(3, []), []);
+    assert.deepEqual(R.splitEvery(1, 'abcd'), ['a', 'b', 'c', 'd']);
+    assert.deepEqual(R.splitEvery(2, 'abcd'), ['ab', 'cd']);
+    assert.deepEqual(R.splitEvery(3, 'abcd'), ['abc', 'd']);
+    assert.deepEqual(R.splitEvery(4, 'abcd'), ['abcd']);
+    assert.deepEqual(R.splitEvery(5, 'abcd'), ['abcd']);
+    assert.deepEqual(R.splitEvery(3, ''), []);
+  });
+
+  it('throws if first argument is not positive', function() {
+    var test = function(err) {
+      return err.constructor === Error &&
+             err.message === 'First argument to splitEvery must be a positive integer';
+    };
+    assert.throws(function() { R.splitEvery(0, []); }, test);
+    assert.throws(function() { R.splitEvery(0, ''); }, test);
+    assert.throws(function() { R.splitEvery(-1, []); }, test);
+    assert.throws(function() { R.splitEvery(-1, ''); }, test);
+  });
+
+});


### PR DESCRIPTION
Supersedes #1050

This pull request differs from #1050 in several ways:

  - the implementation is significantly simpler;

  - this version of `splitEvery` throws if given a non-positive slice length; and

  - this version of `splitEvery` is defined in terms of `slice` so is defined for String as well as Array<sup>†</sup>.

---

† I'm picking up on a theme here: provide `slice`, get lots of things free.
