### PR TITLE
add R.str{Slice,Take,Drop,Init,Tail}

### DIFF
--- a/src/drop.js
+++ b/src/drop.js
@@ -1,7 +1,7 @@
 var _curry2 = require('./internal/_curry2');
 var _dispatchable = require('./internal/_dispatchable');
+var _slice = require('./internal/_slice');
 var _xdrop = require('./internal/_xdrop');
-var slice = require('./slice');
 
 
 /**
@@ -9,9 +9,6 @@ var slice = require('./slice');
  *
  * Acts as a transducer if a transformer is given in list position.
  * @see R.transduce
- *
- * Dispatches to its second argument's `slice` method if present. As a
- * result, one may replace `[a]` with `String` in the type signature.
  *
  * @func
  * @memberOf R
@@ -29,5 +26,5 @@ var slice = require('./slice');
  *      R.drop(3, 'ramda');               //=> 'da'
  */
 module.exports = _curry2(_dispatchable('drop', _xdrop, function drop(n, xs) {
-  return slice(Math.max(0, n), Infinity, xs);
+  return _slice(xs, Math.max(0, n));
 }));

--- a/src/slice.js
+++ b/src/slice.js
@@ -6,9 +6,6 @@ var _curry3 = require('./internal/_curry3');
  * Returns a list containing the elements of `xs` from `fromIndex` (inclusive)
  * to `toIndex` (exclusive).
  *
- * Dispatches to its third argument's `slice` method if present. As a
- * result, one may replace `[a]` with `String` in the type signature.
- *
  * @func
  * @memberOf R
  * @category List
@@ -23,7 +20,6 @@ var _curry3 = require('./internal/_curry3');
  *      R.slice(1, Infinity, ['a', 'b', 'c', 'd']); //=> ['b', 'c', 'd']
  *      R.slice(0, -1, ['a', 'b', 'c', 'd']);       //=> ['a', 'b', 'c']
  *      R.slice(-3, -1, ['a', 'b', 'c', 'd']);      //=> ['b', 'c']
- *      R.slice(0, 3, 'ramda');                     //=> 'ram'
  */
 module.exports = _curry3(_checkForMethod('slice', function slice(fromIndex, toIndex, xs) {
   return Array.prototype.slice.call(xs, fromIndex, toIndex);

--- a/src/strDrop.js
+++ b/src/strDrop.js
@@ -1,0 +1,6 @@
+var _curry2 = require('./internal/_curry2');
+
+
+module.exports = _curry2(function strDrop(n, str) {
+  return str.slice(n);
+});

--- a/src/strInit.js
+++ b/src/strInit.js
@@ -1,0 +1,6 @@
+var _curry1 = require('./internal/_curry1');
+
+
+module.exports = _curry1(function strInit(str) {
+  return str.slice(0, -1);
+});

--- a/src/strSlice.js
+++ b/src/strSlice.js
@@ -1,0 +1,25 @@
+var _curry3 = require('./internal/_curry3');
+
+
+/**
+ * Returns the substring `str` from `fromIndex` (inclusive) to `toIndex`
+ * (exclusive).
+ *
+ * @func
+ * @memberOf R
+ * @category List
+ * @sig Number -> Number -> String -> String
+ * @param {Number} fromIndex
+ * @param {Number} toIndex
+ * @param {String} str
+ * @return {String}
+ * @example
+ *
+ *      R.strSlice(1, 3, 'ramda');        //=> 'am'
+ *      R.strSlice(1, Infinity, 'ramda'); //=> 'amda'
+ *      R.strSlice(0, -1, 'ramda');       //=> 'ramd'
+ *      R.strSlice(-3, -1, 'ramda');      //=> 'md'
+ */
+module.exports = _curry3(function strSlice(fromIndex, toIndex, str) {
+  return str.slice(fromIndex, toIndex);
+});

--- a/src/strTail.js
+++ b/src/strTail.js
@@ -1,0 +1,6 @@
+var _curry1 = require('./internal/_curry1');
+
+
+module.exports = _curry1(function strTail(str) {
+  return str.slice(1);
+});

--- a/src/strTake.js
+++ b/src/strTake.js
@@ -1,0 +1,6 @@
+var _curry2 = require('./internal/_curry2');
+
+
+module.exports = _curry2(function strTake(n, str) {
+  return str.slice(0, n);
+});

--- a/src/take.js
+++ b/src/take.js
@@ -1,7 +1,7 @@
 var _curry2 = require('./internal/_curry2');
 var _dispatchable = require('./internal/_dispatchable');
+var _slice = require('./internal/_slice');
 var _xtake = require('./internal/_xtake');
-var slice = require('./slice');
 
 
 /**
@@ -10,9 +10,6 @@ var slice = require('./slice');
  *
  * Acts as a transducer if a transformer is given in list position.
  * @see R.transduce
- *
- * Dispatches to its second argument's `slice` method if present. As a
- * result, one may replace `[a]` with `String` in the type signature.
  *
  * @func
  * @memberOf R
@@ -27,7 +24,6 @@ var slice = require('./slice');
  *      R.take(2, ['foo', 'bar', 'baz']); //=> ['foo', 'bar']
  *      R.take(3, ['foo', 'bar', 'baz']); //=> ['foo', 'bar', 'baz']
  *      R.take(4, ['foo', 'bar', 'baz']); //=> ['foo', 'bar', 'baz']
- *      R.take(3, 'ramda');               //=> 'ram'
  *
  *      var personnel = [
  *        'Dave Brubeck',
@@ -44,5 +40,5 @@ var slice = require('./slice');
  *      //=> ['Dave Brubeck', 'Paul Desmond', 'Eugene Wright', 'Joe Morello', 'Gerry Mulligan']
  */
 module.exports = _curry2(_dispatchable('take', _xtake, function take(n, xs) {
-  return slice(0, n < 0 ? Infinity : n, xs);
+  return _slice(xs, 0, n < 0 ? Infinity : n);
 }));

--- a/test/drop.js
+++ b/test/drop.js
@@ -4,6 +4,7 @@ var R = require('..');
 
 
 describe('drop', function() {
+
   it('skips the first `n` elements from a list, returning the remainder', function() {
     assert.deepEqual(R.drop(3, ['a', 'b', 'c', 'd', 'e', 'f', 'g']), ['d', 'e', 'f', 'g']);
   });
@@ -25,16 +26,10 @@ describe('drop', function() {
     assert.notStrictEqual(R.drop(-1, xs), xs);
   });
 
-  it('dispatches to `slice` method', function() {
-    var o = {slice: function(a, b) { return '[' + a + ':' + b + ']'; }};
-
-    assert.strictEqual(R.drop(3, 'Ramda'), 'da');
-    assert.strictEqual(R.drop(3, o), '[3:Infinity]');
-  });
-
   it('is curried', function() {
     var drop2 = R.drop(2);
     assert.deepEqual(drop2(['a', 'b', 'c', 'd', 'e']), ['c', 'd', 'e']);
     assert.deepEqual(drop2(['x', 'y', 'z']), ['z']);
   });
+
 });

--- a/test/slice.js
+++ b/test/slice.js
@@ -4,16 +4,15 @@ var R = require('..');
 
 
 describe('slice', function() {
+
   it('retrieves the proper sublist of a list', function() {
     var list = [8, 6, 7, 5, 3, 0, 9];
     assert.deepEqual(R.slice(2, 5, list), [7, 5, 3]);
   });
+
   it('handles array-like object', function() {
     var args = (function() { return arguments; }(1, 2, 3, 4, 5));
     assert.deepEqual(R.slice(1, 4, args), [2, 3, 4]);
   });
-  it('dispatches to `slice` method', function() {
-    var obj = {slice: function() { return 42; }};
-    assert.strictEqual(R.slice(1, 4, obj), 42);
-  });
+
 });

--- a/test/strDrop.js
+++ b/test/strDrop.js
@@ -1,0 +1,16 @@
+var assert = require('assert');
+
+var R = require('..');
+
+
+describe('strDrop', function() {
+
+  it('returns the substring containing all but the first N characters', function() {
+    assert.strictEqual(R.strDrop(0, 'abc'), 'abc');
+    assert.strictEqual(R.strDrop(1, 'abc'), 'bc');
+    assert.strictEqual(R.strDrop(2, 'abc'), 'c');
+    assert.strictEqual(R.strDrop(3, 'abc'), '');
+    assert.strictEqual(R.strDrop(4, 'abc'), '');
+  });
+
+});

--- a/test/strInit.js
+++ b/test/strInit.js
@@ -1,0 +1,15 @@
+var assert = require('assert');
+
+var R = require('..');
+
+
+describe('strInit', function() {
+
+  it('returns the substring containing all characters but the last', function() {
+    assert.strictEqual(R.strInit('abc'), 'ab');
+    assert.strictEqual(R.strInit('ab'), 'a');
+    assert.strictEqual(R.strInit('a'), '');
+    assert.strictEqual(R.strInit(''), '');
+  });
+
+});

--- a/test/strSlice.js
+++ b/test/strSlice.js
@@ -1,0 +1,37 @@
+var assert = require('assert');
+
+var R = require('..');
+
+
+describe('strSlice', function() {
+
+  it('returns a slice of the given string', function() {
+    assert.strictEqual(R.strSlice(0, 0, 'abc'), '');
+    assert.strictEqual(R.strSlice(0, 1, 'abc'), 'a');
+    assert.strictEqual(R.strSlice(0, 2, 'abc'), 'ab');
+    assert.strictEqual(R.strSlice(0, 3, 'abc'), 'abc');
+    assert.strictEqual(R.strSlice(0, 4, 'abc'), 'abc');
+    assert.strictEqual(R.strSlice(2, 1, 'abc'), '');
+    assert.strictEqual(R.strSlice(2, 2, 'abc'), '');
+    assert.strictEqual(R.strSlice(2, 3, 'abc'), 'c');
+    assert.strictEqual(R.strSlice(2, 4, 'abc'), 'c');
+  });
+
+  it('accepts a negative start offset', function() {
+    assert.strictEqual(R.strSlice(-1, 9, 'abc'), 'c');
+    assert.strictEqual(R.strSlice(-2, 9, 'abc'), 'bc');
+    assert.strictEqual(R.strSlice(-3, 9, 'abc'), 'abc');
+    assert.strictEqual(R.strSlice(-4, 9, 'abc'), 'abc');
+  });
+
+  it('accepts a negative end offset', function() {
+    assert.strictEqual(R.strSlice(0, -1, 'abc'), 'ab');
+    assert.strictEqual(R.strSlice(0, -2, 'abc'), 'a');
+    assert.strictEqual(R.strSlice(0, -3, 'abc'), '');
+    assert.strictEqual(R.strSlice(0, -4, 'abc'), '');
+    assert.strictEqual(R.strSlice(-2, -1, 'abc'), 'b');
+    assert.strictEqual(R.strSlice(-2, -2, 'abc'), '');
+    assert.strictEqual(R.strSlice(-2, -3, 'abc'), '');
+  });
+
+});

--- a/test/strTail.js
+++ b/test/strTail.js
@@ -1,0 +1,15 @@
+var assert = require('assert');
+
+var R = require('..');
+
+
+describe('strTail', function() {
+
+  it('returns the substring containing all characters but the first', function() {
+    assert.strictEqual(R.strTail('abc'), 'bc');
+    assert.strictEqual(R.strTail('ab'), 'b');
+    assert.strictEqual(R.strTail('a'), '');
+    assert.strictEqual(R.strTail(''), '');
+  });
+
+});

--- a/test/strTake.js
+++ b/test/strTake.js
@@ -1,0 +1,16 @@
+var assert = require('assert');
+
+var R = require('..');
+
+
+describe('strTake', function() {
+
+  it('returns the substring containing the first N characters', function() {
+    assert.strictEqual(R.strTake(0, 'abc'), '');
+    assert.strictEqual(R.strTake(1, 'abc'), 'a');
+    assert.strictEqual(R.strTake(2, 'abc'), 'ab');
+    assert.strictEqual(R.strTake(3, 'abc'), 'abc');
+    assert.strictEqual(R.strTake(4, 'abc'), 'abc');
+  });
+
+});

--- a/test/take.js
+++ b/test/take.js
@@ -4,6 +4,7 @@ var R = require('..');
 
 
 describe('take', function() {
+
   it('takes only the first `n` elements from a list', function() {
     assert.deepEqual(R.take(3, ['a', 'b', 'c', 'd', 'e', 'f', 'g']), ['a', 'b', 'c']);
   });
@@ -26,16 +27,10 @@ describe('take', function() {
     assert.notStrictEqual(R.take(-1, xs), xs);
   });
 
-  it('dispatches to `slice` method', function() {
-    var o = {slice: function(a, b) { return '[' + a + ':' + b + ']'; }};
-
-    assert.strictEqual(R.take(3, 'Ramda'), 'Ram');
-    assert.strictEqual(R.take(3, o), '[0:3]');
-  });
-
   it('is curried', function() {
     var take3 = R.take(3);
     assert.deepEqual(take3(['a', 'b', 'c', 'd', 'e', 'f', 'g']), ['a', 'b', 'c']);
     assert.deepEqual(take3(['w', 'x', 'y', 'z']), ['w', 'x', 'y']);
   });
+
 });


### PR DESCRIPTION
`slice`-based derivations have met resistance, so we need to include String-specific functions if we want to officially support strings:

```haskell
R.strSlice :: Number -> Number -> String -> String
R.strTake  :: Number -> String -> String
R.strDrop  :: Number -> String -> String
R.strInit  :: String -> String
R.strTail  :: String -> String
```

I'd prefer to *specify* that the fallback definitions of `R.take`, `R.drop`, `R.init`, and `R.tail` dispatch to `slice`, which removes the need for String-specific functions. But if we don't want to formalize this, we must choose one of the following options:

  - support strings in `R.take` and friends as an *undocumented feature* which could be removed at any time;

  - add String-specific slice functions; or

  - suggest that users use `R.slice(1, Infinity)` rather than `R.tail` when dealing with strings, `R.slice(0, 3)` rather than `R.take(3)`, etc.
