### PR TITLE
Make `and` and `or` sensible

### DIFF
--- a/src/and.js
+++ b/src/and.js
@@ -1,27 +1,24 @@
 var _curry2 = require('./internal/_curry2');
-var _hasMethod = require('./internal/_hasMethod');
 
 
 /**
- * A function that returns the first argument if it's falsy otherwise the second
- * argument. Note that this is NOT short-circuited, meaning that if expressions
- * are passed they are both evaluated.
- *
- * Dispatches to the `and` method of the first argument if applicable.
+ * A function that returns `true` only if both its arguments are strictly equal
+ * to `true`.
  *
  * @func
  * @memberOf R
  * @category Logic
- * @sig * -> * -> *
- * @param {*} a any value
- * @param {*} b any other value
- * @return {*} the first argument if falsy otherwise the second argument.
+ * @sig Boolean -> Boolean -> Boolean
+ * @param {Boolean} a A boolean value
+ * @param {Boolean} b A boolean value
+ * @return {Boolean} `true` if both arguments are `true`, `false` otherwise
  * @example
  *
+ *      R.and(true, true); //=> true
+ *      R.and(true, false); //=> false
  *      R.and(false, true); //=> false
- *      R.and(0, []); //=> 0
- *      R.and(null, ''); => null
+ *      R.and(false, false); //=> false
  */
 module.exports = _curry2(function and(a, b) {
-  return _hasMethod('and', a) ? a.and(b) : a && b;
+  return a === true && b === true;
 });

--- a/src/or.js
+++ b/src/or.js
@@ -1,27 +1,24 @@
 var _curry2 = require('./internal/_curry2');
-var _hasMethod = require('./internal/_hasMethod');
 
 
 /**
- * A function that returns the first truthy of two arguments otherwise the
- * last argument. Note that this is NOT short-circuited, meaning that if
- * expressions are passed they are both evaluated.
- *
- * Dispatches to the `or` method of the first argument if applicable.
+ * A function that returns `true` if one or both of its arguments are strictly
+ * equal to `true` argument.
  *
  * @func
  * @memberOf R
  * @category Logic
- * @sig * -> * -> *
- * @param {*} a any value
- * @param {*} b any other value
- * @return {*} the first truthy argument, otherwise the last argument.
+ * @sig Boolean -> Boolean -> Boolean
+ * @param {Boolean} a A boolean value
+ * @param {Boolean} b A boolean value
+ * @return {Boolean} `true` if one or both arguments are `true`, `false` otherwise
  * @example
  *
+ *      R.or(true, true); //=> true
+ *      R.or(true, false); //=> true
  *      R.or(false, true); //=> true
- *      R.or(0, []); //=> []
- *      R.or(null, ''); => ''
+ *      R.or(false, false); //=> false
  */
 module.exports = _curry2(function or(a, b) {
-  return _hasMethod('or', a) ? a.or(b) : a || b;
+  return a === true || b === true;
 });

--- a/test/and.js
+++ b/test/and.js
@@ -4,36 +4,16 @@ var R = require('..');
 
 
 describe('and', function() {
-  it('compares two values with js &&', function() {
-    var someAr = [];
-    assert.strictEqual(R.and(1, 1), 1);
-    assert.strictEqual(R.and(1, 0), 0);
-    assert.strictEqual(R.and(true, someAr), someAr);
-  });
-
-  it('dispatches to `and` method', function() {
-    function Nothing() {}
-    Nothing.prototype.and = function() { return this; };
-
-    function Just(x) { this.value = x; }
-    Just.prototype.and = R.identity;
-
-    var n1 = new Nothing();
-    var n2 = new Nothing();
-    var j1 = new Just(1);
-    var j2 = new Just(2);
-
-    assert.strictEqual(R.and(n1, n2), n1);
-    assert.strictEqual(R.and(n2, n1), n2);
-    assert.strictEqual(R.and(n1, j2), n1);
-    assert.strictEqual(R.and(j2, n1), n1);
-    assert.strictEqual(R.and(j1, j2), j2);
-    assert.strictEqual(R.and(j2, j1), j1);
+  it('checks is both its values are true', function() {
+    assert.strictEqual(R.and(true, true), true);
+    assert.strictEqual(R.and(true, false), false);
+    assert.strictEqual(R.and(false, true), false);
+    assert.strictEqual(R.and(false, false), false);
   });
 
   it('is curried', function() {
     var halfTruth = R.and(true);
     assert.strictEqual(halfTruth(false), false);
-    assert.strictEqual(halfTruth('lie'), 'lie');
+    assert.strictEqual(halfTruth(true), true);
   });
 });

--- a/test/or.js
+++ b/test/or.js
@@ -5,36 +5,14 @@ var R = require('..');
 
 describe('or', function() {
   it('compares two values with js &&', function() {
-    var someAr = [];
-    assert.strictEqual(R.or(1, 0), 1);
-    assert.strictEqual(R.or(0, 1), 1);
-    assert.strictEqual(R.or(someAr, false), someAr);
-    assert.strictEqual(R.or('', 0), 0);
-  });
-
-  it('dispatches to `or` method', function() {
-    function Nothing() {}
-    Nothing.prototype.or = R.identity;
-
-    function Just(x) { this.value = x; }
-    Just.prototype.or = function() { return this; };
-
-    var n1 = new Nothing();
-    var n2 = new Nothing();
-    var j1 = new Just(1);
-    var j2 = new Just(2);
-
-    assert.strictEqual(R.or(n1, n2), n2);
-    assert.strictEqual(R.or(n2, n1), n1);
-    assert.strictEqual(R.or(n1, j2), j2);
-    assert.strictEqual(R.or(j2, n1), j2);
-    assert.strictEqual(R.or(j1, j2), j1);
-    assert.strictEqual(R.or(j2, j1), j2);
+    assert.strictEqual(R.or(true, true), true);
+    assert.strictEqual(R.or(true, false), true);
+    assert.strictEqual(R.or(false, true), true);
+    assert.strictEqual(R.or(false, false), false);
   });
 
   it('is curried', function() {
-    assert.strictEqual(R.or('lie')(false), 'lie');
+    assert.strictEqual(R.or(false)(false), false);
     assert.strictEqual(R.or(false)(true), true);
-    assert.strictEqual(R.or('')(0), 0);
   });
 });


### PR DESCRIPTION
After the last wonderful change to `equals` it appears that we are no longer fixed on implementing the flaws of JavaScript's operators in our equivalent functions.

This PR implements `and` and `or` functions with simple sensible semantics and without type coercion.

We _might_ consider throwing if non-boolean arguments are received since JavaScript programmers are somewhat used to the crazy semantics of `&&` and `||`.

I also took out dispatching. This case is actually a perfect example of how harmful dispatching is! Dispatching was originally added in #1015 since @davidchambers wanted to use it with Sanctuary. The reasoning was that it would make it possible to write code like this:

```javascript
var a = S.Just(true);
var b = S.Nothing();
R.or(a, b);  // => S.Just(true);
```

But that is the wrong way to achieve the goal. The correct way is this:

```javascript
var a = S.Just(true);
var b = S.Nothing();
R.lift(R.or)(a, b);
```

At first the difference might not look like much – but it is _huge_. The first code relies on a magic correspondence between dispatching in `R.or` and a method named `or` on `a` and `b`. It forces users into _thinking_ and _knowing_ about dispatching at a low level.

In the second code however the only thing that matters is that `a` and `b` are applicatives. We could swap out `a` and `b` with _any_ applicative and the code would still work!

In other words the first code is an example of brittle code that relies on implementation details and only pretends to be general but really isn't. The second code however is an example of actually general code where one only works on abstract types specified by well defined interfaces.

Once again dispatching deceives us away from proper abstractions.

Removing the dispatching also means that we and only us decides the semantics of `or` and `and`. Third party libraries can no longer overload it with additional meaning and complexity.