### PR TITLE
do not mention "slice" in the R.take and R.drop docstrings and tests

### DIFF
--- a/src/drop.js
+++ b/src/drop.js
@@ -10,13 +10,11 @@ var slice = require('./slice');
  * Acts as a transducer if a transformer is given in list position.
  * @see R.transduce
  *
- * Dispatches to its second argument's `slice` method if present. As a
- * result, one may replace `[a]` with `String` in the type signature.
- *
  * @func
  * @memberOf R
  * @category List
  * @sig Number -> [a] -> [a]
+ * @sig Number -> String -> String
  * @param {Number} n The number of elements of `xs` to skip.
  * @param {Array} xs The collection to consider.
  * @return {Array}

--- a/src/slice.js
+++ b/src/slice.js
@@ -6,13 +6,11 @@ var _curry3 = require('./internal/_curry3');
  * Returns a list containing the elements of `xs` from `fromIndex` (inclusive)
  * to `toIndex` (exclusive).
  *
- * Dispatches to its third argument's `slice` method if present. As a
- * result, one may replace `[a]` with `String` in the type signature.
- *
  * @func
  * @memberOf R
  * @category List
  * @sig Number -> Number -> [a] -> [a]
+ * @sig Number -> Number -> String -> String
  * @param {Number} fromIndex The start index (inclusive).
  * @param {Number} toIndex The end index (exclusive).
  * @param {Array} xs The list to take elements from.

--- a/src/take.js
+++ b/src/take.js
@@ -11,13 +11,11 @@ var slice = require('./slice');
  * Acts as a transducer if a transformer is given in list position.
  * @see R.transduce
  *
- * Dispatches to its second argument's `slice` method if present. As a
- * result, one may replace `[a]` with `String` in the type signature.
- *
  * @func
  * @memberOf R
  * @category List
  * @sig Number -> [a] -> [a]
+ * @sig Number -> String -> String
  * @param {Number} n The number of elements to return.
  * @param {Array} xs The collection to consider.
  * @return {Array}

--- a/test/drop.js
+++ b/test/drop.js
@@ -25,11 +25,8 @@ describe('drop', function() {
     assert.notStrictEqual(R.drop(-1, xs), xs);
   });
 
-  it('dispatches to `slice` method', function() {
-    var o = {slice: function(a, b) { return '[' + a + ':' + b + ']'; }};
-
+  it('can operate on strings', function() {
     assert.strictEqual(R.drop(3, 'Ramda'), 'da');
-    assert.strictEqual(R.drop(3, o), '[3:Infinity]');
   });
 
   it('is curried', function() {

--- a/test/slice.js
+++ b/test/slice.js
@@ -12,8 +12,26 @@ describe('slice', function() {
     var args = (function() { return arguments; }(1, 2, 3, 4, 5));
     assert.deepEqual(R.slice(1, 4, args), [2, 3, 4]);
   });
-  it('dispatches to `slice` method', function() {
-    var obj = {slice: function() { return 42; }};
-    assert.strictEqual(R.slice(1, 4, obj), 42);
+  it('can operate on strings', function() {
+    assert.strictEqual(R.slice(0, 0, 'abc'), '');
+    assert.strictEqual(R.slice(0, 1, 'abc'), 'a');
+    assert.strictEqual(R.slice(0, 2, 'abc'), 'ab');
+    assert.strictEqual(R.slice(0, 3, 'abc'), 'abc');
+    assert.strictEqual(R.slice(0, 4, 'abc'), 'abc');
+    assert.strictEqual(R.slice(1, 0, 'abc'), '');
+    assert.strictEqual(R.slice(1, 1, 'abc'), '');
+    assert.strictEqual(R.slice(1, 2, 'abc'), 'b');
+    assert.strictEqual(R.slice(1, 3, 'abc'), 'bc');
+    assert.strictEqual(R.slice(1, 4, 'abc'), 'bc');
+    assert.strictEqual(R.slice(0, -4, 'abc'), '');
+    assert.strictEqual(R.slice(0, -3, 'abc'), '');
+    assert.strictEqual(R.slice(0, -2, 'abc'), 'a');
+    assert.strictEqual(R.slice(0, -1, 'abc'), 'ab');
+    assert.strictEqual(R.slice(0, -0, 'abc'), '');
+    assert.strictEqual(R.slice(-2, -4, 'abc'), '');
+    assert.strictEqual(R.slice(-2, -3, 'abc'), '');
+    assert.strictEqual(R.slice(-2, -2, 'abc'), '');
+    assert.strictEqual(R.slice(-2, -1, 'abc'), 'b');
+    assert.strictEqual(R.slice(-2, -0, 'abc'), '');
   });
 });

--- a/test/take.js
+++ b/test/take.js
@@ -26,11 +26,8 @@ describe('take', function() {
     assert.notStrictEqual(R.take(-1, xs), xs);
   });
 
-  it('dispatches to `slice` method', function() {
-    var o = {slice: function(a, b) { return '[' + a + ':' + b + ']'; }};
-
+  it('can operate on strings', function() {
     assert.strictEqual(R.take(3, 'Ramda'), 'Ram');
-    assert.strictEqual(R.take(3, o), '[0:3]');
   });
 
   it('is curried', function() {


### PR DESCRIPTION
Shall we remove this test as well?

```javascript
it('dispatches to `slice` method', function() {
  var obj = {slice: function() { return 42; }};
  assert.strictEqual(R.slice(1, 4, obj), 42);
});
```
