### PR TITLE
make R.converge a binary function

### DIFF
--- a/src/converge.js
+++ b/src/converge.js
@@ -1,24 +1,25 @@
+var _curry2 = require('./internal/_curry2');
 var _map = require('./internal/_map');
-var _slice = require('./internal/_slice');
 var curryN = require('./curryN');
 var max = require('./max');
 var pluck = require('./pluck');
 
 
 /**
- * Accepts at least three functions and returns a new function. When invoked, this new
- * function will invoke the first function, `after`, passing as its arguments the
- * results of invoking the subsequent functions with whatever arguments are passed to
- * the new function.
+ * Takes a combining function, `combine`, and a list of functions, `fns`.
+ * Returns a function which returns the result of applying `combine` to
+ * the results of applying each function in `fns` to its arguments.
+ *
+ * This is best explained by example: `R.converge(c, [f, g, h])(1, 2)`
+ * is equivalent to `c(f(1, 2), g(1, 2), h(1, 2))`.
  *
  * @func
  * @memberOf R
  * @category Function
- * @sig (x1 -> x2 -> ... -> z) -> ((a -> b -> ... -> x1), (a -> b -> ... -> x2), ...) -> (a -> b -> ... -> z)
- * @param {Function} after A function. `after` will be invoked with the return values of
- *        `fn1` and `fn2` as its arguments.
- * @param {...Function} functions A variable number of functions.
- * @return {Function} A new function.
+ * @sig ((b, c, ..., n) -> v) -> [(a -> b), (a -> c), ..., (a -> n)] -> (a -> v)
+ * @param {Function} combine
+ * @param {Array} fns
+ * @return {Function}
  * @example
  *
  *      var add = function(a, b) { return a + b; };
@@ -26,17 +27,16 @@ var pluck = require('./pluck');
  *      var subtract = function(a, b) { return a - b; };
  *
  *      //≅ multiply( add(1, 2), subtract(1, 2) );
- *      R.converge(multiply, add, subtract)(1, 2); //=> -3
+ *      R.converge(multiply, [add, subtract])(1, 2); //=> -3
  *
  *      var add3 = function(a, b, c) { return a + b + c; };
- *      R.converge(add3, multiply, add, subtract)(1, 2); //=> 4
+ *      R.converge(add3, [multiply, add, subtract])(1, 2); //=> 4
  */
-module.exports = curryN(3, function(after) {
-  var fns = _slice(arguments, 1);
+module.exports = _curry2(function converge(combine, fns) {
   return curryN(max(pluck('length', fns)), function() {
     var args = arguments;
     var context = this;
-    return after.apply(context, _map(function(fn) {
+    return combine.apply(context, _map(function(fn) {
       return fn.apply(context, args);
     }, fns));
   });

--- a/test/converge.js
+++ b/test/converge.js
@@ -7,20 +7,20 @@ describe('converge', function() {
   var mult = function(a, b) {return a * b;};
 
   var f1 = R.converge(mult,
-                      function(a) { return a; },
-                      function(a) { return a; });
+                      [function(a) { return a; },
+                       function(a) { return a; }]);
   var f2 = R.converge(mult,
-                      function(a) { return a; },
-                      function(a, b) { return b; });
+                      [function(a) { return a; },
+                       function(a, b) { return b; }]);
   var f3 = R.converge(mult,
-                      function(a) { return a; },
-                      function(a, b, c) { return c; });
+                      [function(a) { return a; },
+                       function(a, b, c) { return c; }]);
 
   it('passes the results of applying the arguments individually to two separate functions into a single one', function() {
-    assert.strictEqual(R.converge(mult, R.add(1), R.add(3))(2), 15); // mult(add1(2), add3(2)) = mult(3, 5) = 3 * 15;
+    assert.strictEqual(R.converge(mult, [R.add(1), R.add(3)])(2), 15); // mult(add1(2), add3(2)) = mult(3, 5) = 3 * 15;
   });
 
-  it('returns a function with the length of the "longest" argument', function() {
+  it('returns a function with the length of the "longest" function in the list', function() {
     assert.strictEqual(f1.length, 1);
     assert.strictEqual(f2.length, 2);
     assert.strictEqual(f3.length, 3);
@@ -30,7 +30,7 @@ describe('converge', function() {
     var a = function(x) { return this.f1(x); };
     var b = function(x) { return this.f2(x); };
     var c = function(x, y) { return this.f3(x, y); };
-    var d = R.converge(c, a, b);
+    var d = R.converge(c, [a, b]);
     var context = {f1: R.add(1), f2: R.add(2), f3: R.add};
     assert.equal(a.call(context, 1), 2);
     assert.equal(b.call(context, 1), 3);


### PR DESCRIPTION
Variadic functions with one or more "special" positions should be avoided. `R.converge` is currently in this category: the first argument is special, but the structure of `R.converge(f, g, h)` provides no indication of this. `R.converge(f, [g, h])` indicates that `g` and `h` are more closely related than `f` and `g`.
