### PR TITLE
fix metadata for R.addIndex

### DIFF
--- a/src/addIndex.js
+++ b/src/addIndex.js
@@ -19,8 +19,8 @@ var curryN = require('./curryN');
  * @category Function
  * @category List
  * @sig ((a ... -> b) ... -> [a] -> *) -> (a ..., Int, [a] -> b) ... -> [a] -> *)
- * @param {Function} fn A list iteration function that does not pass index/list to its callback
- * @return An altered list iteration function thats passes index/list to its callback
+ * @param {Function} fn A list iteration function that does not pass index or list to its callback
+ * @return {Function} An altered list iteration function that passes (item, index, list) to its callback
  * @example
  *
  *      var mapIndexed = R.addIndex(R.map);


### PR DESCRIPTION
The missing type breaks our script for generating the HTML documentation.
