### PR TITLE
diverge via exactly two unary functions in R.converge

### DIFF
--- a/src/converge.js
+++ b/src/converge.js
@@ -1,42 +1,27 @@
-var _map = require('./internal/_map');
-var _slice = require('./internal/_slice');
-var curryN = require('./curryN');
-var pluck = require('./pluck');
+var _curry3 = require('./internal/_curry3');
 
 
 /**
- * Accepts at least three functions and returns a new function. When invoked, this new
- * function will invoke the first function, `after`, passing as its arguments the
- * results of invoking the subsequent functions with whatever arguments are passed to
- * the new function.
+ * Takes a binary function, `combine`, and unary functions `f` and `g`.
+ * Returns a function with one parameter, `x`, which returns the result
+ * of applying `combine` to `f(x)` and `g(x)`.
+ *
+ * `R.converge(combine, f, g)(x)` is equivalent to `combine(f(x), g(x))`.
  *
  * @func
  * @memberOf R
  * @category Function
- * @sig (x1 -> x2 -> ... -> z) -> ((a -> b -> ... -> x1), (a -> b -> ... -> x2), ...) -> (a -> b -> ... -> z)
- * @param {Function} after A function. `after` will be invoked with the return values of
- *        `fn1` and `fn2` as its arguments.
- * @param {...Function} functions A variable number of functions.
- * @return {Function} A new function.
+ * @sig ((b, c) -> d) -> (a -> b) -> (a -> c) -> (a -> d)
+ * @param {Function} combine
+ * @param {Function} f
+ * @param {Function} g
+ * @return {Function}
  * @example
  *
- *      var add = function(a, b) { return a + b; };
- *      var multiply = function(a, b) { return a * b; };
- *      var subtract = function(a, b) { return a - b; };
- *
- *      //≅ multiply( add(1, 2), subtract(1, 2) );
- *      R.converge(multiply, add, subtract)(1, 2); //=> -3
- *
- *      var add3 = function(a, b, c) { return a + b + c; };
- *      R.converge(add3, multiply, add, subtract)(1, 2); //=> 4
+ *      R.converge(R.subtract, square, R.inc)(10); //=> (10 * 10) - (10 + 1)
  */
-module.exports = curryN(3, function(after) {
-  var fns = _slice(arguments, 1);
-  return curryN(Math.max.apply(Math, pluck('length', fns)), function() {
-    var args = arguments;
-    var context = this;
-    return after.apply(context, _map(function(fn) {
-      return fn.apply(context, args);
-    }, fns));
-  });
+module.exports = _curry3(function converge(combine, f, g) {
+  return function(x) {
+    return combine.call(this, f.call(this, x), g.call(this, x));
+  };
 });

--- a/test/converge.js
+++ b/test/converge.js
@@ -3,42 +3,38 @@ var assert = require('assert');
 var R = require('..');
 
 
+//  square :: Number -> Number
+var square = function(n) { return n * n; };
+
+
 describe('converge', function() {
-  var mult = function(a, b) {return a * b;};
 
-  var f1 = R.converge(mult,
-                      function(a) { return a; },
-                      function(a) { return a; });
-  var f2 = R.converge(mult,
-                      function(a) { return a; },
-                      function(a, b) { return b; });
-  var f3 = R.converge(mult,
-                      function(a) { return a; },
-                      function(a, b, c) { return c; });
-
-  it('passes the results of applying the arguments individually to two separate functions into a single one', function() {
-    assert.strictEqual(R.converge(mult, R.add(1), R.add(3))(2), 15); // mult(add1(2), add3(2)) = mult(3, 5) = 3 * 15;
+  it('is a ternary function', function() {
+    assert.strictEqual(typeof R.converge, 'function');
+    assert.strictEqual(R.converge.length, 3);
   });
 
-  it('returns a function with the length of the "longest" argument', function() {
-    assert.strictEqual(f1.length, 1);
-    assert.strictEqual(f2.length, 2);
-    assert.strictEqual(f3.length, 3);
+  it('diverges and converges', function() {
+    assert.strictEqual(R.converge(R.subtract, square, R.inc)(10), (10 * 10) - (10 + 1));
   });
 
   it('passes context to its functions', function() {
-    var a = function(x) { return this.f1(x); };
-    var b = function(x) { return this.f2(x); };
-    var c = function(x, y) { return this.f3(x, y); };
-    var d = R.converge(c, a, b);
-    var context = {f1: R.add(1), f2: R.add(2), f3: R.add};
-    assert.equal(a.call(context, 1), 2);
-    assert.equal(b.call(context, 1), 3);
-    assert.equal(d.call(context, 1), 5);
+    var c = function(a, b) { return this.f(a, b); };
+    var f = function(a) { return this.x + a; };
+    var g = function(a) { return this.x - a; };
+    var ctx = {
+      f: function(a, b) { return Math.pow(a - b, this.x); },
+      x: 3
+    };
+
+    assert.strictEqual(R.converge(c, f, g).call(ctx, 0), 0);  // Math.pow((3 + 0) - (3 - 0), 3)
+    assert.strictEqual(R.converge(c, f, g).call(ctx, 1), 8);  // Math.pow((3 + 1) - (3 - 1), 3)
+    assert.strictEqual(R.converge(c, f, g).call(ctx, 2), 64); // Math.pow((3 + 2) - (3 - 2), 3)
   });
 
-  it('returns a curried function', function() {
-    assert.strictEqual(f2(6)(7), 42);
-    assert.strictEqual(f3(R.__).length, 3);
+  it('is curried', function() {
+    assert.strictEqual(R.converge(R.subtract).length, 2);
+    assert.strictEqual(R.converge(R.subtract)(square).length, 1);
   });
+
 });


### PR DESCRIPTION
This pull request is based on suggestions by @scott-christopher and @buzzdecafe in #1229. It gives `R.converge` a dramatically simpler signature:

    R.converge :: ((b, c) -> d) -> (a -> b) -> (a -> c) -> a -> d

The implementation is now trivial:

```javascript
module.exports = curry(function converge(combine, f, g, x) {
  return combine(f(x), g(x));
});
```

I looked at a project with 34 occurrences of `R.converge`. The vast majority of these are compatible with the simpler signature. The few which are not are likely better expressed via lambdas. ;)
