### PR TITLE
Make match return an empty array when there are no matches

### DIFF
--- a/src/match.js
+++ b/src/match.js
@@ -1,19 +1,24 @@
+var _curry2 = require('./internal/_curry2');
+var compose = require('./internal/compose');
+var defaultTo = require('./defaultTo');
 var invoker = require('./invoker');
 
 
 /**
- * Tests a regular expression against a String
+ * Tests a regular expression against a String. Note that this function
+ * will return an empty array when there are no matches. This differs
+ * from [`String.prototype.match`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/match)
+ * which returns `null` when there are no matches.
  *
  * @func
  * @memberOf R
  * @category String
- * @sig RegExp -> String -> [String] | null
+ * @sig RegExp -> String -> [String | Undefined]
  * @param {RegExp} rx A regular expression.
  * @param {String} str The string to match against
- * @return {Array} The list of matches, or null if no matches found.
- * @see R.invoker
+ * @return {Array} The list of matches.
  * @example
  *
  *      R.match(/([a-z]a)/g, 'bananas'); //=> ['ba', 'na', 'na']
  */
-module.exports = invoker(1, 'match');
+module.exports = _curry2(compose(defaultTo([]), invoker(1, 'match')));

--- a/test/match.js
+++ b/test/match.js
@@ -8,12 +8,12 @@ describe('match', function() {
 
   it('determines whether a string matches a regex', function() {
     assert.strictEqual(R.match(re, 'B17-afn').length, 1);
-    assert.strictEqual(R.match(re, 'B1-afn'), null);
+    assert.deepEqual(R.match(re, 'B1-afn'), []);
   });
 
   it('is curried', function() {
     var format = R.match(re);
     assert.strictEqual(format('B17-afn').length, 1);
-    assert.strictEqual(format('B1-afn'), null);
+    assert.deepEqual(format('B1-afn'), []);
   });
 });


### PR DESCRIPTION
This is a breaking change which will return an empty array for the
`match` function when there are no matches. The old behavior had the
function return `null` in that case.

This deviates from the standard API but is IMHO an improvement. The deviation is also documented.