### PR TITLE
define R.isEmpty in terms of R.empty

### DIFF
--- a/src/empty.js
+++ b/src/empty.js
@@ -1,10 +1,15 @@
 var _curry1 = require('./internal/_curry1');
+var _isArguments = require('./internal/_isArguments');
+var _isArray = require('./internal/_isArray');
+var _isObject = require('./internal/_isObject');
+var _isString = require('./internal/_isString');
 
 
 /**
  * Returns the empty value of its argument's type. Ramda defines the empty
- * value of Array (`[]`), Object (`{}`), and String (`''`). Other types are
- * supported if they define `<Type>.empty` and/or `<Type>.prototype.empty`.
+ * value of Array (`[]`), Object (`{}`), String (`''`), and Arguments.
+ * Other types are supported if they define `<Type>.empty` and/or
+ * `<Type>.prototype.empty`.
  *
  * @func
  * @memberOf R
@@ -20,15 +25,20 @@ var _curry1 = require('./internal/_curry1');
  *      R.empty({x: 1, y: 2});  //=> {}
  */
 module.exports = _curry1(function empty(x) {
-  if (x != null && typeof x.empty === 'function') {
-    return x.empty();
-  } else if (x != null && typeof x.constructor != null && typeof x.constructor.empty === 'function') {
-    return x.constructor.empty();
-  } else {
-    switch (Object.prototype.toString.call(x)) {
-      case '[object Array]':  return [];
-      case '[object Object]': return {};
-      case '[object String]': return '';
-    }
-  }
+  return (
+    (x != null && typeof x.empty === 'function') ?
+      x.empty() :
+    (x != null && x.constructor != null && typeof x.constructor.empty === 'function') ?
+      x.constructor.empty() :
+    _isArray(x) ?
+      [] :
+    _isString(x) ?
+      '' :
+    _isObject(x) ?
+      {} :
+    _isArguments(x) ?
+      (function() { return arguments; }()) :
+    // else
+      void 0
+  );
 });

--- a/src/internal/_isArguments.js
+++ b/src/internal/_isArguments.js
@@ -1,0 +1,9 @@
+var _has = require('./_has');
+
+
+module.exports = (function() {
+  var toString = Object.prototype.toString;
+  return toString.call(arguments) === '[object Arguments]' ?
+    function _isArguments(x) { return toString.call(x) === '[object Arguments]'; } :
+    function _isArguments(x) { return _has('callee', x); };
+}());

--- a/src/internal/_isObject.js
+++ b/src/internal/_isObject.js
@@ -1,0 +1,3 @@
+module.exports = function _isObject(x) {
+  return Object.prototype.toString.call(x) === '[object Object]';
+};

--- a/src/isEmpty.js
+++ b/src/isEmpty.js
@@ -1,25 +1,28 @@
 var _curry1 = require('./internal/_curry1');
+var empty = require('./empty');
+var equals = require('./equals');
 
 
 /**
- * Reports whether the list has zero elements.
+ * Returns `true` if the given value is its type's empty value; `false`
+ * otherwise.
  *
  * @func
  * @memberOf R
  * @category Logic
- * @sig [a] -> Boolean
- * @param {Array} list
+ * @sig a -> Boolean
+ * @param {*} x
  * @return {Boolean}
+ * @see R.empty
  * @example
  *
  *      R.isEmpty([1, 2, 3]);   //=> false
  *      R.isEmpty([]);          //=> true
  *      R.isEmpty('');          //=> true
  *      R.isEmpty(null);        //=> false
- *      R.isEmpty(R.keys({}));  //=> true
- *      R.isEmpty({});          //=> false ({} does not have a length property)
- *      R.isEmpty({length: 0}); //=> true
+ *      R.isEmpty({});          //=> true
+ *      R.isEmpty({length: 0}); //=> false
  */
-module.exports = _curry1(function isEmpty(list) {
-  return Object(list).length === 0;
+module.exports = _curry1(function isEmpty(x) {
+  return x != null && equals(x, empty(x));
 });

--- a/test/empty.js
+++ b/test/empty.js
@@ -42,4 +42,9 @@ describe('empty', function() {
     /* jshint +W053 */
   });
 
+  it('returns empty arguments object given arguments object', function() {
+    var x = (function() { return arguments; }(1, 2, 3));
+    assert.strictEqual(R.toString(R.empty(x)), '(function() { return arguments; }())');
+  });
+
 });

--- a/test/isEmpty.js
+++ b/test/isEmpty.js
@@ -4,6 +4,7 @@ var R = require('..');
 
 
 describe('isEmpty', function() {
+
   it('returns false for null', function() {
     assert.strictEqual(R.isEmpty(null), false);
   });
@@ -14,34 +15,28 @@ describe('isEmpty', function() {
 
   it('returns true for empty string', function() {
     assert.strictEqual(R.isEmpty(''), true);
+    assert.strictEqual(R.isEmpty(' '), false);
   });
 
   it('returns true for empty array', function() {
     assert.strictEqual(R.isEmpty([]), true);
+    assert.strictEqual(R.isEmpty([[]]), false);
+  });
+
+  it('returns true for empty object', function() {
+    assert.strictEqual(R.isEmpty({}), true);
+    assert.strictEqual(R.isEmpty({x: 0}), false);
   });
 
   it('returns true for empty arguments object', function() {
     assert.strictEqual(R.isEmpty((function() { return arguments; }())), true);
-  });
-
-  it('returns true for object with own length property whose value is 0', function() {
-    assert.strictEqual(R.isEmpty({length: 0, x: 1, y: 2}), true);
-  });
-
-  it('returns true for object with inherited length property whose value is 0', function() {
-    function Empty() {}
-    Empty.prototype.length = 0;
-    assert.strictEqual(R.isEmpty(new Empty()), true);
+    assert.strictEqual(R.isEmpty((function() { return arguments; }(0))), false);
   });
 
   it('returns false for every other value', function() {
     assert.strictEqual(R.isEmpty(0), false);
     assert.strictEqual(R.isEmpty(NaN), false);
     assert.strictEqual(R.isEmpty(['']), false);
-    assert.strictEqual(R.isEmpty({}), false);
-
-    function Nonempty() {}
-    Nonempty.prototype.length = 1;
-    assert.strictEqual(R.isEmpty(new Nonempty()), false);
   });
+
 });


### PR DESCRIPTION
This pull request changes the meaning of `R.isEmpty(x)` from

> `x.length` is zero

to

> `x` is the empty value of its type

as discussed in #1236.

This pull request also updates `R.empty` to support Arguments.
