### PR TITLE
add R.propIs and R.propSatisfies

### DIFF
--- a/src/find.js
+++ b/src/find.js
@@ -21,8 +21,8 @@ var _xfind = require('./internal/_xfind');
  * @example
  *
  *      var xs = [{a: 1}, {a: 2}, {a: 3}];
- *      R.find(R.propEq('a', 2))(xs); //=> {a: 2}
- *      R.find(R.propEq('a', 4))(xs); //=> undefined
+ *      R.find(R.propEq(2, 'a'))(xs); //=> {a: 2}
+ *      R.find(R.propEq(4, 'a'))(xs); //=> undefined
  */
 module.exports = _curry2(_dispatchable('find', _xfind, function find(fn, list) {
   var idx = 0;

--- a/src/findIndex.js
+++ b/src/findIndex.js
@@ -21,8 +21,8 @@ var _xfindIndex = require('./internal/_xfindIndex');
  * @example
  *
  *      var xs = [{a: 1}, {a: 2}, {a: 3}];
- *      R.findIndex(R.propEq('a', 2))(xs); //=> 1
- *      R.findIndex(R.propEq('a', 4))(xs); //=> -1
+ *      R.findIndex(R.propEq(2, 'a'))(xs); //=> 1
+ *      R.findIndex(R.propEq(4, 'a'))(xs); //=> -1
  */
 module.exports = _curry2(_dispatchable('findIndex', _xfindIndex, function findIndex(fn, list) {
   var idx = 0;

--- a/src/findLast.js
+++ b/src/findLast.js
@@ -21,8 +21,8 @@ var _xfindLast = require('./internal/_xfindLast');
  * @example
  *
  *      var xs = [{a: 1, b: 0}, {a:1, b: 1}];
- *      R.findLast(R.propEq('a', 1))(xs); //=> {a: 1, b: 1}
- *      R.findLast(R.propEq('a', 4))(xs); //=> undefined
+ *      R.findLast(R.propEq(1, 'a'))(xs); //=> {a: 1, b: 1}
+ *      R.findLast(R.propEq(4, 'a'))(xs); //=> undefined
  */
 module.exports = _curry2(_dispatchable('findLast', _xfindLast, function findLast(fn, list) {
   var idx = list.length - 1;

--- a/src/findLastIndex.js
+++ b/src/findLastIndex.js
@@ -21,8 +21,8 @@ var _xfindLastIndex = require('./internal/_xfindLastIndex');
  * @example
  *
  *      var xs = [{a: 1, b: 0}, {a:1, b: 1}];
- *      R.findLastIndex(R.propEq('a', 1))(xs); //=> 1
- *      R.findLastIndex(R.propEq('a', 4))(xs); //=> -1
+ *      R.findLastIndex(R.propEq(1, 'a'))(xs); //=> 1
+ *      R.findLastIndex(R.propEq(4, 'a'))(xs); //=> -1
  */
 module.exports = _curry2(_dispatchable('findLastIndex', _xfindLastIndex, function findLastIndex(fn, list) {
   var idx = list.length - 1;

--- a/src/match.js
+++ b/src/match.js
@@ -1,5 +1,5 @@
 var _curry2 = require('./internal/_curry2');
-var compose = require('./internal/compose');
+var compose = require('./compose');
 var defaultTo = require('./defaultTo');
 var invoker = require('./invoker');
 

--- a/src/propEq.js
+++ b/src/propEq.js
@@ -1,18 +1,22 @@
 var _curry3 = require('./internal/_curry3');
 var equals = require('./equals');
+var propSatisfies = require('./propSatisfies');
 
 
 /**
- * Determines whether the given property of an object has a specific value,
- * in `R.equals` terms. Most likely used to filter a list.
+ * Returns `true` if the specified object property is equal, in `R.equals`
+ * terms, to the given value; `false` otherwise.
  *
  * @func
  * @memberOf R
  * @category Relation
- * @sig k -> v -> {k: v} -> Boolean
- * @param {Number|String} name The property name (or index) to use.
- * @param {*} val The value to compare the property with.
- * @return {Boolean} `true` if the properties are equal, `false` otherwise.
+ * @sig a -> String -> Object -> Boolean
+ * @param {*} val
+ * @param {String} name
+ * @param {*} obj
+ * @return {Boolean}
+ * @see R.equals
+ * @see R.propSatisfies
  * @example
  *
  *      var abby = {name: 'Abby', age: 7, hair: 'blond'};
@@ -20,9 +24,9 @@ var equals = require('./equals');
  *      var rusty = {name: 'Rusty', age: 10, hair: 'brown'};
  *      var alois = {name: 'Alois', age: 15, disposition: 'surly'};
  *      var kids = [abby, fred, rusty, alois];
- *      var hasBrownHair = R.propEq('hair', 'brown');
+ *      var hasBrownHair = R.propEq('brown', 'hair');
  *      R.filter(hasBrownHair, kids); //=> [fred, rusty]
  */
-module.exports = _curry3(function propEq(name, val, obj) {
-  return equals(obj[name], val);
+module.exports = _curry3(function propEq(val, name, obj) {
+  return propSatisfies(equals(val), name, obj);
 });

--- a/src/propIs.js
+++ b/src/propIs.js
@@ -1,0 +1,28 @@
+var _curry3 = require('./internal/_curry3');
+var is = require('./is');
+var propSatisfies = require('./propSatisfies');
+
+
+/**
+ * Returns `true` if the specified object property is of the given type;
+ * `false` otherwise.
+ *
+ * @func
+ * @memberOf R
+ * @category Type
+ * @sig Type -> String -> Object -> Boolean
+ * @param {Function} type
+ * @param {String} name
+ * @param {*} obj
+ * @return {Boolean}
+ * @see R.is
+ * @see R.propSatisfies
+ * @example
+ *
+ *      R.propIs(Number, 'x', {x: 1, y: 2});  //=> true
+ *      R.propIs(Number, 'x', {x: 'foo'});    //=> false
+ *      R.propIs(Number, 'x', {});            //=> false
+ */
+module.exports = _curry3(function propIs(type, name, obj) {
+  return propSatisfies(is(type), name, obj);
+});

--- a/src/propSatisfies.js
+++ b/src/propSatisfies.js
@@ -1,0 +1,24 @@
+var _curry3 = require('./internal/_curry3');
+
+
+/**
+ * Returns `true` if the specified object property satisfies the given
+ * predicate; `false` otherwise.
+ *
+ * @func
+ * @memberOf R
+ * @category Logic
+ * @sig (a -> Boolean) -> String -> {String: a} -> Boolean
+ * @param {Function} pred
+ * @param {String} name
+ * @param {*} obj
+ * @return {Boolean}
+ * @see R.propEq
+ * @see R.propIs
+ * @example
+ *
+ *      R.propSatisfies(x => x > 0, 'x', {x: 1, y: 2}); //=> true
+ */
+module.exports = _curry3(function propSatisfies(pred, name, obj) {
+  return pred(obj[name]);
+});

--- a/src/useWith.js
+++ b/src/useWith.js
@@ -23,23 +23,6 @@ var curry = require('./curry');
  * @return {Function} The wrapped function.
  * @example
  *
- *      // Example 1:
- *
- *      // Number -> [Person] -> [Person]
- *      var byAge = R.useWith(R.filter, R.propEq('age'), R.identity);
- *
- *      var kids = [
- *        {name: 'Abbie', age: 6},
- *        {name: 'Brian', age: 5},
- *        {name: 'Chris', age: 6},
- *        {name: 'David', age: 4},
- *        {name: 'Ellie', age: 5}
- *      ];
- *
- *      byAge(5, kids); //=> [{name: 'Brian', age: 5}, {name: 'Ellie', age: 5}]
- *
- *      // Example 2:
- *
  *      var double = function(y) { return y * 2; };
  *      var square = function(x) { return x * x; };
  *      var add = function(a, b) { return a + b; };

--- a/test/propEq.js
+++ b/test/propEq.js
@@ -4,15 +4,14 @@ var R = require('..');
 
 
 describe('propEq', function() {
-  var obj1 = {name: 'Abby', age: 7, hair: 'blond'};
-  var obj2 = {name: 'Fred', age: 12, hair: 'brown'};
-  var obj3 = {name: 'Rusty', age: 10, hair: 'brown'};
-  var obj4 = {name: 'Alois', age: 15, disposition: 'surly'};
+
+  var abby = {name: 'Abby', age: 7, hair: 'blond'};
+  var fred = {name: 'Fred', age: 12, hair: 'brown'};
 
   it('determines whether a particular property matches a given value for a specific object', function() {
-    assert.strictEqual(R.propEq('name', 'Abby', obj1), true);
-    assert.strictEqual(R.propEq('hair', 'brown', obj2), true);
-    assert.strictEqual(R.propEq('hair', 'blond', obj2), false);
+    assert.strictEqual(R.propEq('Abby', 'name', abby), true);
+    assert.strictEqual(R.propEq('brown', 'hair', fred), true);
+    assert.strictEqual(R.propEq('blond', 'hair', fred), false);
   });
 
   it('has R.equals semantics', function() {
@@ -21,20 +20,14 @@ describe('propEq', function() {
       return x instanceof Just && R.equals(x.value, this.value);
     };
 
-    assert.strictEqual(R.propEq('value', 0, {value: -0}), false);
-    assert.strictEqual(R.propEq('value', -0, {value: 0}), false);
-    assert.strictEqual(R.propEq('value', NaN, {value: NaN}), true);
-    assert.strictEqual(R.propEq('value', new Just([42]), {value: new Just([42])}), true);
+    assert.strictEqual(R.propEq(0, 'value', {value: -0}), false);
+    assert.strictEqual(R.propEq(-0, 'value', {value: 0}), false);
+    assert.strictEqual(R.propEq(NaN, 'value', {value: NaN}), true);
+    assert.strictEqual(R.propEq(new Just([42]), 'value', {value: new Just([42])}), true);
   });
 
   it('is curried', function() {
-    var kids = [obj1, obj2, obj3, obj4];
-    var hairMatch = R.propEq('hair');
-    assert.strictEqual(typeof hairMatch, 'function');
-    var brunette = hairMatch('brown');
-    assert.deepEqual(R.filter(brunette, kids), [obj2, obj3]);
-    // more likely usage:
-    assert.deepEqual(R.filter(R.propEq('hair', 'brown'), kids), [obj2, obj3]);
+    assert.strictEqual(R.propEq('Abby')('name')(abby), true);
   });
 
 });

--- a/test/propIs.js
+++ b/test/propIs.js
@@ -1,0 +1,17 @@
+var assert = require('assert');
+
+var R = require('..');
+
+
+describe('propIs', function() {
+
+  it('returns true if the specified object property is of the given type', function() {
+    assert.strictEqual(R.propIs(Number, 'value', {value: 1}), true);
+  });
+
+  it('returns false otherwise', function() {
+    assert.strictEqual(R.propIs(String, 'value', {value: 1}), false);
+    assert.strictEqual(R.propIs(String, 'value', {}), false);
+  });
+
+});

--- a/test/propSatisfies.js
+++ b/test/propSatisfies.js
@@ -1,0 +1,18 @@
+var assert = require('assert');
+
+var R = require('..');
+
+
+describe('propSatisfies', function() {
+
+  var isPositive = function(n) { return n > 0; };
+
+  it('returns true if the specified object property satisfies the given predicate', function() {
+    assert.strictEqual(R.propSatisfies(isPositive, 'x', {x: 1, y: 0}), true);
+  });
+
+  it('returns false otherwise', function() {
+    assert.strictEqual(R.propSatisfies(isPositive, 'y', {x: 1, y: 0}), false);
+  });
+
+});


### PR DESCRIPTION
In #1241, @bySabi defined this function:

```javascript
R.compose(R.is(String), R.prop('type'))
```

In JavaScript it's (sadly) quite common to need to check a property's type. I suggest it's at least as common as checking a property's value. `R.propEq` gives us a convenient way to check a property's value. `R.propIs` would give us a convenient way to check a property's type. The code above could then be rewritten as:

```javascript
R.propIs('type', String)
```

`R.propIs(a, b, c)` will throw a TypeError if `c` is null/undefined, as we'll attempt `c[a]`. This may or may not be optimal, but it matches the current behaviour of `R.propEq`.

---

__2015-07-08 update__

I've added `R.propSatisfies` and changed the signatures of `R.propEq` and `R.propIs`.

```haskell
R.propEq        :: a -> String -> Object -> Boolean
R.propIs        :: Type -> String -> Object -> Boolean
R.propSatisfies :: (a -> Boolean) -> String -> {String: a} -> Boolean
```

The change to `R.propEq` is breaking so will warrant a `:warning:` in the 0.16.0 upgrade guide.
