### PR TITLE
fix behaviour of R.take(0)

### DIFF
--- a/src/internal/_xtake.js
+++ b/src/internal/_xtake.js
@@ -11,9 +11,12 @@ module.exports = (function() {
   XTake.prototype['@@transducer/init'] = _xfBase.init;
   XTake.prototype['@@transducer/result'] = _xfBase.result;
   XTake.prototype['@@transducer/step'] = function(result, input) {
-    this.n -= 1;
-    return this.n === 0 ? _reduced(this.xf['@@transducer/step'](result, input))
-                        : this.xf['@@transducer/step'](result, input);
+    if (this.n === 0) {
+      return _reduced(result);
+    } else {
+      this.n -= 1;
+      return this.xf['@@transducer/step'](result, input);
+    }
   };
 
   return _curry2(function _xtake(n, xf) { return new XTake(n, xf); });

--- a/test/take.js
+++ b/test/take.js
@@ -4,6 +4,7 @@ var R = require('..');
 
 
 describe('take', function() {
+
   it('takes only the first `n` elements from a list', function() {
     assert.deepEqual(R.take(3, ['a', 'b', 'c', 'd', 'e', 'f', 'g']), ['a', 'b', 'c']);
   });
@@ -30,9 +31,14 @@ describe('take', function() {
     assert.strictEqual(R.take(3, 'Ramda'), 'Ram');
   });
 
+  it('handles zero correctly (#1224)', function() {
+    assert.deepEqual(R.into([], R.take(0), [1, 2, 3]), []);
+  });
+
   it('is curried', function() {
     var take3 = R.take(3);
     assert.deepEqual(take3(['a', 'b', 'c', 'd', 'e', 'f', 'g']), ['a', 'b', 'c']);
     assert.deepEqual(take3(['w', 'x', 'y', 'z']), ['w', 'x', 'y']);
   });
+
 });


### PR DESCRIPTION
Fixes #1224

I was able to reduce the failure case: `R.into([], R.take(0), [1, 2, 3])` currently evaluates to `[1, 2, 3]` rather than `[]`. The fix is straightforward.
