### PR TITLE
Simplify the defenition of isEmpty

### DIFF
--- a/src/isEmpty.js
+++ b/src/isEmpty.js
@@ -15,10 +15,7 @@ var _curry1 = require('./internal/_curry1');
  *      R.isEmpty([1, 2, 3]);   //=> false
  *      R.isEmpty([]);          //=> true
  *      R.isEmpty('');          //=> true
- *      R.isEmpty(null);        //=> false
- *      R.isEmpty(R.keys({}));  //=> true
- *      R.isEmpty({});          //=> false ({} does not have a length property)
- *      R.isEmpty({length: 0}); //=> true
+ *      R.isEmpty('foo');        //=> false
  */
 module.exports = _curry1(function isEmpty(list) {
   return Object(list).length === 0;

--- a/test/isEmpty.js
+++ b/test/isEmpty.js
@@ -4,44 +4,25 @@ var R = require('..');
 
 
 describe('isEmpty', function() {
-  it('returns false for null', function() {
-    assert.strictEqual(R.isEmpty(null), false);
-  });
-
-  it('returns false for undefined', function() {
-    assert.strictEqual(R.isEmpty(undefined), false);
-  });
 
   it('returns true for empty string', function() {
     assert.strictEqual(R.isEmpty(''), true);
+  });
+
+  it('returns false for a non empty string', function() {
+    assert.strictEqual(R.isEmpty('f'), false);
   });
 
   it('returns true for empty array', function() {
     assert.strictEqual(R.isEmpty([]), true);
   });
 
+  it('returns false for a non empty array', function() {
+    assert.strictEqual(R.isEmpty(['']), false);
+  });
+
   it('returns true for empty arguments object', function() {
     assert.strictEqual(R.isEmpty((function() { return arguments; }())), true);
   });
 
-  it('returns true for object with own length property whose value is 0', function() {
-    assert.strictEqual(R.isEmpty({length: 0, x: 1, y: 2}), true);
-  });
-
-  it('returns true for object with inherited length property whose value is 0', function() {
-    function Empty() {}
-    Empty.prototype.length = 0;
-    assert.strictEqual(R.isEmpty(new Empty()), true);
-  });
-
-  it('returns false for every other value', function() {
-    assert.strictEqual(R.isEmpty(0), false);
-    assert.strictEqual(R.isEmpty(NaN), false);
-    assert.strictEqual(R.isEmpty(['']), false);
-    assert.strictEqual(R.isEmpty({}), false);
-
-    function Nonempty() {}
-    Nonempty.prototype.length = 1;
-    assert.strictEqual(R.isEmpty(new Nonempty()), false);
-  });
 });


### PR DESCRIPTION
This is my suggestion on how to improve `isEmpty`. 

The code examples now only show cases that match up with the description
of the function. This has been reflected in the tests as well.
Implementation is left unchanged.

Note: I left examples with strings because it has been argued that *a string is just a list of characters*. I am willing to accept this but then I also think that we should make sure that all list functions support strings.