### PR TITLE
Change outdated reference in documentation for props

### DIFF
--- a/src/props.js
+++ b/src/props.js
@@ -2,7 +2,7 @@ var _curry2 = require('./internal/_curry2');
 
 
 /**
- * Acts as multiple `get`: array of keys in, array of values out. Preserves order.
+ * Acts as multiple `prop`: array of keys in, array of values out. Preserves order.
  *
  * @func
  * @memberOf R


### PR DESCRIPTION
`get` has been renamed to `prop`.