### PR TITLE
Add `R.uniqBy`

### DIFF
--- a/src/uniqBy.js
+++ b/src/uniqBy.js
@@ -1,0 +1,35 @@
+var _contains = require('./internal/_contains');
+var _curry2 = require('./internal/_curry2');
+
+
+/**
+ * Returns a new list containing only one copy of each element in the original
+ * list, based upon the value returned by applying the supplied function to each
+ * list element. Prefers the first item if the supplied function produces the
+ * same value on two items. `R.equals` is used for comparison.
+ *
+ * @func
+ * @memberOf R
+ * @category List
+ * @sig (a, b) -> [a] -> [a]
+ * @param {Function} fn A function used to produce a value to use during comparisons.
+ * @param {Array} list The array to consider.
+ * @return {Array} The list of unique items.
+ * @example
+ *
+ *      R.uniqBy(Math.abs, [-1, -5, 2, 10, 1, 2]); //=> [-1, -5, 2, 10]
+ *      R.uniqBy(R.prop("id"), [{id: 1, value: 10 }, {id: 2, value: true}, {id: 1, value: "foo"}]); //=> [{id: 1, value: 10}, {id: 2, value: true}]
+ */
+module.exports = _curry2(function uniqBy(fn, list) {
+  var idx = 0, applied = [], result = [], appliedItem, item;
+  while (idx < list.length) {
+    item = list[idx];
+    appliedItem = fn(item);
+    if (!_contains(appliedItem, applied)) {
+      result.push(item);
+      applied.push(appliedItem);
+    }
+    idx += 1;
+  }
+  return result;
+});

--- a/test/uniqBy.js
+++ b/test/uniqBy.js
@@ -1,0 +1,43 @@
+var assert = require('assert');
+
+var R = require('..');
+
+
+describe('uniqBy', function() {
+
+  var objs = [
+    {i: 1, v: 1}, {i: 2, v: 2}, {i: 3, v: 3}, {i: 4, v: 4}, {i: 5, v: 5},
+    {i: 6, v: 6}, {i: 7, v: 7}, {i: 8, v: 8}, {i: 9, v: 9}, {i: 10, v: 10}
+  ];
+
+  var objs2 = [
+    {i: 1, v: 1}, {i: 2, v: 2}, {i: 2, v: 3}, {i: 4, v: 4}, {i: 5, v: 5},
+    {i: 6, v: 6}, {i: 6, v: 7}, {i: 6, v: 8}, {i: 9, v: 9}, {i: 5, v: 10}
+  ];
+
+  it('returns a set from any array (i.e. purges duplicate elements) based on predicate', function() {
+    assert.deepEqual(R.uniqBy(R.prop('i'), objs), objs);
+    assert.deepEqual(R.uniqBy(R.prop('i'), objs2), [{i: 1, v: 1}, {i: 2, v: 2}, {i: 4, v: 4}, {i: 5, v: 5}, {i: 6, v: 6}, {i: 9, v: 9}]);
+  });
+
+  it('keeps elements from the left', function() {
+    assert.deepEqual(R.uniqBy(Math.abs, [-1, 2, 4, 3, 1, 3]), [-1, 2, 4, 3]);
+  });
+
+  it('returns an empty array for an empty array', function() {
+    assert.deepEqual(R.uniqBy(R.prop('i'), []), []);
+  });
+
+  it('has R.equals semantics', function() {
+    function Just(x) {
+      this.value = x;
+    }
+    Just.prototype.equals = function(x) {
+      return x instanceof Just && R.equals(x.value, this.value);
+    };
+    assert.strictEqual(R.uniqBy(Math.abs, [-1, 1]).length, 1);
+    assert.strictEqual(R.uniqBy(R.identity, [new Just([-1]), new Just([-1])]).length, 1);
+    assert.strictEqual(R.uniqBy(R.identity, [-0, 0]).length, 2);
+    assert.strictEqual(R.uniqBy(R.identity, [NaN, NaN]).length, 1);
+  });
+});


### PR DESCRIPTION
I was converting some code using `lodash` into using `ramda` instead and I wasn't able to find a straight alternative to `_.uniqBy`. 

I was able to compose a comparator in a point-free way, but my best attempt was just an unwieldy composition using `uniqWith`, `converge`, `equals`, `nthArg`, and `compose`:

```javascript
_.uniqBy(_.property("id")); // lodash

R.uniqWith(R.converge(R.equals, R.compose(R.prop("id"), R.nthArg(0))), R.compose(R.prop("id"), R.nthArg(1)))
```

I'm totally not discounting the possibility that there is a way to do this more concisely in a point-free manner, as I'm rather new to functional paradigms. If it turns out that there *is* a more concise way, I would love to take a look at it as it will be a good study for me.

However I figured I just implement `R.uniqBy` in case its something that actually adds value to `ramda`:

A simple example:

```javascript
R.uniqBy(Math.abs)([1, -2, 3, 5, 2, -3, 5]); // [1, -2, 3, 5] 
```