### PR TITLE
support strings in index and slice functions

### DIFF
--- a/src/drop.js
+++ b/src/drop.js
@@ -5,9 +5,8 @@ var slice = require('./slice');
 
 
 /**
- * Returns a list containing all but the first `n` elements of the given `list`.
- *
- * Acts as a transducer if a transformer is given in list position.
+ * Returns all but the first `n` elements of the given list, string, or
+ * transducer/transformer (or object with a `drop` method).
  *
  * @func
  * @memberOf R
@@ -15,9 +14,9 @@ var slice = require('./slice');
  * @see R.transduce
  * @sig Number -> [a] -> [a]
  * @sig Number -> String -> String
- * @param {Number} n The number of elements of `xs` to skip.
- * @param {Array} xs The collection to consider.
- * @return {Array}
+ * @param {Number} n
+ * @param {*} list
+ * @return {*}
  * @example
  *
  *      R.drop(1, ['foo', 'bar', 'baz']); //=> ['bar', 'baz']

--- a/src/head.js
+++ b/src/head.js
@@ -2,19 +2,23 @@ var nth = require('./nth');
 
 
 /**
- * Returns the first element in a list.
- * In some libraries this function is named `first`.
+ * Returns the first element of the given list or string. In some libraries
+ * this function is named `first`.
  *
  * @func
  * @memberOf R
  * @category List
  * @see R.tail, R.init, R.last
  * @sig [a] -> a | Undefined
- * @param {Array} list The array to consider.
- * @return {*} The first element of the list, or `undefined` if the list is empty.
+ * @sig String -> String
+ * @param {*} list
+ * @return {*}
  * @example
  *
  *      R.head(['fi', 'fo', 'fum']); //=> 'fi'
  *      R.head([]); //=> undefined
+ *
+ *      R.head('abc'); //=> 'a'
+ *      R.head(''); //=> ''
  */
 module.exports = nth(0);

--- a/src/init.js
+++ b/src/init.js
@@ -2,18 +2,26 @@ var slice = require('./slice');
 
 
 /**
- * Returns all but the last element of a list.
+ * Returns all but the last element of the given list or string.
  *
  * @func
  * @memberOf R
  * @category List
  * @see R.last, R.head, R.tail
  * @sig [a] -> [a]
- * @param {Array} list The array to consider.
- * @return {Array} A new array containing all but the last element of the input list, or an
- *         empty list if the input list is empty.
+ * @sig String -> String
+ * @param {*} list
+ * @return {*}
  * @example
  *
- *      R.init(['fi', 'fo', 'fum']); //=> ['fi', 'fo']
+ *      R.init([1, 2, 3]);  //=> [1, 2]
+ *      R.init([1, 2]);     //=> [1]
+ *      R.init([1]);        //=> []
+ *      R.init([]);         //=> []
+ *
+ *      R.init('abc');  //=> 'ab'
+ *      R.init('ab');   //=> 'a'
+ *      R.init('a');    //=> ''
+ *      R.init('');     //=> ''
  */
 module.exports = slice(0, -1);

--- a/src/internal/_isString.js
+++ b/src/internal/_isString.js
@@ -1,0 +1,3 @@
+module.exports = function _isString(x) {
+  return Object.prototype.toString.call(x) === '[object String]';
+};

--- a/src/last.js
+++ b/src/last.js
@@ -2,18 +2,22 @@ var nth = require('./nth');
 
 
 /**
- * Returns the last element from a list.
+ * Returns the last element of the given list or string.
  *
  * @func
  * @memberOf R
  * @category List
  * @see R.init, R.head, R.tail
  * @sig [a] -> a | Undefined
- * @param {Array} list The array to consider.
- * @return {*} The last element of the list, or `undefined` if the list is empty.
+ * @sig String -> String
+ * @param {*} list
+ * @return {*}
  * @example
  *
  *      R.last(['fi', 'fo', 'fum']); //=> 'fum'
  *      R.last([]); //=> undefined
+ *
+ *      R.last('abc'); //=> 'c'
+ *      R.last(''); //=> ''
  */
 module.exports = nth(-1);

--- a/src/nth.js
+++ b/src/nth.js
@@ -1,24 +1,30 @@
 var _curry2 = require('./internal/_curry2');
+var _isString = require('./internal/_isString');
 
 
 /**
- * Returns the nth element in a list.
+ * Returns the nth element of the given list or string.
  * If n is negative the element at index length + n is returned.
  *
  * @func
  * @memberOf R
  * @category List
  * @sig Number -> [a] -> a | Undefined
- * @param {Number} idx
- * @param {Array} list
- * @return {*} The nth element of the list.
+ * @sig Number -> String -> String
+ * @param {Number} offset
+ * @param {*} list
+ * @return {*}
  * @example
  *
  *      var list = ['foo', 'bar', 'baz', 'quux'];
  *      R.nth(1, list); //=> 'bar'
  *      R.nth(-1, list); //=> 'quux'
  *      R.nth(-99, list); //=> undefined
+ *
+ *      R.nth('abc', 2); //=> 'c'
+ *      R.nth('abc', 3); //=> ''
  */
-module.exports = _curry2(function nth(n, list) {
-  return n < 0 ? list[list.length + n] : list[n];
+module.exports = _curry2(function nth(offset, list) {
+  var idx = offset < 0 ? list.length + offset : offset;
+  return _isString(list) ? list.charAt(idx) : list[idx];
 });

--- a/src/nthChar.js
+++ b/src/nthChar.js
@@ -11,6 +11,7 @@ var _curry2 = require('./internal/_curry2');
  * @param {Number} n
  * @param {String} str
  * @return {String}
+ * @deprecated since v0.16.0
  * @example
  *
  *      R.nthChar(2, 'Ramda'); //=> 'm'

--- a/src/nthCharCode.js
+++ b/src/nthCharCode.js
@@ -11,6 +11,7 @@ var _curry2 = require('./internal/_curry2');
  * @param {Number} n
  * @param {String} str
  * @return {Number}
+ * @deprecated since v0.16.0
  * @example
  *
  *      R.nthCharCode(2, 'Ramda'); //=> 'm'.charCodeAt(0)

--- a/src/slice.js
+++ b/src/slice.js
@@ -3,8 +3,8 @@ var _curry3 = require('./internal/_curry3');
 
 
 /**
- * Returns a list containing the elements of `xs` from `fromIndex` (inclusive)
- * to `toIndex` (exclusive).
+ * Returns the elements of the given list or string (or object with a `slice`
+ * method) from `fromIndex` (inclusive) to `toIndex` (exclusive).
  *
  * @func
  * @memberOf R
@@ -13,8 +13,8 @@ var _curry3 = require('./internal/_curry3');
  * @sig Number -> Number -> String -> String
  * @param {Number} fromIndex The start index (inclusive).
  * @param {Number} toIndex The end index (exclusive).
- * @param {Array} xs The list to take elements from.
- * @return {Array} The slice of `xs` from `fromIndex` to `toIndex`.
+ * @param {*} list
+ * @return {*}
  * @example
  *
  *      R.slice(1, 3, ['a', 'b', 'c', 'd']);        //=> ['b', 'c']
@@ -23,6 +23,6 @@ var _curry3 = require('./internal/_curry3');
  *      R.slice(-3, -1, ['a', 'b', 'c', 'd']);      //=> ['b', 'c']
  *      R.slice(0, 3, 'ramda');                     //=> 'ram'
  */
-module.exports = _curry3(_checkForMethod('slice', function slice(fromIndex, toIndex, xs) {
-  return Array.prototype.slice.call(xs, fromIndex, toIndex);
+module.exports = _curry3(_checkForMethod('slice', function slice(fromIndex, toIndex, list) {
+  return Array.prototype.slice.call(list, fromIndex, toIndex);
 }));

--- a/src/tail.js
+++ b/src/tail.js
@@ -1,23 +1,29 @@
 var _checkForMethod = require('./internal/_checkForMethod');
-var _slice = require('./internal/_slice');
+var slice = require('./slice');
 
 
 /**
- * Returns all but the first element of a list. If the list provided has the `tail` method,
- * it will instead return `list.tail()`.
+ * Returns all but the first element of the given list or string (or object
+ * with a `tail` method).
  *
  * @func
  * @memberOf R
  * @category List
  * @see R.head, R.init, R.last
  * @sig [a] -> [a]
- * @param {Array} list The array to consider.
- * @return {Array} A new array containing all but the first element of the input list, or an
- *         empty list if the input list is empty.
+ * @sig String -> String
+ * @param {*} list
+ * @return {*}
  * @example
  *
- *      R.tail(['fi', 'fo', 'fum']); //=> ['fo', 'fum']
+ *      R.tail([1, 2, 3]);  //=> [2, 3]
+ *      R.tail([1, 2]);     //=> [2]
+ *      R.tail([1]);        //=> []
+ *      R.tail([]);         //=> []
+ *
+ *      R.tail('abc');  //=> 'bc'
+ *      R.tail('ab');   //=> 'b'
+ *      R.tail('a');    //=> ''
+ *      R.tail('');     //=> ''
  */
-module.exports = _checkForMethod('tail', function tail(list) {
-  return _slice(list, 1);
-});
+module.exports = _checkForMethod('tail', slice(1, Infinity));

--- a/src/take.js
+++ b/src/take.js
@@ -5,20 +5,17 @@ var slice = require('./slice');
 
 
 /**
- * Returns a new list containing the first `n` elements of the given list.
- * If `n > list.length`, returns a list of `list.length` elements.
- *
- * Acts as a transducer if a transformer is given in list position.
- * @see R.transduce
+ * Returns the first `n` elements of the given list, string, or
+ * transducer/transformer (or object with a `take` method).
  *
  * @func
  * @memberOf R
  * @category List
  * @sig Number -> [a] -> [a]
  * @sig Number -> String -> String
- * @param {Number} n The number of elements to return.
- * @param {Array} xs The collection to consider.
- * @return {Array}
+ * @param {Number} n
+ * @param {*} list
+ * @return {*}
  * @example
  *
  *      R.take(1, ['foo', 'bar', 'baz']); //=> ['foo']

--- a/test/drop.js
+++ b/test/drop.js
@@ -4,6 +4,7 @@ var R = require('..');
 
 
 describe('drop', function() {
+
   it('skips the first `n` elements from a list, returning the remainder', function() {
     assert.deepEqual(R.drop(3, ['a', 'b', 'c', 'd', 'e', 'f', 'g']), ['d', 'e', 'f', 'g']);
   });
@@ -27,11 +28,9 @@ describe('drop', function() {
 
   it('can operate on strings', function() {
     assert.strictEqual(R.drop(3, 'Ramda'), 'da');
+    assert.strictEqual(R.drop(4, 'Ramda'), 'a');
+    assert.strictEqual(R.drop(5, 'Ramda'), '');
+    assert.strictEqual(R.drop(6, 'Ramda'), '');
   });
 
-  it('is curried', function() {
-    var drop2 = R.drop(2);
-    assert.deepEqual(drop2(['a', 'b', 'c', 'd', 'e']), ['c', 'd', 'e']);
-    assert.deepEqual(drop2(['x', 'y', 'z']), ['z']);
-  });
 });

--- a/test/head.js
+++ b/test/head.js
@@ -4,14 +4,22 @@ var R = require('..');
 
 
 describe('head', function() {
-  it('returns undefined for an empty list', function() {
-    assert.strictEqual(typeof(R.head([])),  'undefined');
+
+  it('returns the first element of an ordered collection', function() {
+    assert.strictEqual(R.head([1, 2, 3]), 1);
+    assert.strictEqual(R.head([2, 3]), 2);
+    assert.strictEqual(R.head([3]), 3);
+    assert.strictEqual(R.head([]), undefined);
+
+    assert.strictEqual(R.head('abc'), 'a');
+    assert.strictEqual(R.head('bc'), 'b');
+    assert.strictEqual(R.head('c'), 'c');
+    assert.strictEqual(R.head(''), '');
   });
-  it('returns the first element of a list', function() {
-    assert.strictEqual(R.head(['a', 'b', 'c', 'd']), 'a');
-  });
+
   it('throws if applied to null or undefined', function() {
     assert.throws(function() { R.head(null); }, TypeError);
     assert.throws(function() { R.head(undefined); }, TypeError);
   });
+
 });

--- a/test/init.js
+++ b/test/init.js
@@ -4,18 +4,27 @@ var R = require('..');
 
 
 describe('init', function() {
-  it('returns an empty list for an empty list', function() {
+
+  it('returns all but the last element of an ordered collection', function() {
+    assert.deepEqual(R.init([1, 2, 3]), [1, 2]);
+    assert.deepEqual(R.init([2, 3]), [2]);
+    assert.deepEqual(R.init([3]), []);
     assert.deepEqual(R.init([]), []);
+
+    assert.strictEqual(R.init('abc'), 'ab');
+    assert.strictEqual(R.init('bc'), 'b');
+    assert.strictEqual(R.init('c'), '');
+    assert.strictEqual(R.init(''), '');
   });
-  it('returns a new list containing all the elements except the last element of a list', function() {
-    assert.deepEqual(R.init(['a', 'b', 'c', 'd']), ['a', 'b', 'c']);
-  });
+
   it('throws if applied to null or undefined', function() {
     assert.throws(function() { R.init(null); }, TypeError);
     assert.throws(function() { R.init(undefined); }, TypeError);
   });
+
   it('handles array-like object', function() {
     var args = (function() { return arguments; }(1, 2, 3, 4, 5));
     assert.deepEqual(R.init(args), [1, 2, 3, 4]);
   });
+
 });

--- a/test/last.js
+++ b/test/last.js
@@ -4,14 +4,22 @@ var R = require('..');
 
 
 describe('last', function() {
-  it('returns undefined for an empty list', function() {
-    assert.strictEqual(typeof(R.last([])),  'undefined');
+
+  it('returns the first element of an ordered collection', function() {
+    assert.strictEqual(R.last([1, 2, 3]), 3);
+    assert.strictEqual(R.last([1, 2]), 2);
+    assert.strictEqual(R.last([1]), 1);
+    assert.strictEqual(R.last([]), undefined);
+
+    assert.strictEqual(R.last('abc'), 'c');
+    assert.strictEqual(R.last('ab'), 'b');
+    assert.strictEqual(R.last('a'), 'a');
+    assert.strictEqual(R.last(''), '');
   });
-  it('returns the first element of a list', function() {
-    assert.strictEqual(R.last(['a', 'b', 'c', 'd']), 'd');
-  });
+
   it('throws if applied to null or undefined', function() {
     assert.throws(function() { R.last(null); }, TypeError);
     assert.throws(function() { R.last(undefined); }, TypeError);
   });
+
 });

--- a/test/nth.js
+++ b/test/nth.js
@@ -4,6 +4,7 @@ var R = require('..');
 
 
 describe('nth', function() {
+
   var list = ['foo', 'bar', 'baz', 'quux'];
 
   it('accepts positive offsets', function() {
@@ -12,19 +13,29 @@ describe('nth', function() {
     assert.strictEqual(R.nth(2, list), 'baz');
     assert.strictEqual(R.nth(3, list), 'quux');
     assert.strictEqual(R.nth(4, list), undefined);
+
+    assert.strictEqual(R.nth(0, 'abc'), 'a');
+    assert.strictEqual(R.nth(1, 'abc'), 'b');
+    assert.strictEqual(R.nth(2, 'abc'), 'c');
+    assert.strictEqual(R.nth(3, 'abc'), '');
   });
+
   it('accepts negative offsets', function() {
     assert.strictEqual(R.nth(-1, list), 'quux');
     assert.strictEqual(R.nth(-2, list), 'baz');
     assert.strictEqual(R.nth(-3, list), 'bar');
     assert.strictEqual(R.nth(-4, list), 'foo');
     assert.strictEqual(R.nth(-5, list), undefined);
+
+    assert.strictEqual(R.nth(-1, 'abc'), 'c');
+    assert.strictEqual(R.nth(-2, 'abc'), 'b');
+    assert.strictEqual(R.nth(-3, 'abc'), 'a');
+    assert.strictEqual(R.nth(-4, 'abc'), '');
   });
-  it('is curried', function() {
-    assert.strictEqual(R.nth(0)(list), 'foo');
-  });
+
   it('throws if applied to null or undefined', function() {
     assert.throws(function() { R.nth(0, null); }, TypeError);
     assert.throws(function() { R.nth(0, undefined); }, TypeError);
   });
+
 });

--- a/test/tail.js
+++ b/test/tail.js
@@ -4,14 +4,22 @@ var R = require('..');
 
 
 describe('tail', function() {
-  it('returns an empty list for an empty list', function() {
+
+  it('returns the tail of an ordered collection', function() {
+    assert.deepEqual(R.tail([1, 2, 3]), [2, 3]);
+    assert.deepEqual(R.tail([2, 3]), [3]);
+    assert.deepEqual(R.tail([3]), []);
     assert.deepEqual(R.tail([]), []);
+
+    assert.strictEqual(R.tail('abc'), 'bc');
+    assert.strictEqual(R.tail('bc'), 'c');
+    assert.strictEqual(R.tail('c'), '');
+    assert.strictEqual(R.tail(''), '');
   });
-  it('returns a new list containing all the elements after the first element of a list', function() {
-    assert.deepEqual(R.tail(['a', 'b', 'c', 'd']), ['b', 'c', 'd']);
-  });
+
   it('throws if applied to null or undefined', function() {
     assert.throws(function() { R.tail(null); }, TypeError);
     assert.throws(function() { R.tail(undefined); }, TypeError);
   });
+
 });

--- a/test/take.js
+++ b/test/take.js
@@ -29,16 +29,13 @@ describe('take', function() {
 
   it('can operate on strings', function() {
     assert.strictEqual(R.take(3, 'Ramda'), 'Ram');
+    assert.strictEqual(R.take(2, 'Ramda'), 'Ra');
+    assert.strictEqual(R.take(1, 'Ramda'), 'R');
+    assert.strictEqual(R.take(0, 'Ramda'), '');
   });
 
   it('handles zero correctly (#1224)', function() {
     assert.deepEqual(R.into([], R.take(0), [1, 2, 3]), []);
-  });
-
-  it('is curried', function() {
-    var take3 = R.take(3);
-    assert.deepEqual(take3(['a', 'b', 'c', 'd', 'e', 'f', 'g']), ['a', 'b', 'c']);
-    assert.deepEqual(take3(['w', 'x', 'y', 'z']), ['w', 'x', 'y']);
   });
 
 });


### PR DESCRIPTION
Closes #1199

Changes:

  - :scroll: `R.nth`: reword description; add doctests; update behaviour
  - :scroll: `R.head`: reword description; add doctests
  - :scroll: `R.last`: reword description; add doctests
  - :scroll: `R.slice`: reword description
  - :scroll: `R.tail`: reword description; add doctests; update behaviour
  - :scroll: `R.init`: reword description; add doctests
  - :scroll: `R.take`: reword description
  - :scroll: `R.drop`: reword description
  - :floppy_disk: `R.nthChar`: deprecate, since `R.nth` is now polymorphic
  - :floppy_disk: `R.nthCharCode`: deprecate, since it has a niche role already served by `R.invoker`
