### PR TITLE
deprecate R.times

### DIFF
--- a/src/times.js
+++ b/src/times.js
@@ -15,6 +15,7 @@ var _curry2 = require('./internal/_curry2');
  * @param {Function} fn The function to invoke. Passed one argument, the current value of `n`.
  * @param {Number} n A value between `0` and `n - 1`. Increments after each function call.
  * @return {Array} An array containing the return values of all calls to `fn`.
+ * @deprecated since v0.18.0
  * @example
  *
  *      R.times(R.identity, 5); //=> [0, 1, 2, 3, 4]


### PR DESCRIPTION
Closes #1250

As discussed in #1251, `R.times(f, n)` is sugar for `R.map(f, R.range(0, n))`. In my view this sugar is not warranted.

As an aside, several of my colleagues have complained about the number of functions in the library. Although my position is that no one is being forced to use *all* the functions, we should remain on the lookout for functions which no longer pull their weight.
