### PR TITLE
add missing function names

### DIFF
--- a/src/addIndex.js
+++ b/src/addIndex.js
@@ -27,7 +27,7 @@ var curryN = require('./curryN');
  *      mapIndexed(function(val, idx) {return idx + '-' + val;}, ['f', 'o', 'o', 'b', 'a', 'r']);
  *      //=> ['0-f', '1-o', '2-o', '3-b', '4-a', '5-r']
  */
-module.exports = _curry1(function(fn) {
+module.exports = _curry1(function addIndex(fn) {
   return curryN(fn.length, function() {
     var idx = 0;
     var origFn = arguments[0];

--- a/src/adjust.js
+++ b/src/adjust.js
@@ -23,7 +23,7 @@ var _curry3 = require('./internal/_curry3');
  *      R.adjust(R.add(10), 1, [0, 1, 2]);     //=> [0, 11, 2]
  *      R.adjust(R.add(10))(1)([0, 1, 2]);     //=> [0, 11, 2]
  */
-module.exports = _curry3(function(fn, idx, list) {
+module.exports = _curry3(function adjust(fn, idx, list) {
   if (idx >= list.length || idx < -list.length) {
     return list;
   }

--- a/src/composeL.js
+++ b/src/composeL.js
@@ -27,7 +27,7 @@ var _composeL = require('./internal/_composeL');
  *      secondOfXOfHeadLens(source); //=> 1
  *      secondOfXOfHeadLens.set(123, source); //=> [{x: [0, 123], y: [2, 3]}, {x: [4, 5], y: [6, 7]}]
  */
-module.exports = function() {
+module.exports = function composeL() {
   var fn = arguments[arguments.length - 1];
   var idx = arguments.length - 2;
   while (idx >= 0) {

--- a/src/concat.js
+++ b/src/concat.js
@@ -25,7 +25,7 @@ var _isArray = require('./internal/_isArray');
  *      R.concat([4, 5, 6], [1, 2, 3]); //=> [4, 5, 6, 1, 2, 3]
  *      R.concat('ABC', 'DEF'); // 'ABCDEF'
  */
-module.exports = _curry2(function(set1, set2) {
+module.exports = _curry2(function concat(set1, set2) {
   if (_isArray(set2)) {
     return _concat(set1, set2);
   } else if (_hasMethod('concat', set1)) {

--- a/src/converge.js
+++ b/src/converge.js
@@ -30,7 +30,7 @@ var pluck = require('./pluck');
  *      var add3 = function(a, b, c) { return a + b + c; };
  *      R.converge(add3, multiply, add, subtract)(1, 2); //=> 4
  */
-module.exports = curryN(3, function(after) {
+module.exports = curryN(3, function converge(after) {
   var fns = _slice(arguments, 1);
   return curryN(Math.max.apply(Math, pluck('length', fns)), function() {
     var args = arguments;

--- a/src/hasIn.js
+++ b/src/hasIn.js
@@ -26,6 +26,6 @@ var _curry2 = require('./internal/_curry2');
  *      R.hasIn('width', square);  //=> true
  *      R.hasIn('area', square);  //=> true
  */
-module.exports = _curry2(function(prop, obj) {
+module.exports = _curry2(function hasIn(prop, obj) {
   return prop in obj;
 });

--- a/src/internal/_equals.js
+++ b/src/internal/_equals.js
@@ -5,7 +5,7 @@ var type = require('../type');
 
 // The algorithm used to handle cyclic structures is
 // inspired by underscore's isEqual
-module.exports = function _eqDeep(a, b, stackA, stackB) {
+module.exports = function _equals(a, b, stackA, stackB) {
   var typeA = type(a);
   if (typeA !== type(b)) {
     return false;
@@ -54,7 +54,7 @@ module.exports = function _eqDeep(a, b, stackA, stackB) {
     idx = keysA.length - 1;
     while (idx >= 0) {
       var key = keysA[idx];
-      if (!_has(key, b) || !_eqDeep(b[key], a[key], stackA, stackB)) {
+      if (!_has(key, b) || !_equals(b[key], a[key], stackA, stackB)) {
         return false;
       }
       idx -= 1;

--- a/src/mapObj.js
+++ b/src/mapObj.js
@@ -26,7 +26,7 @@ var keys = require('./keys');
  *
  *      R.mapObj(double, values); //=> { x: 2, y: 4, z: 6 }
  */
-module.exports = _curry2(function mapObject(fn, obj) {
+module.exports = _curry2(function mapObj(fn, obj) {
   return _reduce(function(acc, key) {
     acc[key] = fn(obj[key]);
     return acc;

--- a/src/mapObjIndexed.js
+++ b/src/mapObjIndexed.js
@@ -25,7 +25,7 @@ var keys = require('./keys');
  *
  *      R.mapObjIndexed(prependKeyAndDouble, values); //=> { x: 'x2', y: 'y4', z: 'z6' }
  */
-module.exports = _curry2(function mapObjectIndexed(fn, obj) {
+module.exports = _curry2(function mapObjIndexed(fn, obj) {
   return _reduce(function(acc, key) {
     acc[key] = fn(obj[key], key, obj);
     return acc;

--- a/src/nAry.js
+++ b/src/nAry.js
@@ -26,7 +26,7 @@ var _curry2 = require('./internal/_curry2');
  *      // Only `n` arguments are passed to the wrapped function
  *      takesOneArg(1, 2); //=> [1, undefined]
  */
-module.exports = _curry2(function(n, fn) {
+module.exports = _curry2(function nAry(n, fn) {
   switch (n) {
     case 0: return function() {return fn.call(this);};
     case 1: return function(a0) {return fn.call(this, a0);};

--- a/src/tail.js
+++ b/src/tail.js
@@ -18,6 +18,6 @@ var _slice = require('./internal/_slice');
  *
  *      R.tail(['fi', 'fo', 'fum']); //=> ['fo', 'fum']
  */
-module.exports = _checkForMethod('tail', function(list) {
+module.exports = _checkForMethod('tail', function tail(list) {
   return _slice(list, 1);
 });

--- a/src/transduce.js
+++ b/src/transduce.js
@@ -44,6 +44,6 @@ var curryN = require('./curryN');
  *
  *      R.transduce(transducer, R.flip(R.append), [], numbers); //=> [2, 3]
  */
-module.exports = curryN(4, function(xf, fn, acc, list) {
+module.exports = curryN(4, function transduce(xf, fn, acc, list) {
   return _reduce(xf(typeof fn === 'function' ? _xwrap(fn) : fn), acc, list);
 });

--- a/src/update.js
+++ b/src/update.js
@@ -20,6 +20,6 @@ var always = require('./always');
  *      R.update(1, 11, [0, 1, 2]);     //=> [0, 11, 2]
  *      R.update(1)(11)([0, 1, 2]);     //=> [0, 11, 2]
  */
-module.exports = _curry3(function(idx, x, list) {
+module.exports = _curry3(function update(idx, x, list) {
   return adjust(always(x), idx, list);
 });


### PR DESCRIPTION
This is the shell script I used to find these:

```bash
#!/usr/bin/env bash
set -e

for filename in $(find src -name '*.js') ; do
  printf "%s\t%s\n" "$(basename $filename .js)" "$(grep 'module[.]exports =' $filename)" \
  | sed -e '/;/d' \
        -e '/module[.]exports = (function() [{]/d' \
        -e $'/^\([^\t]*\)\tmodule[.]exports.*function \\1(/d'
done
```
