### PR TITLE
Fix `R.match` empty array default

### DIFF
--- a/src/match.js
+++ b/src/match.js
@@ -1,7 +1,4 @@
 var _curry2 = require('./internal/_curry2');
-var compose = require('./compose');
-var defaultTo = require('./defaultTo');
-var invoker = require('./invoker');
 
 
 /**
@@ -12,13 +9,18 @@ var invoker = require('./invoker');
  *
  * @func
  * @memberOf R
+ * @see R.test
  * @category String
  * @sig RegExp -> String -> [String | Undefined]
  * @param {RegExp} rx A regular expression.
  * @param {String} str The string to match against
- * @return {Array} The list of matches.
+ * @return {Array} The list of matches or empty array.
  * @example
  *
  *      R.match(/([a-z]a)/g, 'bananas'); //=> ['ba', 'na', 'na']
+ *      R.match(/a/, 'b'); //=> []
+ *      R.match(/a/, null); //=> TypeError: null does not have a method named "match"
  */
-module.exports = _curry2(compose(defaultTo([]), invoker(1, 'match')));
+module.exports = _curry2(function match(rx, str) {
+  return str.match(rx) || [];
+});

--- a/src/test.js
+++ b/src/test.js
@@ -7,6 +7,7 @@ var _curry2 = require('./internal/_curry2');
  *
  * @func
  * @memberOf R
+ * @see R.match
  * @category String
  * @sig RegExp -> String -> Boolean
  * @param {RegExp} pattern

--- a/test/match.js
+++ b/test/match.js
@@ -5,15 +5,27 @@ var R = require('..');
 
 describe('match', function() {
   var re = /[A-Z]\d\d\-[a-zA-Z]+/;
+  var matching = 'B17-afn';
+  var notMatching = 'B1-afn';
 
   it('determines whether a string matches a regex', function() {
-    assert.strictEqual(R.match(re, 'B17-afn').length, 1);
-    assert.deepEqual(R.match(re, 'B1-afn'), []);
+    assert.strictEqual(R.match(re, matching).length, 1);
+    assert.deepEqual(R.match(re, notMatching), []);
   });
 
   it('is curried', function() {
     var format = R.match(re);
-    assert.strictEqual(format('B17-afn').length, 1);
-    assert.deepEqual(format('B1-afn'), []);
+    assert.strictEqual(format(matching).length, 1);
+    assert.deepEqual(format(notMatching), []);
+  });
+
+  it('defaults to a different empty array each time', function() {
+    var first = R.match(re, notMatching);
+    var second = R.match(re, notMatching);
+    assert.notStrictEqual(first, second);
+  });
+
+  it('throws on null input', function() {
+    assert.throws(function shouldThrow() { R.match(re, null); }, TypeError);
   });
 });


### PR DESCRIPTION
Problem: if someone evil will change resulting default array then everybody will suffer because of shared default array pointer. Example:
```js
R.match(/a/, '')[1] = 'fail';
R.match(/a/, ''); // [, 'fail']
```
-----
Imperative style looks better and cleaner here IMHO.
Functional approach may look like this:
```js
var defaultToEmptyArray = ifElse(isNil, constructN(0, Array), identity);
R.match = compose(defaultToEmptyArray, invoker(1, 'match'));
```