### PR TITLE
Handle empty list of predicates in _predicateWrap

### DIFF
--- a/src/internal/_predicateWrap.js
+++ b/src/internal/_predicateWrap.js
@@ -1,7 +1,8 @@
 var _arity = require('./_arity');
 var _slice = require('./_slice');
+var max = require('../max');
 var pluck = require('../pluck');
-
+var reduce = require('../reduce');
 
 /**
  * Create a predicate wrapper which will call a pick function (all/any) for each predicate
@@ -18,10 +19,13 @@ module.exports = function _predicateWrap(predPicker) {
         return predicate.apply(null, args);
       }, preds);
     };
+
+    var longest = reduce(max, 0, pluck('length', preds));
+
     return arguments.length > 1 ?
       // Call function immediately if given arguments
       predIterator.apply(null, _slice(arguments, 1)) :
       // Return a function which will call the predicates with the provided arguments
-      _arity(Math.max.apply(Math, pluck('length', preds)), predIterator);
+      _arity(longest, predIterator);
   };
 };

--- a/test/allPass.js
+++ b/test/allPass.js
@@ -23,6 +23,15 @@ describe('allPass', function() {
     assert.strictEqual(R.allPass([odd, gt5], 7), true);
   });
 
+  it('can be curried', function() {
+    assert.strictEqual(R.allPass([odd, gt5])(3), false);
+    assert.strictEqual(R.allPass([odd, gt5])(7), true);
+  });
+
+  it('returns true on empty predicate list', function() {
+    assert.strictEqual(R.allPass([])(3), true);
+  });
+
   it('reports its arity as the longest predicate length', function() {
     assert.strictEqual(R.allPass([odd, gt5, plusEq]).length, 4);
   });

--- a/test/anyPass.js
+++ b/test/anyPass.js
@@ -24,6 +24,10 @@ describe('anyPass', function() {
     assert.strictEqual(R.anyPass([odd, lt5], 22), false);
   });
 
+  it('returns false for an empty predicate list', function() {
+    assert.strictEqual(R.anyPass([])(3), false);
+  });
+
   it('reports its arity as the longest predicate length', function() {
     assert.strictEqual(R.anyPass([odd, lt5, plusEq]).length, 4);
   });


### PR DESCRIPTION
Math.max on an empty array returns -Infinity, causing things to go wrong. Instead, I reduce the list of lengths with `max` as iterator function and 0 as default value.

I'd love to hear back from you. If there is anything I can improve, let me know.

Fixes #1298