### PR TITLE
calculate arity in _predicateWrap only when necessary

### DIFF
--- a/src/internal/_predicateWrap.js
+++ b/src/internal/_predicateWrap.js
@@ -4,6 +4,7 @@ var max = require('../max');
 var pluck = require('../pluck');
 var reduce = require('../reduce');
 
+
 /**
  * Create a predicate wrapper which will call a pick function (all/any) for each predicate
  *
@@ -19,13 +20,10 @@ module.exports = function _predicateWrap(predPicker) {
         return predicate.apply(null, args);
       }, preds);
     };
-
-    var longest = reduce(max, 0, pluck('length', preds));
-
     return arguments.length > 1 ?
       // Call function immediately if given arguments
       predIterator.apply(null, _slice(arguments, 1)) :
       // Return a function which will call the predicates with the provided arguments
-      _arity(longest, predIterator);
+      _arity(reduce(max, 0, pluck('length', preds)), predIterator);
   };
 };


### PR DESCRIPTION
This addresses a niggle I noticed when reviewing #1299.
