### PR TITLE
support any Chain in R.unnest

### DIFF
--- a/src/chain.js
+++ b/src/chain.js
@@ -1,8 +1,8 @@
 var _curry2 = require('./internal/_curry2');
 var _dispatchable = require('./internal/_dispatchable');
+var _makeFlat = require('./internal/_makeFlat');
 var _xchain = require('./internal/_xchain');
 var map = require('./map');
-var unnest = require('./unnest');
 
 
 /**
@@ -26,5 +26,5 @@ var unnest = require('./unnest');
  *      R.chain(duplicate, [1, 2, 3]); //=> [1, 1, 2, 2, 3, 3]
  */
 module.exports = _curry2(_dispatchable('chain', _xchain, function chain(fn, list) {
-  return unnest(map(fn, list));
+  return _makeFlat(false)(map(fn, list));
 }));

--- a/src/unnest.js
+++ b/src/unnest.js
@@ -1,21 +1,21 @@
-var _curry1 = require('./internal/_curry1');
-var _makeFlat = require('./internal/_makeFlat');
+var _identity = require('./internal/_identity');
+var chain = require('./chain');
 
 
 /**
- * Returns a new list by pulling every item at the first level of nesting out, and putting
- * them in a new array.
+ * Shorthand for `R.chain(R.identity)`, which removes one level of nesting
+ * from any [Chain](https://github.com/fantasyland/fantasy-land#chain).
  *
  * @func
  * @memberOf R
  * @category List
- * @sig [a] -> [b]
- * @param {Array} list The array to consider.
- * @return {Array} The flattened list.
- * @see R.flatten
+ * @sig Chain c => c (c a) -> c a
+ * @param {*} list
+ * @return {*}
+ * @see R.flatten, R.chain
  * @example
  *
  *      R.unnest([1, [2], [[3]]]); //=> [1, 2, [3]]
  *      R.unnest([[1, 2], [3, 4], [5, 6]]); //=> [1, 2, 3, 4, 5, 6]
  */
-module.exports = _curry1(_makeFlat(false));
+module.exports = chain(_identity);

--- a/test/shared/Maybe.js
+++ b/test/shared/Maybe.js
@@ -27,6 +27,15 @@ Maybe.of = Maybe.Just;
 Maybe.prototype.of = Maybe.Just;
 
 
+_Just.prototype.toString = function() {
+  return 'Just(' + this.value + ')';
+};
+
+_Nothing.prototype.toString = function() {
+  return 'Nothing()';
+};
+
+
 // functor
 _Just.prototype.map = function(f) {
   return this.of(f(this.value));

--- a/test/unnest.js
+++ b/test/unnest.js
@@ -1,9 +1,11 @@
 var assert = require('assert');
 
 var R = require('..');
+var Maybe = require('./shared/Maybe');
 
 
 describe('unnest', function() {
+
   it('only flattens one layer deep of a nested list', function() {
     var nest = [1, [2], [3, [4, 5], 6, [[[7], 8]]], 9, 10];
     assert.deepEqual(R.unnest(nest), [1, 2, 3, [4, 5], 6, [[[7], 8]], 9, 10]);
@@ -26,4 +28,16 @@ describe('unnest', function() {
     assert.deepEqual(R.unnest([[], [], []]), []);
     assert.deepEqual(R.unnest([]), []);
   });
+
+  it('is equivalent to R.chain(R.identity)', function() {
+    var Nothing = Maybe.Nothing;
+    var Just = Maybe.Just;
+
+    assert.strictEqual(R.toString(R.unnest(Nothing())), 'Nothing()');
+    assert.strictEqual(R.toString(R.unnest(Just(Nothing()))), 'Nothing()');
+    assert.strictEqual(R.toString(R.unnest(Just(Just(Nothing())))), 'Just(Nothing())');
+    assert.strictEqual(R.toString(R.unnest(Just(Just(42)))), 'Just(42)');
+    assert.strictEqual(R.toString(R.unnest(Just(Just(Just(42))))), 'Just(Just(42))');
+  });
+
 });


### PR DESCRIPTION
If we're to provide sugar for `R.chain(R.identity)` it should work for any [Chain][1], not just Array-like ones.

This change enables nested maybes to be unnested:

```javascript
> R.unnest(Just(Just(42)))
Just(42)
```


[1]: https://github.com/fantasyland/fantasy-land#chain
