### PR TITLE
Adds R.when and R.unless

### DIFF
--- a/src/ifElse.js
+++ b/src/ifElse.js
@@ -9,6 +9,7 @@ var curryN = require('./curryN');
  * @func
  * @memberOf R
  * @category Logic
+ * @see R.unless, R.when
  * @sig (*... -> Boolean) -> (*... -> *) -> (*... -> *) -> (*... -> *)
  * @param {Function} condition A predicate function
  * @param {Function} onTrue A function to invoke when the `condition` evaluates to a truthy value.
@@ -17,11 +18,13 @@ var curryN = require('./curryN');
  *                    function depending upon the result of the `condition` predicate.
  * @example
  *
- *      // Flatten all arrays in the list but leave other values alone.
- *      var flattenArrays = R.map(R.ifElse(Array.isArray, R.flatten, R.identity));
- *
- *      flattenArrays([[0], [[10], [8]], 1234, {}]); //=> [[0], [10, 8], 1234, {}]
- *      flattenArrays([[[10], 123], [8, [10]], "hello"]); //=> [[10, 123], [8, 10], "hello"]
+ *      var incCount = R.ifElse(
+ *        R.has('count'),
+ *        R.over(R.lensProp('count'), R.inc),
+ *        R.assoc('count', 1)
+ *      );
+ *      incCount({});           //=> { count: 1 }
+ *      incCount({ count: 1 }); //=> { count: 2 }
  */
 module.exports = _curry3(function ifElse(condition, onTrue, onFalse) {
   return curryN(Math.max(condition.length, onTrue.length, onFalse.length),

--- a/src/reduced.js
+++ b/src/reduced.js
@@ -21,7 +21,7 @@ var _reduced = require('./internal/_reduced');
  * @example
  *
  *      R.reduce(
- *        R.pipe(R.add, R.ifElse(R.lte(10), R.reduced, R.identity)),
+ *        R.pipe(R.add, R.when(R.gte(R.__, 10), R.reduced)),
  *        0,
  *        [1, 2, 3, 4, 5]) // 10
  */

--- a/src/unless.js
+++ b/src/unless.js
@@ -1,0 +1,30 @@
+var _curry3 = require('./internal/_curry3');
+
+
+/**
+ * Tests the final argument by passing it to the given predicate function.
+ * If the predicate is not satisfied, the function will return the
+ * result of calling the `whenFalseFn` function with the same argument. If the
+ * predicate is satisfied, the argument is returned as is.
+ *
+ * @func
+ * @memberOf R
+ * @category Logic
+ * @see R.ifElse, R.when
+ * @sig (a -> Boolean) -> (a -> a) -> a -> a
+ * @param {Function} pred        A predicate function
+ * @param {Function} whenFalseFn A function to invoke when the `pred` evaluates
+ *                               to a falsy value.
+ * @param {*}        x           An object to test with the `pred` function and
+ *                               pass to `whenFalseFn` if necessary.
+ * @return {*} Either `x` or the result of applying `x` to `whenFalseFn`.
+ * @example
+ *
+ *      // coerceArray :: (a|[a]) -> [a]
+ *      var coerceArray = R.unless(R.isArrayLike, R.of);
+ *      coerceArray([1, 2, 3]); //=> [1, 2, 3]
+ *      coerceArray(1);         //=> [1]
+ */
+module.exports = _curry3(function unless(pred, whenFalseFn, x) {
+  return pred(x) ? x : whenFalseFn(x);
+});

--- a/src/when.js
+++ b/src/when.js
@@ -1,0 +1,33 @@
+var _curry3 = require('./internal/_curry3');
+
+
+/**
+ * Tests the final argument by passing it to the given predicate function.
+ * If the predicate is satisfied, the function will return the result
+ * of calling the `whenTrueFn` function with the same argument. If the predicate
+ * is not satisfied, the argument is returned as is.
+ *
+ * @func
+ * @memberOf R
+ * @category Logic
+ * @see R.ifElse, R.unless
+ * @sig (a -> Boolean) -> (a -> a) -> a -> a
+ * @param {Function} pred       A predicate function
+ * @param {Function} whenTrueFn A function to invoke when the `condition`
+ *                              evaluates to a truthy value.
+ * @param {*}        x          An object to test with the `pred` function and
+ *                              pass to `whenTrueFn` if necessary.
+ * @return {*} Either `x` or the result of applying `x` to `whenTrueFn`.
+ * @example
+ *
+ *      // truncate :: String -> String
+ *      var truncate = R.when(
+ *        R.propSatisfies(R.gt(R.__, 10), 'length'),
+ *        R.pipe(R.take(10), R.append('…'), R.join(''))
+ *      );
+ *      truncate('12345');         //=> '12345'
+ *      truncate('0123456789ABC'); //=> '0123456789…'
+ */
+module.exports = _curry3(function when(pred, whenTrueFn, x) {
+  return pred(x) ? whenTrueFn(x) : x;
+});

--- a/test/unless.js
+++ b/test/unless.js
@@ -1,0 +1,19 @@
+var assert = require('assert');
+
+var R = require('..');
+
+
+describe('unless', function() {
+  it('calls the whenFalse function if the validator returns a falsey value', function() {
+    assert.deepEqual(R.unless(R.isArrayLike, R.of)(10), [10]);
+  });
+
+  it('returns the argument unmodified if the validator returns a truthy value', function() {
+    assert.deepEqual(R.unless(R.isArrayLike, R.of)([10]), [10]);
+  });
+
+  it('returns a curried function', function() {
+    assert.deepEqual(R.unless(R.isArrayLike)(R.of)(10), [10]);
+    assert.deepEqual(R.unless(R.isArrayLike)(R.of)([10]), [10]);
+  });
+});

--- a/test/when.js
+++ b/test/when.js
@@ -1,0 +1,20 @@
+var assert = require('assert');
+
+var R = require('..');
+
+
+describe('when', function() {
+  it('calls the whenTrue function if the validator returns a truthy value', function() {
+    assert.strictEqual(R.when(R.is(Number), R.add(1))(10), 11);
+  });
+
+  it('returns the argument unmodified if the validator returns a falsey value', function() {
+    assert.strictEqual(R.when(R.is(Number), R.add(1))('hello'), 'hello');
+  });
+
+  it('returns a curried function', function() {
+    var ifIsNumber = R.when(R.is(Number));
+    assert.strictEqual(ifIsNumber(R.add(1))(15), 16);
+    assert.strictEqual(ifIsNumber(R.add(1))('hello'), 'hello');
+  });
+});


### PR DESCRIPTION
Not sure how welcome this will be, but in the trend of suggesting sugar for common patterns, I am continually finding myself writing `R.ifElse(pred, doSomething, R.identity)`, or `R.ifElse(pred, R.identity, doSomethingElse)`.

This change introduces `R.when` and `R.unless` as sugar for the above.