### PR TITLE
Fix dropLastWhile example

### DIFF
--- a/src/dropLastWhile.js
+++ b/src/dropLastWhile.js
@@ -21,7 +21,7 @@ var _slice = require('./internal/_slice');
  *        return x <= 3;
  *      };
  *
- *      R.dropLastWhile(lteThree, [1, 2, 3, 4, 3, 2, 1]); //=> [1, 2]
+ *      R.dropLastWhile(lteThree, [1, 2, 3, 4, 3, 2, 1]); //=> [1, 2, 3, 4]
  */
 module.exports = _curry2(function dropLastWhile(pred, list) {
   var idx = list.length - 1;


### PR DESCRIPTION
The example should stop dropping at 4.

See http://ramdajs.com/repl/?v=0.17.1#var%20lteThree%20%3D%20function(x)%20%7B%0A%20%20return%20x%20%3C%3D%203%3B%0A%7D%3B%0A%0AR.dropLastWhile(lteThree%2C%20%5B1%2C%202%2C%203%2C%204%2C%203%2C%202%2C%201%5D)%3B