### PR TITLE
Adds adjustPath

### DIFF
--- a/src/adjustPath.js
+++ b/src/adjustPath.js
@@ -1,0 +1,38 @@
+
+var _curry3 = require('./internal/_curry3');
+var _slice = require('./internal/_slice');
+var assoc = require('./assoc');
+
+
+/**
+ * Makes a shallow clone of an object, setting or overriding the nodes required
+ * to create the given path, applies the function with the value at the tail
+ * end of that path and places the result at the end.  Note that this copies
+ * and flattens prototype properties onto the new object as well.  All
+ * non-primitive properties are copied by reference.
+ * @see R.assocPath
+ * @see R.adjust
+ *
+ * @func
+ * @memberOf R
+ * @category Object
+ * @sig (a -> a) -> [a] -> {k: v} -> {k: v}
+ * @param {Function} fn The function to apply.
+ * @param {Array} path the path to set
+ * @param {Object} obj the object to clone
+ * @return {Object} a new object similar to the original except along the specified path.
+ * @example
+ *
+ *      R.adjustPath(R.add(2), ['a', 'b'], {a: {b: 1}}); //=> {a: {b: 3}}
+ *
+ */
+module.exports = _curry3(function assocPath(fn, path, obj) {
+  switch (path.length) {
+    case 0:
+      return obj;
+    case 1:
+      return assoc(path[0], fn(obj[path[0]]), obj);
+    default:
+      return assoc(path[0], assocPath(fn, _slice(path, 1), Object(obj[path[0]])), obj);
+  }
+});

--- a/test/adjustPath.js
+++ b/test/adjustPath.js
@@ -1,0 +1,46 @@
+var assert = require('assert');
+
+var R = require('..');
+
+
+describe('adjustPath', function() {
+  it('makes a shallow clone of an object, overriding only what is necessary for the path', function() {
+    var obj1 = {a: {b: 1, c: 2, d: {e: 3}}, f: {g: {h: 4, i: 5, j: {k: 6, l: 7}}}, m: 8};
+    var obj2 = R.adjustPath(R.add(1), ['f', 'g', 'i'],  obj1);
+    assert.deepEqual(obj2,
+        {a: {b: 1, c: 2, d: {e: 3}}, f: {g: {h: 4, i: 6, j: {k: 6, l: 7}}}, m: 8}
+    );
+    // Note: reference equality below!
+    assert.strictEqual(obj2.a, obj1.a);
+    assert.strictEqual(obj2.m, obj1.m);
+    assert.strictEqual(obj2.f.g.h, obj1.f.g.h);
+    assert.strictEqual(obj2.f.g.j, obj1.f.g.j);
+
+    // Ensure no inplace mutations. New references for the changed path.
+    assert.notStrictEqual(obj2.f, obj1.f);
+    assert.notStrictEqual(obj2.f.g, obj1.f.g);
+    assert.notStrictEqual(obj2.f.g, obj1.f.g);
+  });
+
+  it('is curried', function() {
+    var obj1 = {a: {b: ['first']}};
+    var expected = {a: {b: ['first', 'second']}};
+    var f = R.adjustPath(R.append('second'));
+    var g = f(['a', 'b']);
+
+    assert.deepEqual(f(['a', 'b'], obj1), expected);
+    assert.deepEqual(g(obj1), expected);
+  });
+
+  it('creates missing objects', function() {
+    assert.deepEqual(R.adjustPath(R.always('foo'), ['a', 'b'], {}), {a: {b: 'foo'}});
+  });
+
+  it('accepts empty path', function() {
+    function fn() {
+      assert(false, 'fn must not execute');
+    }
+    assert.deepEqual(R.adjustPath(fn, [], {a: 1, b: 2}), {a: 1, b: 2});
+  });
+
+});


### PR DESCRIPTION
First stab at #1281

Not quite sure this is right name for the function because plain `adjust` deals with arrays – not objects – but neither did the original proposal of `updatePath` feel any better since `update` is also for arrays and is used for setting values...
