### PR TITLE
escape escape sequences in R.toString

### DIFF
--- a/src/internal/_quote.js
+++ b/src/internal/_quote.js
@@ -1,3 +1,13 @@
 module.exports = function _quote(s) {
-  return '"' + s.replace(/"/g, '\\"') + '"';
+  var escaped = s
+    .replace(/\\/g, '\\\\')
+    .replace(/[\b]/g, '\\b')  // \b matches word boundary; [\b] matches backspace
+    .replace(/\f/g, '\\f')
+    .replace(/\n/g, '\\n')
+    .replace(/\r/g, '\\r')
+    .replace(/\t/g, '\\t')
+    .replace(/\v/g, '\\v')
+    .replace(/\0/g, '\\0');
+
+  return '"' + escaped.replace(/"/g, '\\"') + '"';
 };

--- a/test/toString.js
+++ b/test/toString.js
@@ -35,6 +35,16 @@ describe('toString', function() {
   it('returns the string representation of a string primitive', function() {
     assert.strictEqual(R.toString('abc'), '"abc"');
     assert.strictEqual(R.toString('x "y" z'), '"x \\"y\\" z"');
+    assert.strictEqual(R.toString("' '"), '"\' \'"');
+    assert.strictEqual(R.toString('" "'), '"\\" \\""');
+    assert.strictEqual(R.toString('\b \b'), '"\\b \\b"');
+    assert.strictEqual(R.toString('\f \f'), '"\\f \\f"');
+    assert.strictEqual(R.toString('\n \n'), '"\\n \\n"');
+    assert.strictEqual(R.toString('\r \r'), '"\\r \\r"');
+    assert.strictEqual(R.toString('\t \t'), '"\\t \\t"');
+    assert.strictEqual(R.toString('\v \v'), '"\\v \\v"');
+    assert.strictEqual(R.toString('\0 \0'), '"\\0 \\0"');
+    assert.strictEqual(R.toString('\\ \\'), '"\\\\ \\\\"');
   });
 
   it('returns the string representation of a Boolean object', function() {
@@ -55,6 +65,16 @@ describe('toString', function() {
     /* jshint -W053 */
     assert.strictEqual(R.toString(new String('abc')), 'new String("abc")');
     assert.strictEqual(R.toString(new String('x "y" z')), 'new String("x \\"y\\" z")');
+    assert.strictEqual(R.toString(new String("' '")), 'new String("\' \'")');
+    assert.strictEqual(R.toString(new String('" "')), 'new String("\\" \\"")');
+    assert.strictEqual(R.toString(new String('\b \b')), 'new String("\\b \\b")');
+    assert.strictEqual(R.toString(new String('\f \f')), 'new String("\\f \\f")');
+    assert.strictEqual(R.toString(new String('\n \n')), 'new String("\\n \\n")');
+    assert.strictEqual(R.toString(new String('\r \r')), 'new String("\\r \\r")');
+    assert.strictEqual(R.toString(new String('\t \t')), 'new String("\\t \\t")');
+    assert.strictEqual(R.toString(new String('\v \v')), 'new String("\\v \\v")');
+    assert.strictEqual(R.toString(new String('\0 \0')), 'new String("\\0 \\0")');
+    assert.strictEqual(R.toString(new String('\\ \\')), 'new String("\\\\ \\\\")');
     /* jshint +W053 */
   });
 


### PR DESCRIPTION
`R.toString('\n')` should evaluate to `'"\\n"'` rather than `'"\n"'` in order to uphold the invariant:

```javascript
R.equals(x, eval(R.toString(x))) === true  // for *most* values of x
```

Otherwise, we're essentially doing

```javascript
eval('"
"')
```

which is syntactically invalid.

Before:

```javascript
> R.map(R.converge(R.equals, R.identity, R.compose(eval, R.toString)),
...     ['\b', '\f', '\n', '\r', '\t', '\v', '\0', '\\', '"', "'"])
SyntaxError: Unexpected token ILLEGAL
```

After:

```javascript
> R.map(R.converge(R.equals, R.identity, R.compose(eval, R.toString)),
...     ['\b', '\f', '\n', '\r', '\t', '\v', '\0', '\\', '"', "'"])
[ true, true, true, true, true, true, true, true, true, true ]
```

One practical benefit of this change is better REPL output. Rather than the [current output][1]

```javascript
"foo
bar
"
```

we'll get

```javascript
"foo\nbar\n"
```

which matches the behaviour of the Node REPL.

@mathiasbynens's [JavaScript character escape sequences][2] proved to be an invaluable reference while working on this patch.


[1]: http://ramdajs.com/repl/?v=0.17.1#'foo%5Cnbar%5Cn'
[2]: https://mathiasbynens.be/notes/javascript-escapes
