### PR TITLE
Simplify logical functions

### DIFF
--- a/src/and.js
+++ b/src/and.js
@@ -1,28 +1,24 @@
 var _curry2 = require('./internal/_curry2');
-var _hasMethod = require('./internal/_hasMethod');
 
 
 /**
- * A function that returns the first argument if it's falsy otherwise the second
- * argument. Note that this is NOT short-circuited, meaning that if expressions
- * are passed they are both evaluated.
- *
- * Dispatches to the `and` method of the first argument if applicable.
+ * Returns `true` if both arguments are `true`; `false` otherwise.
  *
  * @func
  * @memberOf R
  * @category Logic
  * @sig * -> * -> *
- * @param {*} a any value
- * @param {*} b any other value
- * @return {*} the first argument if falsy otherwise the second argument.
+ * @param {Boolean} a A boolean value
+ * @param {Boolean} b A boolean value
+ * @return {Boolean} `true` if both arguments are `true`, `false` otherwise
  * @see R.both
  * @example
  *
+ *      R.and(true, true); //=> true
+ *      R.and(true, false); //=> false
  *      R.and(false, true); //=> false
- *      R.and(0, []); //=> 0
- *      R.and(null, ''); => null
+ *      R.and(false, false); //=> false
  */
 module.exports = _curry2(function and(a, b) {
-  return _hasMethod('and', a) ? a.and(b) : a && b;
+  return a && b;
 });

--- a/src/defaultTo.js
+++ b/src/defaultTo.js
@@ -2,8 +2,8 @@ var _curry2 = require('./internal/_curry2');
 
 
 /**
- * Returns the second argument if it is not null or undefined. If it is null
- * or undefined, the first (default) argument is returned.
+ * Returns the second argument if it is not `null`, `undefined` or `NaN`
+ * otherwise the first argument is returned.
  *
  * @func
  * @memberOf R
@@ -19,7 +19,8 @@ var _curry2 = require('./internal/_curry2');
  *      defaultTo42(null);  //=> 42
  *      defaultTo42(undefined);  //=> 42
  *      defaultTo42('Ramda');  //=> 'Ramda'
+ *      defaultTo42(parseInt('string')); //=> 42
  */
 module.exports = _curry2(function defaultTo(d, v) {
-  return v == null ? d : v;
+  return v == null || v !== v ? d : v;
 });

--- a/src/or.js
+++ b/src/or.js
@@ -1,28 +1,25 @@
 var _curry2 = require('./internal/_curry2');
-var _hasMethod = require('./internal/_hasMethod');
 
 
 /**
- * A function that returns the first truthy of two arguments otherwise the
- * last argument. Note that this is NOT short-circuited, meaning that if
- * expressions are passed they are both evaluated.
- *
- * Dispatches to the `or` method of the first argument if applicable.
+ * Returns `true` if one or both of its arguments are `true`. Returns `false`
+ * if both arguments are `false`.
  *
  * @func
  * @memberOf R
  * @category Logic
  * @sig * -> * -> *
- * @param {*} a any value
- * @param {*} b any other value
- * @return {*} the first truthy argument, otherwise the last argument.
+ * @param {Boolean} a A boolean value
+ * @param {Boolean} b A boolean value
+ * @return {Boolean} `true` if one or both arguments are `true`, `false` otherwise
  * @see R.either
  * @example
  *
+ *      R.or(true, true); //=> true
+ *      R.or(true, false); //=> true
  *      R.or(false, true); //=> true
- *      R.or(0, []); //=> []
- *      R.or(null, ''); => ''
+ *      R.or(false, false); //=> false
  */
 module.exports = _curry2(function or(a, b) {
-  return _hasMethod('or', a) ? a.or(b) : a || b;
+  return a || b;
 });

--- a/test/and.js
+++ b/test/and.js
@@ -5,35 +5,15 @@ var R = require('..');
 
 describe('and', function() {
   it('compares two values with js &&', function() {
-    var someAr = [];
-    assert.strictEqual(R.and(1, 1), 1);
-    assert.strictEqual(R.and(1, 0), 0);
-    assert.strictEqual(R.and(true, someAr), someAr);
-  });
-
-  it('dispatches to `and` method', function() {
-    function Nothing() {}
-    Nothing.prototype.and = function() { return this; };
-
-    function Just(x) { this.value = x; }
-    Just.prototype.and = R.identity;
-
-    var n1 = new Nothing();
-    var n2 = new Nothing();
-    var j1 = new Just(1);
-    var j2 = new Just(2);
-
-    assert.strictEqual(R.and(n1, n2), n1);
-    assert.strictEqual(R.and(n2, n1), n2);
-    assert.strictEqual(R.and(n1, j2), n1);
-    assert.strictEqual(R.and(j2, n1), n1);
-    assert.strictEqual(R.and(j1, j2), j2);
-    assert.strictEqual(R.and(j2, j1), j1);
+    assert.strictEqual(R.and(true, true), true);
+    assert.strictEqual(R.and(true, false), false);
+    assert.strictEqual(R.and(false, true), false);
+    assert.strictEqual(R.and(false, false), false);
   });
 
   it('is curried', function() {
     var halfTruth = R.and(true);
     assert.strictEqual(halfTruth(false), false);
-    assert.strictEqual(halfTruth('lie'), 'lie');
+    assert.strictEqual(halfTruth(true), true);
   });
 });

--- a/test/defaultTo.js
+++ b/test/defaultTo.js
@@ -6,9 +6,10 @@ describe('defaultTo', function() {
 
   var defaultTo42 = R.defaultTo(42);
 
-  it('returns the default value if input is null/undefined', function() {
+  it('returns the default value if input is null, undefined or NaN', function() {
     assert.strictEqual(42, defaultTo42(null));
     assert.strictEqual(42, defaultTo42(undefined));
+    assert.strictEqual(42, defaultTo42(NaN));
   });
 
   it('returns the input value if it is not null/undefined', function() {

--- a/test/or.js
+++ b/test/or.js
@@ -5,36 +5,14 @@ var R = require('..');
 
 describe('or', function() {
   it('compares two values with js &&', function() {
-    var someAr = [];
-    assert.strictEqual(R.or(1, 0), 1);
-    assert.strictEqual(R.or(0, 1), 1);
-    assert.strictEqual(R.or(someAr, false), someAr);
-    assert.strictEqual(R.or('', 0), 0);
-  });
-
-  it('dispatches to `or` method', function() {
-    function Nothing() {}
-    Nothing.prototype.or = R.identity;
-
-    function Just(x) { this.value = x; }
-    Just.prototype.or = function() { return this; };
-
-    var n1 = new Nothing();
-    var n2 = new Nothing();
-    var j1 = new Just(1);
-    var j2 = new Just(2);
-
-    assert.strictEqual(R.or(n1, n2), n2);
-    assert.strictEqual(R.or(n2, n1), n1);
-    assert.strictEqual(R.or(n1, j2), j2);
-    assert.strictEqual(R.or(j2, n1), j2);
-    assert.strictEqual(R.or(j1, j2), j1);
-    assert.strictEqual(R.or(j2, j1), j2);
+    assert.strictEqual(R.or(true, true), true);
+    assert.strictEqual(R.or(true, false), true);
+    assert.strictEqual(R.or(false, true), true);
+    assert.strictEqual(R.or(false, false), false);
   });
 
   it('is curried', function() {
-    assert.strictEqual(R.or('lie')(false), 'lie');
+    assert.strictEqual(R.or(false)(false), false);
     assert.strictEqual(R.or(false)(true), true);
-    assert.strictEqual(R.or('')(0), 0);
   });
 });


### PR DESCRIPTION
This is a second attempt at simplifying Ramdas logical functions. The first attempt is #1218.

This PR makes the following changes:

* `and` and `or` does not dispatch. This didn't receive any resistance in the first PR so I want repeat the arguments.
* `and` and `or` are now documented as if they only worked on booleans. We no longer advertise that you can pass non-logical values to these logical functions. They are both documented with a truth table which is how these functions are [often defined in math](https://en.wikipedia.org/wiki/Logical_conjunction#Truth_table).
* `defaultTo` now returns it first argument if it's last argument is `NaN`.

These changes are made to achieve the following advantages:

* `and` and `or` are now semantically significantly simpler since they don't reference the quite complex and arbitrary concepts "truthy" and "falsy". The denotation (the meaning) of these functions are now equal to their counterparts in math. I believe simple denotation is a fundamental to functional programming (some people even prefer the term denotational programming to functional programming).
* `and` and `or` are now _single purpose_ functions. This makes code clearer and more explicit. This is not enforced in code, only in documentation.
* `defaultTo` now handles `NaN` this makes it more useful in many cases (for instance with `parseInt`) and removes the need to misuse `or` to achieve the same. Using `defaultTo` is also safer. Consider code like this `R.or(parseInt(student.score), 40)`. This would result in an unexpected behavior if the result of `parseInt(student.score)` returned `0`. `defaultTo` does not suffer from this problem.

I would also like to point out that the current behavior of `defaultTo` appears to [surprise people](https://gitter.im/ramda/ramda?at=55b8f72e4c04f0cc22e73104).

This PR would make it possible to replace code like this (an example by @CrossEye in the previous PR)

```js
R.map(student => R.assoc('grade', R.or(parseInt(student.score), 0), student), students);
```

With this code that better expresses the intent and doesn't rely on a multi-purpose `or`.

```js
R.map(student => R.assoc('grade', R.defaultTo(0, parseInt(student.score)), student), students);
```