### PR TITLE
update description of R.over

### DIFF
--- a/src/over.js
+++ b/src/over.js
@@ -3,7 +3,8 @@ var _curry3 = require('./internal/_curry3');
 
 /**
  * Returns the result of "setting" the portion of the given data structure
- * focused by the given lens to the given value.
+ * focused by the given lens to the result of applying the given function to
+ * the focused value.
  *
  * @func
  * @memberOf R


### PR DESCRIPTION
The current description was copied from __set.js__ but not altered, meaning that `R.over` and `R.set` have the same description.

/cc @soroushjp
