### PR TITLE
handle non-existent paths in R.lensIndex and R.lensProp

### DIFF
--- a/src/lensIndex.js
+++ b/src/lensIndex.js
@@ -1,7 +1,5 @@
 var _curry1 = require('./internal/_curry1');
 var lens = require('./lens');
-var nth = require('./nth');
-var update = require('./update');
 
 
 /**
@@ -24,5 +22,22 @@ var update = require('./update');
  *      R.over(headLens, R.toUpper, ['a', 'b', 'c']); //=> ['A', 'b', 'c']
  */
 module.exports = _curry1(function lensIndex(n) {
-  return lens(nth(n), update(n));
+  return lens(
+    function(_xs) {
+      var xs = _xs == null ? [] : _xs;
+      return xs[n];
+    },
+    function(x, _xs) {
+      var xs = _xs == null ? [] : _xs;
+      var result = [];
+      var max = Math.max(n, xs.length - 1);
+      var idx = 0;
+      while (idx <= max) {
+        result.push(xs[idx]);
+        idx += 1;
+      }
+      result[n] = x;
+      return result;
+    }
+  );
 });

--- a/src/lensProp.js
+++ b/src/lensProp.js
@@ -1,7 +1,5 @@
 var _curry1 = require('./internal/_curry1');
-var assoc = require('./assoc');
 var lens = require('./lens');
-var prop = require('./prop');
 
 
 /**
@@ -24,5 +22,19 @@ var prop = require('./prop');
  *      R.over(xLens, R.negate, {x: 1, y: 2});  //=> {x: -1, y: 2}
  */
 module.exports = _curry1(function lensProp(k) {
-  return lens(prop(k), assoc(k));
+  return lens(
+    function(_o) {
+      var o = _o == null ? {} : _o;
+      return o[k];
+    },
+    function(v, _o) {
+      var o = _o == null ? {} : _o;
+      var result = {};
+      for (var p in o) {
+        result[p] = o[p];
+      }
+      result[k] = v;
+      return result;
+    }
+  );
 });

--- a/test/lensIndex.js
+++ b/test/lensIndex.js
@@ -1,0 +1,37 @@
+var assert = require('assert');
+
+var R = require('..');
+
+
+var eq = function(actual, expected) {
+  assert.strictEqual(R.toString(actual), R.toString(expected));
+};
+
+
+describe('lensIndex', function() {
+
+  it('handles non-existent path', function() {
+    //  inc :: Number? -> Number
+    var inc = R.compose(R.inc, R.defaultTo(0));
+    var lens = R.compose(R.lensIndex(1), R.lensIndex(1));
+
+    eq(R.view(lens, [[1, 2], [3, 4]]),      4);
+    eq(R.view(lens, [[1, 2], [3]]),         undefined);
+    eq(R.view(lens, [[1, 2], []]),          undefined);
+    eq(R.view(lens, [[1, 2]]),              undefined);
+    eq(R.view(lens, []),                    undefined);
+
+    eq(R.over(lens, inc, [[1, 2], [3, 4]]), [[1, 2], [3, 5]]);
+    eq(R.over(lens, inc, [[1, 2], [3]]),    [[1, 2], [3, 1]]);
+    eq(R.over(lens, inc, [[1, 2], []]),     [[1, 2], [undefined, 1]]);
+    eq(R.over(lens, inc, [[1, 2]]),         [[1, 2], [undefined, 1]]);
+    eq(R.over(lens, inc, []),               [undefined, [undefined, 1]]);
+
+    eq(R.set(lens, 9, [[1, 2], [3, 4]]),    [[1, 2], [3, 9]]);
+    eq(R.set(lens, 9, [[1, 2], [3]]),       [[1, 2], [3, 9]]);
+    eq(R.set(lens, 9, [[1, 2], []]),        [[1, 2], [undefined, 9]]);
+    eq(R.set(lens, 9, [[1, 2]]),            [[1, 2], [undefined, 9]]);
+    eq(R.set(lens, 9, []),                  [undefined, [undefined, 9]]);
+  });
+
+});

--- a/test/lensProp.js
+++ b/test/lensProp.js
@@ -1,0 +1,34 @@
+var assert = require('assert');
+
+var R = require('..');
+
+
+var eq = function(actual, expected) {
+  assert.strictEqual(R.toString(actual), R.toString(expected));
+};
+
+
+describe('lensProp', function() {
+
+  it('handles non-existent path', function() {
+    //  inc :: Number? -> Number
+    var inc = R.compose(R.inc, R.defaultTo(0));
+    var lens = R.compose(R.lensProp('a'), R.lensProp('b'), R.lensProp('c'));
+
+    eq(R.view(lens, {$: 0, a: {b: {c: 42}}}),       42);
+    eq(R.view(lens, {$: 0, a: {b: {}}}),            undefined);
+    eq(R.view(lens, {$: 0, a: {}}),                 undefined);
+    eq(R.view(lens, {$: 0}),                        undefined);
+
+    eq(R.over(lens, inc, {$: 0, a: {b: {c: 42}}}),  {$: 0, a: {b: {c: 43}}});
+    eq(R.over(lens, inc, {$: 0, a: {b: {}}}),       {$: 0, a: {b: {c: 1}}});
+    eq(R.over(lens, inc, {$: 0, a: {}}),            {$: 0, a: {b: {c: 1}}});
+    eq(R.over(lens, inc, {$: 0}),                   {$: 0, a: {b: {c: 1}}});
+
+    eq(R.set(lens, 99, {$: 0, a: {b: {c: 42}}}),    {$: 0, a: {b: {c: 99}}});
+    eq(R.set(lens, 99, {$: 0, a: {b: {}}}),         {$: 0, a: {b: {c: 99}}});
+    eq(R.set(lens, 99, {$: 0, a: {}}),              {$: 0, a: {b: {c: 99}}});
+    eq(R.set(lens, 99, {$: 0}),                     {$: 0, a: {b: {c: 99}}});
+  });
+
+});


### PR DESCRIPTION
These changes are motivated by https://github.com/ramda/ramda/pull/1328#issuecomment-133120377. I'm keen to hear from @epeli, @scott-christopher, and others.
