### PR TITLE
Added feature pickValues

### DIFF
--- a/src/pickValues.js
+++ b/src/pickValues.js
@@ -1,0 +1,31 @@
+var _curry2 = require('./internal/_curry2');
+
+
+/**
+ * Returns a list of values matching the keys specified.
+ * property is ignored.
+ *
+ * @func
+ * @memberOf R
+ * @category Object
+ * @sig [k] -> {k: v} -> [v]
+ * @param {Array} names an array of String property names get values for
+ * @param {Object} obj The object to get values from
+ * @return {Array} A new object with only properties from `names` on it.
+ * @return {Array} A new list with values mathcing the keys specified
+ * @example
+ *
+ *      R.pickValues(['a', 'd'], {a: 1, b: 2, c: 3, d: 4}); //=> [1, 4]
+ *      R.pickValues(['a', 'e', 'f'], {a: 1, b: 2, c: 3, d: 4}); //=> [1]
+ */
+module.exports = _curry2(function pick(keys, obj) {
+  var result = [];
+  var idx = 0;
+  while (idx < keys.length) {
+    if (keys[idx] in obj) {
+      result.push(obj[keys[idx]]);
+    }
+    idx += 1;
+  }
+  return result;
+});

--- a/test/pickValues.js
+++ b/test/pickValues.js
@@ -1,0 +1,33 @@
+var assert = require('assert');
+
+var R = require('..');
+
+
+describe('pickValues', function() {
+  var obj = {a: 1, b: 2, c: 3, d: 4, e: 5, f: 6, 1: 7};
+
+  it('returns the values of the named properties of an object', function() {
+    assert.deepEqual(R.pickValues(['a', 'c', 'f'], obj), [1, 3, 6]);
+  });
+
+  it('handles numbers as properties', function() {
+    assert.deepEqual(R.pickValues([1], obj), [7]);
+  });
+
+  it('ignores properties not included', function() {
+    assert.deepEqual(R.pickValues(['a', 'c', 'g'], obj), [1, 3]);
+  });
+
+  it('retrieves prototype properties', function() {
+    var F = function(param) {this.x = param;};
+    F.prototype.y = 40; F.prototype.z = 50;
+    var obj = new F(30);
+    obj.v = 10; obj.w = 20;
+    assert.deepEqual(R.pickValues(['w', 'x', 'y'], obj), [20, 30, 40]);
+  });
+
+  it('is curried', function() {
+    var copyAB = R.pickValues(['a', 'b']);
+    assert.deepEqual(copyAB(obj), [1, 2]);
+  });
+});


### PR DESCRIPTION
works like pick, but returns the values as an Array

pickValues is similar to compose(values, pick([...])
but ensures that values are returned in the correct order on all platforms.

I have used the function quite alot.
E.g Google charts expect data as a set of touples: [x, y].
pickValues makes this very easy:

```
// data [ {time: '2015-01-01', revenue: 5, ...}, ... ]
var prepareDataForChart = R.map(R.pickValues(['time', 'revenue']))

prepareDataForChart(data);
// => [ ['2015-01-10', 5], ... ]
```
