### PR TITLE
replace R.containsWith examples

### DIFF
--- a/src/containsWith.js
+++ b/src/containsWith.js
@@ -16,8 +16,10 @@ var _curry3 = require('./internal/_curry3');
  * @return {Boolean} `true` if `x` is in `list`, else `false`.
  * @example
  *
- *      var xs = [{x: 12}, {x: 11}, {x: 10}];
- *      R.containsWith(function(a, b) { return a.x === b.x; }, {x: 10}, xs); //=> true
- *      R.containsWith(function(a, b) { return a.x === b.x; }, {x: 1}, xs); //=> false
+ *      var absEq = function(a, b) { return Math.abs(a) === Math.abs(b); };
+ *      R.containsWith(absEq, 5, [1, 2, 3]); //=> false
+ *      R.containsWith(absEq, 5, [4, 5, 6]); //=> true
+ *      R.containsWith(absEq, 5, [-1, -2, -3]); //=> false
+ *      R.containsWith(absEq, 5, [-4, -5, -6]); //=> true
  */
 module.exports = _curry3(_containsWith);

--- a/test/containsWith.js
+++ b/test/containsWith.js
@@ -4,17 +4,13 @@ var R = require('..');
 
 
 describe('containsWith', function() {
-  var Ro = [{a: 1}, {a: 2}, {a: 3}, {a: 4}];
-  var So = [{a: 3}, {a: 4}, {a: 5}, {a: 6}];
-  var eqA = function(r, s) { return r.a === s.a; };
 
   it('determines if an element is the list based on the predicate', function() {
-    assert.strictEqual(R.containsWith(eqA, {a: 3}, So), true);
-    assert.strictEqual(R.containsWith(eqA, {a: 3000}, So), false);
+    var absEq = function(a, b) { return Math.abs(a) === Math.abs(b); };
+    assert.strictEqual(R.containsWith(absEq, 5, [1, 2, 3]), false);
+    assert.strictEqual(R.containsWith(absEq, 5, [4, 5, 6]), true);
+    assert.strictEqual(R.containsWith(absEq, 5, [-1, -2, -3]), false);
+    assert.strictEqual(R.containsWith(absEq, 5, [-4, -5, -6]), true);
   });
-  it('is curried', function() {
-    assert.strictEqual(typeof R.containsWith(eqA), 'function');
-    assert.strictEqual(typeof R.containsWith(eqA)({a: 3}), 'function');
-    assert.strictEqual(R.containsWith(eqA)({a: 3})(Ro), true);
-  });
+
 });


### PR DESCRIPTION
The current examples were fine at the time they were written, but now that we have [value-based equality][1] they could be more simply expressed in terms of [`R.contains`][2].


[1]: https://github.com/ramda/ramda/pull/1096
[2]: http://ramdajs.com/docs/#contains
