### PR TITLE
deprecate R.functions and R.functionsIn

### DIFF
--- a/src/functions.js
+++ b/src/functions.js
@@ -12,6 +12,7 @@ var keys = require('./keys');
  * @sig {*} -> [String]
  * @param {Object} obj The objects with functions in it
  * @return {Array} A list of the object's own properties that map to functions.
+ * @deprecated since v0.18.0
  * @example
  *
  *      R.functions(R); // returns list of ramda's own function names

--- a/src/functionsIn.js
+++ b/src/functionsIn.js
@@ -13,6 +13,7 @@ var keysIn = require('./keysIn');
  * @param {Object} obj The objects with functions in it
  * @return {Array} A list of the object's own properties and prototype
  *         properties that map to functions.
+ * @deprecated since v0.18.0
  * @example
  *
  *      R.functionsIn(R); // returns list of ramda's own and prototype function names


### PR DESCRIPTION
These functions are oddly specific: _given an object, give me the names of each of its properties whose value is a function_. Why do we provide this for Function but not for RegExp or Date?

This could instead live in the [cookbook][1]:

```javascript
const functions = R.compose(R.keys, R.pickBy(R.is(Function)));

functions({abs: Math.abs, negate: R.negate, x: 0, y: 0}); //=> ['abs', 'negate']
```


[1]: https://github.com/ramda/ramda/wiki/Cookbook
