### PR TITLE
add R.eqBy

### DIFF
--- a/src/eqBy.js
+++ b/src/eqBy.js
@@ -1,0 +1,23 @@
+var _curry3 = require('./internal/_curry3');
+var equals = require('./equals');
+
+
+/**
+ * Takes a function and two values in its domain and returns `true` if
+ * the values map to the same value in the codomain; `false` otherwise.
+ *
+ * @func
+ * @memberOf R
+ * @category Relation
+ * @sig (a -> b) -> a -> a -> Boolean
+ * @param {Function} f
+ * @param {*} x
+ * @param {*} y
+ * @return {Boolean}
+ * @example
+ *
+ *      R.eqBy(Math.abs, 5, -5); //=> true
+ */
+module.exports = _curry3(function eqBy(f, x, y) {
+  return equals(f(x), f(y));
+});

--- a/test/eqBy.js
+++ b/test/eqBy.js
@@ -1,0 +1,28 @@
+var assert = require('assert');
+
+var R = require('..');
+
+
+describe('eqBy', function() {
+
+  it('determines whether two values map to the same value in the codomain', function() {
+    assert.strictEqual(R.eqBy(Math.abs, 5, 5), true);
+    assert.strictEqual(R.eqBy(Math.abs, 5, -5), true);
+    assert.strictEqual(R.eqBy(Math.abs, -5, 5), true);
+    assert.strictEqual(R.eqBy(Math.abs, -5, -5), true);
+    assert.strictEqual(R.eqBy(Math.abs, 42, 99), false);
+  });
+
+  it('has R.equals semantics', function() {
+    function Just(x) { this.value = x; }
+    Just.prototype.equals = function(x) {
+      return x instanceof Just && R.equals(x.value, this.value);
+    };
+
+    assert.strictEqual(R.eqBy(R.identity, 0, -0), false);
+    assert.strictEqual(R.eqBy(R.identity, -0, 0), false);
+    assert.strictEqual(R.eqBy(R.identity, NaN, NaN), true);
+    assert.strictEqual(R.eqBy(R.identity, new Just([42]), new Just([42])), true);
+  });
+
+});


### PR DESCRIPTION
I've written `a.x === b.x` and `f(a) === f(b)` many times. Ramda should provide a function for more succinctly expressing such relationships.
