### PR TITLE
add R.containsBy

### DIFF
--- a/src/containsBy.js
+++ b/src/containsBy.js
@@ -1,0 +1,30 @@
+var _curry3 = require('./internal/_curry3');
+var any = require('./any');
+var compose = require('./compose');
+var equals = require('./equals');
+
+
+/**
+ * Returns `true` if `f(x)` is equal, in `R.equals` terms, to one or more
+ * of the elements of `R.map(f, xs)`; `false` otherwise.
+ *
+ * Short-circuits as soon as a match is found.
+ *
+ * @func
+ * @memberOf R
+ * @category List
+ * @sig (a -> b) -> a -> [a] -> Boolean
+ * @param {Function} f
+ * @param {*} x
+ * @param {Array} xs
+ * @return {Boolean}
+ * @example
+ *
+ *      R.containsBy(Math.abs, 5, [1, 2, 3]); //=> false
+ *      R.containsBy(Math.abs, 5, [4, 5, 6]); //=> true
+ *      R.containsBy(Math.abs, 5, [-1, -2, -3]); //=> false
+ *      R.containsBy(Math.abs, 5, [-4, -5, -6]); //=> true
+ */
+module.exports = _curry3(function containsBy(f, x, xs) {
+  return any(compose(equals(f(x)), f), xs);
+});

--- a/src/containsWith.js
+++ b/src/containsWith.js
@@ -14,6 +14,7 @@ var _curry3 = require('./internal/_curry3');
  * @param {*} x The item to find
  * @param {Array} list The list to iterate over
  * @return {Boolean} `true` if `x` is in `list`, else `false`.
+ * @deprecated since v0.18.0
  * @example
  *
  *      var absEq = function(a, b) { return Math.abs(a) === Math.abs(b); };

--- a/test/containsBy.js
+++ b/test/containsBy.js
@@ -1,0 +1,15 @@
+var assert = require('assert');
+
+var R = require('..');
+
+
+describe('containsBy', function() {
+
+  it('determines whether a projected list contains a projected value', function() {
+    assert.strictEqual(R.containsBy(Math.abs, 5, [1, 2, 3]), false);
+    assert.strictEqual(R.containsBy(Math.abs, 5, [4, 5, 6]), true);
+    assert.strictEqual(R.containsBy(Math.abs, 5, [-1, -2, -3]), false);
+    assert.strictEqual(R.containsBy(Math.abs, 5, [-4, -5, -6]), true);
+  });
+
+});


### PR DESCRIPTION
See #1349

[`R.containsWith`][1] is usually used in conjunction with a function such as `(a, b) => a.x === b.x` or `(a, b) => f(a) === f(b)` ([occurrences on GitHub][2]). `R.containsBy` would be more convenient in such cases.

In the rare cases where the symmetry of `R.containsBy` is undesirable, one can always use [`R.any`][3]. It's thus unnecessary to retain `R.containsWith`.


[1]: http://ramdajs.com/docs/#containsWith
[2]: https://github.com/search?p=8&q=ramda+containsWith+language%3Ajavascript&type=Code
[3]: http://ramdajs.com/docs/#any
