### PR TITLE
Adds R.around

### DIFF
--- a/src/around.js
+++ b/src/around.js
@@ -1,0 +1,32 @@
+var curryN = require('./curryN');
+/**
+ * Accepts three functions, `before`, `after` and `fn`, and a single value.
+ * `R.around` effectively wraps `fn` with `before` and `after` by first passing the
+ * given value to `before`, which returns a value that is then passed to `fn`,
+ * whose return value is finally passed to `after`. The return value of
+ * `R.around` is the result of this call to `after`.
+ *
+ * This can be useful for converting some type `a` to be compatible with some
+ * function `(b -> b)` and back again, where an isomorphism exists between
+ * `a` and `b`: `R.around(aToB, bToA, bFn)`.
+ *
+ * @func
+ * @memberOf R
+ * @category Function
+ * @sig (a -> b) -> (c -> d) -> (b -> c) -> a -> d
+ * @param {Function} before
+ * @param {Function} after
+ * @param {Function} fn
+ * @param {*}        x
+ * @return {*}
+ * @example
+ *
+ *      var withPairs   = R.around(R.toPairs, R.fromPairs);
+ *      var headToUpper = R.adjust(R.toUpper, 0);
+ *      var upperKeys   = withPairs(R.map(headToUpper));
+ *      upperKeys({ cow: 'moo', dog: 'woof', cat: 'meow' });
+ *      //=> { COW: 'moo', DOG: 'woof', CAT: 'meow' }
+ */
+module.exports = curryN(4, function around(before, after, fn, x) {
+  return after(fn(before(x)));
+});

--- a/test/around.js
+++ b/test/around.js
@@ -1,0 +1,32 @@
+var assert = require('assert');
+
+var R = require('..');
+
+
+describe('around', function() {
+  it('wraps a function with functions before and after', function() {
+    assert.strictEqual(
+      R.around(R.inc, R.negate, R.dec, 42),
+      R.compose(R.negate, R.dec, R.inc)(42)
+    );
+    assert.strictEqual(
+      R.around(R.identity, R.inc, R.negate, 42),
+      R.compose(R.inc, R.negate)(42)
+    );
+    assert.strictEqual(
+      R.around(R.inc, R.identity, R.negate, 42),
+      R.compose(R.negate, R.inc)(42)
+    );
+    assert.strictEqual(
+      R.around(R.inc, R.negate, R.identity, 42),
+      R.compose(R.negate, R.inc)(42)
+    );
+  });
+
+  it('is curried', function() {
+    assert.strictEqual(
+      R.around(R.inc)(R.negate)(R.dec)(42),
+      R.compose(R.negate, R.dec, R.inc)(42)
+    );
+  });
+});


### PR DESCRIPTION
As briefly discussed in #1275, this implements:

```
around :: (a -> b) -> (c -> d) -> (b -> c) -> a -> d
```

From the docs:

> Accepts three functions, `fore`, `hind` and `fn`, and a single value. `R.around` effectively wraps `fn` with `fore` and `hind` by first passing the given value to `fore`, which returns a value that is then passed to `fn`, whose return value is finally passed to `hind`. The return value of `R.around` is the result of this call to `hind`.
> 
> This can be useful for converting some type `a` to be compatible with some function `(b -> b)` and back again, where an isomorphism exists between `a` and `b`: `R.around(aToB, bToA, bFn)`.

Potential controversy: there isn't a whole lot of difference between this and `compose` or `pipe`, except the difference in parameter order making it nicer to work with under certain scenarios.
