### PR TITLE
Change `mapAccum` signature to use arrays

### DIFF
--- a/src/mapAccum.js
+++ b/src/mapAccum.js
@@ -12,7 +12,7 @@ var _curry3 = require('./internal/_curry3');
  * @func
  * @memberOf R
  * @category List
- * @sig (acc -> x -> (acc, y)) -> acc -> [x] -> (acc, [y])
+ * @sig (acc -> x -> [acc, y]) -> acc -> [x] -> [acc, [y]]
  * @param {Function} fn The function to be called on every element of the input `list`.
  * @param {*} acc The accumulator value.
  * @param {Array} list The list to iterate over.

--- a/src/mapAccumRight.js
+++ b/src/mapAccumRight.js
@@ -15,7 +15,7 @@ var _curry3 = require('./internal/_curry3');
  * @func
  * @memberOf R
  * @category List
- * @sig (acc -> x -> (acc, y)) -> acc -> [x] -> (acc, [y])
+ * @sig (acc -> x -> [acc, y]) -> acc -> [x] -> [acc, [y]]
  * @param {Function} fn The function to be called on every element of the input `list`.
  * @param {*} acc The accumulator value.
  * @param {Array} list The list to iterate over.


### PR DESCRIPTION
The current signature of `mapAccum` and `mapAccumRight` are a bit confusing IMO. They use a form of tuple syntax that does not really have a meaning in JavaScript. This PR changes the tuple signature to use arrays which I think better indicates that the function actually returns an array.

There might be a bit of ambiguity between `[a]` which is an array of `a`s and `[a, b]` which is an array where the first element is an `a` and the second a `b`.