### PR TITLE
ignore enumeration order when comparing maps or sets in R.equals

### DIFF
--- a/src/internal/_equals.js
+++ b/src/internal/_equals.js
@@ -2,6 +2,8 @@ var _arrayFromIterator = require('./_arrayFromIterator');
 var _has = require('./_has');
 var identical = require('../identical');
 var keys = require('../keys');
+var sortBy = require('../sortBy');
+var toString = require('../toString');
 var type = require('../type');
 
 
@@ -45,7 +47,10 @@ module.exports = function _equals(a, b, stackA, stackB) {
       break;
     case 'Map':
     case 'Set':
-      if (!_equals(_arrayFromIterator(a.entries()), _arrayFromIterator(b.entries()), stackA, stackB)) {
+      if (!_equals(sortBy(toString, _arrayFromIterator(a.entries())),
+                   sortBy(toString, _arrayFromIterator(b.entries())),
+                   stackA,
+                   stackB)) {
         return false;
       }
       break;

--- a/src/internal/_toString.js
+++ b/src/internal/_toString.js
@@ -1,4 +1,3 @@
-var _contains = require('./_contains');
 var _map = require('./_map');
 var _quote = require('./_quote');
 var _toISOString = require('./_toISOString');
@@ -10,7 +9,14 @@ var test = require('../test');
 module.exports = function _toString(x, seen) {
   var recur = function recur(y) {
     var xs = seen.concat([x]);
-    return _contains(y, xs) ? '<Circular>' : _toString(y, xs);
+    var idx = 0;
+    while (idx < xs.length) {
+      if (xs[idx] === y) {
+        return '<Circular>';
+      }
+      idx += 1;
+    }
+    return _toString(y, xs);
   };
 
   //  mapPairs :: (Object, [String]) -> [String]

--- a/test/equals.js
+++ b/test/equals.js
@@ -207,6 +207,8 @@ describe('equals', function() {
       assert.strictEqual(R.equals(new Map([[1, 'a']]), new Map([])), false);
       assert.strictEqual(R.equals(new Map([[1, 'a']]), new Map([[1, 'a']])), true);
       assert.strictEqual(R.equals(new Map([[1, 'a']]), new Map([[1, 'b']])), false);
+      assert.strictEqual(R.equals(new Map([[1, 'a'], [2, 'b']]), new Map([[2, 'b'], [1, 'a']])), true);
+      assert.strictEqual(R.equals(new Map([[1, 'a'], ['1', 'a']]), new Map([['1', 'a'], [1, 'a']])), true);
       assert.strictEqual(R.equals(new Map([[1, 'a'], [2, new Map([[3, 'c']])]]), new Map([[1, 'a'], [2, new Map([[3, 'c']])]])), true);
       assert.strictEqual(R.equals(new Map([[1, 'a'], [2, new Map([[3, 'c']])]]), new Map([[1, 'a'], [2, new Map([[3, 'd']])]])), false);
       assert.strictEqual(R.equals(new Map([[[1, 2, 3], [4, 5, 6]]]), new Map([[[1, 2, 3], [4, 5, 6]]])), true);
@@ -219,6 +221,8 @@ describe('equals', function() {
       assert.strictEqual(R.equals(new Set([]), new Set([])), true);
       assert.strictEqual(R.equals(new Set([]), new Set([1])), false);
       assert.strictEqual(R.equals(new Set([1]), new Set([])), false);
+      assert.strictEqual(R.equals(new Set([1, 2]), new Set([2, 1])), true);
+      assert.strictEqual(R.equals(new Set([1, '1']), new Set(['1', 1])), true);
       assert.strictEqual(R.equals(new Set([1, new Set([2, new Set([3])])]), new Set([1, new Set([2, new Set([3])])])), true);
       assert.strictEqual(R.equals(new Set([1, new Set([2, new Set([3])])]), new Set([1, new Set([2, new Set([4])])])), false);
       assert.strictEqual(R.equals(new Set([[1, 2, 3], [4, 5, 6]]), new Set([[1, 2, 3], [4, 5, 6]])), true);


### PR DESCRIPTION
Thank you for bringing this to my attention, @jdalton!
