### PR TITLE
dispatch recursively in R.equals

### DIFF
--- a/src/equals.js
+++ b/src/equals.js
@@ -1,6 +1,5 @@
 var _curry2 = require('./internal/_curry2');
 var _equals = require('./internal/_equals');
-var _hasMethod = require('./internal/_hasMethod');
 
 
 /**
@@ -26,6 +25,5 @@ var _hasMethod = require('./internal/_hasMethod');
  *      R.equals(a, b); //=> true
  */
 module.exports = _curry2(function equals(a, b) {
-  return _hasMethod('equals', a) ? a.equals(b) :
-         _hasMethod('equals', b) ? b.equals(a) : _equals(a, b, [], []);
+  return _equals(a, b, [], []);
 });

--- a/src/internal/_equals.js
+++ b/src/internal/_equals.js
@@ -14,10 +14,16 @@ module.exports = function _equals(a, b, stackA, stackB) {
     return false;
   }
 
+  if (a == null || b == null) {
+    return false;
+  }
+
+  if (typeof a.equals === 'function' || typeof b.equals === 'function') {
+    return typeof a.equals === 'function' && a.equals(b) &&
+           typeof b.equals === 'function' && b.equals(a);
+  }
+
   switch (type(a)) {
-    case 'Null':
-    case 'Undefined':
-      return false;
     case 'Array':
     case 'Object':
       break;

--- a/test/equals.js
+++ b/test/equals.js
@@ -242,7 +242,7 @@ describe('equals', function() {
     });
   }
 
-  it('dispatches to `equals` method', function() {
+  it('dispatches to `equals` method recursively', function() {
     function Left(x) { this.value = x; }
     Left.prototype.equals = function(x) {
       return x instanceof Left && R.equals(x.value, this.value);
@@ -259,6 +259,37 @@ describe('equals', function() {
     assert.strictEqual(R.equals({value: 42}, new Left(42)), false);
     assert.strictEqual(R.equals(new Left(42), new Right(42)), false);
     assert.strictEqual(R.equals(new Right(42), new Left(42)), false);
+
+    assert.strictEqual(R.equals([new Left(42)], [new Left(42)]), true);
+    assert.strictEqual(R.equals([new Left(42)], [new Right(42)]), false);
+    assert.strictEqual(R.equals([new Right(42)], [new Left(42)]), false);
+    assert.strictEqual(R.equals([new Right(42)], [new Right(42)]), true);
+  });
+
+  it('is commutative', function() {
+    function Point(x, y) {
+      this.x = x;
+      this.y = y;
+    }
+    Point.prototype.equals = function(point) {
+      return point instanceof Point &&
+             this.x === point.x && this.y === point.y;
+    };
+
+    function ColorPoint(x, y, color) {
+      this.x = x;
+      this.y = y;
+      this.color = color;
+    }
+    ColorPoint.prototype = new Point(0, 0);
+    ColorPoint.prototype.equals = function(point) {
+      return point instanceof ColorPoint &&
+             this.x === point.x && this.y === point.y &&
+             this.color === point.color;
+    };
+
+    assert.strictEqual(R.equals(new Point(2, 2), new ColorPoint(2, 2, 'red')), false);
+    assert.strictEqual(R.equals(new ColorPoint(2, 2, 'red'), new Point(2, 2)), false);
   });
 
   it('is curried', function() {


### PR DESCRIPTION
Fixes #1368

It's unusual for dispatching to take place in a private function, but it's necessary in this case.
