### PR TITLE
equals should return true for Maps with same keys and values but different order insertion

### DIFF
--- a/src/find.js
+++ b/src/find.js
@@ -1,5 +1,6 @@
 var _curry2 = require('./internal/_curry2');
 var _dispatchable = require('./internal/_dispatchable');
+var _find = require('./internal/_find');
 var _xfind = require('./internal/_xfind');
 
 
@@ -24,13 +25,4 @@ var _xfind = require('./internal/_xfind');
  *      R.find(R.propEq('a', 2))(xs); //=> {a: 2}
  *      R.find(R.propEq('a', 4))(xs); //=> undefined
  */
-module.exports = _curry2(_dispatchable('find', _xfind, function find(fn, list) {
-  var idx = 0;
-  var len = list.length;
-  while (idx < len) {
-    if (fn(list[idx])) {
-      return list[idx];
-    }
-    idx += 1;
-  }
-}));
+module.exports = _curry2(_dispatchable('find', _xfind, _find));

--- a/src/internal/_equals.js
+++ b/src/internal/_equals.js
@@ -1,5 +1,8 @@
-var _arrayFromIterator = require('./_arrayFromIterator');
+var _find = require('./_find');
 var _has = require('./_has');
+var _identity = require('./_identity');
+var _map = require('./_map');
+var all = require('../all');
 var identical = require('../identical');
 var keys = require('../keys');
 var type = require('../type');
@@ -45,7 +48,18 @@ module.exports = function _equals(a, b, stackA, stackB) {
       break;
     case 'Map':
     case 'Set':
-      if (!_equals(_arrayFromIterator(a.entries()), _arrayFromIterator(b.entries()), stackA, stackB)) {
+      if (a.size !== b.size) {
+        return false;
+      }
+      var paired = _map(
+        function(entryA) {
+          return _find(function(entryB) {
+            return _equals(entryA, entryB, stackA.slice(0), stackB.slice(0));
+          }, b.entries());
+        },
+        a.entries()
+      );
+      if (!all(_identity, paired)) {
         return false;
       }
       break;

--- a/src/internal/_find.js
+++ b/src/internal/_find.js
@@ -1,0 +1,30 @@
+module.exports = (function() {
+
+  function _arrayFind(fn, list) {
+    var idx = 0;
+    var len = list.length;
+    while (idx < len) {
+      if (fn(list[idx])) {
+        return list[idx];
+      }
+      idx += 1;
+    }
+  }
+
+  function _iteratorFind(fn, iter) {
+    var step = iter.next();
+    while (!step.done) {
+      if (fn(step.value)) {
+        return step.value;
+      }
+      step = iter.next();
+    }
+  }
+
+  var symIterator = (typeof Symbol !== 'undefined') ? Symbol.iterator : '@@iterator';
+
+  return function _find(fn, list) {
+    return list[symIterator] ? _iteratorFind(fn, list[symIterator]())
+                             : _arrayFind(fn, list) ;
+  };
+})();

--- a/src/internal/_map.js
+++ b/src/internal/_map.js
@@ -1,8 +1,30 @@
-module.exports = function _map(fn, list) {
-  var idx = 0, len = list.length, result = Array(len);
-  while (idx < len) {
-    result[idx] = fn(list[idx]);
-    idx += 1;
+var _isArray = require('./_isArray');
+
+module.exports = (function() {
+  function _arrayMap(fn, list) {
+    var idx = 0, len = list.length, result = Array(len);
+    while (idx < len) {
+      result[idx] = fn(list[idx]);
+      idx += 1;
+    }
+    return result;
   }
-  return result;
-};
+
+  function _iteratorMap(fn, iter) {
+    var acc = [];
+    var step = iter.next();
+    while (!step.done) {
+      acc[acc.length] = fn(step.value);
+      step = iter.next();
+    }
+    return acc;
+  }
+
+  var symIterator = (typeof Symbol !== 'undefined') ? Symbol.iterator : '@@iterator';
+
+  return function _map(fn, list) {
+    return _isArray(list)    ? _arrayMap(fn, list) :
+           list[symIterator] ? _iteratorMap(fn, list[symIterator]())
+                             : _arrayMap(fn, list);
+  };
+})();

--- a/test/equals.js
+++ b/test/equals.js
@@ -210,6 +210,10 @@ describe('equals', function() {
       assert.strictEqual(R.equals(new Map([[1, 'a'], [2, new Map([[3, 'c']])]]), new Map([[1, 'a'], [2, new Map([[3, 'c']])]])), true);
       assert.strictEqual(R.equals(new Map([[1, 'a'], [2, new Map([[3, 'c']])]]), new Map([[1, 'a'], [2, new Map([[3, 'd']])]])), false);
       assert.strictEqual(R.equals(new Map([[[1, 2, 3], [4, 5, 6]]]), new Map([[[1, 2, 3], [4, 5, 6]]])), true);
+      assert.strictEqual(R.equals(
+        new Map([[[1, 2, 3], [4, 5, 6]],    [[7, 8, 9], [10, 11, 12]]]),
+        new Map([[[7, 8, 9], [10, 11, 12]], [[1, 2, 3], [4, 5, 6]]])
+      ), true);
       assert.strictEqual(R.equals(new Map([[[1, 2, 3], [4, 5, 6]]]), new Map([[[1, 2, 3], [7, 8, 9]]])), false);
     });
   }

--- a/test/find.js
+++ b/test/find.js
@@ -43,6 +43,24 @@ describe('find', function() {
     assert.deepEqual(intoArray(R.find(even), []), [undefined]);
   });
 
+  it('finds elements inside iterables', function() {
+    var symIterator = (typeof Symbol !== 'undefined') ? Symbol.iterator : '@@iterator';
+    var numbers = {};
+    numbers[symIterator] = function() {
+      var i = 0;
+      return {
+        next: function() {
+          i += 1;
+          return {
+            value: i,
+            done: false
+          };
+        }
+      };
+    };
+    assert.strictEqual(R.find(gt100, numbers), 101);
+  });
+
   it('is curried', function() {
     assert.strictEqual(typeof R.find(even), 'function');
     assert.strictEqual(R.find(even)(a), 10);

--- a/test/map.js
+++ b/test/map.js
@@ -54,4 +54,20 @@ describe('map', function() {
     assert.strictEqual(inc.length, 1);
   });
 
+  it('maps simple functions over iterables', function() {
+    var symIterator = (typeof Symbol !== 'undefined') ? Symbol.iterator : '@@iterator';
+    var numbers = {};
+    var max = 4;
+    numbers[symIterator] = function() {
+      var i = 0;
+      return {
+        next: function() {
+          i += 1;
+          return i <= max ? {value: i, done: false} : {done: true};
+        }
+      };
+    };
+    assert.deepEqual(R.map(add1, numbers), [2, 3, 4, 5]);
+  });
+
 });


### PR DESCRIPTION
this two maps should be considered the same:

```

new Map([[[1, 2, 3], [4, 5, 6]],    [[7, 8, 9], [10, 11, 12]]]),
new Map([[[7, 8, 9], [10, 11, 12]], [[1, 2, 3], [4, 5, 6]]])
```

on the way of solving it, I made `map` and `find` compatible with iterables.
If this looks like the way to go, I will make `all`compatible with iterables, so there's no need to use map and simplify the implementation.
