### PR TITLE
do not curry functions returned by R.{compose,pipe}{,P}

### DIFF
--- a/src/compose.js
+++ b/src/compose.js
@@ -9,7 +9,7 @@ var reverse = require('./reverse');
  * @func
  * @memberOf R
  * @category Function
- * @sig ((y -> z), (x -> y), ..., (o -> p), ((a, b, ..., n) -> o)) -> (a -> b -> ... -> n -> z)
+ * @sig ((y -> z), (x -> y), ..., (o -> p), ((a, b, ..., n) -> o)) -> ((a, b, ..., n) -> z)
  * @param {...Function} functions
  * @return {Function}
  * @see R.pipe

--- a/src/composeK.js
+++ b/src/composeK.js
@@ -2,6 +2,7 @@ var chain = require('./chain');
 var compose = require('./compose');
 var identity = require('./identity');
 var map = require('./map');
+var prepend = require('./prepend');
 
 
 /**
@@ -37,7 +38,5 @@ var map = require('./map');
  *      //=> Nothing()
  */
 module.exports = function composeK() {
-  return arguments.length === 0 ?
-    identity :
-    compose.apply(this, map(chain, arguments));
+  return compose.apply(this, prepend(identity, map(chain, arguments)));
 };

--- a/src/pipe.js
+++ b/src/pipe.js
@@ -1,5 +1,5 @@
+var _arity = require('./internal/_arity');
 var _pipe = require('./internal/_pipe');
-var curryN = require('./curryN');
 var reduce = require('./reduce');
 var tail = require('./tail');
 
@@ -13,7 +13,7 @@ var tail = require('./tail');
  * @func
  * @memberOf R
  * @category Function
- * @sig (((a, b, ..., n) -> o), (o -> p), ..., (x -> y), (y -> z)) -> (a -> b -> ... -> n -> z)
+ * @sig (((a, b, ..., n) -> o), (o -> p), ..., (x -> y), (y -> z)) -> ((a, b, ..., n) -> z)
  * @param {...Function} functions
  * @return {Function}
  * @see R.compose
@@ -27,6 +27,6 @@ module.exports = function pipe() {
   if (arguments.length === 0) {
     throw new Error('pipe requires at least one argument');
   }
-  return curryN(arguments[0].length,
+  return _arity(arguments[0].length,
                 reduce(_pipe, arguments[0], tail(arguments)));
 };

--- a/src/pipeP.js
+++ b/src/pipeP.js
@@ -1,5 +1,5 @@
+var _arity = require('./internal/_arity');
 var _pipeP = require('./internal/_pipeP');
-var curryN = require('./curryN');
 var reduce = require('./reduce');
 var tail = require('./tail');
 
@@ -25,6 +25,6 @@ module.exports = function pipeP() {
   if (arguments.length === 0) {
     throw new Error('pipeP requires at least one argument');
   }
-  return curryN(arguments[0].length,
+  return _arity(arguments[0].length,
                 reduce(_pipeP, arguments[0], tail(arguments)));
 };

--- a/test/compose.js
+++ b/test/compose.js
@@ -11,27 +11,12 @@ describe('compose', function() {
   });
 
   it('performs right-to-left function composition', function() {
-    var f = function(a) { return [a]; };
-    var g = function(a, b) { return [a, b]; };
-    var h = function(a, b, c) { return [a, b, c]; };
+    //  f :: (String, Number?) -> ([Number] -> [Number])
+    var f = R.compose(R.map, R.multiply, parseInt);
 
-    assert.strictEqual(R.compose(f, f, f).length, 1);
-    assert.strictEqual(R.compose(f, f, g).length, 2);
-    assert.strictEqual(R.compose(f, f, h).length, 3);
-
-    assert.deepEqual(R.compose(f, f, f)(1), [[[1]]]);
-    assert.deepEqual(R.compose(f, f, g)(1, 2), [[[1, 2]]]);
-    assert.deepEqual(R.compose(f, f, g)(1)(2), [[[1, 2]]]);
-    assert.deepEqual(R.compose(f, f, h)(1, 2, 3), [[[1, 2, 3]]]);
-    assert.deepEqual(R.compose(f, f, h)(1, 2)(3), [[[1, 2, 3]]]);
-    assert.deepEqual(R.compose(f, f, h)(1)(2, 3), [[[1, 2, 3]]]);
-    assert.deepEqual(R.compose(f, f, h)(1)(2)(3), [[[1, 2, 3]]]);
-
-    var $g = R.curry(g);
-
-    assert.strictEqual(R.compose($g, $g).length, 2);
-    assert.deepEqual(R.compose($g, $g)(1, 2)(3), [[1, 2], 3]);
-    assert.deepEqual(R.compose($g, $g)(1)(2)(3), [[1, 2], 3]);
+    assert.strictEqual(f.length, 2);
+    assert.deepEqual(f('10')([1, 2, 3]), [10, 20, 30]);
+    assert.deepEqual(f('10', 2)([1, 2, 3]), [2, 4, 6]);
   });
 
   it('passes context to functions', function() {

--- a/test/composeP.js
+++ b/test/composeP.js
@@ -12,26 +12,34 @@ describe('composeP', function() {
     assert.strictEqual(R.composeP.length, 0);
   });
 
-  it('performs right-to-left composition of Promise-returning functions', function() {
+  it('performs right-to-left composition of Promise-returning functions', function(done) {
     var f = function(a) { return Q.Promise(function(res) { res([a]); }); };
     var g = function(a, b) { return Q.Promise(function(res) { res([a, b]); }); };
-    var h = function(a, b, c) { return Q.Promise(function(res) { res([a, b, c]); }); };
 
-    assert.strictEqual(R.composeP(f, f, f).length, 1);
-    assert.strictEqual(R.composeP(f, f, g).length, 2);
-    assert.strictEqual(R.composeP(f, f, h).length, 3);
+    assert.strictEqual(R.composeP(f).length, 1);
+    assert.strictEqual(R.composeP(g).length, 2);
+    assert.strictEqual(R.composeP(f, f).length, 1);
+    assert.strictEqual(R.composeP(f, g).length, 2);
+    assert.strictEqual(R.composeP(g, f).length, 1);
+    assert.strictEqual(R.composeP(g, g).length, 2);
 
-    R.composeP(f, f, f)(1).then(function(result) {
-      assert.deepEqual(result, [[[1]]]);
-    });
+    R.composeP(f, g)(1).then(function(result) {
+      assert.deepEqual(result, [[1, undefined]]);
 
-    R.composeP(f, f, g)(1)(2).then(function(result) {
-      assert.deepEqual(result, [[[1, 2]]]);
-    });
+      R.composeP(g, f)(1).then(function(result) {
+        assert.deepEqual(result, [[1], undefined]);
 
-    R.composeP(f, f, h)(1)(2)(3).then(function(result) {
-      assert.deepEqual(result, [[[1, 2, 3]]]);
-    });
+        R.composeP(f, g)(1, 2).then(function(result) {
+          assert.deepEqual(result, [[1, 2]]);
+
+          R.composeP(g, f)(1, 2).then(function(result) {
+            assert.deepEqual(result, [[1], undefined]);
+
+            done();
+          })['catch'](done);
+        })['catch'](done);
+      })['catch'](done);
+    })['catch'](done);
   });
 
   it('throws if given no arguments', function() {

--- a/test/pipe.js
+++ b/test/pipe.js
@@ -11,27 +11,12 @@ describe('pipe', function() {
   });
 
   it('performs left-to-right function composition', function() {
-    var f = function(a) { return [a]; };
-    var g = function(a, b) { return [a, b]; };
-    var h = function(a, b, c) { return [a, b, c]; };
+    //  f :: (String, Number?) -> ([Number] -> [Number])
+    var f = R.pipe(parseInt, R.multiply, R.map);
 
-    assert.strictEqual(R.pipe(f, f, f).length, 1);
-    assert.strictEqual(R.pipe(g, f, f).length, 2);
-    assert.strictEqual(R.pipe(h, f, f).length, 3);
-
-    assert.deepEqual(R.pipe(f, f, f)(1), [[[1]]]);
-    assert.deepEqual(R.pipe(g, f, f)(1, 2), [[[1, 2]]]);
-    assert.deepEqual(R.pipe(g, f, f)(1)(2), [[[1, 2]]]);
-    assert.deepEqual(R.pipe(h, f, f)(1, 2, 3), [[[1, 2, 3]]]);
-    assert.deepEqual(R.pipe(h, f, f)(1, 2)(3), [[[1, 2, 3]]]);
-    assert.deepEqual(R.pipe(h, f, f)(1)(2, 3), [[[1, 2, 3]]]);
-    assert.deepEqual(R.pipe(h, f, f)(1)(2)(3), [[[1, 2, 3]]]);
-
-    var $g = R.curry(g);
-
-    assert.strictEqual(R.pipe($g, $g).length, 2);
-    assert.deepEqual(R.pipe($g, $g)(1, 2)(3), [[1, 2], 3]);
-    assert.deepEqual(R.pipe($g, $g)(1)(2)(3), [[1, 2], 3]);
+    assert.strictEqual(f.length, 2);
+    assert.deepEqual(f('10')([1, 2, 3]), [10, 20, 30]);
+    assert.deepEqual(f('10', 2)([1, 2, 3]), [2, 4, 6]);
   });
 
   it('passes context to functions', function() {

--- a/test/pipeP.js
+++ b/test/pipeP.js
@@ -12,26 +12,34 @@ describe('pipeP', function() {
     assert.strictEqual(R.pipeP.length, 0);
   });
 
-  it('performs left-to-right composition of Promise-returning functions', function() {
+  it('performs left-to-right composition of Promise-returning functions', function(done) {
     var f = function(a) { return Q.Promise(function(res) { res([a]); }); };
     var g = function(a, b) { return Q.Promise(function(res) { res([a, b]); }); };
-    var h = function(a, b, c) { return Q.Promise(function(res) { res([a, b, c]); }); };
 
-    assert.strictEqual(R.pipeP(f, f, f).length, 1);
-    assert.strictEqual(R.pipeP(g, f, f).length, 2);
-    assert.strictEqual(R.pipeP(h, f, f).length, 3);
+    assert.strictEqual(R.pipeP(f).length, 1);
+    assert.strictEqual(R.pipeP(g).length, 2);
+    assert.strictEqual(R.pipeP(f, f).length, 1);
+    assert.strictEqual(R.pipeP(f, g).length, 1);
+    assert.strictEqual(R.pipeP(g, f).length, 2);
+    assert.strictEqual(R.pipeP(g, g).length, 2);
 
-    R.pipeP(f, f, f)(1).then(function(result) {
-      assert.deepEqual(result, [[[1]]]);
-    });
+    R.pipeP(f, g)(1).then(function(result) {
+      assert.deepEqual(result, [[1], undefined]);
 
-    R.pipeP(g, f, f)(1)(2).then(function(result) {
-      assert.deepEqual(result, [[[1, 2]]]);
-    });
+      R.pipeP(g, f)(1).then(function(result) {
+        assert.deepEqual(result, [[1, undefined]]);
 
-    R.pipeP(h, f, f)(1)(2)(3).then(function(result) {
-      assert.deepEqual(result, [[[1, 2, 3]]]);
-    });
+        R.pipeP(f, g)(1, 2).then(function(result) {
+          assert.deepEqual(result, [[1], undefined]);
+
+          R.pipeP(g, f)(1, 2).then(function(result) {
+            assert.deepEqual(result, [[1, 2]]);
+
+            done();
+          })['catch'](done);
+        })['catch'](done);
+      })['catch'](done);
+    })['catch'](done);
   });
 
   it('throws if given no arguments', function() {


### PR DESCRIPTION
This pull request partially reverts #1260. It means a pipeline may begin with a function with optional arguments, in which case the resulting function will itself have optional arguments. As a result, `R.compose`, `R.pipe`, `R.composeP`, and `R.pipeP` no longer return curried functions.

Various more significant changes have been discussed in #1318, but we've yet to reach consensus and our indecision is blocking the release of v0.18.0. My hope is that this pull request will unblock us.

As stated in https://github.com/ramda/ramda/issues/1318#issuecomment-132005376, I prefer simpler definitions of `compose` and `pipe`. I've opened plaid/sanctuary#94 to add these, along with `meld`, to Sanctuary. @CrossEye has expressed interest in `meld`; I'll open a Ramda pull request for a variadic `meld` if and when this pull request is merged.
