### PR TITLE
implement map, ap and chain for functions

### DIFF
--- a/src/ap.js
+++ b/src/ap.js
@@ -1,11 +1,14 @@
 var _concat = require('./internal/_concat');
 var _curry2 = require('./internal/_curry2');
 var _reduce = require('./internal/_reduce');
+var curryN = require('./curryN');
 var map = require('./map');
 
 
 /**
  * ap applies a list of functions to a list of values.
+ *
+ * ap also treats functions as applicatives.
  *
  * @func
  * @memberOf R
@@ -18,8 +21,15 @@ var map = require('./map');
  *
  *      R.ap([R.multiply(2), R.add(3)], [1,2,3]); //=> [2, 4, 6, 4, 5, 6]
  */
-module.exports = _curry2(function ap(fns, vs) {
-  return typeof fns.ap === 'function' ?
-    fns.ap(vs) :
-    _reduce(function(acc, fn) { return _concat(acc, map(fn, vs)); }, [], fns);
+module.exports = _curry2(function ap(applicative, fn) {
+  return (
+    typeof applicative.ap === 'function' ?
+      applicative.ap(fn) :
+    typeof applicative === 'function' ?
+      curryN(Math.max(applicative.length, fn.length), function() {
+        return applicative.apply(this, arguments)(fn.apply(this, arguments));
+      }) :
+    // else
+      _reduce(function(acc, f) { return _concat(acc, map(f, fn)); }, [], applicative)
+  );
 });

--- a/src/both.js
+++ b/src/both.js
@@ -1,11 +1,12 @@
-var _curry2 = require('./internal/_curry2');
+var and = require('./and');
+var lift = require('./lift');
 
 
 /**
  * A function wrapping calls to the two functions in an `&&` operation, returning the result of the first
- * function if it is false-y and the result of the second function otherwise.  Note that this is
- * short-circuited, meaning that the second function will not be invoked if the first returns a false-y
- * value.
+ * function if it is false-y and the result of the second function otherwise.
+ *
+ * `R.both` will work on all other applicatives as well.
  *
  * @func
  * @memberOf R
@@ -23,8 +24,4 @@ var _curry2 = require('./internal/_curry2');
  *      f(100); //=> true
  *      f(101); //=> false
  */
-module.exports = _curry2(function both(f, g) {
-  return function _both() {
-    return f.apply(this, arguments) && g.apply(this, arguments);
-  };
-});
+module.exports = lift(and);

--- a/src/chain.js
+++ b/src/chain.js
@@ -23,6 +23,11 @@ var map = require('./map');
  *      var duplicate = n => [n, n];
  *      R.chain(duplicate, [1, 2, 3]); //=> [1, 1, 2, 2, 3, 3]
  */
-module.exports = _curry2(_dispatchable('chain', _xchain, function chain(fn, list) {
-  return _makeFlat(false)(map(fn, list));
+module.exports = _curry2(_dispatchable('chain', _xchain, function chain(fn, monad) {
+  if (typeof monad === 'function') {
+    return function() {
+      return monad.call(this, fn.apply(this, arguments)).apply(this, arguments);
+    };
+  }
+  return _makeFlat(false)(map(fn, monad));
 }));

--- a/src/complement.js
+++ b/src/complement.js
@@ -1,5 +1,5 @@
-var _complement = require('./internal/_complement');
-var _curry1 = require('./internal/_curry1');
+var lift = require('./lift');
+var not = require('./not');
 
 
 /**
@@ -10,6 +10,8 @@ var _curry1 = require('./internal/_curry1');
  *
  *   - applying `g` to zero or more arguments will give __false__ if applying
  *     the same arguments to `f` gives a logical __true__ value.
+ *
+ * `R.complement` will work on all other functors as well.
  *
  * @func
  * @memberOf R
@@ -25,4 +27,4 @@ var _curry1 = require('./internal/_curry1');
  *      isOdd(21); //=> true
  *      isOdd(42); //=> false
  */
-module.exports = _curry1(_complement);
+module.exports = lift(not);

--- a/src/either.js
+++ b/src/either.js
@@ -1,11 +1,12 @@
-var _curry2 = require('./internal/_curry2');
+var lift = require('./lift');
+var or = require('./or');
 
 
 /**
  * A function wrapping calls to the two functions in an `||` operation, returning the result of the first
- * function if it is truth-y and the result of the second function otherwise.  Note that this is
- * short-circuited, meaning that the second function will not be invoked if the first returns a truth-y
- * value.
+ * function if it is truth-y and the result of the second function otherwise.
+ *
+ * `R.either` will work on all other applicatives as well.
  *
  * @func
  * @memberOf R
@@ -23,8 +24,4 @@ var _curry2 = require('./internal/_curry2');
  *      f(101); //=> true
  *      f(8); //=> true
  */
-module.exports = _curry2(function either(f, g) {
-  return function _either() {
-    return f.apply(this, arguments) || g.apply(this, arguments);
-  };
-});
+module.exports = lift(or);

--- a/src/internal/_map.js
+++ b/src/internal/_map.js
@@ -1,8 +1,16 @@
-module.exports = function _map(fn, list) {
-  var idx = 0, len = list.length, result = Array(len);
-  while (idx < len) {
-    result[idx] = fn(list[idx]);
-    idx += 1;
+var curryN = require('../curryN');
+
+module.exports = function _map(fn, functor) {
+  if (typeof functor === 'function') {
+    return curryN(functor.length, function() {
+      return fn.call(this, functor.apply(this, arguments));
+    });
+  } else {
+    var idx = 0, len = functor.length, result = Array(len);
+    while (idx < len) {
+      result[idx] = fn(functor[idx]);
+      idx += 1;
+    }
+    return result;
   }
-  return result;
 };

--- a/src/map.js
+++ b/src/map.js
@@ -15,6 +15,8 @@ var _xmap = require('./internal/_xmap');
  * Acts as a transducer if a transformer is given in list position.
  * @see R.transduce
  *
+ * Map treats also treats functions as functors and will compose them together.
+ *
  * @func
  * @memberOf R
  * @category List

--- a/test/ap.js
+++ b/test/ap.js
@@ -7,8 +7,21 @@ describe('ap', function() {
   function mult2(x) { return x * 2; }
   function plus3(x) { return x + 3; }
 
-  it('applies a list of functions to a list of values', function() {
+  it('interprets [a] as an applicative', function() {
     assert.deepEqual(R.ap([mult2, plus3], [1, 2, 3]), [2, 4, 6, 4, 5, 6]);
+  });
+
+  it('interprets ((->) r) as an applicative', function() {
+    var f = function(r) {
+      return function(a) {
+        return r + a;
+      };
+    };
+    var g = function(r) { return r * 2; };
+    var h = R.ap(f, g);
+    // (<*>) :: (r -> a -> b) -> (r -> a) -> (r -> b)
+    // f <*> g = \x -> f x (g x)
+    assert.strictEqual(h(10), 10 + (10 * 2));
   });
 
   it('dispatches to the passed object\'s ap method when values is a non-Array object', function() {

--- a/test/chain.js
+++ b/test/chain.js
@@ -26,6 +26,19 @@ describe('chain', function() {
     assert.deepEqual(intoArray(R.chain(times2), [1, 2, 3, 4]), [2, 4, 6, 8]);
   });
 
+  it('interprets ((->) r) as a monad', function() {
+    var h = function(r) { return r * 2; };
+    var f = function(a) {
+      return function(r) {
+        return r + a;
+      };
+    };
+    var bound = R.chain(h, f);
+    // (>>=) :: (r -> a) -> (a -> r -> b) -> (r -> b)
+    // h >>= f = \w -> f (h w) w
+    assert.strictEqual(bound(10), (10 * 2) + 10);
+  });
+
   it('dispatches to objects that implement `chain`', function() {
     var obj = {x: 100, chain: function(f) { return f(this.x); }};
     assert.deepEqual(R.chain(add1, obj), [101]);

--- a/test/liftN.js
+++ b/test/liftN.js
@@ -28,12 +28,6 @@ describe('liftN', function() {
     assert.deepEqual(addN3([1, 10], [2], [3]), [6, 15]);
   });
 
-  it('produces a cross-product of array values', function() {
-    assert.deepEqual(addN3([1, 2, 3], [1, 2], [1, 2, 3]), [3, 4, 5, 4, 5, 6, 4, 5, 6, 5, 6, 7, 5, 6, 7, 6, 7, 8]);
-    assert.deepEqual(addN3([1], [2], [3]), [6]);
-    assert.deepEqual(addN3([1, 2], [3, 4], [5, 6]), [9, 10, 10, 11, 10, 11, 11, 12]);
-  });
-
   it('can lift functions of any arity', function() {
     assert.deepEqual(addN3([1, 10], [2], [3]), [6, 15]);
     assert.deepEqual(addN4([1, 10], [2], [3], [40]), [46, 55]);
@@ -49,5 +43,25 @@ describe('liftN', function() {
   it('works with other functors such as "Maybe"', function() {
     var addM = R.liftN(2, R.add);
     assert.deepEqual(addM(Maybe(3), Maybe(5)), Maybe(8));
+  });
+
+  it('interprets [a] as a functor', function() {
+    assert.deepEqual(addN3([1, 2, 3], [10, 20], [100, 200, 300]), [111, 211, 311, 121, 221, 321, 112, 212, 312, 122, 222, 322, 113, 213, 313, 123, 223, 323]);
+    assert.deepEqual(addN3([1], [2], [3]), [6]);
+    assert.deepEqual(addN3([1, 2], [10, 20], [100, 200]), [111, 211, 121, 221, 112, 212, 122, 222]);
+  });
+
+  it('interprets ((->) r) as a functor', function() {
+    var convergedOnInt = addN3(R.add(2), R.multiply(3), R.subtract(4));
+    var convergedOnBool = R.liftN(2, R.and)(R.gt(R.__, 0), R.lt(R.__, 3));
+    assert.strictEqual(typeof convergedOnInt, 'function');
+    assert.strictEqual(typeof convergedOnBool, 'function');
+    assert.strictEqual(convergedOnInt(10), (10 + 2) + (10 * 3) + (4 - 10));
+    // jscs:disable disallowYodaConditions
+    assert.strictEqual(convergedOnBool(0), (0 > 0) && (0 < 3));
+    assert.strictEqual(convergedOnBool(1), (1 > 0) && (1 < 3));
+    assert.strictEqual(convergedOnBool(2), (2 > 0) && (2 < 3));
+    assert.strictEqual(convergedOnBool(3), (3 > 0) && (3 < 3));
+    // jscs:enable disallowYodaConditions
   });
 });

--- a/test/map.js
+++ b/test/map.js
@@ -18,6 +18,13 @@ describe('map', function() {
     assert.deepEqual(intoArray(R.map(times2), [1, 2, 3, 4]), [2, 4, 6, 8]);
   });
 
+  it('interprets ((->) r) as a functor', function() {
+    var f = function(a) { return a - 1; };
+    var g = function(b) { return b * 2; };
+    var h = R.map(f, g);
+    assert.strictEqual(h(10), (10 * 2) - 1);
+  });
+
   it('dispatches to objects that implement `map`', function() {
     var obj = {x: 100, map: function(f) { return f(this.x); }};
     assert.strictEqual(R.map(add1, obj), 101);


### PR DESCRIPTION
This change was motivated by some [discussion](https://github.com/plaid/sanctuary/issues/102) around porting some higher order Ramda functions into Sanctuary. The common theme among many of these functions is that they are essentially gluing together the results of different functions in different ways. If we implement Functor and Applicative for functions then we get this behavior for free.
```haskell
instance Functor ((->) r) where
    fmap = (.)

instance Applicative ((->) a) where
    pure = const
    (<*>) f g x = f x (g x)
```
The following simplifications become possible
 - `R.both` -> `R.lift(R.and)`
 - `R.either` -> `R.lift(R.or)`
 - `R.negate` -> `R.lift(R.not)`
 - `R.converge` -> `R.lift`

There are 2 issues that I ran into

What to do about converging functions that take multiple arguments, for example: 
```javascript
const f = R.converge((a, b) => a + b, a => a, (a, b) => a);
f.length; // 2
```
Right now `ap` just assumes there will only be one argument supplied to a function (but I could easily change it to apply the function to the entire arguments object). `R.converge` takes the max length of all of the functions but it can only do this because it knows the length of both input functions at the same time. If you were to perform the equivalent operation with `R.lift` you'd supply the input functions 1 at a time (although both at once is possible as well):
```javascript
const g = R.lift((a, b) => a + b); 
// g :: (Applicative f, Num c) => f c -> f c -> f c
const h = g(a => a); // should the function returned have length 1 now? How do you keep track of that? 
// h :: (Applicative f, Num c) => f c -> f c
const i = h((a, b) => a); // should the function returned have length 2 now?
```
I think the simplest solution is just to make `R.both`, `R.either`, etc. just take unary functions as arguments and call it a day.

The second problem is around preserving context but it seems like that has already been figured out for converge, I'm just not sure how to add it in to `R.map` and `R.ap`.