### PR TITLE
fix R.commute and R.commuteMap

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "q": "^1.1.1",
     "ramda": "0.17.x",
     "rimraf": "~2.3.2",
+    "sanctuary": "0.7.x",
     "testem": "^0.6.18",
     "uglify-js": "2.4.x",
     "xyz": "0.5.x"

--- a/src/commuteMap.js
+++ b/src/commuteMap.js
@@ -1,7 +1,8 @@
 var _curry3 = require('./internal/_curry3');
+var _of = require('./internal/_of');
 var _reduce = require('./internal/_reduce');
-var ap = require('./ap');
-var append = require('./append');
+var concat = require('./concat');
+var lift = require('./lift');
 var map = require('./map');
 
 
@@ -27,8 +28,9 @@ var map = require('./map');
  *      R.commuteMap(R.map(R.add(10)), Maybe.of, [Just(1), Just(2), Nothing()]); //=> Nothing()
  */
 module.exports = _curry3(function commuteMap(fn, of, list) {
+  var concatF = lift(concat);
   function consF(acc, ftor) {
-    return ap(map(append, fn(ftor)), acc);
+    return concatF(acc, map(_of, fn(ftor)));
   }
   return _reduce(consF, of([]), list);
 });

--- a/src/internal/_of.js
+++ b/src/internal/_of.js
@@ -1,0 +1,1 @@
+module.exports = function _of(x) { return [x]; };

--- a/src/of.js
+++ b/src/of.js
@@ -1,4 +1,5 @@
 var _curry1 = require('./internal/_curry1');
+var _of = require('./internal/_of');
 
 
 /**
@@ -18,4 +19,4 @@ var _curry1 = require('./internal/_curry1');
  *      R.of(null); //=> [null]
  *      R.of([42]); //=> [[42]]
  */
-module.exports = _curry1(function of(x) { return [x]; });
+module.exports = _curry1(_of);

--- a/test/commute.js
+++ b/test/commute.js
@@ -1,5 +1,6 @@
-var Maybe = require('./shared/Maybe');
+var S = require('sanctuary');
 
+var Maybe = require('./shared/Maybe');
 var R = require('..');
 var eq = require('./shared/eq');
 
@@ -13,11 +14,18 @@ describe('commute', function() {
   it('"pivots" a list (list of functors => functor of a list)', function() {
     eq(R.commute(R.of, as), [[1, 3], [1, 4]]);
     eq(R.commute(R.of, bs), [[1, 3], [2, 3]]);
-    eq(R.commute(R.of, cs), [[1, 3], [2, 3], [1, 4], [2, 4]]);
+    eq(R.commute(R.of, cs), [[1, 3], [1, 4], [2, 3], [2, 4]]);
   });
 
   it('works on Algebraic Data Types such as "Maybe"', function() {
     eq(R.commute(Maybe.of, [Maybe(3), Maybe(4), Maybe(5)]), Maybe([3, 4, 5]));
+  });
+
+  it('traverses left to right', function() {
+    eq(R.commute(S.Either.of, [S.Right(1), S.Right(2)]), S.Right([1, 2]));
+    eq(R.commute(S.Either.of, [S.Right(1), S.Left('XXX')]), S.Left('XXX'));
+    eq(R.commute(S.Either.of, [S.Left('XXX'), S.Right(1)]), S.Left('XXX'));
+    eq(R.commute(S.Either.of, [S.Left('XXX'), S.Left('YYY')]), S.Left('XXX'));
   });
 
   it('is curried', function() {
@@ -25,7 +33,7 @@ describe('commute', function() {
     eq(typeof cmtArr, 'function');
     eq(cmtArr(as), [[1, 3], [1, 4]]);
     eq(cmtArr(bs), [[1, 3], [2, 3]]);
-    eq(cmtArr(cs), [[1, 3], [2, 3], [1, 4], [2, 4]]);
+    eq(cmtArr(cs), [[1, 3], [1, 4], [2, 3], [2, 4]]);
 
   });
 });

--- a/test/commuteMap.js
+++ b/test/commuteMap.js
@@ -1,5 +1,6 @@
-var Maybe = require('./shared/Maybe');
+var S = require('sanctuary');
 
+var Maybe = require('./shared/Maybe');
 var R = require('..');
 var eq = require('./shared/eq');
 
@@ -14,11 +15,18 @@ describe('commuteMap', function() {
   it('"pivots" a list (list of functors => functor of a list) and applies a transformation', function() {
     eq(R.commuteMap(plus10map, R.of, as), [[11, 13], [11, 14]]);
     eq(R.commuteMap(plus10map, R.of, bs), [[11, 13], [12, 13]]);
-    eq(R.commuteMap(plus10map, R.of, cs), [[11, 13], [12, 13], [11, 14], [12, 14]]);
+    eq(R.commuteMap(plus10map, R.of, cs), [[11, 13], [11, 14], [12, 13], [12, 14]]);
   });
 
   it('works on Algebraic Data Types such as "Maybe"', function() {
     eq(R.commuteMap(plus10map, Maybe, [Maybe(3), Maybe(4), Maybe(5)]), Maybe([13, 14, 15]));
+  });
+
+  it('traverses left to right', function() {
+    eq(R.commuteMap(R.identity, S.Either.of, [S.Right(1), S.Right(2)]), S.Right([1, 2]));
+    eq(R.commuteMap(R.identity, S.Either.of, [S.Right(1), S.Left('XXX')]), S.Left('XXX'));
+    eq(R.commuteMap(R.identity, S.Either.of, [S.Left('XXX'), S.Right(1)]), S.Left('XXX'));
+    eq(R.commuteMap(R.identity, S.Either.of, [S.Left('XXX'), S.Left('YYY')]), S.Left('XXX'));
   });
 
   it('is curried', function() {
@@ -29,6 +37,6 @@ describe('commuteMap', function() {
     eq(typeof cmtmArr, 'function');
     eq(cmtmArr(as), [[11, 13], [11, 14]]);
     eq(cmtmArr(bs), [[11, 13], [12, 13]]);
-    eq(cmtmArr(cs), [[11, 13], [12, 13], [11, 14], [12, 14]]);
+    eq(cmtmArr(cs), [[11, 13], [11, 14], [12, 13], [12, 14]]);
   });
 });


### PR DESCRIPTION
Before:

```javascript
> R.commute(S.Either.of, [S.Left('XXX'), S.Left('YYY'), S.Left('ZZZ')])
Left("ZZZ")
```

After:

```javascript
> R.commute(S.Either.of, [S.Left('XXX'), S.Left('YYY'), S.Left('ZZZ')])
Left("XXX")
```

It seems to me the leftmost failure should be returned, as is the case with Haskell's [`sequence`][1]:

```haskell
> sequence [Right 1, Right 2]
Right [1,2]
> sequence [Right 1, Left "XXX"]
Left "XXX"
> sequence [Left "XXX", Right 1]
Left "XXX"
> sequence [Left "XXX", Left "YYY"]
Left "XXX"
```


[1]: http://hackage.haskell.org/package/base-4.8.1.0/docs/Prelude.html#v:sequence
