### PR TITLE
test: define "eq" function for asserting equivalence

### DIFF
--- a/test/F.js
+++ b/test/F.js
@@ -1,12 +1,11 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('F', function() {
   it('always returns false', function() {
-    assert.strictEqual(R.F(), false);
-    assert.strictEqual(R.F(10), false);
-    assert.strictEqual(R.F(true), false);
+    eq(R.F(), false);
+    eq(R.F(10), false);
+    eq(R.F(true), false);
   });
 });

--- a/test/T.js
+++ b/test/T.js
@@ -1,12 +1,11 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('T', function() {
   it('always returns true', function() {
-    assert.strictEqual(R.T(), true);
-    assert.strictEqual(R.T(10), true);
-    assert.strictEqual(R.T(true), true);
+    eq(R.T(), true);
+    eq(R.T(10), true);
+    eq(R.T(true), true);
   });
 });

--- a/test/add.js
+++ b/test/add.js
@@ -1,15 +1,14 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('add', function() {
   it('adds together two numbers', function() {
-    assert.strictEqual(R.add(3, 7), 10);
+    eq(R.add(3, 7), 10);
   });
 
   it('is curried', function() {
     var incr = R.add(1);
-    assert.strictEqual(incr(42), 43);
+    eq(incr(42), 43);
   });
 });

--- a/test/addIndex.js
+++ b/test/addIndex.js
@@ -1,6 +1,5 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('addIndex', function() {
@@ -13,20 +12,20 @@ describe('addIndex', function() {
     var mapIndexed = R.addIndex(R.map);
 
     it('working just like a normal map', function() {
-      assert.deepEqual(mapIndexed(times2, [1, 2, 3, 4]), [2, 4, 6, 8]);
+      eq(mapIndexed(times2, [1, 2, 3, 4]), [2, 4, 6, 8]);
     });
 
     it('passing the index as a second parameter to the callback', function() {
-      assert.deepEqual(mapIndexed(addIndexParam, [8, 6, 7, 5, 3, 0, 9]), [8, 7, 9, 8, 7, 5, 15]); // [8 + 0, 6 + 1...]
+      eq(mapIndexed(addIndexParam, [8, 6, 7, 5, 3, 0, 9]), [8, 7, 9, 8, 7, 5, 15]); // [8 + 0, 6 + 1...]
     });
 
     it('passing the entire list as a third parameter to the callback', function() {
-      assert.deepEqual(mapIndexed(squareEnds, [8, 6, 7, 5, 3, 0, 9]), [64, 6, 7, 5, 3, 0, 81]);
+      eq(mapIndexed(squareEnds, [8, 6, 7, 5, 3, 0, 9]), [64, 6, 7, 5, 3, 0, 81]);
     });
 
     it('acting as a curried function', function() {
       var makeSquareEnds = mapIndexed(squareEnds);
-      assert.deepEqual(makeSquareEnds([8, 6, 7, 5, 3, 0, 9]), [64, 6, 7, 5, 3, 0, 81]);
+      eq(makeSquareEnds([8, 6, 7, 5, 3, 0, 9]), [64, 6, 7, 5, 3, 0, 81]);
     });
   });
 
@@ -36,14 +35,14 @@ describe('addIndex', function() {
     var objectify = function(acc, elem, idx) { acc[elem] = idx; return acc;};
 
     it('passing the index as a third parameter to the predicate', function() {
-      assert.strictEqual(reduceIndexed(timesIndexed, 0, [1, 2, 3, 4, 5]), 40);
-      assert.deepEqual(reduceIndexed(objectify, {}, ['a', 'b', 'c', 'd', 'e']), {a: 0, b: 1, c: 2, d: 3, e: 4});
+      eq(reduceIndexed(timesIndexed, 0, [1, 2, 3, 4, 5]), 40);
+      eq(reduceIndexed(objectify, {}, ['a', 'b', 'c', 'd', 'e']), {a: 0, b: 1, c: 2, d: 3, e: 4});
     });
 
     it('passing the entire list as a fourth parameter to the predicate', function() {
       var list = [1, 2, 3];
       reduceIndexed(function(acc, x, idx, ls) {
-        assert.strictEqual(ls, list);
+        eq(ls, list);
         return acc;
       }, 0, list);
     });
@@ -53,8 +52,8 @@ describe('addIndex', function() {
     var allIndexed = R.addIndex(R.all);
     var superDiagonal = allIndexed(R.gt);
     it('passing the index as a second parameter', function() {
-      assert.strictEqual(superDiagonal([8, 6, 5, 4, 9]), true); // 8 > 0, 6 > 1, 5 > 2, 4 > 3, 9 > 5
-      assert.strictEqual(superDiagonal([8, 6, 1, 3, 9]), false); //  1 !> 2, 3 !> 3
+      eq(superDiagonal([8, 6, 5, 4, 9]), true); // 8 > 0, 6 > 1, 5 > 2, 4 > 3, 9 > 5
+      eq(superDiagonal([8, 6, 1, 3, 9]), false); //  1 !> 2, 3 !> 3
     });
   });
 
@@ -64,7 +63,7 @@ describe('addIndex', function() {
     };
     var mapFilterIndexed = R.addIndex(mapFilter);
     it('passing the index as an additional parameter', function() {
-      assert.deepEqual(mapFilterIndexed(
+      eq(mapFilterIndexed(
         R.multiply,
         R.gt(R.__, 13),
         [8, 6, 7, 5, 3, 0, 9]

--- a/test/adjust.js
+++ b/test/adjust.js
@@ -1,36 +1,35 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 describe('adjust', function() {
   it('applies the given function to the value at the given index of the supplied array', function() {
-    assert.deepEqual(R.adjust(R.add(1), 2, [0, 1, 2, 3]), [0, 1, 3, 3]);
+    eq(R.adjust(R.add(1), 2, [0, 1, 2, 3]), [0, 1, 3, 3]);
   });
 
   it('offsets negative indexes from the end of the array', function() {
-    assert.deepEqual(R.adjust(R.add(1), -3, [0, 1, 2, 3]), [0, 2, 2, 3]);
+    eq(R.adjust(R.add(1), -3, [0, 1, 2, 3]), [0, 2, 2, 3]);
   });
 
   it('returns the original array if the supplied index is out of bounds', function() {
     var list = [0, 1, 2, 3];
-    assert.deepEqual(R.adjust(R.add(1), 4, list), list);
-    assert.deepEqual(R.adjust(R.add(1), -5, list), list);
+    eq(R.adjust(R.add(1), 4, list), list);
+    eq(R.adjust(R.add(1), -5, list), list);
   });
 
   it('does not mutate the original array', function() {
     var list = [0, 1, 2, 3];
-    assert.deepEqual(R.adjust(R.add(1), 2, list), [0, 1, 3, 3]);
-    assert.deepEqual(list, [0, 1, 2, 3]);
+    eq(R.adjust(R.add(1), 2, list), [0, 1, 3, 3]);
+    eq(list, [0, 1, 2, 3]);
   });
 
   it('curries the arguments', function() {
-    assert.deepEqual(R.adjust(R.add(1))(2)([0, 1, 2, 3]), [0, 1, 3, 3]);
+    eq(R.adjust(R.add(1))(2)([0, 1, 2, 3]), [0, 1, 3, 3]);
   });
 
   it('accepts an array-like object', function() {
     function args() {
       return arguments;
     }
-    assert.deepEqual(R.adjust(R.add(1), 2, args(0, 1, 2, 3)), [0, 1, 3, 3]);
+    eq(R.adjust(R.add(1), 2, args(0, 1, 2, 3)), [0, 1, 3, 3]);
   });
 });

--- a/test/all.js
+++ b/test/all.js
@@ -1,7 +1,7 @@
-var assert = require('assert');
 var listXf = require('./helpers/listXf');
 
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('all', function() {
@@ -11,41 +11,41 @@ describe('all', function() {
   var intoArray = R.into([]);
 
   it('returns true if all elements satisfy the predicate', function() {
-    assert.strictEqual(R.all(even, [2, 4, 6, 8, 10, 12]), true);
-    assert.strictEqual(R.all(isFalse, [false, false, false]), true);
+    eq(R.all(even, [2, 4, 6, 8, 10, 12]), true);
+    eq(R.all(isFalse, [false, false, false]), true);
   });
 
   it('returns false if any element fails to satisfy the predicate', function() {
-    assert.strictEqual(R.all(even, [2, 4, 6, 8, 9, 10]), false);
+    eq(R.all(even, [2, 4, 6, 8, 9, 10]), false);
   });
 
   it('returns true for an empty list', function() {
-    assert.strictEqual(R.all(T, []), true);
+    eq(R.all(T, []), true);
   });
 
   it('returns true into array if all elements satisfy the predicate', function() {
-    assert.deepEqual(intoArray(R.all(even), [2, 4, 6, 8, 10, 12]), [true]);
-    assert.deepEqual(intoArray(R.all(isFalse), [false, false, false]), [true]);
+    eq(intoArray(R.all(even), [2, 4, 6, 8, 10, 12]), [true]);
+    eq(intoArray(R.all(isFalse), [false, false, false]), [true]);
   });
 
   it('returns false into array if any element fails to satisfy the predicate', function() {
-    assert.deepEqual(intoArray(R.all(even), [2, 4, 6, 8, 9, 10]), [false]);
+    eq(intoArray(R.all(even), [2, 4, 6, 8, 9, 10]), [false]);
   });
 
   it('returns true into array for an empty list', function() {
-    assert.deepEqual(intoArray(R.all(T), []), [true]);
+    eq(intoArray(R.all(T), []), [true]);
   });
 
   it('works with more complex objects', function() {
     var xs = [{x: 'abc'}, {x: 'ade'}, {x: 'fghiajk'}];
     function len3(o) { return o.x.length === 3; }
     function hasA(o) { return o.x.indexOf('a') > -1; }
-    assert.strictEqual(R.all(len3, xs), false);
-    assert.strictEqual(R.all(hasA, xs), true);
+    eq(R.all(len3, xs), false);
+    eq(R.all(hasA, xs), true);
   });
 
   it('dispatches when given a transformer in list position', function() {
-    assert.deepEqual(R.all(even, listXf), {
+    eq(R.all(even, listXf), {
       all: true,
       f: even,
       xf: listXf
@@ -55,6 +55,6 @@ describe('all', function() {
   it('is curried', function() {
     var count = 0;
     var test = function(n) {count += 1; return even(n);};
-    assert.strictEqual(R.all(test)([2, 4, 6, 7, 8, 10]), false);
+    eq(R.all(test)([2, 4, 6, 7, 8, 10]), false);
   });
 });

--- a/test/allPass.js
+++ b/test/allPass.js
@@ -1,6 +1,5 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('allPass', function() {
@@ -11,20 +10,20 @@ describe('allPass', function() {
 
   it('reports whether all predicates are satisfied by a given value', function() {
     var ok = R.allPass([odd, lt20, gt5]);
-    assert.strictEqual(ok(7), true);
-    assert.strictEqual(ok(9), true);
-    assert.strictEqual(ok(10), false);
-    assert.strictEqual(ok(3), false);
-    assert.strictEqual(ok(21), false);
+    eq(ok(7), true);
+    eq(ok(9), true);
+    eq(ok(10), false);
+    eq(ok(3), false);
+    eq(ok(21), false);
   });
 
   it('returns true on empty predicate list', function() {
-    assert.strictEqual(R.allPass([])(3), true);
+    eq(R.allPass([])(3), true);
   });
 
   it('returns a curried function whose arity matches that of the highest-arity predicate', function() {
-    assert.strictEqual(R.allPass([odd, gt5, plusEq]).length, 4);
-    assert.strictEqual(R.allPass([odd, gt5, plusEq])(9, 9, 9, 9), true);
-    assert.strictEqual(R.allPass([odd, gt5, plusEq])(9)(9)(9)(9), true);
+    eq(R.allPass([odd, gt5, plusEq]).length, 4);
+    eq(R.allPass([odd, gt5, plusEq])(9, 9, 9, 9), true);
+    eq(R.allPass([odd, gt5, plusEq])(9)(9)(9)(9), true);
   });
 });

--- a/test/allUniq.js
+++ b/test/allUniq.js
@@ -1,17 +1,16 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('allUniq', function() {
   it('returns true if a list is composed of unique elements', function() {
     var list = [1, 2, 3, 1, 2, 3, 1, 2, 3];
-    assert.strictEqual(R.allUniq(list), false);
-    assert.strictEqual(R.allUniq([3, 1, 4, 2, 5, 7, 9]), true);
+    eq(R.allUniq(list), false);
+    eq(R.allUniq([3, 1, 4, 2, 5, 7, 9]), true);
   });
 
   it('returns true for an empty array', function() {
-    assert.strictEqual(R.allUniq([]), true);
+    eq(R.allUniq([]), true);
   });
 
   it('has R.equals semantics', function() {
@@ -20,10 +19,10 @@ describe('allUniq', function() {
       return x instanceof Just && R.equals(x.value, this.value);
     };
 
-    assert.strictEqual(R.allUniq([0, -0]), true);
-    assert.strictEqual(R.allUniq([-0, 0]), true);
-    assert.strictEqual(R.allUniq([NaN, NaN]), false);
-    assert.strictEqual(R.allUniq([new Just([42]), new Just([42])]), false);
+    eq(R.allUniq([0, -0]), true);
+    eq(R.allUniq([-0, 0]), true);
+    eq(R.allUniq([NaN, NaN]), false);
+    eq(R.allUniq([new Just([42]), new Just([42])]), false);
   });
 
 });

--- a/test/always.js
+++ b/test/always.js
@@ -1,24 +1,23 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('always', function() {
   it('returns a function that returns the object initially supplied', function() {
     var theMeaning = R.always(42);
-    assert.strictEqual(theMeaning(), 42);
-    assert.strictEqual(theMeaning(10), 42);
-    assert.strictEqual(theMeaning(false), 42);
+    eq(theMeaning(), 42);
+    eq(theMeaning(10), 42);
+    eq(theMeaning(false), 42);
   });
 
   it('works with various types', function() {
-    assert.strictEqual(R.always(false)(), false);
-    assert.strictEqual(R.always('abc')(), 'abc');
-    assert.deepEqual(R.always({a: 1, b: 2})(), {a: 1, b: 2});
+    eq(R.always(false)(), false);
+    eq(R.always('abc')(), 'abc');
+    eq(R.always({a: 1, b: 2})(), {a: 1, b: 2});
     var obj = {a: 1, b: 2};
-    assert.strictEqual(R.always(obj)(), obj);
+    eq(R.always(obj)(), obj);
     var now = new Date(1776, 6, 4);
-    assert.deepEqual(R.always(now)(), new Date(1776, 6, 4));
-    assert.strictEqual(R.always(undefined)(), undefined);
+    eq(R.always(now)(), new Date(1776, 6, 4));
+    eq(R.always(undefined)(), undefined);
   });
 });

--- a/test/and.js
+++ b/test/and.js
@@ -1,19 +1,18 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('and', function() {
   it('compares two values with js &&', function() {
-    assert.strictEqual(R.and(true, true), true);
-    assert.strictEqual(R.and(true, false), false);
-    assert.strictEqual(R.and(false, true), false);
-    assert.strictEqual(R.and(false, false), false);
+    eq(R.and(true, true), true);
+    eq(R.and(true, false), false);
+    eq(R.and(false, true), false);
+    eq(R.and(false, false), false);
   });
 
   it('is curried', function() {
     var halfTruth = R.and(true);
-    assert.strictEqual(halfTruth(false), false);
-    assert.strictEqual(halfTruth(true), true);
+    eq(halfTruth(false), false);
+    eq(halfTruth(true), true);
   });
 });

--- a/test/any.js
+++ b/test/any.js
@@ -1,7 +1,7 @@
-var assert = require('assert');
 var listXf = require('./helpers/listXf');
 
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('any', function() {
@@ -10,46 +10,46 @@ describe('any', function() {
   var intoArray = R.into([]);
 
   it('returns true if any element satisfies the predicate', function() {
-    assert.strictEqual(R.any(odd, [2, 4, 6, 8, 10, 11, 12]), true);
+    eq(R.any(odd, [2, 4, 6, 8, 10, 11, 12]), true);
   });
 
   it('returns false if all elements fails to satisfy the predicate', function() {
-    assert.strictEqual(R.any(odd, [2, 4, 6, 8, 10, 12]), false);
+    eq(R.any(odd, [2, 4, 6, 8, 10, 12]), false);
   });
 
   it('returns true into array if any element satisfies the predicate', function() {
-    assert.deepEqual(intoArray(R.any(odd), [2, 4, 6, 8, 10, 11, 12]), [true]);
+    eq(intoArray(R.any(odd), [2, 4, 6, 8, 10, 11, 12]), [true]);
   });
 
   it('returns false if all elements fails to satisfy the predicate', function() {
-    assert.deepEqual(intoArray(R.any(odd), [2, 4, 6, 8, 10, 12]), [false]);
+    eq(intoArray(R.any(odd), [2, 4, 6, 8, 10, 12]), [false]);
   });
 
   it('works with more complex objects', function() {
     var people = [{first: 'Paul', last: 'Grenier'}, {first:'Mike', last: 'Hurley'}, {first: 'Will', last: 'Klein'}];
     var alliterative = function(person) {return person.first.charAt(0) === person.last.charAt(0);};
-    assert.strictEqual(R.any(alliterative, people), false);
+    eq(R.any(alliterative, people), false);
     people.push({first: 'Scott', last: 'Sauyet'});
-    assert.strictEqual(R.any(alliterative, people), true);
+    eq(R.any(alliterative, people), true);
   });
 
   it('can use a configurable function', function() {
     var teens = [{name: 'Alice', age: 14}, {name: 'Betty', age: 18}, {name: 'Cindy', age: 17}];
     var atLeast = function(age) {return function(person) {return person.age >= age;};};
-    assert.strictEqual(R.any(atLeast(16), teens), true, 'Some can legally drive');
-    assert.strictEqual(R.any(atLeast(21), teens), false, 'None can legally drink');
+    eq(R.any(atLeast(16), teens), true);
+    eq(R.any(atLeast(21), teens), false);
   });
 
   it('returns false for an empty list', function() {
-    assert.strictEqual(R.any(T, []), false);
+    eq(R.any(T, []), false);
   });
 
   it('returns false into array for an empty list', function() {
-    assert.deepEqual(intoArray(R.any(T), []), [false]);
+    eq(intoArray(R.any(T), []), [false]);
   });
 
   it('dispatches when given a transformer in list position', function() {
-    assert.deepEqual(R.any(odd, listXf), {
+    eq(R.any(odd, listXf), {
       any: false,
       f: odd,
       xf: listXf
@@ -59,6 +59,6 @@ describe('any', function() {
   it('is curried', function() {
     var count = 0;
     var test = function(n) {count += 1; return odd(n);};
-    assert.strictEqual(R.any(test)([2, 4, 6, 7, 8, 10]), true);
+    eq(R.any(test)([2, 4, 6, 7, 8, 10]), true);
   });
 });

--- a/test/anyPass.js
+++ b/test/anyPass.js
@@ -1,6 +1,5 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('anyPass', function() {
@@ -11,21 +10,21 @@ describe('anyPass', function() {
 
   it('reports whether any predicates are satisfied by a given value', function() {
     var ok = R.anyPass([odd, gt20, lt5]);
-    assert.strictEqual(ok(7), true);
-    assert.strictEqual(ok(9), true);
-    assert.strictEqual(ok(10), false);
-    assert.strictEqual(ok(18), false);
-    assert.strictEqual(ok(3), true);
-    assert.strictEqual(ok(22), true);
+    eq(ok(7), true);
+    eq(ok(9), true);
+    eq(ok(10), false);
+    eq(ok(18), false);
+    eq(ok(3), true);
+    eq(ok(22), true);
   });
 
   it('returns false for an empty predicate list', function() {
-    assert.strictEqual(R.anyPass([])(3), false);
+    eq(R.anyPass([])(3), false);
   });
 
   it('returns a curried function whose arity matches that of the highest-arity predicate', function() {
-    assert.strictEqual(R.anyPass([odd, lt5, plusEq]).length, 4);
-    assert.strictEqual(R.anyPass([odd, lt5, plusEq])(6, 7, 8, 9), false);
-    assert.strictEqual(R.anyPass([odd, lt5, plusEq])(6)(7)(8)(9), false);
+    eq(R.anyPass([odd, lt5, plusEq]).length, 4);
+    eq(R.anyPass([odd, lt5, plusEq])(6, 7, 8, 9), false);
+    eq(R.anyPass([odd, lt5, plusEq])(6)(7)(8)(9), false);
   });
 });

--- a/test/ap.js
+++ b/test/ap.js
@@ -1,6 +1,5 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('ap', function() {
@@ -8,7 +7,7 @@ describe('ap', function() {
   function plus3(x) { return x + 3; }
 
   it('interprets [a] as an applicative', function() {
-    assert.deepEqual(R.ap([mult2, plus3], [1, 2, 3]), [2, 4, 6, 4, 5, 6]);
+    eq(R.ap([mult2, plus3], [1, 2, 3]), [2, 4, 6, 4, 5, 6]);
   });
 
   it('interprets ((->) r) as an applicative', function() {
@@ -21,17 +20,17 @@ describe('ap', function() {
     var h = R.ap(f, g);
     // (<*>) :: (r -> a -> b) -> (r -> a) -> (r -> b)
     // f <*> g = \x -> f x (g x)
-    assert.strictEqual(h(10), 10 + (10 * 2));
+    eq(h(10), 10 + (10 * 2));
   });
 
   it('dispatches to the passed object\'s ap method when values is a non-Array object', function() {
     var obj = {ap: function(n) { return 'called ap with ' + n; }};
-    assert.deepEqual(R.ap(obj, 10), obj.ap(10));
+    eq(R.ap(obj, 10), obj.ap(10));
   });
 
   it('is curried', function() {
     var val = R.ap([mult2, plus3]);
-    assert.strictEqual(typeof val, 'function');
-    assert.deepEqual(val([1, 2, 3]), [2, 4, 6, 4, 5, 6]);
+    eq(typeof val, 'function');
+    eq(val([1, 2, 3]), [2, 4, 6, 4, 5, 6]);
   });
 });

--- a/test/aperture.js
+++ b/test/aperture.js
@@ -1,28 +1,27 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('aperture', function() {
   var sevenLs = [1, 2, 3, 4, 5, 6, 7];
   it('creates a list of n-tuples from a list', function() {
-    assert.deepEqual(R.aperture(1, sevenLs), [[1], [2], [3], [4], [5], [6], [7]]);
-    assert.deepEqual(R.aperture(2, sevenLs), [[1, 2], [2, 3], [3, 4], [4, 5], [5, 6], [6, 7]]);
-    assert.deepEqual(R.aperture(3, sevenLs), [[1, 2, 3], [2, 3, 4], [3, 4, 5], [4, 5, 6], [5, 6, 7]]);
-    assert.deepEqual(R.aperture(4, [1, 2, 3, 4]), [[1, 2, 3, 4]]);
+    eq(R.aperture(1, sevenLs), [[1], [2], [3], [4], [5], [6], [7]]);
+    eq(R.aperture(2, sevenLs), [[1, 2], [2, 3], [3, 4], [4, 5], [5, 6], [6, 7]]);
+    eq(R.aperture(3, sevenLs), [[1, 2, 3], [2, 3, 4], [3, 4, 5], [4, 5, 6], [5, 6, 7]]);
+    eq(R.aperture(4, [1, 2, 3, 4]), [[1, 2, 3, 4]]);
   });
 
   it('returns an empty list when `n` > `list.length`', function() {
-    assert.deepEqual(R.aperture(6, [1, 2, 3]), []);
-    assert.deepEqual(R.aperture(1, []), []);
+    eq(R.aperture(6, [1, 2, 3]), []);
+    eq(R.aperture(1, []), []);
   });
 
   it('is curried', function() {
     var pairwise = R.aperture(2);
-    assert.deepEqual(pairwise(sevenLs), [[1, 2], [2, 3], [3, 4], [4, 5], [5, 6], [6, 7]]);
+    eq(pairwise(sevenLs), [[1, 2], [2, 3], [3, 4], [4, 5], [5, 6], [6, 7]]);
   });
 
   it('can act as a transducer', function() {
-    assert.deepEqual(R.into([], R.aperture(2), sevenLs), [[1, 2], [2, 3], [3, 4], [4, 5], [5, 6], [6, 7]]);
+    eq(R.into([], R.aperture(2), sevenLs), [[1, 2], [2, 3], [3, 4], [4, 5], [5, 6], [6, 7]]);
   });
 });

--- a/test/append.js
+++ b/test/append.js
@@ -1,20 +1,19 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('append', function() {
   it('adds the element to the end of the list', function() {
-    assert.deepEqual(R.append('z', ['x', 'y']), ['x', 'y', 'z']);
-    assert.deepEqual(R.append(['a', 'z'], ['x', 'y']), ['x', 'y', ['a', 'z']]);
+    eq(R.append('z', ['x', 'y']), ['x', 'y', 'z']);
+    eq(R.append(['a', 'z'], ['x', 'y']), ['x', 'y', ['a', 'z']]);
   });
 
   it('works on empty list', function() {
-    assert.deepEqual(R.append(1, []), [1]);
+    eq(R.append(1, []), [1]);
   });
 
   it('is curried', function() {
-    assert.strictEqual(typeof R.append(4), 'function');
-    assert.deepEqual(R.append(1)([4, 3, 2]), [4, 3, 2, 1]);
+    eq(typeof R.append(4), 'function');
+    eq(R.append(1)([4, 3, 2]), [4, 3, 2, 1]);
   });
 });

--- a/test/apply.js
+++ b/test/apply.js
@@ -1,20 +1,19 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('apply', function() {
   it('applies function to argument list', function() {
-    assert.strictEqual(R.apply(Math.max, [1, 2, 3, -99, 42, 6, 7]), 42);
+    eq(R.apply(Math.max, [1, 2, 3, -99, 42, 6, 7]), 42);
   });
 
   it('is curried', function() {
-    assert.strictEqual(R.apply(Math.max)([1, 2, 3, -99, 42, 6, 7]), 42);
+    eq(R.apply(Math.max)([1, 2, 3, -99, 42, 6, 7]), 42);
   });
 
   it('provides no way to specify context', function() {
     var obj = {method: function() { return this === obj; }};
-    assert.strictEqual(R.apply(obj.method, []), false);
-    assert.strictEqual(R.apply(R.bind(obj.method, obj), []), true);
+    eq(R.apply(obj.method, []), false);
+    eq(R.apply(R.bind(obj.method, obj), []), true);
   });
 });

--- a/test/assoc.js
+++ b/test/assoc.js
@@ -1,13 +1,14 @@
 var assert = require('assert');
 
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('assoc', function() {
   it('makes a shallow clone of an object, overriding only the specified property', function() {
     var obj1 = {a: 1, b: {c: 2, d: 3}, e: 4, f: 5};
     var obj2 = R.assoc('e', {x: 42}, obj1);
-    assert.deepEqual(obj2, {a: 1, b: {c: 2, d: 3}, e: {x: 42}, f: 5});
+    eq(obj2, {a: 1, b: {c: 2, d: 3}, e: {x: 42}, f: 5});
     // Note: reference equality below!
     assert.strictEqual(obj2.a, obj1.a);
     assert.strictEqual(obj2.b, obj1.b);
@@ -17,7 +18,7 @@ describe('assoc', function() {
   it('is the equivalent of clone and set if the property is not on the original', function() {
     var obj1 = {a: 1, b: {c: 2, d: 3}, e: 4, f: 5};
     var obj2 = R.assoc('z', {x: 42}, obj1);
-    assert.deepEqual(obj2, {a: 1, b: {c: 2, d: 3}, e: 4, f: 5, z: {x: 42}});
+    eq(obj2, {a: 1, b: {c: 2, d: 3}, e: 4, f: 5, z: {x: 42}});
     // Note: reference equality below!
     assert.strictEqual(obj2.a, obj1.a);
     assert.strictEqual(obj2.b, obj1.b);
@@ -29,7 +30,7 @@ describe('assoc', function() {
     var expected = {a: 1, b: {c: 2, d: 3}, e: {x: 42}, f: 5};
     var f = R.assoc('e');
     var g = f({x: 42});
-    assert.deepEqual(f({x: 42}, obj1), expected);
-    assert.deepEqual(g(obj1), expected);
+    eq(f({x: 42}, obj1), expected);
+    eq(g(obj1), expected);
   });
 });

--- a/test/assocPath.js
+++ b/test/assocPath.js
@@ -1,13 +1,14 @@
 var assert = require('assert');
 
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('assocPath', function() {
   it('makes a shallow clone of an object, overriding only what is necessary for the path', function() {
     var obj1 = {a: {b: 1, c: 2, d: {e: 3}}, f: {g: {h: 4, i: 5, j: {k: 6, l: 7}}}, m: 8};
     var obj2 = R.assocPath(['f', 'g', 'i'], {x: 42}, obj1);
-    assert.deepEqual(obj2,
+    eq(obj2,
       {a: {b: 1, c: 2, d: {e: 3}}, f: {g: {h: 4, i: {x: 42}, j: {k: 6, l: 7}}}, m: 8}
     );
     // Note: reference equality below!
@@ -20,7 +21,7 @@ describe('assocPath', function() {
   it('is the equivalent of clone and setPath if the property is not on the original', function() {
     var obj1 = {a: 1, b: {c: 2, d: 3}, e: 4, f: 5};
     var obj2 = R.assocPath(['x', 'y', 'z'], {w: 42}, obj1);
-    assert.deepEqual(obj2, {a: 1, b: {c: 2, d: 3}, e: 4, f: 5, x: {y: {z: {w: 42}}}});
+    eq(obj2, {a: 1, b: {c: 2, d: 3}, e: 4, f: 5, x: {y: {z: {w: 42}}}});
     // Note: reference equality below!
     assert.strictEqual(obj2.a, obj1.a);
     assert.strictEqual(obj2.b, obj1.b);
@@ -32,11 +33,11 @@ describe('assocPath', function() {
     var expected = {a: {b: 1, c: 2, d: {e: 3}}, f: {g: {h: 4, i: {x: 42}, j: {k: 6, l: 7}}}, m: 8};
     var f = R.assocPath(['f', 'g', 'i']);
     var g = f({x: 42});
-    assert.deepEqual(f({x: 42}, obj1), expected);
-    assert.deepEqual(g(obj1), expected);
+    eq(f({x: 42}, obj1), expected);
+    eq(g(obj1), expected);
   });
 
   it('accepts empty path', function() {
-    assert.deepEqual(R.assocPath([], 3, {a: 1, b: 2}), {a: 1, b: 2});
+    eq(R.assocPath([], 3, {a: 1, b: 2}), {a: 1, b: 2});
   });
 });

--- a/test/binary.js
+++ b/test/binary.js
@@ -1,20 +1,19 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('binary', function() {
   it('turns multiple-argument function into binary one', function() {
     R.binary(function(x, y, z) {
-      assert.strictEqual(arguments.length, 2);
-      assert.strictEqual(typeof z, 'undefined');
+      eq(arguments.length, 2);
+      eq(typeof z, 'undefined');
     })(10, 20, 30);
   });
 
   it('initial arguments are passed through normally', function() {
     R.binary(function(x, y, z) {
-      assert.strictEqual(x, 10);
-      assert.strictEqual(y, 20);
+      eq(x, 10);
+      eq(y, 20);
       void z;
     })(10, 20, 30);
   });

--- a/test/bind.js
+++ b/test/bind.js
@@ -1,8 +1,7 @@
 /* jshint -W053 */
 
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('bind', function() {
@@ -23,7 +22,7 @@ describe('bind', function() {
   };
 
   it('returns a function', function() {
-    assert.strictEqual(typeof R.bind(add, Foo), 'function');
+    eq(typeof R.bind(add, Foo), 'function');
   });
 
   it('returns a function bound to the specified context object', function() {
@@ -32,14 +31,14 @@ describe('bind', function() {
       return this instanceof Foo;
     }
     var isFooBound = R.bind(isFoo, f);
-    assert.strictEqual(isFoo(), false);
-    assert.strictEqual(isFooBound(), true);
+    eq(isFoo(), false);
+    eq(isFooBound(), true);
   });
 
   it('works with built-in types', function() {
     var abc = R.bind(String.prototype.toLowerCase, 'ABCDEFG');
-    assert.strictEqual(typeof abc, 'function');
-    assert.strictEqual(abc(), 'abcdefg');
+    eq(typeof abc, 'function');
+    eq(abc(), 'abcdefg');
   });
 
   it('works with user-defined types', function() {
@@ -48,7 +47,7 @@ describe('bind', function() {
       return this.x;
     }
     var getXFooBound = R.bind(getX, f);
-    assert.strictEqual(getXFooBound(), 12);
+    eq(getXFooBound(), 12);
   });
 
   it('works with plain objects', function() {
@@ -59,8 +58,8 @@ describe('bind', function() {
       return this.x + 1;
     }
     var incPojso = R.bind(incThis, pojso);
-    assert.strictEqual(typeof incPojso, 'function');
-    assert.strictEqual(incPojso(), 101);
+    eq(typeof incPojso, 'function');
+    eq(incPojso(), 101);
   });
 
   it('does not interefere with existing object methods', function() {
@@ -69,13 +68,13 @@ describe('bind', function() {
       return this.x;
     }
     var getXBarBound = R.bind(getX, b);
-    assert.strictEqual(b.getX(), 'prototype getX');
-    assert.strictEqual(getXBarBound(), 'a');
+    eq(b.getX(), 'prototype getX');
+    eq(getXBarBound(), 'a');
   });
 
   it('is curried', function() {
     var f = new Foo(1);
-    assert.strictEqual(R.bind(add)(f)(10), 11);
+    eq(R.bind(add)(f)(10), 11);
   });
 
   it('preserves arity', function() {
@@ -84,9 +83,9 @@ describe('bind', function() {
     var f2 = function(a, b) { return a + b; };
     var f3 = function(a, b, c) { return a + b + c; };
 
-    assert.strictEqual(R.bind(f0, {}).length, 0);
-    assert.strictEqual(R.bind(f1, {}).length, 1);
-    assert.strictEqual(R.bind(f2, {}).length, 2);
-    assert.strictEqual(R.bind(f3, {}).length, 3);
+    eq(R.bind(f0, {}).length, 0);
+    eq(R.bind(f1, {}).length, 1);
+    eq(R.bind(f2, {}).length, 2);
+    eq(R.bind(f3, {}).length, 3);
   });
 });

--- a/test/both.js
+++ b/test/both.js
@@ -1,6 +1,5 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('both', function() {
@@ -8,18 +7,18 @@ describe('both', function() {
     var even = function(x) {return x % 2 === 0;};
     var gt10 = function(x) {return x > 10;};
     var f = R.both(even, gt10);
-    assert.strictEqual(f(8), false);
-    assert.strictEqual(f(13), false);
-    assert.strictEqual(f(14), true);
+    eq(f(8), false);
+    eq(f(13), false);
+    eq(f(14), true);
   });
 
   it('accepts functions that take multiple parameters', function() {
     var between = function(a, b, c) {return a < b && b < c;};
     var total20 = function(a, b, c) {return a + b + c === 20;};
     var f = R.both(between, total20);
-    assert.strictEqual(f(4, 5, 11), true);
-    assert.strictEqual(f(12, 2, 6), false);
-    assert.strictEqual(f(5, 6, 15), false);
+    eq(f(4, 5, 11), true);
+    eq(f(12, 2, 6), false);
+    eq(f(5, 6, 15), false);
   });
 
   it('does not evaluate the second expression if the first one is false', function() {
@@ -27,15 +26,15 @@ describe('both', function() {
     var Z = function() { effect = 'Z got evaluated'; };
     var effect = 'not evaluated';
     R.both(F, Z);
-    assert.strictEqual(effect, 'not evaluated');
+    eq(effect, 'not evaluated');
   });
 
   it('is curried', function() {
     var even = function(x) {return x % 2 === 0;};
     var gt10 = function(x) {return x > 10;};
     var evenAnd = R.both(even);
-    assert.strictEqual(typeof evenAnd(gt10), 'function');
-    assert.strictEqual(evenAnd(gt10)(11), false);
-    assert.strictEqual(evenAnd(gt10)(12), true);
+    eq(typeof evenAnd(gt10), 'function');
+    eq(evenAnd(gt10)(11), false);
+    eq(evenAnd(gt10)(12), true);
   });
 });

--- a/test/call.js
+++ b/test/call.js
@@ -1,24 +1,23 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('call', function() {
   it('returns the result of calling its first argument with the remaining arguments', function() {
-    assert.strictEqual(R.call(Math.max, 1, 2, 3, -99, 42, 6, 7), 42);
+    eq(R.call(Math.max, 1, 2, 3, -99, 42, 6, 7), 42);
   });
 
   it('accepts one or more arguments', function() {
     var fn = function() { return arguments.length; };
-    assert.strictEqual(R.call(fn), 0);
-    assert.strictEqual(R.call(fn, 'x'), 1);
-    assert.strictEqual(R.call(fn, 'x', 'y'), 2);
-    assert.strictEqual(R.call(fn, 'x', 'y', 'z'), 3);
+    eq(R.call(fn), 0);
+    eq(R.call(fn, 'x'), 1);
+    eq(R.call(fn, 'x', 'y'), 2);
+    eq(R.call(fn, 'x', 'y', 'z'), 3);
   });
 
   it('provides no way to specify context', function() {
     var obj = {method: function() { return this === obj; }};
-    assert.strictEqual(R.call(obj.method), false);
-    assert.strictEqual(R.call(R.bind(obj.method, obj)), true);
+    eq(R.call(obj.method), false);
+    eq(R.call(R.bind(obj.method, obj)), true);
   });
 });

--- a/test/chain.js
+++ b/test/chain.js
@@ -1,7 +1,7 @@
-var assert = require('assert');
 var listXf = require('./helpers/listXf');
 
 var R = require('..');
+var eq = require('./shared/eq');
 var _isTransformer = require('../src/internal/_isTransformer');
 
 describe('chain', function() {
@@ -11,19 +11,19 @@ describe('chain', function() {
   function times2(x) { return [x * 2]; }
 
   it('maps a function over a nested list and returns the (shallow) flattened result', function() {
-    assert.deepEqual(R.chain(times2, [1, 2, 3, 1, 0, 10, -3, 5, 7]), [2, 4, 6, 2, 0, 20, -6, 10, 14]);
-    assert.deepEqual(R.chain(times2, [1, 2, 3]), [2, 4, 6]);
+    eq(R.chain(times2, [1, 2, 3, 1, 0, 10, -3, 5, 7]), [2, 4, 6, 2, 0, 20, -6, 10, 14]);
+    eq(R.chain(times2, [1, 2, 3]), [2, 4, 6]);
   });
 
   it('does not flatten recursively', function() {
     function f(xs) {
       return xs[0] ? [xs[0]] : [];
     }
-    assert.deepEqual(R.chain(f, [[1], [[2], 100], [], [3, [4]]]), [1, [2], 3]);
+    eq(R.chain(f, [[1], [[2], 100], [], [3, [4]]]), [1, [2], 3]);
   });
 
   it('maps a function (a -> [b]) into a (shallow) flat result', function() {
-    assert.deepEqual(intoArray(R.chain(times2), [1, 2, 3, 4]), [2, 4, 6, 8]);
+    eq(intoArray(R.chain(times2), [1, 2, 3, 4]), [2, 4, 6, 8]);
   });
 
   it('interprets ((->) r) as a monad', function() {
@@ -36,39 +36,39 @@ describe('chain', function() {
     var bound = R.chain(h, f);
     // (>>=) :: (r -> a) -> (a -> r -> b) -> (r -> b)
     // h >>= f = \w -> f (h w) w
-    assert.strictEqual(bound(10), (10 * 2) + 10);
+    eq(bound(10), (10 * 2) + 10);
   });
 
   it('dispatches to objects that implement `chain`', function() {
     var obj = {x: 100, chain: function(f) { return f(this.x); }};
-    assert.deepEqual(R.chain(add1, obj), [101]);
+    eq(R.chain(add1, obj), [101]);
   });
 
   it('dispatches to transformer objects', function() {
-    assert.strictEqual(_isTransformer(R.chain(add1, listXf)), true);
+    eq(_isTransformer(R.chain(add1, listXf)), true);
   });
 
   it('composes', function() {
     var mdouble = R.chain(times2);
     var mdec = R.chain(dec);
-    assert.deepEqual(mdec(mdouble([10, 20, 30])), [19, 39, 59]);
+    eq(mdec(mdouble([10, 20, 30])), [19, 39, 59]);
   });
 
   it('can compose transducer-style', function() {
     var mdouble = R.chain(times2);
     var mdec = R.chain(dec);
     var xcomp = R.compose(mdec, mdouble);
-    assert.deepEqual(intoArray(xcomp, [10, 20, 30]), [18, 38, 58]);
+    eq(intoArray(xcomp, [10, 20, 30]), [18, 38, 58]);
   });
 
   it('is curried', function() {
     var flatInc = R.chain(add1);
-    assert.deepEqual(flatInc([1, 2, 3, 4, 5, 6]), [2, 3, 4, 5, 6, 7]);
+    eq(flatInc([1, 2, 3, 4, 5, 6]), [2, 3, 4, 5, 6, 7]);
   });
 
   it('correctly reports the arity of curried versions', function() {
     var inc = R.chain(add1);
-    assert.strictEqual(inc.length, 1);
+    eq(inc.length, 1);
   });
 
 });

--- a/test/clone.js
+++ b/test/clone.js
@@ -1,25 +1,26 @@
 var assert = require('assert');
 
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('deep clone integers, strings and booleans', function() {
   it('clone integers', function() {
-    assert.strictEqual(R.clone(-4), -4);
-    assert.strictEqual(R.clone(9007199254740991), 9007199254740991);
+    eq(R.clone(-4), -4);
+    eq(R.clone(9007199254740991), 9007199254740991);
   });
 
   it('clone floats', function() {
-    assert.strictEqual(R.clone(-4.5), -4.5);
-    assert.strictEqual(R.clone(0.0), 0.0);
+    eq(R.clone(-4.5), -4.5);
+    eq(R.clone(0.0), 0.0);
   });
 
   it('clone strings', function() {
-    assert.strictEqual(R.clone('ramda'), 'ramda');
+    eq(R.clone('ramda'), 'ramda');
   });
 
   it('clone booleans', function() {
-    assert.strictEqual(R.clone(true), true);
+    eq(R.clone(true), true);
   });
 });
 
@@ -29,14 +30,14 @@ describe('deep clone objects', function() {
     var clone = R.clone(obj);
     obj.c = false;
     obj.d.setDate(31);
-    assert.deepEqual(clone, {a: 1, b: 'ramda', c: true, d: new Date(2013, 11, 25)});
+    eq(clone, {a: 1, b: 'ramda', c: true, d: new Date(2013, 11, 25)});
   });
 
   it('clone deep object', function() {
     var obj = {a: {b: {c: 'ramda'}}};
     var clone = R.clone(obj);
     obj.a.b.c = null;
-    assert.deepEqual(clone, {a: {b: {c: 'ramda'}}});
+    eq(clone, {a: {b: {c: 'ramda'}}});
   });
 
   it('clone objects with circular references', function() {
@@ -50,11 +51,11 @@ describe('deep clone objects', function() {
     assert.notStrictEqual(x.c.b, clone.c.b);
     assert.notStrictEqual(x.c.b.a, clone.c.b.a);
     assert.notStrictEqual(x.c.b.a.c, clone.c.b.a.c);
-    assert.deepEqual(R.keys(clone), R.keys(x));
-    assert.deepEqual(R.keys(clone.c), R.keys(x.c));
-    assert.deepEqual(R.keys(clone.c.b), R.keys(x.c.b));
-    assert.deepEqual(R.keys(clone.c.b.a), R.keys(x.c.b.a));
-    assert.deepEqual(R.keys(clone.c.b.a.c), R.keys(x.c.b.a.c));
+    eq(R.keys(clone), R.keys(x));
+    eq(R.keys(clone.c), R.keys(x.c));
+    eq(R.keys(clone.c.b), R.keys(x.c.b));
+    eq(R.keys(clone.c.b.a), R.keys(x.c.b.a));
+    eq(R.keys(clone.c.b.a.c), R.keys(x.c.b.a.c));
 
     x.c.b = 1;
     assert.notDeepEqual(R.keys(clone.c.b), R.keys(x.c.b));
@@ -72,16 +73,16 @@ describe('deep clone objects', function() {
     };
 
     var obj = new Obj(10);
-    assert.strictEqual(obj.get(), 10);
+    eq(obj.get(), 10);
 
     var clone = R.clone(obj);
-    assert.strictEqual(clone.get(), 10);
+    eq(clone.get(), 10);
 
     assert.notStrictEqual(obj, clone);
 
     obj.set(11);
-    assert.strictEqual(obj.get(), 11);
-    assert.strictEqual(clone.get(), 10);
+    eq(obj.get(), 11);
+    eq(clone.get(), 10);
   });
 });
 
@@ -90,7 +91,7 @@ describe('deep clone arrays', function() {
     var list = [1, 2, 3];
     var clone = R.clone(list);
     list.pop();
-    assert.deepEqual(clone, [1, 2, 3]);
+    eq(clone, [1, 2, 3]);
   });
 
   it('clone deep arrays', function() {
@@ -101,7 +102,7 @@ describe('deep clone arrays', function() {
     assert.notStrictEqual(list[2], clone[2]);
     assert.notStrictEqual(list[2][0], clone[2][0]);
 
-    assert.deepEqual(clone, [1, [1, 2, 3], [[[5]]]]);
+    eq(clone, [1, [1, 2, 3], [[[5]]]]);
   });
 });
 
@@ -112,8 +113,8 @@ describe('deep `clone` functions', function() {
 
     var clone = R.clone(list);
 
-    assert.strictEqual(clone[0].a(10), 20);
-    assert.strictEqual(list[0].a, clone[0].a);
+    eq(clone[0].a(10), 20);
+    eq(list[0].a, clone[0].a);
   });
 });
 
@@ -124,20 +125,20 @@ describe('built-in types', function() {
     var clone = R.clone(date);
 
     assert.notStrictEqual(date, clone);
-    assert.deepEqual(clone.toString(), new Date(2014, 10, 14, 23, 59, 59, 999).toString());
+    eq(clone, new Date(2014, 10, 14, 23, 59, 59, 999));
 
-    assert.strictEqual(clone.getDay(), 5); // friday
+    eq(clone.getDay(), 5); // friday
   });
 
   it('clones RegExp object', function() {
     R.forEach(function(pattern) {
       var clone = R.clone(pattern);
       assert.notStrictEqual(clone, pattern);
-      assert.strictEqual(clone.constructor, RegExp);
-      assert.strictEqual(clone.source, pattern.source);
-      assert.strictEqual(clone.global, pattern.global);
-      assert.strictEqual(clone.ignoreCase, pattern.ignoreCase);
-      assert.strictEqual(clone.multiline, pattern.multiline);
+      eq(clone.constructor, RegExp);
+      eq(clone.source, pattern.source);
+      eq(clone.global, pattern.global);
+      eq(clone.ignoreCase, pattern.ignoreCase);
+      eq(clone.multiline, pattern.multiline);
     }, [/x/, /x/g, /x/i, /x/m, /x/gi, /x/gm, /x/im, /x/gim]);
   });
 });
@@ -147,14 +148,14 @@ describe('deep clone deep nested mixed objects', function() {
     var list = [{a: {b: 1}}, [{c: {d: 1}}]];
     var clone = R.clone(list);
     list[1][0] = null;
-    assert.deepEqual(clone, [{a: {b: 1}}, [{c: {d: 1}}]]);
+    eq(clone, [{a: {b: 1}}, [{c: {d: 1}}]]);
   });
 
   it('clone array with arrays', function() {
     var list = [[1], [[3]]];
     var clone = R.clone(list);
     list[1][0] = null;
-    assert.deepEqual(clone, [[1], [[3]]]);
+    eq(clone, [[1], [[3]]]);
   });
 
   it('clone array with mutual ref object', function() {
@@ -167,19 +168,19 @@ describe('deep clone deep nested mixed objects', function() {
     assert.notStrictEqual(clone[0].b, list[0].b);
     assert.notStrictEqual(clone[1].b, list[1].b);
 
-    assert.deepEqual(clone[0].b, {a:1});
-    assert.deepEqual(clone[1].b, {a:1});
+    eq(clone[0].b, {a:1});
+    eq(clone[1].b, {a:1});
 
     obj.a = 2;
-    assert.deepEqual(clone[0].b, {a:1});
-    assert.deepEqual(clone[1].b, {a:1});
+    eq(clone[0].b, {a:1});
+    eq(clone[1].b, {a:1});
   });
 });
 
 describe('deep clone edge cases', function() {
   it('nulls, undefineds and empty objects and arrays', function() {
-    assert.strictEqual(R.clone(null), null);
-    assert.strictEqual(R.clone(undefined), undefined);
+    eq(R.clone(null), null);
+    eq(R.clone(undefined), undefined);
     assert.notStrictEqual(R.clone(undefined), null);
 
     var obj = {};
@@ -199,7 +200,7 @@ describe('Let `R.clone` use an arbitrary user defined `clone` method', function(
 
     var obj = new ArbitraryClone(42);
     var arbitraryClonedObj = R.clone(obj);
-    assert.deepEqual(arbitraryClonedObj, new ArbitraryClone(42), true);
-    assert.strictEqual(arbitraryClonedObj instanceof ArbitraryClone, true);
+    eq(arbitraryClonedObj, new ArbitraryClone(42));
+    eq(arbitraryClonedObj instanceof ArbitraryClone, true);
   });
 });

--- a/test/commute.js
+++ b/test/commute.js
@@ -1,7 +1,7 @@
-var assert = require('assert');
 var Maybe = require('./shared/Maybe');
 
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 var as = [[1], [3, 4]];
@@ -11,21 +11,21 @@ var cs = [[1, 2], [3, 4]];
 
 describe('commute', function() {
   it('"pivots" a list (list of functors => functor of a list)', function() {
-    assert.deepEqual(R.commute(R.of, as), [[1, 3], [1, 4]]);
-    assert.deepEqual(R.commute(R.of, bs), [[1, 3], [2, 3]]);
-    assert.deepEqual(R.commute(R.of, cs), [[1, 3], [2, 3], [1, 4], [2, 4]]);
+    eq(R.commute(R.of, as), [[1, 3], [1, 4]]);
+    eq(R.commute(R.of, bs), [[1, 3], [2, 3]]);
+    eq(R.commute(R.of, cs), [[1, 3], [2, 3], [1, 4], [2, 4]]);
   });
 
   it('works on Algebraic Data Types such as "Maybe"', function() {
-    assert.deepEqual(R.commute(Maybe.of, [Maybe(3), Maybe(4), Maybe(5)]), Maybe([3, 4, 5]));
+    eq(R.commute(Maybe.of, [Maybe(3), Maybe(4), Maybe(5)]), Maybe([3, 4, 5]));
   });
 
   it('is curried', function() {
     var cmtArr = R.commute(R.of);
-    assert.strictEqual(typeof cmtArr, 'function');
-    assert.deepEqual(cmtArr(as), [[1, 3], [1, 4]]);
-    assert.deepEqual(cmtArr(bs), [[1, 3], [2, 3]]);
-    assert.deepEqual(cmtArr(cs), [[1, 3], [2, 3], [1, 4], [2, 4]]);
+    eq(typeof cmtArr, 'function');
+    eq(cmtArr(as), [[1, 3], [1, 4]]);
+    eq(cmtArr(bs), [[1, 3], [2, 3]]);
+    eq(cmtArr(cs), [[1, 3], [2, 3], [1, 4], [2, 4]]);
 
   });
 });

--- a/test/commuteMap.js
+++ b/test/commuteMap.js
@@ -1,7 +1,7 @@
-var assert = require('assert');
 var Maybe = require('./shared/Maybe');
 
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 var as = [[1], [3, 4]];
@@ -12,23 +12,23 @@ var cs = [[1, 2], [3, 4]];
 describe('commuteMap', function() {
   var plus10map = R.map(function(x) { return x + 10; });
   it('"pivots" a list (list of functors => functor of a list) and applies a transformation', function() {
-    assert.deepEqual(R.commuteMap(plus10map, R.of, as), [[11, 13], [11, 14]]);
-    assert.deepEqual(R.commuteMap(plus10map, R.of, bs), [[11, 13], [12, 13]]);
-    assert.deepEqual(R.commuteMap(plus10map, R.of, cs), [[11, 13], [12, 13], [11, 14], [12, 14]]);
+    eq(R.commuteMap(plus10map, R.of, as), [[11, 13], [11, 14]]);
+    eq(R.commuteMap(plus10map, R.of, bs), [[11, 13], [12, 13]]);
+    eq(R.commuteMap(plus10map, R.of, cs), [[11, 13], [12, 13], [11, 14], [12, 14]]);
   });
 
   it('works on Algebraic Data Types such as "Maybe"', function() {
-    assert.deepEqual(R.commuteMap(plus10map, Maybe, [Maybe(3), Maybe(4), Maybe(5)]), Maybe([13, 14, 15]));
+    eq(R.commuteMap(plus10map, Maybe, [Maybe(3), Maybe(4), Maybe(5)]), Maybe([13, 14, 15]));
   });
 
   it('is curried', function() {
     var cmtPlus10 = R.commuteMap(plus10map);
-    assert.strictEqual(typeof cmtPlus10, 'function');
+    eq(typeof cmtPlus10, 'function');
 
     var cmtmArr = cmtPlus10(R.of);
-    assert.strictEqual(typeof cmtmArr, 'function');
-    assert.deepEqual(cmtmArr(as), [[11, 13], [11, 14]]);
-    assert.deepEqual(cmtmArr(bs), [[11, 13], [12, 13]]);
-    assert.deepEqual(cmtmArr(cs), [[11, 13], [12, 13], [11, 14], [12, 14]]);
+    eq(typeof cmtmArr, 'function');
+    eq(cmtmArr(as), [[11, 13], [11, 14]]);
+    eq(cmtmArr(bs), [[11, 13], [12, 13]]);
+    eq(cmtmArr(cs), [[11, 13], [12, 13], [11, 14], [12, 14]]);
   });
 });

--- a/test/comparator.js
+++ b/test/comparator.js
@@ -1,10 +1,9 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('comparator', function() {
   it('builds a comparator function for sorting out of a simple predicate that reports whether the first param is smaller', function() {
-    assert.deepEqual([3, 1, 8, 1, 2, 5].sort(R.comparator(function(a, b) {return a < b;})), [1, 1, 2, 3, 5, 8]);
+    eq([3, 1, 8, 1, 2, 5].sort(R.comparator(function(a, b) {return a < b;})), [1, 1, 2, 3, 5, 8]);
   });
 });

--- a/test/complement.js
+++ b/test/complement.js
@@ -1,20 +1,19 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('complement', function() {
   it('creates boolean-returning function that reverses another', function() {
     var even = function(x) {return x % 2 === 0;};
     var f = R.complement(even);
-    assert.strictEqual(f(8), false);
-    assert.strictEqual(f(13), true);
+    eq(f(8), false);
+    eq(f(13), true);
   });
 
   it('accepts a function that take multiple parameters', function() {
     var between = function(a, b, c) {return a < b && b < c;};
     var f = R.complement(between);
-    assert.strictEqual(f(4, 5, 11), false);
-    assert.strictEqual(f(12, 2, 6), true);
+    eq(f(4, 5, 11), false);
+    eq(f(12, 2, 6), true);
   });
 });

--- a/test/compose.js
+++ b/test/compose.js
@@ -1,22 +1,23 @@
 var assert = require('assert');
 
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('compose', function() {
 
   it('is a variadic function', function() {
-    assert.strictEqual(typeof R.compose, 'function');
-    assert.strictEqual(R.compose.length, 0);
+    eq(typeof R.compose, 'function');
+    eq(R.compose.length, 0);
   });
 
   it('performs right-to-left function composition', function() {
     //  f :: (String, Number?) -> ([Number] -> [Number])
     var f = R.compose(R.map, R.multiply, parseInt);
 
-    assert.strictEqual(f.length, 2);
-    assert.deepEqual(f('10')([1, 2, 3]), [10, 20, 30]);
-    assert.deepEqual(f('10', 2)([1, 2, 3]), [2, 4, 6]);
+    eq(f.length, 2);
+    eq(f('10')([1, 2, 3]), [10, 20, 30]);
+    eq(f('10', 2)([1, 2, 3]), [2, 4, 6]);
   });
 
   it('passes context to functions', function() {
@@ -35,7 +36,7 @@ describe('compose', function() {
       y: 2,
       z: 1
     };
-    assert.strictEqual(context.a(5), 40);
+    eq(context.a(5), 40);
   });
 
   it('throws if given no arguments', function() {
@@ -51,8 +52,8 @@ describe('compose', function() {
   it('can be applied to one argument', function() {
     var f = function(a, b, c) { return [a, b, c]; };
     var g = R.compose(f);
-    assert.strictEqual(g.length, 3);
-    assert.deepEqual(g(1, 2, 3), [1, 2, 3]);
+    eq(g.length, 3);
+    eq(g(1, 2, 3), [1, 2, 3]);
   });
 
 });

--- a/test/composeK.js
+++ b/test/composeK.js
@@ -1,6 +1,5 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 var Identity = function(x) {
@@ -15,8 +14,8 @@ Identity.prototype.chain = function(f) {
 describe('composeK', function() {
 
   it('is a variadic function', function() {
-    assert.strictEqual(typeof R.composeK, 'function');
-    assert.strictEqual(R.composeK.length, 0);
+    eq(typeof R.composeK, 'function');
+    eq(R.composeK.length, 0);
   });
 
   it('performs right-to-left Kleisli composition', function() {
@@ -27,15 +26,15 @@ describe('composeK', function() {
     var fn = R.composeK(h, g, f);
     var id = new Identity(8);
 
-    assert.strictEqual(fn(id).value, 50);
-    assert.strictEqual(fn(id).value, R.compose(R.chain(h), R.chain(g), R.chain(f))(id).value);
+    eq(fn(id).value, 50);
+    eq(fn(id).value, R.compose(R.chain(h), R.chain(g), R.chain(f))(id).value);
   });
 
   it('returns the identity function given no arguments', function() {
     var identity = R.composeK();
-    assert.strictEqual(identity.length, 1);
-    assert.strictEqual(identity(R.__).length, 1);
-    assert.strictEqual(identity(42), 42);
+    eq(identity.length, 1);
+    eq(identity(R.__).length, 1);
+    eq(identity(42), 42);
   });
 
 });

--- a/test/composeP.js
+++ b/test/composeP.js
@@ -3,37 +3,38 @@ var assert = require('assert');
 var Q = require('q');
 
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('composeP', function() {
 
   it('is a variadic function', function() {
-    assert.strictEqual(typeof R.composeP, 'function');
-    assert.strictEqual(R.composeP.length, 0);
+    eq(typeof R.composeP, 'function');
+    eq(R.composeP.length, 0);
   });
 
   it('performs right-to-left composition of Promise-returning functions', function(done) {
     var f = function(a) { return Q.Promise(function(res) { res([a]); }); };
     var g = function(a, b) { return Q.Promise(function(res) { res([a, b]); }); };
 
-    assert.strictEqual(R.composeP(f).length, 1);
-    assert.strictEqual(R.composeP(g).length, 2);
-    assert.strictEqual(R.composeP(f, f).length, 1);
-    assert.strictEqual(R.composeP(f, g).length, 2);
-    assert.strictEqual(R.composeP(g, f).length, 1);
-    assert.strictEqual(R.composeP(g, g).length, 2);
+    eq(R.composeP(f).length, 1);
+    eq(R.composeP(g).length, 2);
+    eq(R.composeP(f, f).length, 1);
+    eq(R.composeP(f, g).length, 2);
+    eq(R.composeP(g, f).length, 1);
+    eq(R.composeP(g, g).length, 2);
 
     R.composeP(f, g)(1).then(function(result) {
-      assert.deepEqual(result, [[1, undefined]]);
+      eq(result, [[1, undefined]]);
 
       R.composeP(g, f)(1).then(function(result) {
-        assert.deepEqual(result, [[1], undefined]);
+        eq(result, [[1], undefined]);
 
         R.composeP(f, g)(1, 2).then(function(result) {
-          assert.deepEqual(result, [[1, 2]]);
+          eq(result, [[1, 2]]);
 
           R.composeP(g, f)(1, 2).then(function(result) {
-            assert.deepEqual(result, [[1], undefined]);
+            eq(result, [[1], undefined]);
 
             done();
           })['catch'](done);

--- a/test/concat.js
+++ b/test/concat.js
@@ -1,12 +1,13 @@
 var assert = require('assert');
 
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('concat', function() {
   it('adds combines the elements of the two lists', function() {
-    assert.deepEqual(R.concat(['a', 'b'], ['c', 'd']), ['a', 'b', 'c', 'd']);
-    assert.deepEqual(R.concat([], ['c', 'd']), ['c', 'd']);
+    eq(R.concat(['a', 'b'], ['c', 'd']), ['a', 'b', 'c', 'd']);
+    eq(R.concat([], ['c', 'd']), ['c', 'd']);
   });
 
   var z1 = {
@@ -18,27 +19,27 @@ describe('concat', function() {
   };
 
   it('adds combines the elements of the two lists', function() {
-    assert.deepEqual(R.concat(['a', 'b'], ['c', 'd']), ['a', 'b', 'c', 'd']);
-    assert.deepEqual(R.concat([], ['c', 'd']), ['c', 'd']);
+    eq(R.concat(['a', 'b'], ['c', 'd']), ['a', 'b', 'c', 'd']);
+    eq(R.concat([], ['c', 'd']), ['c', 'd']);
   });
   it('works on strings', function() {
-    assert.strictEqual(R.concat('foo', 'bar'), 'foobar');
-    assert.strictEqual(R.concat('x', ''), 'x');
-    assert.strictEqual(R.concat('', 'x'), 'x');
-    assert.strictEqual(R.concat('', ''), '');
+    eq(R.concat('foo', 'bar'), 'foobar');
+    eq(R.concat('x', ''), 'x');
+    eq(R.concat('', 'x'), 'x');
+    eq(R.concat('', ''), '');
   });
   it('delegates to non-String object with a concat method, as second param', function() {
-    assert.strictEqual(R.concat(z1, z2), 'z1 z2');
+    eq(R.concat(z1, z2), 'z1 z2');
   });
   it('is curried', function() {
     var conc123 = R.concat([1, 2, 3]);
-    assert.deepEqual(conc123([4, 5, 6]), [1, 2, 3, 4, 5, 6]);
-    assert.deepEqual(conc123(['a', 'b', 'c']), [1, 2, 3, 'a', 'b', 'c']);
+    eq(conc123([4, 5, 6]), [1, 2, 3, 4, 5, 6]);
+    eq(conc123(['a', 'b', 'c']), [1, 2, 3, 'a', 'b', 'c']);
   });
   it('is curried like a binary operator, that accepts an inital placeholder', function() {
     var appendBar = R.concat(R.__, 'bar');
-    assert.strictEqual(typeof appendBar, 'function');
-    assert.strictEqual(appendBar('foo'), 'foobar');
+    eq(typeof appendBar, 'function');
+    eq(appendBar('foo'), 'foobar');
   });
   it('throws if not an array, String, or object with a concat method', function() {
     assert.throws(function() { return R.concat({}, {}); }, TypeError);

--- a/test/cond.js
+++ b/test/cond.js
@@ -1,11 +1,10 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('cond', function() {
   it('returns a function', function() {
-    assert.strictEqual(typeof R.cond([]), 'function');
+    eq(typeof R.cond([]), 'function');
   });
 
   it('returns a conditional function', function() {
@@ -14,9 +13,9 @@ describe('cond', function() {
       [R.equals(100), R.always('water boils at 100°C')],
       [R.T,           function(temp) { return 'nothing special happens at ' + temp + '°C'; }]
     ]);
-    assert.strictEqual(fn(0), 'water freezes at 0°C');
-    assert.strictEqual(fn(50), 'nothing special happens at 50°C');
-    assert.strictEqual(fn(100), 'water boils at 100°C');
+    eq(fn(0), 'water freezes at 0°C');
+    eq(fn(50), 'nothing special happens at 50°C');
+    eq(fn(100), 'water boils at 100°C');
   });
 
   it('returns a function which returns undefined if none of the predicates matches', function() {
@@ -24,7 +23,7 @@ describe('cond', function() {
       [R.equals('foo'), R.always(1)],
       [R.equals('bar'), R.always(2)]
     ]);
-    assert.strictEqual(fn('quux'), undefined);
+    eq(fn('quux'), undefined);
   });
 
   it('predicates are tested in order', function() {
@@ -33,13 +32,13 @@ describe('cond', function() {
       [R.T, R.always('bar')],
       [R.T, R.always('baz')]
     ]);
-    assert.strictEqual(fn(), 'foo');
+    eq(fn(), 'foo');
   });
 
   it('forwards all arguments to predicates and to transformers', function() {
     var fn = R.cond([
       [function(_, x) { return x === 42; }, function() { return arguments.length; }]
     ]);
-    assert.strictEqual(fn(21, 42, 84), 3);
+    eq(fn(21, 42, 84), 3);
   });
 });

--- a/test/construct.js
+++ b/test/construct.js
@@ -1,6 +1,7 @@
 var assert = require('assert');
 
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('construct', function() {
@@ -10,27 +11,27 @@ describe('construct', function() {
   it('turns a constructor function into one that can be called without `new`', function() {
     var rect = R.construct(Rectangle);
     var r1 = rect(3, 4);
-    assert.strictEqual(r1.constructor, Rectangle);
-    assert.strictEqual(r1.width, 3);
-    assert.strictEqual(r1.area(), 12);
+    eq(r1.constructor, Rectangle);
+    eq(r1.width, 3);
+    eq(r1.area(), 12);
 
     var regex = R.construct(RegExp);
     var word = regex('word', 'gi');
-    assert.strictEqual(word.constructor, RegExp);
-    assert.strictEqual(word.source, 'word');
-    assert.strictEqual(word.global, true);
+    eq(word.constructor, RegExp);
+    eq(word.source, 'word');
+    eq(word.global, true);
   });
 
   it('can be used to create Date object', function() {
     var date = R.construct(Date)(1984, 3, 26, 0, 0, 0, 0);
-    assert.strictEqual(date.constructor, Date);
-    assert.strictEqual(date.getFullYear(), 1984);
+    eq(date.constructor, Date);
+    eq(date.getFullYear(), 1984);
   });
 
   it('supports constructors with no arguments', function() {
     function Foo() {}
     var foo = R.construct(Foo)();
-    assert.strictEqual(foo.constructor, Foo);
+    eq(foo.constructor, Foo);
   });
 
   it('does not support constructor with greater than ten arguments', function() {
@@ -49,16 +50,16 @@ describe('construct', function() {
     var rect = R.construct(Rectangle);
     var rect3 = rect(3);
     var r1 = rect3(4);
-    assert.strictEqual(r1.constructor, Rectangle);
-    assert.strictEqual(r1.width, 3);
-    assert.strictEqual(r1.height, 4);
-    assert.strictEqual(r1.area(), 12);
+    eq(r1.constructor, Rectangle);
+    eq(r1.width, 3);
+    eq(r1.height, 4);
+    eq(r1.area(), 12);
 
     var regex = R.construct(RegExp);
     var word = regex('word');
     var complete = word('gi');
-    assert.strictEqual(complete.constructor, RegExp);
-    assert.strictEqual(complete.source, 'word');
-    assert.strictEqual(complete.global, true);
+    eq(complete.constructor, RegExp);
+    eq(complete.source, 'word');
+    eq(complete.global, true);
   });
 });

--- a/test/constructN.js
+++ b/test/constructN.js
@@ -1,6 +1,7 @@
 var assert = require('assert');
 
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('constructN', function() {
@@ -13,27 +14,27 @@ describe('constructN', function() {
   it('turns a constructor function into a function with n arguments', function() {
     var circle = R.constructN(2, Circle);
     var c1 = circle(1, 'red');
-    assert.strictEqual(c1.constructor, Circle);
-    assert.strictEqual(c1.r, 1);
-    assert.strictEqual(c1.area(), Math.PI);
-    assert.deepEqual(c1.colors, ['red']);
+    eq(c1.constructor, Circle);
+    eq(c1.r, 1);
+    eq(c1.area(), Math.PI);
+    eq(c1.colors, ['red']);
 
     var regex = R.constructN(1, RegExp);
     var pattern = regex('[a-z]');
-    assert.strictEqual(pattern.constructor, RegExp);
-    assert.strictEqual(pattern.source, '[a-z]');
+    eq(pattern.constructor, RegExp);
+    eq(pattern.source, '[a-z]');
   });
 
   it('can be used to create Date object', function() {
     var date = R.constructN(3, Date)(1984, 3, 26);
-    assert.strictEqual(date.constructor, Date);
-    assert.strictEqual(date.getFullYear(), 1984);
+    eq(date.constructor, Date);
+    eq(date.getFullYear(), 1984);
   });
 
   it('supports constructors with no arguments', function() {
     function Foo() {}
     var foo = R.constructN(0, Foo)();
-    assert.strictEqual(foo.constructor, Foo);
+    eq(foo.constructor, Foo);
   });
 
   it('does not support constructor with greater than ten arguments', function() {
@@ -51,10 +52,10 @@ describe('constructN', function() {
   it('is curried', function() {
     function G(a, b, c) { this.a = a; this.b = b; this.c = c; }
     var construct2 = R.constructN(2);
-    assert.strictEqual(typeof construct2, 'function');
+    eq(typeof construct2, 'function');
     var g2 = construct2(G);
-    assert.strictEqual(typeof g2, 'function');
-    assert.strictEqual(g2('a', 'b').constructor, G);
-    assert.strictEqual(g2('a')('b').constructor, G);
+    eq(typeof g2, 'function');
+    eq(g2('a', 'b').constructor, G);
+    eq(g2('a')('b').constructor, G);
   });
 });

--- a/test/contains.js
+++ b/test/contains.js
@@ -1,19 +1,18 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('contains', function() {
   it('returns true if an element is in a list', function() {
-    assert.strictEqual(R.contains(7, [1, 2, 3, 9, 8, 7, 100, 200, 300]), true);
+    eq(R.contains(7, [1, 2, 3, 9, 8, 7, 100, 200, 300]), true);
   });
 
   it('returns false if an element is not in a list', function() {
-    assert.strictEqual(R.contains(99, [1, 2, 3, 9, 8, 7, 100, 200, 300]), false);
+    eq(R.contains(99, [1, 2, 3, 9, 8, 7, 100, 200, 300]), false);
   });
 
   it('returns false for the empty list', function() {
-    assert.strictEqual(R.contains(1, []), false);
+    eq(R.contains(1, []), false);
   });
 
   it('has R.equals semantics', function() {
@@ -22,23 +21,23 @@ describe('contains', function() {
       return x instanceof Just && R.equals(x.value, this.value);
     };
 
-    assert.strictEqual(R.contains(0, [-0]), false);
-    assert.strictEqual(R.contains(-0, [0]), false);
-    assert.strictEqual(R.contains(NaN, [NaN]), true);
-    assert.strictEqual(R.contains(new Just([42]), [new Just([42])]), true);
+    eq(R.contains(0, [-0]), false);
+    eq(R.contains(-0, [0]), false);
+    eq(R.contains(NaN, [NaN]), true);
+    eq(R.contains(new Just([42]), [new Just([42])]), true);
   });
 
   it('is curried', function() {
-    assert.strictEqual(typeof R.contains(7), 'function');
-    assert.strictEqual(R.contains(7)([1, 2, 3]), false);
-    assert.strictEqual(R.contains(7)([1, 2, 7, 3]), true);
+    eq(typeof R.contains(7), 'function');
+    eq(R.contains(7)([1, 2, 3]), false);
+    eq(R.contains(7)([1, 2, 7, 3]), true);
   });
 
   it('is curried like a binary operator, that accepts an inital placeholder', function() {
     var isDigit = R.contains(R.__, ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']);
-    assert.strictEqual(typeof isDigit, 'function');
-    assert.strictEqual(isDigit('0'), true);
-    assert.strictEqual(isDigit('1'), true);
-    assert.strictEqual(isDigit('x'), false);
+    eq(typeof isDigit, 'function');
+    eq(isDigit('0'), true);
+    eq(isDigit('1'), true);
+    eq(isDigit('x'), false);
   });
 });

--- a/test/containsWith.js
+++ b/test/containsWith.js
@@ -1,16 +1,15 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('containsWith', function() {
 
   it('determines if an element is the list based on the predicate', function() {
     var absEq = function(a, b) { return Math.abs(a) === Math.abs(b); };
-    assert.strictEqual(R.containsWith(absEq, 5, [1, 2, 3]), false);
-    assert.strictEqual(R.containsWith(absEq, 5, [4, 5, 6]), true);
-    assert.strictEqual(R.containsWith(absEq, 5, [-1, -2, -3]), false);
-    assert.strictEqual(R.containsWith(absEq, 5, [-4, -5, -6]), true);
+    eq(R.containsWith(absEq, 5, [1, 2, 3]), false);
+    eq(R.containsWith(absEq, 5, [4, 5, 6]), true);
+    eq(R.containsWith(absEq, 5, [-1, -2, -3]), false);
+    eq(R.containsWith(absEq, 5, [-4, -5, -6]), true);
   });
 
 });

--- a/test/converge.js
+++ b/test/converge.js
@@ -1,6 +1,5 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('converge', function() {
@@ -17,13 +16,13 @@ describe('converge', function() {
                       function(a, b, c) { return c; });
 
   it('passes the results of applying the arguments individually to two separate functions into a single one', function() {
-    assert.strictEqual(R.converge(mult, R.add(1), R.add(3))(2), 15); // mult(add1(2), add3(2)) = mult(3, 5) = 3 * 15;
+    eq(R.converge(mult, R.add(1), R.add(3))(2), 15); // mult(add1(2), add3(2)) = mult(3, 5) = 3 * 15;
   });
 
   it('returns a function with the length of the "longest" argument', function() {
-    assert.strictEqual(f1.length, 1);
-    assert.strictEqual(f2.length, 2);
-    assert.strictEqual(f3.length, 3);
+    eq(f1.length, 1);
+    eq(f2.length, 2);
+    eq(f3.length, 3);
   });
 
   it('passes context to its functions', function() {
@@ -32,13 +31,13 @@ describe('converge', function() {
     var c = function(x, y) { return this.f3(x, y); };
     var d = R.converge(c, a, b);
     var context = {f1: R.add(1), f2: R.add(2), f3: R.add};
-    assert.equal(a.call(context, 1), 2);
-    assert.equal(b.call(context, 1), 3);
-    assert.equal(d.call(context, 1), 5);
+    eq(a.call(context, 1), 2);
+    eq(b.call(context, 1), 3);
+    eq(d.call(context, 1), 5);
   });
 
   it('returns a curried function', function() {
-    assert.strictEqual(f2(6)(7), 42);
-    assert.strictEqual(f3(R.__).length, 3);
+    eq(f2(6)(7), 42);
+    eq(f3(R.__).length, 3);
   });
 });

--- a/test/countBy.js
+++ b/test/countBy.js
@@ -1,6 +1,5 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 var albums = [
@@ -33,27 +32,27 @@ var derivedGenre = (function() {
 
 describe('countBy', function() {
   it('counts by a simple property of the objects', function() {
-    assert.deepEqual(R.countBy(R.prop('genre'), albums), {
+    eq(R.countBy(R.prop('genre'), albums), {
       Baroque: 2, Rock: 2, Jazz: 2, Romantic: 1, Metal: 1, Modern: 1, Broadway: 1, Folk: 1, Classical: 1
     });
   });
 
   it('counts by a more complex function on the objects', function() {
-    assert.deepEqual(R.countBy(derivedGenre, albums), {
+    eq(R.countBy(derivedGenre, albums), {
       Classical: 5, Rock: 3, Jazz: 2, Broadway: 1, Folk: 1
     });
   });
 
   it('is curried', function() {
     var counter = R.countBy(R.prop('genre'));
-    assert.deepEqual(counter(albums), {
+    eq(counter(albums), {
       Baroque: 2, Rock: 2, Jazz: 2, Romantic: 1, Metal: 1, Modern: 1, Broadway: 1, Folk: 1, Classical: 1
     });
   });
 
   it('ignores inherited properties', function() {
     var result = R.countBy(R.identity, ['abc', 'toString']);
-    assert.strictEqual(result.abc, 1);
-    assert.strictEqual(result.toString, 1);
+    eq(result.abc, 1);
+    eq(result.toString, 1);
   });
 });

--- a/test/createMapEntry.js
+++ b/test/createMapEntry.js
@@ -1,14 +1,13 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('createMapEntry', function() {
   it('creates an object containing a single key:value pair', function() {
-    assert.deepEqual(R.createMapEntry('foo', 42), {foo: 42});
+    eq(R.createMapEntry('foo', 42), {foo: 42});
   });
 
   it('is curried', function() {
-    assert.deepEqual(R.createMapEntry('foo')(42), {foo: 42});
+    eq(R.createMapEntry('foo')(42), {foo: 42});
   });
 });

--- a/test/curry.js
+++ b/test/curry.js
@@ -1,40 +1,39 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('curry', function() {
   it('curries a single value', function() {
     var f = R.curry(function(a, b, c, d) {return (a + b * c) / d;}); // f(12, 3, 6, 2) == 15
     var g = f(12);
-    assert.strictEqual(g(3, 6, 2), 15);
+    eq(g(3, 6, 2), 15);
   });
 
   it('curries multiple values', function() {
     var f = R.curry(function(a, b, c, d) {return (a + b * c) / d;}); // f(12, 3, 6, 2) == 15
     var g = f(12, 3);
-    assert.strictEqual(g(6, 2), 15);
+    eq(g(6, 2), 15);
     var h = f(12, 3, 6);
-    assert.strictEqual(h(2), 15);
+    eq(h(2), 15);
   });
 
   it('allows further currying of a curried function', function() {
     var f = R.curry(function(a, b, c, d) {return (a + b * c) / d;}); // f(12, 3, 6, 2) == 15
     var g = f(12);
-    assert.strictEqual(g(3, 6, 2), 15);
+    eq(g(3, 6, 2), 15);
     var h = g(3);
-    assert.strictEqual(h(6, 2), 15);
-    assert.strictEqual(g(3, 6)(2), 15);
+    eq(h(6, 2), 15);
+    eq(g(3, 6)(2), 15);
   });
 
   it('properly reports the length of the curried function', function() {
     var f = R.curry(function(a, b, c, d) {return (a + b * c) / d;});
-    assert.strictEqual(f.length, 4);
+    eq(f.length, 4);
     var g = f(12);
-    assert.strictEqual(g.length, 3);
+    eq(g.length, 3);
     var h = g(3);
-    assert.strictEqual(h.length, 2);
-    assert.strictEqual(g(3, 6).length, 1);
+    eq(h.length, 2);
+    eq(g(3, 6).length, 1);
   });
 
   it('preserves context', function() {
@@ -42,8 +41,8 @@ describe('curry', function() {
     var f = function(a, b) { return a + b * this.x; };
     var g = R.curry(f);
 
-    assert.strictEqual(g.call(ctx, 2, 4), 42);
-    assert.strictEqual(g.call(ctx, 2).call(ctx, 4), 42);
+    eq(g.call(ctx, 2, 4), 42);
+    eq(g.call(ctx, 2).call(ctx, 4), 42);
   });
 
   it('supports R.__ placeholder', function() {
@@ -51,29 +50,29 @@ describe('curry', function() {
     var g = R.curry(f);
     var _ = R.__;
 
-    assert.deepEqual(g(1)(2)(3), [1, 2, 3]);
-    assert.deepEqual(g(1)(2, 3), [1, 2, 3]);
-    assert.deepEqual(g(1, 2)(3), [1, 2, 3]);
-    assert.deepEqual(g(1, 2, 3), [1, 2, 3]);
+    eq(g(1)(2)(3), [1, 2, 3]);
+    eq(g(1)(2, 3), [1, 2, 3]);
+    eq(g(1, 2)(3), [1, 2, 3]);
+    eq(g(1, 2, 3), [1, 2, 3]);
 
-    assert.deepEqual(g(_, 2, 3)(1), [1, 2, 3]);
-    assert.deepEqual(g(1, _, 3)(2), [1, 2, 3]);
-    assert.deepEqual(g(1, 2, _)(3), [1, 2, 3]);
+    eq(g(_, 2, 3)(1), [1, 2, 3]);
+    eq(g(1, _, 3)(2), [1, 2, 3]);
+    eq(g(1, 2, _)(3), [1, 2, 3]);
 
-    assert.deepEqual(g(1, _, _)(2)(3), [1, 2, 3]);
-    assert.deepEqual(g(_, 2, _)(1)(3), [1, 2, 3]);
-    assert.deepEqual(g(_, _, 3)(1)(2), [1, 2, 3]);
+    eq(g(1, _, _)(2)(3), [1, 2, 3]);
+    eq(g(_, 2, _)(1)(3), [1, 2, 3]);
+    eq(g(_, _, 3)(1)(2), [1, 2, 3]);
 
-    assert.deepEqual(g(1, _, _)(2, 3), [1, 2, 3]);
-    assert.deepEqual(g(_, 2, _)(1, 3), [1, 2, 3]);
-    assert.deepEqual(g(_, _, 3)(1, 2), [1, 2, 3]);
+    eq(g(1, _, _)(2, 3), [1, 2, 3]);
+    eq(g(_, 2, _)(1, 3), [1, 2, 3]);
+    eq(g(_, _, 3)(1, 2), [1, 2, 3]);
 
-    assert.deepEqual(g(1, _, _)(_, 3)(2), [1, 2, 3]);
-    assert.deepEqual(g(_, 2, _)(_, 3)(1), [1, 2, 3]);
-    assert.deepEqual(g(_, _, 3)(_, 2)(1), [1, 2, 3]);
+    eq(g(1, _, _)(_, 3)(2), [1, 2, 3]);
+    eq(g(_, 2, _)(_, 3)(1), [1, 2, 3]);
+    eq(g(_, _, 3)(_, 2)(1), [1, 2, 3]);
 
-    assert.deepEqual(g(_, _, _)(_, _)(_)(1, 2, 3), [1, 2, 3]);
-    assert.deepEqual(g(_, _, _)(1, _, _)(_, _)(2, _)(_)(3), [1, 2, 3]);
+    eq(g(_, _, _)(_, _)(_)(1, 2, 3), [1, 2, 3]);
+    eq(g(_, _, _)(1, _, _)(_, _)(2, _)(_)(3), [1, 2, 3]);
   });
 
   it('supports @@functional/placeholder', function() {
@@ -81,29 +80,29 @@ describe('curry', function() {
     var g = R.curry(f);
     var _ = {'@@functional/placeholder': true, x: Math.random()};
 
-    assert.deepEqual(g(1)(2)(3), [1, 2, 3]);
-    assert.deepEqual(g(1)(2, 3), [1, 2, 3]);
-    assert.deepEqual(g(1, 2)(3), [1, 2, 3]);
-    assert.deepEqual(g(1, 2, 3), [1, 2, 3]);
+    eq(g(1)(2)(3), [1, 2, 3]);
+    eq(g(1)(2, 3), [1, 2, 3]);
+    eq(g(1, 2)(3), [1, 2, 3]);
+    eq(g(1, 2, 3), [1, 2, 3]);
 
-    assert.deepEqual(g(_, 2, 3)(1), [1, 2, 3]);
-    assert.deepEqual(g(1, _, 3)(2), [1, 2, 3]);
-    assert.deepEqual(g(1, 2, _)(3), [1, 2, 3]);
+    eq(g(_, 2, 3)(1), [1, 2, 3]);
+    eq(g(1, _, 3)(2), [1, 2, 3]);
+    eq(g(1, 2, _)(3), [1, 2, 3]);
 
-    assert.deepEqual(g(1, _, _)(2)(3), [1, 2, 3]);
-    assert.deepEqual(g(_, 2, _)(1)(3), [1, 2, 3]);
-    assert.deepEqual(g(_, _, 3)(1)(2), [1, 2, 3]);
+    eq(g(1, _, _)(2)(3), [1, 2, 3]);
+    eq(g(_, 2, _)(1)(3), [1, 2, 3]);
+    eq(g(_, _, 3)(1)(2), [1, 2, 3]);
 
-    assert.deepEqual(g(1, _, _)(2, 3), [1, 2, 3]);
-    assert.deepEqual(g(_, 2, _)(1, 3), [1, 2, 3]);
-    assert.deepEqual(g(_, _, 3)(1, 2), [1, 2, 3]);
+    eq(g(1, _, _)(2, 3), [1, 2, 3]);
+    eq(g(_, 2, _)(1, 3), [1, 2, 3]);
+    eq(g(_, _, 3)(1, 2), [1, 2, 3]);
 
-    assert.deepEqual(g(1, _, _)(_, 3)(2), [1, 2, 3]);
-    assert.deepEqual(g(_, 2, _)(_, 3)(1), [1, 2, 3]);
-    assert.deepEqual(g(_, _, 3)(_, 2)(1), [1, 2, 3]);
+    eq(g(1, _, _)(_, 3)(2), [1, 2, 3]);
+    eq(g(_, 2, _)(_, 3)(1), [1, 2, 3]);
+    eq(g(_, _, 3)(_, 2)(1), [1, 2, 3]);
 
-    assert.deepEqual(g(_, _, _)(_, _)(_)(1, 2, 3), [1, 2, 3]);
-    assert.deepEqual(g(_, _, _)(1, _, _)(_, _)(2, _)(_)(3), [1, 2, 3]);
+    eq(g(_, _, _)(_, _)(_)(1, 2, 3), [1, 2, 3]);
+    eq(g(_, _, _)(1, _, _)(_, _)(2, _)(_)(3), [1, 2, 3]);
   });
 
   it('forwards extra arguments', function() {
@@ -113,10 +112,10 @@ describe('curry', function() {
     };
     var g = R.curry(f);
 
-    assert.deepEqual(g(1, 2, 3), [1, 2, 3]);
-    assert.deepEqual(g(1, 2, 3, 4), [1, 2, 3, 4]);
-    assert.deepEqual(g(1, 2)(3, 4), [1, 2, 3, 4]);
-    assert.deepEqual(g(1)(2, 3, 4), [1, 2, 3, 4]);
-    assert.deepEqual(g(1)(2)(3, 4), [1, 2, 3, 4]);
+    eq(g(1, 2, 3), [1, 2, 3]);
+    eq(g(1, 2, 3, 4), [1, 2, 3, 4]);
+    eq(g(1, 2)(3, 4), [1, 2, 3, 4]);
+    eq(g(1)(2, 3, 4), [1, 2, 3, 4]);
+    eq(g(1)(2)(3, 4), [1, 2, 3, 4]);
   });
 });

--- a/test/curryN.js
+++ b/test/curryN.js
@@ -1,6 +1,5 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('curryN', function() {
@@ -10,20 +9,20 @@ describe('curryN', function() {
   }
   it('accepts an arity', function() {
     var curried = R.curryN(3, source);
-    assert.strictEqual(curried(1)(2)(3), 6);
-    assert.strictEqual(curried(1, 2)(3), 6);
-    assert.strictEqual(curried(1)(2, 3), 6);
-    assert.strictEqual(curried(1, 2, 3), 6);
+    eq(curried(1)(2)(3), 6);
+    eq(curried(1, 2)(3), 6);
+    eq(curried(1)(2, 3), 6);
+    eq(curried(1, 2, 3), 6);
   });
 
   it('can be partially applied', function() {
     var curry3 = R.curryN(3);
     var curried = curry3(source);
-    assert.strictEqual(curried.length, 3);
-    assert.strictEqual(curried(1)(2)(3), 6);
-    assert.strictEqual(curried(1, 2)(3), 6);
-    assert.strictEqual(curried(1)(2, 3), 6);
-    assert.strictEqual(curried(1, 2, 3), 6);
+    eq(curried.length, 3);
+    eq(curried(1)(2)(3), 6);
+    eq(curried(1, 2)(3), 6);
+    eq(curried(1)(2, 3), 6);
+    eq(curried(1, 2, 3), 6);
   });
 
   it('preserves context', function() {
@@ -31,8 +30,8 @@ describe('curryN', function() {
     var f = function(a, b) { return a + b * this.x; };
     var g = R.curryN(2, f);
 
-    assert.strictEqual(g.call(ctx, 2, 4), 42);
-    assert.strictEqual(g.call(ctx, 2).call(ctx, 4), 42);
+    eq(g.call(ctx, 2, 4), 42);
+    eq(g.call(ctx, 2).call(ctx, 4), 42);
   });
 
   it('supports R.__ placeholder', function() {
@@ -40,29 +39,29 @@ describe('curryN', function() {
     var g = R.curryN(3, f);
     var _ = R.__;
 
-    assert.deepEqual(g(1)(2)(3), [1, 2, 3]);
-    assert.deepEqual(g(1)(2, 3), [1, 2, 3]);
-    assert.deepEqual(g(1, 2)(3), [1, 2, 3]);
-    assert.deepEqual(g(1, 2, 3), [1, 2, 3]);
+    eq(g(1)(2)(3), [1, 2, 3]);
+    eq(g(1)(2, 3), [1, 2, 3]);
+    eq(g(1, 2)(3), [1, 2, 3]);
+    eq(g(1, 2, 3), [1, 2, 3]);
 
-    assert.deepEqual(g(_, 2, 3)(1), [1, 2, 3]);
-    assert.deepEqual(g(1, _, 3)(2), [1, 2, 3]);
-    assert.deepEqual(g(1, 2, _)(3), [1, 2, 3]);
+    eq(g(_, 2, 3)(1), [1, 2, 3]);
+    eq(g(1, _, 3)(2), [1, 2, 3]);
+    eq(g(1, 2, _)(3), [1, 2, 3]);
 
-    assert.deepEqual(g(1, _, _)(2)(3), [1, 2, 3]);
-    assert.deepEqual(g(_, 2, _)(1)(3), [1, 2, 3]);
-    assert.deepEqual(g(_, _, 3)(1)(2), [1, 2, 3]);
+    eq(g(1, _, _)(2)(3), [1, 2, 3]);
+    eq(g(_, 2, _)(1)(3), [1, 2, 3]);
+    eq(g(_, _, 3)(1)(2), [1, 2, 3]);
 
-    assert.deepEqual(g(1, _, _)(2, 3), [1, 2, 3]);
-    assert.deepEqual(g(_, 2, _)(1, 3), [1, 2, 3]);
-    assert.deepEqual(g(_, _, 3)(1, 2), [1, 2, 3]);
+    eq(g(1, _, _)(2, 3), [1, 2, 3]);
+    eq(g(_, 2, _)(1, 3), [1, 2, 3]);
+    eq(g(_, _, 3)(1, 2), [1, 2, 3]);
 
-    assert.deepEqual(g(1, _, _)(_, 3)(2), [1, 2, 3]);
-    assert.deepEqual(g(_, 2, _)(_, 3)(1), [1, 2, 3]);
-    assert.deepEqual(g(_, _, 3)(_, 2)(1), [1, 2, 3]);
+    eq(g(1, _, _)(_, 3)(2), [1, 2, 3]);
+    eq(g(_, 2, _)(_, 3)(1), [1, 2, 3]);
+    eq(g(_, _, 3)(_, 2)(1), [1, 2, 3]);
 
-    assert.deepEqual(g(_, _, _)(_, _)(_)(1, 2, 3), [1, 2, 3]);
-    assert.deepEqual(g(_, _, _)(1, _, _)(_, _)(2, _)(_)(3), [1, 2, 3]);
+    eq(g(_, _, _)(_, _)(_)(1, 2, 3), [1, 2, 3]);
+    eq(g(_, _, _)(1, _, _)(_, _)(2, _)(_)(3), [1, 2, 3]);
   });
 
   it('supports @@functional/placeholder', function() {
@@ -70,39 +69,39 @@ describe('curryN', function() {
     var g = R.curryN(3, f);
     var _ = {'@@functional/placeholder': true, x: Math.random()};
 
-    assert.deepEqual(g(1)(2)(3), [1, 2, 3]);
-    assert.deepEqual(g(1)(2, 3), [1, 2, 3]);
-    assert.deepEqual(g(1, 2)(3), [1, 2, 3]);
-    assert.deepEqual(g(1, 2, 3), [1, 2, 3]);
+    eq(g(1)(2)(3), [1, 2, 3]);
+    eq(g(1)(2, 3), [1, 2, 3]);
+    eq(g(1, 2)(3), [1, 2, 3]);
+    eq(g(1, 2, 3), [1, 2, 3]);
 
-    assert.deepEqual(g(_, 2, 3)(1), [1, 2, 3]);
-    assert.deepEqual(g(1, _, 3)(2), [1, 2, 3]);
-    assert.deepEqual(g(1, 2, _)(3), [1, 2, 3]);
+    eq(g(_, 2, 3)(1), [1, 2, 3]);
+    eq(g(1, _, 3)(2), [1, 2, 3]);
+    eq(g(1, 2, _)(3), [1, 2, 3]);
 
-    assert.deepEqual(g(1, _, _)(2)(3), [1, 2, 3]);
-    assert.deepEqual(g(_, 2, _)(1)(3), [1, 2, 3]);
-    assert.deepEqual(g(_, _, 3)(1)(2), [1, 2, 3]);
+    eq(g(1, _, _)(2)(3), [1, 2, 3]);
+    eq(g(_, 2, _)(1)(3), [1, 2, 3]);
+    eq(g(_, _, 3)(1)(2), [1, 2, 3]);
 
-    assert.deepEqual(g(1, _, _)(2, 3), [1, 2, 3]);
-    assert.deepEqual(g(_, 2, _)(1, 3), [1, 2, 3]);
-    assert.deepEqual(g(_, _, 3)(1, 2), [1, 2, 3]);
+    eq(g(1, _, _)(2, 3), [1, 2, 3]);
+    eq(g(_, 2, _)(1, 3), [1, 2, 3]);
+    eq(g(_, _, 3)(1, 2), [1, 2, 3]);
 
-    assert.deepEqual(g(1, _, _)(_, 3)(2), [1, 2, 3]);
-    assert.deepEqual(g(_, 2, _)(_, 3)(1), [1, 2, 3]);
-    assert.deepEqual(g(_, _, 3)(_, 2)(1), [1, 2, 3]);
+    eq(g(1, _, _)(_, 3)(2), [1, 2, 3]);
+    eq(g(_, 2, _)(_, 3)(1), [1, 2, 3]);
+    eq(g(_, _, 3)(_, 2)(1), [1, 2, 3]);
 
-    assert.deepEqual(g(_, _, _)(_, _)(_)(1, 2, 3), [1, 2, 3]);
-    assert.deepEqual(g(_, _, _)(1, _, _)(_, _)(2, _)(_)(3), [1, 2, 3]);
+    eq(g(_, _, _)(_, _)(_)(1, 2, 3), [1, 2, 3]);
+    eq(g(_, _, _)(1, _, _)(_, _)(2, _)(_)(3), [1, 2, 3]);
   });
 
   it('forwards extra arguments', function() {
     var f = function() { return Array.prototype.slice.call(arguments); };
     var g = R.curryN(3, f);
 
-    assert.deepEqual(g(1, 2, 3), [1, 2, 3]);
-    assert.deepEqual(g(1, 2, 3, 4), [1, 2, 3, 4]);
-    assert.deepEqual(g(1, 2)(3, 4), [1, 2, 3, 4]);
-    assert.deepEqual(g(1)(2, 3, 4), [1, 2, 3, 4]);
-    assert.deepEqual(g(1)(2)(3, 4), [1, 2, 3, 4]);
+    eq(g(1, 2, 3), [1, 2, 3]);
+    eq(g(1, 2, 3, 4), [1, 2, 3, 4]);
+    eq(g(1, 2)(3, 4), [1, 2, 3, 4]);
+    eq(g(1)(2, 3, 4), [1, 2, 3, 4]);
+    eq(g(1)(2)(3, 4), [1, 2, 3, 4]);
   });
 });

--- a/test/dec.js
+++ b/test/dec.js
@@ -1,17 +1,16 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('dec', function() {
 
   it('decrements its argument', function() {
-    assert.strictEqual(R.dec(-1), -2);
-    assert.strictEqual(R.dec(0), -1);
-    assert.strictEqual(R.dec(1), 0);
-    assert.strictEqual(R.dec(12.34), 11.34);
-    assert.strictEqual(R.dec(-Infinity), -Infinity);
-    assert.strictEqual(R.dec(Infinity), Infinity);
+    eq(R.dec(-1), -2);
+    eq(R.dec(0), -1);
+    eq(R.dec(1), 0);
+    eq(R.dec(12.34), 11.34);
+    eq(R.dec(-Infinity), -Infinity);
+    eq(R.dec(Infinity), Infinity);
   });
 
 });

--- a/test/defaultTo.js
+++ b/test/defaultTo.js
@@ -1,31 +1,30 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 describe('defaultTo', function() {
 
   var defaultTo42 = R.defaultTo(42);
 
   it('returns the default value if input is null, undefined or NaN', function() {
-    assert.strictEqual(42, defaultTo42(null));
-    assert.strictEqual(42, defaultTo42(undefined));
-    assert.strictEqual(42, defaultTo42(NaN));
+    eq(42, defaultTo42(null));
+    eq(42, defaultTo42(undefined));
+    eq(42, defaultTo42(NaN));
   });
 
   it('returns the input value if it is not null/undefined', function() {
-    assert.strictEqual('a real value', defaultTo42('a real value'));
+    eq('a real value', defaultTo42('a real value'));
   });
 
   it('returns the input value even if it is considered falsy', function() {
-    assert.strictEqual('', defaultTo42(''));
-    assert.strictEqual(0, defaultTo42(0));
-    assert.strictEqual(false, defaultTo42(false));
-    assert.deepEqual([], defaultTo42([]));
+    eq('', defaultTo42(''));
+    eq(0, defaultTo42(0));
+    eq(false, defaultTo42(false));
+    eq([], defaultTo42([]));
   });
 
   it('can be called with both arguments directly', function() {
-    assert.strictEqual(42, R.defaultTo(42, null));
-    assert.strictEqual('a real value', R.defaultTo(42, 'a real value'));
+    eq(42, R.defaultTo(42, null));
+    eq('a real value', R.defaultTo(42, 'a real value'));
   });
 
 });

--- a/test/difference.js
+++ b/test/difference.js
@@ -1,6 +1,5 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('difference', function() {
@@ -11,11 +10,11 @@ describe('difference', function() {
   var Z = [3, 4, 5, 6, 10];
   var Z2 = [1, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 8];
   it('finds the set of all elements in the first list not contained in the second', function() {
-    assert.deepEqual(R.difference(M, N), [1, 2]);
+    eq(R.difference(M, N), [1, 2]);
   });
 
   it('does not allow duplicates in the output even if the input lists had duplicates', function() {
-    assert.deepEqual(R.difference(M2, N2), [1, 2]);
+    eq(R.difference(M2, N2), [1, 2]);
   });
 
   it('has R.equals semantics', function() {
@@ -24,29 +23,29 @@ describe('difference', function() {
       return x instanceof Just && R.equals(x.value, this.value);
     };
 
-    assert.strictEqual(R.difference([0], [-0]).length, 1);
-    assert.strictEqual(R.difference([-0], [0]).length, 1);
-    assert.strictEqual(R.difference([NaN], [NaN]).length, 0);
-    assert.strictEqual(R.difference([new Just([42])], [new Just([42])]).length, 0);
+    eq(R.difference([0], [-0]).length, 1);
+    eq(R.difference([-0], [0]).length, 1);
+    eq(R.difference([NaN], [NaN]).length, 0);
+    eq(R.difference([new Just([42])], [new Just([42])]).length, 0);
   });
 
   it('works for arrays of different lengths', function() {
-    assert.deepEqual(R.difference(Z, Z2), [10]);
-    assert.deepEqual(R.difference(Z2, Z), [1, 2, 7, 8]);
+    eq(R.difference(Z, Z2), [10]);
+    eq(R.difference(Z2, Z), [1, 2, 7, 8]);
   });
 
   it('will not create a "sparse" array', function() {
-    assert.strictEqual(R.difference(M2, [3]).length, 3);
+    eq(R.difference(M2, [3]).length, 3);
   });
 
   it('returns an empty array if there are no different elements', function() {
-    assert.deepEqual(R.difference(M2, M), []);
-    assert.deepEqual(R.difference(M, M2), []);
-    assert.deepEqual(R.difference([], M2), []);
+    eq(R.difference(M2, M), []);
+    eq(R.difference(M, M2), []);
+    eq(R.difference([], M2), []);
   });
 
   it('is curried', function() {
-    assert.strictEqual(typeof R.difference([1, 2, 3]), 'function');
-    assert.deepEqual(R.difference([1, 2, 3])([1, 3]), [2]);
+    eq(typeof R.difference([1, 2, 3]), 'function');
+    eq(R.difference([1, 2, 3])([1, 3]), [2]);
   });
 });

--- a/test/differenceWith.js
+++ b/test/differenceWith.js
@@ -1,6 +1,5 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('differenceWith', function() {
@@ -9,18 +8,18 @@ describe('differenceWith', function() {
   var So = [{a: 3}, {a: 4}, {a: 5}, {a: 6}];
   var So2 = [{a: 3}, {a: 4}, {a: 5}, {a: 6}, {a: 3}, {a: 4}, {a: 5}, {a: 6}];
   var eqA = function(r, s) { return r.a === s.a; };
-  var eq = function(a, b) { return a === b; };
+  var identical = function(a, b) { return a === b; };
 
   it('combines two lists into the set of all their elements based on the passed-in equality predicate', function() {
-    assert.deepEqual(R.differenceWith(eqA, Ro, So), [{a: 1}, {a: 2}]);
+    eq(R.differenceWith(eqA, Ro, So), [{a: 1}, {a: 2}]);
   });
 
   it('does not allow duplicates in the output even if the input lists had duplicates', function() {
-    assert.deepEqual(R.differenceWith(eqA, Ro2, So2), [{a: 1}, {a: 2}]);
+    eq(R.differenceWith(eqA, Ro2, So2), [{a: 1}, {a: 2}]);
   });
 
   it('does not return a "sparse" array', function() {
-    assert.strictEqual(R.differenceWith(eq, [1, 3, 2, 1, 3, 1, 2, 3], [3]).length, 2);
+    eq(R.differenceWith(identical, [1, 3, 2, 1, 3, 1, 2, 3], [3]).length, 2);
   });
 
 });

--- a/test/dissoc.js
+++ b/test/dissoc.js
@@ -1,12 +1,11 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('dissoc', function() {
   it('copies an object omitting the specified property', function() {
-    assert.deepEqual(R.dissoc('b', {a: 1, b: 2, c: 3}), {a: 1, c: 3});
-    assert.deepEqual(R.dissoc('d', {a: 1, b: 2, c: 3}), {a: 1, b: 2, c: 3});
+    eq(R.dissoc('b', {a: 1, b: 2, c: 3}), {a: 1, c: 3});
+    eq(R.dissoc('d', {a: 1, b: 2, c: 3}), {a: 1, b: 2, c: 3});
   });
 
   it('includes prototype properties', function() {
@@ -19,12 +18,12 @@ describe('dissoc', function() {
     };
     var rect = new Rectangle(7, 6);
 
-    assert.deepEqual(R.dissoc('area', rect), {width: 7, height: 6});
-    assert.deepEqual(R.dissoc('width', rect), {height: 6, area: area});
-    assert.deepEqual(R.dissoc('depth', rect), {width: 7, height: 6, area: area});
+    eq(R.dissoc('area', rect), {width: 7, height: 6});
+    eq(R.dissoc('width', rect), {height: 6, area: area});
+    eq(R.dissoc('depth', rect), {width: 7, height: 6, area: area});
   });
 
   it('is curried', function() {
-    assert.deepEqual(R.dissoc('b')({a: 1, b: 2, c: 3}), {a: 1, c: 3});
+    eq(R.dissoc('b')({a: 1, b: 2, c: 3}), {a: 1, c: 3});
   });
 });

--- a/test/dissocPath.js
+++ b/test/dissocPath.js
@@ -1,13 +1,14 @@
 var assert = require('assert');
 
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('dissocPath', function() {
   it('makes a shallow clone of an object, omitting only what is necessary for the path', function() {
     var obj1 = {a: {b: 1, c: 2, d: {e: 3}}, f: {g: {h: 4, i: 5, j: {k: 6, l: 7}}}, m: 8};
     var obj2 = R.dissocPath(['f', 'g', 'i'], obj1);
-    assert.deepEqual(obj2,
+    eq(obj2,
       {a: {b: 1, c: 2, d: {e: 3}}, f: {g: {h: 4, j: {k: 6, l: 7}}}, m: 8}
     );
     // Note: reference equality below!
@@ -20,7 +21,7 @@ describe('dissocPath', function() {
   it('does not try to omit inner properties that do not exist', function() {
     var obj1 = {a: 1, b: {c: 2, d: 3}, e: 4, f: 5};
     var obj2 = R.dissocPath(['x', 'y', 'z'], obj1);
-    assert.deepEqual(obj2, {a: 1, b: {c: 2, d: 3}, e: 4, f: 5});
+    eq(obj2, {a: 1, b: {c: 2, d: 3}, e: 4, f: 5});
     // Note: reference equality below!
     assert.strictEqual(obj2.a, obj1.a);
     assert.strictEqual(obj2.b, obj1.b);
@@ -30,7 +31,7 @@ describe('dissocPath', function() {
   it('leaves an empty object when all properties omitted', function() {
     var obj1 = {a: 1, b: {c: 2}, d: 3};
     var obj2 = R.dissocPath(['b', 'c'], obj1);
-    assert.deepEqual(obj2,
+    eq(obj2,
       {a: 1, b: {}, d: 3}
     );
   });
@@ -41,7 +42,7 @@ describe('dissocPath', function() {
     var obj1 = new F();
     obj1.b = {c: 2, d: 3};
     var obj2 = R.dissocPath(['b', 'c'], obj1);
-    assert.deepEqual(obj2,
+    eq(obj2,
       {a: 1, b: {d: 3}}
     );
   });
@@ -50,10 +51,10 @@ describe('dissocPath', function() {
     var obj1 = {a: {b: 1, c: 2, d: {e: 3}}, f: {g: {h: 4, i: 5, j: {k: 6, l: 7}}}, m: 8};
     var expected = {a: {b: 1, c: 2, d: {e: 3}}, f: {g: {h: 4, j: {k: 6, l: 7}}}, m: 8};
     var f = R.dissocPath(['f', 'g', 'i']);
-    assert.deepEqual(f(obj1), expected);
+    eq(f(obj1), expected);
   });
 
   it('accepts empty path', function() {
-    assert.deepEqual(R.dissocPath([], {a: 1, b: 2}), {a: 1, b: 2});
+    eq(R.dissocPath([], {a: 1, b: 2}), {a: 1, b: 2});
   });
 });

--- a/test/divide.js
+++ b/test/divide.js
@@ -1,20 +1,19 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('divide', function() {
   it('divides two numbers', function() {
-    assert.strictEqual(R.divide(28, 7), 4);
+    eq(R.divide(28, 7), 4);
   });
 
   it('is curried', function() {
     var into28 = R.divide(28);
-    assert.strictEqual(into28(7), 4);
+    eq(into28(7), 4);
   });
 
   it('behaves right curried when passed `R.__` for its first argument', function() {
     var half = R.divide(R.__, 2);
-    assert.strictEqual(half(40), 20);
+    eq(half(40), 20);
   });
 });

--- a/test/drop.js
+++ b/test/drop.js
@@ -1,22 +1,23 @@
 var assert = require('assert');
 
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('drop', function() {
 
   it('skips the first `n` elements from a list, returning the remainder', function() {
-    assert.deepEqual(R.drop(3, ['a', 'b', 'c', 'd', 'e', 'f', 'g']), ['d', 'e', 'f', 'g']);
+    eq(R.drop(3, ['a', 'b', 'c', 'd', 'e', 'f', 'g']), ['d', 'e', 'f', 'g']);
   });
 
   it('returns an empty array if `n` is too large', function() {
-    assert.deepEqual(R.drop(20, ['a', 'b', 'c', 'd', 'e', 'f', 'g']), []);
+    eq(R.drop(20, ['a', 'b', 'c', 'd', 'e', 'f', 'g']), []);
   });
 
   it('returns an equivalent list if `n` is <= 0', function() {
-    assert.deepEqual(R.drop(0, [1, 2, 3]), [1, 2, 3]);
-    assert.deepEqual(R.drop(-1, [1, 2, 3]), [1, 2, 3]);
-    assert.deepEqual(R.drop(-Infinity, [1, 2, 3]), [1, 2, 3]);
+    eq(R.drop(0, [1, 2, 3]), [1, 2, 3]);
+    eq(R.drop(-1, [1, 2, 3]), [1, 2, 3]);
+    eq(R.drop(-Infinity, [1, 2, 3]), [1, 2, 3]);
   });
 
   it('never returns the input array', function() {
@@ -27,10 +28,10 @@ describe('drop', function() {
   });
 
   it('can operate on strings', function() {
-    assert.strictEqual(R.drop(3, 'Ramda'), 'da');
-    assert.strictEqual(R.drop(4, 'Ramda'), 'a');
-    assert.strictEqual(R.drop(5, 'Ramda'), '');
-    assert.strictEqual(R.drop(6, 'Ramda'), '');
+    eq(R.drop(3, 'Ramda'), 'da');
+    eq(R.drop(4, 'Ramda'), 'a');
+    eq(R.drop(5, 'Ramda'), '');
+    eq(R.drop(6, 'Ramda'), '');
   });
 
 });

--- a/test/dropLast.js
+++ b/test/dropLast.js
@@ -1,21 +1,22 @@
 var assert = require('assert');
 
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('dropLast', function() {
   it('skips the last `n` elements from a list, returning the remainder', function() {
-    assert.deepEqual(R.dropLast(3, ['a', 'b', 'c', 'd', 'e', 'f', 'g']), ['a', 'b', 'c', 'd']);
+    eq(R.dropLast(3, ['a', 'b', 'c', 'd', 'e', 'f', 'g']), ['a', 'b', 'c', 'd']);
   });
 
   it('returns an empty array if `n` is too large', function() {
-    assert.deepEqual(R.dropLast(20, ['a', 'b', 'c', 'd', 'e', 'f', 'g']), []);
+    eq(R.dropLast(20, ['a', 'b', 'c', 'd', 'e', 'f', 'g']), []);
   });
 
   it('returns an equivalent list if `n` is <= 0', function() {
-    assert.deepEqual(R.dropLast(0, [1, 2, 3]), [1, 2, 3]);
-    assert.deepEqual(R.dropLast(-1, [1, 2, 3]), [1, 2, 3]);
-    assert.deepEqual(R.dropLast(-Infinity, [1, 2, 3]), [1, 2, 3]);
+    eq(R.dropLast(0, [1, 2, 3]), [1, 2, 3]);
+    eq(R.dropLast(-1, [1, 2, 3]), [1, 2, 3]);
+    eq(R.dropLast(-Infinity, [1, 2, 3]), [1, 2, 3]);
   });
 
   it('never returns the input array', function() {
@@ -26,12 +27,12 @@ describe('dropLast', function() {
   });
 
   it('can operate on strings', function() {
-    assert.strictEqual(R.dropLast(3, 'Ramda'), 'Ra');
+    eq(R.dropLast(3, 'Ramda'), 'Ra');
   });
 
   it('is curried', function() {
     var dropLast2 = R.dropLast(2);
-    assert.deepEqual(dropLast2(['a', 'b', 'c', 'd', 'e']), ['a', 'b', 'c']);
-    assert.deepEqual(dropLast2(['x', 'y', 'z']), ['x']);
+    eq(dropLast2(['a', 'b', 'c', 'd', 'e']), ['a', 'b', 'c']);
+    eq(dropLast2(['x', 'y', 'z']), ['x']);
   });
 });

--- a/test/dropLastWhile.js
+++ b/test/dropLastWhile.js
@@ -1,29 +1,28 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('dropLastWhile', function() {
   it('skips elements while the function reports `true`', function() {
-    assert.deepEqual(R.dropLastWhile(function(x) {return x >= 5;}, [1, 3, 5, 7, 9]), [1, 3]);
+    eq(R.dropLastWhile(function(x) {return x >= 5;}, [1, 3, 5, 7, 9]), [1, 3]);
   });
 
   it('returns an empty list for an empty list', function() {
-    assert.deepEqual(R.dropLastWhile(function() { return false; }, []), []);
-    assert.deepEqual(R.dropLastWhile(function() { return true; }, []), []);
+    eq(R.dropLastWhile(function() { return false; }, []), []);
+    eq(R.dropLastWhile(function() { return true; }, []), []);
   });
 
   it('starts at the right arg and acknowledges undefined', function() {
     var sublist = R.dropLastWhile(function(x) {return x !== void 0;}, [1, 3, void 0, 5, 7]);
-    assert.strictEqual(sublist.length, 3);
-    assert.strictEqual(sublist[0], 1);
-    assert.strictEqual(sublist[1], 3);
-    assert.strictEqual(sublist[2], void 0);
+    eq(sublist.length, 3);
+    eq(sublist[0], 1);
+    eq(sublist[1], 3);
+    eq(sublist[2], void 0);
   });
 
   it('is curried', function() {
     var dropGt7 = R.dropLastWhile(function(x) {return x > 7;});
-    assert.deepEqual(dropGt7([1, 3, 5, 7, 9]), [1, 3, 5, 7]);
-    assert.deepEqual(dropGt7([1, 3, 5]), [1, 3, 5]);
+    eq(dropGt7([1, 3, 5, 7, 9]), [1, 3, 5, 7]);
+    eq(dropGt7([1, 3, 5]), [1, 3, 5]);
   });
 });

--- a/test/dropRepeats.js
+++ b/test/dropRepeats.js
@@ -1,6 +1,5 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('dropRepeats', function() {
@@ -8,16 +7,16 @@ describe('dropRepeats', function() {
   var objs2 = [1, 2, 2, 2, 3, 4, 4, 5, 5, 3, 2, 2];
 
   it('removes repeated elements', function() {
-    assert.deepEqual(R.dropRepeats(objs2), objs);
-    assert.deepEqual(R.dropRepeats(objs), objs);
+    eq(R.dropRepeats(objs2), objs);
+    eq(R.dropRepeats(objs), objs);
   });
 
   it('returns an empty array for an empty array', function() {
-    assert.deepEqual(R.dropRepeats([]), []);
+    eq(R.dropRepeats([]), []);
   });
 
   it('can act as a transducer', function() {
-    assert.deepEqual(R.into([], R.dropRepeats, objs2), objs);
+    eq(R.into([], R.dropRepeats, objs2), objs);
   });
 
   it('has R.equals semantics', function() {
@@ -26,9 +25,9 @@ describe('dropRepeats', function() {
       return x instanceof Just && R.equals(x.value, this.value);
     };
 
-    assert.strictEqual(R.dropRepeats([0, -0]).length, 2);
-    assert.strictEqual(R.dropRepeats([-0, 0]).length, 2);
-    assert.strictEqual(R.dropRepeats([NaN, NaN]).length, 1);
-    assert.strictEqual(R.dropRepeats([new Just([42]), new Just([42])]).length, 1);
+    eq(R.dropRepeats([0, -0]).length, 2);
+    eq(R.dropRepeats([-0, 0]).length, 2);
+    eq(R.dropRepeats([NaN, NaN]).length, 1);
+    eq(R.dropRepeats([new Just([42]), new Just([42])]).length, 1);
   });
 });

--- a/test/dropRepeatsWith.js
+++ b/test/dropRepeatsWith.js
@@ -1,6 +1,5 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('dropRepeatsWith', function() {
@@ -14,28 +13,28 @@ describe('dropRepeatsWith', function() {
   var eqI = R.eqProps('i');
 
   it('removes repeated elements based on predicate', function() {
-    assert.deepEqual(R.dropRepeatsWith(eqI, objs2), objs);
-    assert.deepEqual(R.dropRepeatsWith(eqI, objs), objs);
+    eq(R.dropRepeatsWith(eqI, objs2), objs);
+    eq(R.dropRepeatsWith(eqI, objs), objs);
   });
 
   it('keeps elements from the left', function() {
-    assert.deepEqual(
+    eq(
       R.dropRepeatsWith(eqI, [{i: 1, n: 1}, {i: 1, n: 2}, {i: 1, n: 3}, {i: 4, n: 1}, {i: 4, n: 2}]),
       [{i: 1, n: 1}, {i: 4, n: 1}]
     );
   });
 
   it('returns an empty array for an empty array', function() {
-    assert.deepEqual(R.dropRepeatsWith(eqI, []), []);
+    eq(R.dropRepeatsWith(eqI, []), []);
   });
 
   it('is curried', function() {
-    assert.strictEqual(typeof R.dropRepeatsWith(eqI), 'function');
-    assert.deepEqual(R.dropRepeatsWith(eqI)(objs), objs);
-    assert.deepEqual(R.dropRepeatsWith(eqI)(objs2), objs);
+    eq(typeof R.dropRepeatsWith(eqI), 'function');
+    eq(R.dropRepeatsWith(eqI)(objs), objs);
+    eq(R.dropRepeatsWith(eqI)(objs2), objs);
   });
 
   it('can act as a transducer', function() {
-    assert.deepEqual(R.into([], R.dropRepeatsWith(eqI), objs2), objs);
+    eq(R.into([], R.dropRepeatsWith(eqI), objs2), objs);
   });
 });

--- a/test/dropWhile.js
+++ b/test/dropWhile.js
@@ -1,29 +1,28 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('dropWhile', function() {
   it('skips elements while the function reports `true`', function() {
-    assert.deepEqual(R.dropWhile(function(x) {return x < 5;}, [1, 3, 5, 7, 9]), [5, 7, 9]);
+    eq(R.dropWhile(function(x) {return x < 5;}, [1, 3, 5, 7, 9]), [5, 7, 9]);
   });
 
   it('returns an empty list for an ampty list', function() {
-    assert.deepEqual(R.dropWhile(function() { return false; }, []), []);
-    assert.deepEqual(R.dropWhile(function() { return true; }, []), []);
+    eq(R.dropWhile(function() { return false; }, []), []);
+    eq(R.dropWhile(function() { return true; }, []), []);
   });
 
   it('starts at the right arg and acknowledges undefined', function() {
     var sublist = R.dropWhile(function(x) {return x !== void 0;}, [1, 3, void 0, 5, 7]);
-    assert.strictEqual(sublist.length, 3);
-    assert.strictEqual(sublist[0], void 0);
-    assert.strictEqual(sublist[1], 5);
-    assert.strictEqual(sublist[2], 7);
+    eq(sublist.length, 3);
+    eq(sublist[0], void 0);
+    eq(sublist[1], 5);
+    eq(sublist[2], 7);
   });
 
   it('is curried', function() {
     var dropLt7 = R.dropWhile(function(x) {return x < 7;});
-    assert.deepEqual(dropLt7([1, 3, 5, 7, 9]), [7, 9]);
-    assert.deepEqual(dropLt7([2, 4, 6, 8, 10]), [8, 10]);
+    eq(dropLt7([1, 3, 5, 7, 9]), [7, 9]);
+    eq(dropLt7([2, 4, 6, 8, 10]), [8, 10]);
   });
 });

--- a/test/either.js
+++ b/test/either.js
@@ -1,6 +1,5 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('either', function() {
@@ -8,18 +7,18 @@ describe('either', function() {
     var even = function(x) {return x % 2 === 0;};
     var gt10 = function(x) {return x > 10;};
     var f = R.either(even, gt10);
-    assert.strictEqual(f(8), true);
-    assert.strictEqual(f(13), true);
-    assert.strictEqual(f(7), false);
+    eq(f(8), true);
+    eq(f(13), true);
+    eq(f(7), false);
   });
 
   it('accepts functions that take multiple parameters', function() {
     var between = function(a, b, c) {return a < b && b < c;};
     var total20 = function(a, b, c) {return a + b + c === 20;};
     var f = R.either(between, total20);
-    assert.strictEqual(f(4, 5, 8), true);
-    assert.strictEqual(f(12, 2, 6), true);
-    assert.strictEqual(f(7, 5, 1), false);
+    eq(f(4, 5, 8), true);
+    eq(f(12, 2, 6), true);
+    eq(f(7, 5, 1), false);
   });
 
   it('does not evaluate the second expression if the first one is true', function() {
@@ -27,15 +26,15 @@ describe('either', function() {
     var Z = function() { effect = 'Z got evaluated'; };
     var effect = 'not evaluated';
     R.either(T, Z);
-    assert.strictEqual(effect, 'not evaluated');
+    eq(effect, 'not evaluated');
   });
 
   it('is curried', function() {
     var even = function(x) {return x % 2 === 0;};
     var gt10 = function(x) {return x > 10;};
     var evenOr = R.either(even);
-    assert.strictEqual(typeof evenOr(gt10), 'function');
-    assert.strictEqual(evenOr(gt10)(11), true);
-    assert.strictEqual(evenOr(gt10)(9), false);
+    eq(typeof evenOr(gt10), 'function');
+    eq(evenOr(gt10)(11), true);
+    eq(evenOr(gt10)(9), false);
   });
 });

--- a/test/empty.js
+++ b/test/empty.js
@@ -1,6 +1,5 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('empty', function() {
@@ -12,8 +11,8 @@ describe('empty', function() {
     function Just(x) { this.value = x; }
     Just.prototype.empty = function() { return new Nothing(); };
 
-    assert.strictEqual(R.empty(new Nothing()).constructor, Nothing);
-    assert.strictEqual(R.empty(new Just(123)).constructor, Nothing);
+    eq(R.empty(new Nothing()).constructor, Nothing);
+    eq(R.empty(new Just(123)).constructor, Nothing);
   });
 
   it('dispatches to `empty` function on constructor', function() {
@@ -23,28 +22,28 @@ describe('empty', function() {
     function Just(x) { this.value = x; }
     Just.empty = function() { return new Nothing(); };
 
-    assert.strictEqual(R.empty(new Nothing()).constructor, Nothing);
-    assert.strictEqual(R.empty(new Just(123)).constructor, Nothing);
+    eq(R.empty(new Nothing()).constructor, Nothing);
+    eq(R.empty(new Just(123)).constructor, Nothing);
   });
 
   it('returns empty array given array', function() {
-    assert.strictEqual(R.toString(R.empty([1, 2, 3])), '[]');
+    eq(R.empty([1, 2, 3]), []);
   });
 
   it('returns empty object given object', function() {
-    assert.strictEqual(R.toString(R.empty({x: 1, y: 2})), '{}');
+    eq(R.empty({x: 1, y: 2}), {});
   });
 
   it('returns empty string given string', function() {
-    assert.strictEqual(R.empty('abc'), '');
+    eq(R.empty('abc'), '');
     /* jshint -W053 */
-    assert.strictEqual(R.empty(new String('abc')), '');
+    eq(R.empty(new String('abc')), '');
     /* jshint +W053 */
   });
 
   it('returns empty arguments object given arguments object', function() {
     var x = (function() { return arguments; }(1, 2, 3));
-    assert.strictEqual(R.toString(R.empty(x)), '(function() { return arguments; }())');
+    eq(R.empty(x), (function() { return arguments; }()));
   });
 
 });

--- a/test/eqBy.js
+++ b/test/eqBy.js
@@ -1,16 +1,15 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('eqBy', function() {
 
   it('determines whether two values map to the same value in the codomain', function() {
-    assert.strictEqual(R.eqBy(Math.abs, 5, 5), true);
-    assert.strictEqual(R.eqBy(Math.abs, 5, -5), true);
-    assert.strictEqual(R.eqBy(Math.abs, -5, 5), true);
-    assert.strictEqual(R.eqBy(Math.abs, -5, -5), true);
-    assert.strictEqual(R.eqBy(Math.abs, 42, 99), false);
+    eq(R.eqBy(Math.abs, 5, 5), true);
+    eq(R.eqBy(Math.abs, 5, -5), true);
+    eq(R.eqBy(Math.abs, -5, 5), true);
+    eq(R.eqBy(Math.abs, -5, -5), true);
+    eq(R.eqBy(Math.abs, 42, 99), false);
   });
 
   it('has R.equals semantics', function() {
@@ -19,10 +18,10 @@ describe('eqBy', function() {
       return x instanceof Just && R.equals(x.value, this.value);
     };
 
-    assert.strictEqual(R.eqBy(R.identity, 0, -0), false);
-    assert.strictEqual(R.eqBy(R.identity, -0, 0), false);
-    assert.strictEqual(R.eqBy(R.identity, NaN, NaN), true);
-    assert.strictEqual(R.eqBy(R.identity, new Just([42]), new Just([42])), true);
+    eq(R.eqBy(R.identity, 0, -0), false);
+    eq(R.eqBy(R.identity, -0, 0), false);
+    eq(R.eqBy(R.identity, NaN, NaN), true);
+    eq(R.eqBy(R.identity, new Just([42]), new Just([42])), true);
   });
 
 });

--- a/test/eqProps.js
+++ b/test/eqProps.js
@@ -1,12 +1,11 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('eqProps', function() {
   it('reports whether two objects have the same value for a given property', function() {
-    assert.strictEqual(R.eqProps('name', {name: 'fred', age: 10}, {name: 'fred', age: 12}), true);
-    assert.strictEqual(R.eqProps('name', {name: 'fred', age: 10}, {name: 'franny', age: 10}), false);
+    eq(R.eqProps('name', {name: 'fred', age: 10}, {name: 'fred', age: 12}), true);
+    eq(R.eqProps('name', {name: 'fred', age: 10}, {name: 'franny', age: 10}), false);
   });
 
   it('has R.equals semantics', function() {
@@ -15,14 +14,14 @@ describe('eqProps', function() {
       return x instanceof Just && R.equals(x.value, this.value);
     };
 
-    assert.strictEqual(R.eqProps('value', {value: 0}, {value: -0}), false);
-    assert.strictEqual(R.eqProps('value', {value: -0}, {value: 0}), false);
-    assert.strictEqual(R.eqProps('value', {value: NaN}, {value: NaN}), true);
-    assert.strictEqual(R.eqProps('value', {value: new Just([42])}, {value: new Just([42])}), true);
+    eq(R.eqProps('value', {value: 0}, {value: -0}), false);
+    eq(R.eqProps('value', {value: -0}, {value: 0}), false);
+    eq(R.eqProps('value', {value: NaN}, {value: NaN}), true);
+    eq(R.eqProps('value', {value: new Just([42])}, {value: new Just([42])}), true);
   });
 
   it('is curried', function() {
     var sameName = R.eqProps('name');
-    assert.strictEqual(sameName({name: 'fred', age: 10}, {name: 'fred', age: 12}), true);
+    eq(sameName({name: 'fred', age: 10}, {name: 'fred', age: 12}), true);
   });
 });

--- a/test/equals.js
+++ b/test/equals.js
@@ -1,101 +1,100 @@
 /* global Map, Set, WeakMap, WeakSet */
 /* jshint typed: true */
 
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 describe('equals', function() {
   var a = [];
   var b = a;
   it('tests for deep equality of its operands', function() {
-    assert.strictEqual(R.equals(100, 100), true);
-    assert.strictEqual(R.equals(100, '100'), false);
-    assert.strictEqual(R.equals([], []), true);
-    assert.strictEqual(R.equals(a, b), true);
+    eq(R.equals(100, 100), true);
+    eq(R.equals(100, '100'), false);
+    eq(R.equals([], []), true);
+    eq(R.equals(a, b), true);
   });
 
   it('considers equal Boolean primitives equal', function() {
-    assert.strictEqual(R.equals(true, true), true);
-    assert.strictEqual(R.equals(false, false), true);
-    assert.strictEqual(R.equals(true, false), false);
-    assert.strictEqual(R.equals(false, true), false);
+    eq(R.equals(true, true), true);
+    eq(R.equals(false, false), true);
+    eq(R.equals(true, false), false);
+    eq(R.equals(false, true), false);
   });
 
   it('considers equivalent Boolean objects equal', function() {
     /* jshint -W053 */
-    assert.strictEqual(R.equals(new Boolean(true), new Boolean(true)), true);
-    assert.strictEqual(R.equals(new Boolean(false), new Boolean(false)), true);
-    assert.strictEqual(R.equals(new Boolean(true), new Boolean(false)), false);
-    assert.strictEqual(R.equals(new Boolean(false), new Boolean(true)), false);
+    eq(R.equals(new Boolean(true), new Boolean(true)), true);
+    eq(R.equals(new Boolean(false), new Boolean(false)), true);
+    eq(R.equals(new Boolean(true), new Boolean(false)), false);
+    eq(R.equals(new Boolean(false), new Boolean(true)), false);
     /* jshint +W053 */
   });
 
   it('never considers Boolean primitive equal to Boolean object', function() {
     /* jshint -W053 */
-    assert.strictEqual(R.equals(true, new Boolean(true)), false);
-    assert.strictEqual(R.equals(new Boolean(true), true), false);
-    assert.strictEqual(R.equals(false, new Boolean(false)), false);
-    assert.strictEqual(R.equals(new Boolean(false), false), false);
+    eq(R.equals(true, new Boolean(true)), false);
+    eq(R.equals(new Boolean(true), true), false);
+    eq(R.equals(false, new Boolean(false)), false);
+    eq(R.equals(new Boolean(false), false), false);
     /* jshint +W053 */
   });
 
   it('considers equal number primitives equal', function() {
-    assert.strictEqual(R.equals(0, 0), true);
-    assert.strictEqual(R.equals(0, 1), false);
-    assert.strictEqual(R.equals(1, 0), false);
+    eq(R.equals(0, 0), true);
+    eq(R.equals(0, 1), false);
+    eq(R.equals(1, 0), false);
   });
 
   it('considers equivalent Number objects equal', function() {
     /* jshint -W053 */
-    assert.strictEqual(R.equals(new Number(0), new Number(0)), true);
-    assert.strictEqual(R.equals(new Number(0), new Number(1)), false);
-    assert.strictEqual(R.equals(new Number(1), new Number(0)), false);
+    eq(R.equals(new Number(0), new Number(0)), true);
+    eq(R.equals(new Number(0), new Number(1)), false);
+    eq(R.equals(new Number(1), new Number(0)), false);
     /* jshint +W053 */
   });
 
   it('never considers number primitive equal to Number object', function() {
     /* jshint -W053 */
-    assert.strictEqual(R.equals(0, new Number(0)), false);
-    assert.strictEqual(R.equals(new Number(0), 0), false);
+    eq(R.equals(0, new Number(0)), false);
+    eq(R.equals(new Number(0), 0), false);
     /* jshint +W053 */
   });
 
   it('considers equal string primitives equal', function() {
-    assert.strictEqual(R.equals('', ''), true);
-    assert.strictEqual(R.equals('', 'x'), false);
-    assert.strictEqual(R.equals('x', ''), false);
-    assert.strictEqual(R.equals('foo', 'foo'), true);
-    assert.strictEqual(R.equals('foo', 'bar'), false);
-    assert.strictEqual(R.equals('bar', 'foo'), false);
+    eq(R.equals('', ''), true);
+    eq(R.equals('', 'x'), false);
+    eq(R.equals('x', ''), false);
+    eq(R.equals('foo', 'foo'), true);
+    eq(R.equals('foo', 'bar'), false);
+    eq(R.equals('bar', 'foo'), false);
   });
 
   it('considers equivalent String objects equal', function() {
     /* jshint -W053 */
-    assert.strictEqual(R.equals(new String(''), new String('')), true);
-    assert.strictEqual(R.equals(new String(''), new String('x')), false);
-    assert.strictEqual(R.equals(new String('x'), new String('')), false);
-    assert.strictEqual(R.equals(new String('foo'), new String('foo')), true);
-    assert.strictEqual(R.equals(new String('foo'), new String('bar')), false);
-    assert.strictEqual(R.equals(new String('bar'), new String('foo')), false);
+    eq(R.equals(new String(''), new String('')), true);
+    eq(R.equals(new String(''), new String('x')), false);
+    eq(R.equals(new String('x'), new String('')), false);
+    eq(R.equals(new String('foo'), new String('foo')), true);
+    eq(R.equals(new String('foo'), new String('bar')), false);
+    eq(R.equals(new String('bar'), new String('foo')), false);
     /* jshint +W053 */
   });
 
   it('never considers string primitive equal to String object', function() {
     /* jshint -W053 */
-    assert.strictEqual(R.equals('', new String('')), false);
-    assert.strictEqual(R.equals(new String(''), ''), false);
-    assert.strictEqual(R.equals('x', new String('x')), false);
-    assert.strictEqual(R.equals(new String('x'), 'x'), false);
+    eq(R.equals('', new String('')), false);
+    eq(R.equals(new String(''), ''), false);
+    eq(R.equals('x', new String('x')), false);
+    eq(R.equals(new String('x'), 'x'), false);
     /* jshint +W053 */
   });
 
   it('handles objects', function() {
-    assert.strictEqual(R.equals({}, {}), true);
-    assert.strictEqual(R.equals({a:1, b:2}, {a:1, b:2}), true);
-    assert.strictEqual(R.equals({a:2, b:3}, {b:3, a:2}), true);
-    assert.strictEqual(R.equals({a:2, b:3}, {a:3, b:3}), false);
-    assert.strictEqual(R.equals({a:2, b:3, c:1}, {a:2, b:3}), false);
+    eq(R.equals({}, {}), true);
+    eq(R.equals({a:1, b:2}, {a:1, b:2}), true);
+    eq(R.equals({a:2, b:3}, {b:3, a:2}), true);
+    eq(R.equals({a:2, b:3}, {a:3, b:3}), false);
+    eq(R.equals({a:2, b:3, c:1}, {a:2, b:3}), false);
   });
 
   it('considers equivalent Arguments objects equal', function() {
@@ -104,12 +103,12 @@ describe('equals', function() {
     var c = (function() { return arguments; }(1, 2, 3));
     var d = (function() { return arguments; }(1, 2, 3));
 
-    assert.strictEqual(R.equals(a, b), true);
-    assert.strictEqual(R.equals(b, a), true);
-    assert.strictEqual(R.equals(c, d), true);
-    assert.strictEqual(R.equals(d, c), true);
-    assert.strictEqual(R.equals(a, c), false);
-    assert.strictEqual(R.equals(c, a), false);
+    eq(R.equals(a, b), true);
+    eq(R.equals(b, a), true);
+    eq(R.equals(c, d), true);
+    eq(R.equals(d, c), true);
+    eq(R.equals(a, c), false);
+    eq(R.equals(c, a), false);
   });
 
   var supportsSticky = false;
@@ -119,28 +118,28 @@ describe('equals', function() {
   try { RegExp('', 'u'); supportsUnicode = true; } catch (e) {}
 
   it('handles regex', function() {
-    assert.strictEqual(R.equals(/\s/, /\s/), true);
-    assert.strictEqual(R.equals(/\s/, /\d/), false);
-    assert.strictEqual(R.equals(/a/gi, /a/ig), true);
-    assert.strictEqual(R.equals(/a/mgi, /a/img), true);
-    assert.strictEqual(R.equals(/a/gi, /a/i), false);
+    eq(R.equals(/\s/, /\s/), true);
+    eq(R.equals(/\s/, /\d/), false);
+    eq(R.equals(/a/gi, /a/ig), true);
+    eq(R.equals(/a/mgi, /a/img), true);
+    eq(R.equals(/a/gi, /a/i), false);
 
     if (supportsSticky) {
-      // assert.strictEqual(R.equals(/\s/y, /\s/y), true);
-      // assert.strictEqual(R.equals(/a/mygi, /a/imgy), true);
+      // eq(R.equals(/\s/y, /\s/y), true);
+      // eq(R.equals(/a/mygi, /a/imgy), true);
     }
 
     if (supportsUnicode) {
-      // assert.strictEqual(R.equals(/\s/u, /\s/u), true);
-      // assert.strictEqual(R.equals(/a/mugi, /a/imgu), true);
+      // eq(R.equals(/\s/u, /\s/u), true);
+      // eq(R.equals(/a/mugi, /a/imgu), true);
     }
   });
 
   var listA = [1, 2, 3];
   var listB = [1, 3, 2];
   it('handles lists', function() {
-    assert.strictEqual(R.equals([], {}), false);
-    assert.strictEqual(R.equals(listA, listB), false);
+    eq(R.equals([], {}), false);
+    eq(R.equals(listA, listB), false);
   });
 
   var c = {}; c.v = c;
@@ -151,17 +150,17 @@ describe('equals', function() {
   var nestB = {a:[1, 2, {c:1}], b:1};
   var nestC = {a:[1, 2, {c:2}], b:1};
   it('handles recursive data structures', function() {
-    assert.strictEqual(R.equals(c, d), true);
-    assert.strictEqual(R.equals(e, f), true);
-    assert.strictEqual(R.equals(nestA, nestB), true);
-    assert.strictEqual(R.equals(nestA, nestC), false);
+    eq(R.equals(c, d), true);
+    eq(R.equals(e, f), true);
+    eq(R.equals(nestA, nestB), true);
+    eq(R.equals(nestA, nestC), false);
   });
 
   it('handles dates', function() {
-    assert.strictEqual(R.equals(new Date(0), new Date(0)), true);
-    assert.strictEqual(R.equals(new Date(1), new Date(1)), true);
-    assert.strictEqual(R.equals(new Date(0), new Date(1)), false);
-    assert.strictEqual(R.equals(new Date(1), new Date(0)), false);
+    eq(R.equals(new Date(0), new Date(0)), true);
+    eq(R.equals(new Date(1), new Date(1)), true);
+    eq(R.equals(new Date(0), new Date(1)), false);
+    eq(R.equals(new Date(1), new Date(0)), false);
   });
 
   it('requires that both objects have the same enumerable properties with the same values', function() {
@@ -191,12 +190,12 @@ describe('equals', function() {
     s2.x = 0;
     /* jshint +W053 */
 
-    assert.strictEqual(R.equals(a1, a2), false);
-    assert.strictEqual(R.equals(b1, b2), false);
-    assert.strictEqual(R.equals(d1, d2), false);
-    assert.strictEqual(R.equals(n1, n2), false);
-    assert.strictEqual(R.equals(r1, r2), false);
-    assert.strictEqual(R.equals(s1, s2), false);
+    eq(R.equals(a1, a2), false);
+    eq(R.equals(b1, b2), false);
+    eq(R.equals(d1, d2), false);
+    eq(R.equals(n1, n2), false);
+    eq(R.equals(r1, r2), false);
+    eq(R.equals(s1, s2), false);
   });
 
   if (typeof ArrayBuffer !== 'undefined' && typeof Int8Array !== 'undefined') {
@@ -208,51 +207,51 @@ describe('equals', function() {
     var intTypArr = new Int8Array(typArr1);
     typArr3[0] = 0;
     it('handles typed arrays', function() {
-      assert.strictEqual(R.equals(typArr1, typArr2), true);
-      assert.strictEqual(R.equals(typArr1, typArr3), false);
-      assert.strictEqual(R.equals(typArr1, intTypArr), false);
+      eq(R.equals(typArr1, typArr2), true);
+      eq(R.equals(typArr1, typArr3), false);
+      eq(R.equals(typArr1, intTypArr), false);
     });
   }
 
   if (typeof Map !== 'undefined') {
     it('compares Map objects by value', function() {
-      assert.strictEqual(R.equals(new Map([]), new Map([])), true);
-      assert.strictEqual(R.equals(new Map([]), new Map([[1, 'a']])), false);
-      assert.strictEqual(R.equals(new Map([[1, 'a']]), new Map([])), false);
-      assert.strictEqual(R.equals(new Map([[1, 'a']]), new Map([[1, 'a']])), true);
-      assert.strictEqual(R.equals(new Map([[1, 'a']]), new Map([[1, 'b']])), false);
-      assert.strictEqual(R.equals(new Map([[1, 'a'], [2, new Map([[3, 'c']])]]), new Map([[1, 'a'], [2, new Map([[3, 'c']])]])), true);
-      assert.strictEqual(R.equals(new Map([[1, 'a'], [2, new Map([[3, 'c']])]]), new Map([[1, 'a'], [2, new Map([[3, 'd']])]])), false);
-      assert.strictEqual(R.equals(new Map([[[1, 2, 3], [4, 5, 6]]]), new Map([[[1, 2, 3], [4, 5, 6]]])), true);
-      assert.strictEqual(R.equals(new Map([[[1, 2, 3], [4, 5, 6]]]), new Map([[[1, 2, 3], [7, 8, 9]]])), false);
+      eq(R.equals(new Map([]), new Map([])), true);
+      eq(R.equals(new Map([]), new Map([[1, 'a']])), false);
+      eq(R.equals(new Map([[1, 'a']]), new Map([])), false);
+      eq(R.equals(new Map([[1, 'a']]), new Map([[1, 'a']])), true);
+      eq(R.equals(new Map([[1, 'a']]), new Map([[1, 'b']])), false);
+      eq(R.equals(new Map([[1, 'a'], [2, new Map([[3, 'c']])]]), new Map([[1, 'a'], [2, new Map([[3, 'c']])]])), true);
+      eq(R.equals(new Map([[1, 'a'], [2, new Map([[3, 'c']])]]), new Map([[1, 'a'], [2, new Map([[3, 'd']])]])), false);
+      eq(R.equals(new Map([[[1, 2, 3], [4, 5, 6]]]), new Map([[[1, 2, 3], [4, 5, 6]]])), true);
+      eq(R.equals(new Map([[[1, 2, 3], [4, 5, 6]]]), new Map([[[1, 2, 3], [7, 8, 9]]])), false);
     });
   }
 
   if (typeof Set !== 'undefined') {
     it('compares Set objects by value', function() {
-      assert.strictEqual(R.equals(new Set([]), new Set([])), true);
-      assert.strictEqual(R.equals(new Set([]), new Set([1])), false);
-      assert.strictEqual(R.equals(new Set([1]), new Set([])), false);
-      assert.strictEqual(R.equals(new Set([1, new Set([2, new Set([3])])]), new Set([1, new Set([2, new Set([3])])])), true);
-      assert.strictEqual(R.equals(new Set([1, new Set([2, new Set([3])])]), new Set([1, new Set([2, new Set([4])])])), false);
-      assert.strictEqual(R.equals(new Set([[1, 2, 3], [4, 5, 6]]), new Set([[1, 2, 3], [4, 5, 6]])), true);
-      assert.strictEqual(R.equals(new Set([[1, 2, 3], [4, 5, 6]]), new Set([[1, 2, 3], [7, 8, 9]])), false);
+      eq(R.equals(new Set([]), new Set([])), true);
+      eq(R.equals(new Set([]), new Set([1])), false);
+      eq(R.equals(new Set([1]), new Set([])), false);
+      eq(R.equals(new Set([1, new Set([2, new Set([3])])]), new Set([1, new Set([2, new Set([3])])])), true);
+      eq(R.equals(new Set([1, new Set([2, new Set([3])])]), new Set([1, new Set([2, new Set([4])])])), false);
+      eq(R.equals(new Set([[1, 2, 3], [4, 5, 6]]), new Set([[1, 2, 3], [4, 5, 6]])), true);
+      eq(R.equals(new Set([[1, 2, 3], [4, 5, 6]]), new Set([[1, 2, 3], [7, 8, 9]])), false);
     });
   }
 
   if (typeof WeakMap !== 'undefined') {
     it('compares WeakMap objects by identity', function() {
       var m = new WeakMap([]);
-      assert.strictEqual(R.equals(m, m), true);
-      assert.strictEqual(R.equals(m, new WeakMap([])), false);
+      eq(R.equals(m, m), true);
+      eq(R.equals(m, new WeakMap([])), false);
     });
   }
 
   if (typeof WeakSet !== 'undefined') {
     it('compares WeakSet objects by identity', function() {
       var s = new WeakSet([]);
-      assert.strictEqual(R.equals(s, s), true);
-      assert.strictEqual(R.equals(s, new WeakSet([])), false);
+      eq(R.equals(s, s), true);
+      eq(R.equals(s, new WeakSet([])), false);
     });
   }
 
@@ -267,17 +266,17 @@ describe('equals', function() {
       return x instanceof Right && R.equals(x.value, this.value);
     };
 
-    assert.strictEqual(R.equals(new Left([42]), new Left([42])), true);
-    assert.strictEqual(R.equals(new Left([42]), new Left([43])), false);
-    assert.strictEqual(R.equals(new Left(42), {value: 42}), false);
-    assert.strictEqual(R.equals({value: 42}, new Left(42)), false);
-    assert.strictEqual(R.equals(new Left(42), new Right(42)), false);
-    assert.strictEqual(R.equals(new Right(42), new Left(42)), false);
+    eq(R.equals(new Left([42]), new Left([42])), true);
+    eq(R.equals(new Left([42]), new Left([43])), false);
+    eq(R.equals(new Left(42), {value: 42}), false);
+    eq(R.equals({value: 42}, new Left(42)), false);
+    eq(R.equals(new Left(42), new Right(42)), false);
+    eq(R.equals(new Right(42), new Left(42)), false);
 
-    assert.strictEqual(R.equals([new Left(42)], [new Left(42)]), true);
-    assert.strictEqual(R.equals([new Left(42)], [new Right(42)]), false);
-    assert.strictEqual(R.equals([new Right(42)], [new Left(42)]), false);
-    assert.strictEqual(R.equals([new Right(42)], [new Right(42)]), true);
+    eq(R.equals([new Left(42)], [new Left(42)]), true);
+    eq(R.equals([new Left(42)], [new Right(42)]), false);
+    eq(R.equals([new Right(42)], [new Left(42)]), false);
+    eq(R.equals([new Right(42)], [new Right(42)]), true);
   });
 
   it('is commutative', function() {
@@ -302,12 +301,12 @@ describe('equals', function() {
              this.color === point.color;
     };
 
-    assert.strictEqual(R.equals(new Point(2, 2), new ColorPoint(2, 2, 'red')), false);
-    assert.strictEqual(R.equals(new ColorPoint(2, 2, 'red'), new Point(2, 2)), false);
+    eq(R.equals(new Point(2, 2), new ColorPoint(2, 2, 'red')), false);
+    eq(R.equals(new ColorPoint(2, 2, 'red'), new Point(2, 2)), false);
   });
 
   it('is curried', function() {
     var isA = R.equals(a);
-    assert.strictEqual(isA([]), true);
+    eq(isA([]), true);
   });
 });

--- a/test/evolve.js
+++ b/test/evolve.js
@@ -1,6 +1,5 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('evolve', function() {
@@ -8,14 +7,14 @@ describe('evolve', function() {
     var transf   = {elapsed: R.add(1), remaining: R.add(-1)};
     var object   = {name: 'Tomato', elapsed: 100, remaining: 1400};
     var expected = {name: 'Tomato', elapsed: 101, remaining: 1399};
-    assert.deepEqual(R.evolve(transf, object), expected);
+    eq(R.evolve(transf, object), expected);
   });
 
   it('does not invoke function if object does not contain the key', function() {
     var transf   = {n: R.add(1), m: R.add(1)};
     var object   = {m: 3};
     var expected = {m: 4};
-    assert.deepEqual(R.evolve(transf, object), expected);
+    eq(R.evolve(transf, object), expected);
   });
 
   it('is not destructive', function() {
@@ -23,20 +22,20 @@ describe('evolve', function() {
     var object   = {name: 'Tomato', elapsed: 100, remaining: 1400};
     var expected = {name: 'Tomato', elapsed: 100, remaining: 1400};
     R.evolve(transf, object);
-    assert.deepEqual(object, expected);
+    eq(object, expected);
   });
 
   it('is recursive', function() {
     var transf   = {nested: {second: R.add(-1), third: R.add(1)}};
     var object   = {first: 1, nested: {second: 2, third: 3}};
     var expected = {first: 1, nested: {second: 1, third: 4}};
-    assert.deepEqual(R.evolve(transf, object), expected);
+    eq(R.evolve(transf, object), expected);
   });
 
   it('is curried', function() {
     var tick = R.evolve({elapsed: R.add(1), remaining: R.add(-1)});
     var object   = {name: 'Tomato', elapsed: 100, remaining: 1400};
     var expected = {name: 'Tomato', elapsed: 101, remaining: 1399};
-    assert.deepEqual(tick(object), expected);
+    eq(tick(object), expected);
   });
 });

--- a/test/filter.js
+++ b/test/filter.js
@@ -1,30 +1,29 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('filter', function() {
   var even = function(x) {return x % 2 === 0;};
 
   it('reduces an array to those matching a filter', function() {
-    assert.deepEqual(R.filter(even, [1, 2, 3, 4, 5]), [2, 4]);
+    eq(R.filter(even, [1, 2, 3, 4, 5]), [2, 4]);
   });
 
   it('returns an empty array if no element matches', function() {
-    assert.deepEqual(R.filter(function(x) { return x > 100; }, [1, 9, 99]), []);
+    eq(R.filter(function(x) { return x > 100; }, [1, 9, 99]), []);
   });
 
   it('returns an empty array if asked to filter an empty array', function() {
-    assert.deepEqual(R.filter(function(x) { return x > 100; }, []), []);
+    eq(R.filter(function(x) { return x > 100; }, []), []);
   });
 
   it('dispatches to passed-in non-Array object with a `filter` method', function() {
     var f = {filter: function(f) { return f('called f.filter'); }};
-    assert.strictEqual(R.filter(function(s) { return s; }, f), 'called f.filter');
+    eq(R.filter(function(s) { return s; }, f), 'called f.filter');
   });
 
   it('is curried', function() {
     var onlyEven = R.filter(even);
-    assert.deepEqual(onlyEven([1, 2, 3, 4, 5, 6, 7]), [2, 4, 6]);
+    eq(onlyEven([1, 2, 3, 4, 5, 6, 7]), [2, 4, 6]);
   });
 });

--- a/test/find.js
+++ b/test/find.js
@@ -1,6 +1,5 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('find', function() {
@@ -14,37 +13,37 @@ describe('find', function() {
   var intoArray = R.into([]);
 
   it('returns the first element that satisfies the predicate', function() {
-    assert.strictEqual(R.find(even, a), 10);
-    assert.strictEqual(R.find(gt100, a), 200);
-    assert.strictEqual(R.find(isStr, a), 'cow');
-    assert.strictEqual(R.find(xGt100, a), obj2);
+    eq(R.find(even, a), 10);
+    eq(R.find(gt100, a), 200);
+    eq(R.find(isStr, a), 'cow');
+    eq(R.find(xGt100, a), obj2);
   });
 
   it('transduces the first element that satisfies the predicate into an array', function() {
-    assert.deepEqual(intoArray(R.find(even), a), [10]);
-    assert.deepEqual(intoArray(R.find(gt100), a), [200]);
-    assert.deepEqual(intoArray(R.find(isStr), a), ['cow']);
-    assert.deepEqual(intoArray(R.find(xGt100), a), [obj2]);
+    eq(intoArray(R.find(even), a), [10]);
+    eq(intoArray(R.find(gt100), a), [200]);
+    eq(intoArray(R.find(isStr), a), ['cow']);
+    eq(intoArray(R.find(xGt100), a), [obj2]);
   });
 
   it('returns `undefined` when no element satisfies the predicate', function() {
-    assert.strictEqual(R.find(even, ['zing']), undefined);
+    eq(R.find(even, ['zing']), undefined);
   });
 
   it('returns `undefined` in array when no element satisfies the predicate into an array', function() {
-    assert.deepEqual(intoArray(R.find(even), ['zing']), [undefined]);
+    eq(intoArray(R.find(even), ['zing']), [undefined]);
   });
 
   it('returns `undefined` when given an empty list', function() {
-    assert.strictEqual(R.find(even, []), undefined);
+    eq(R.find(even, []), undefined);
   });
 
   it('returns `undefined` into an array when given an empty list', function() {
-    assert.deepEqual(intoArray(R.find(even), []), [undefined]);
+    eq(intoArray(R.find(even), []), [undefined]);
   });
 
   it('is curried', function() {
-    assert.strictEqual(typeof R.find(even), 'function');
-    assert.strictEqual(R.find(even)(a), 10);
+    eq(typeof R.find(even), 'function');
+    eq(R.find(even)(a), 10);
   });
 });

--- a/test/findIndex.js
+++ b/test/findIndex.js
@@ -1,6 +1,5 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('findIndex', function() {
@@ -14,30 +13,30 @@ describe('findIndex', function() {
   var intoArray = R.into([]);
 
   it('returns the index of the first element that satisfies the predicate', function() {
-    assert.strictEqual(R.findIndex(even, a), 1);
-    assert.strictEqual(R.findIndex(gt100, a), 8);
-    assert.strictEqual(R.findIndex(isStr, a), 3);
-    assert.strictEqual(R.findIndex(xGt100, a), 10);
+    eq(R.findIndex(even, a), 1);
+    eq(R.findIndex(gt100, a), 8);
+    eq(R.findIndex(isStr, a), 3);
+    eq(R.findIndex(xGt100, a), 10);
   });
 
   it('returns the index of the first element that satisfies the predicate into an array', function() {
-    assert.deepEqual(intoArray(R.findIndex(even), a), [1]);
-    assert.deepEqual(intoArray(R.findIndex(gt100), a), [8]);
-    assert.deepEqual(intoArray(R.findIndex(isStr), a), [3]);
-    assert.deepEqual(intoArray(R.findIndex(xGt100), a), [10]);
+    eq(intoArray(R.findIndex(even), a), [1]);
+    eq(intoArray(R.findIndex(gt100), a), [8]);
+    eq(intoArray(R.findIndex(isStr), a), [3]);
+    eq(intoArray(R.findIndex(xGt100), a), [10]);
   });
 
   it('returns -1 when no element satisfies the predicate', function() {
-    assert.strictEqual(R.findIndex(even, ['zing']), -1);
-    assert.strictEqual(R.findIndex(even, []), -1);
+    eq(R.findIndex(even, ['zing']), -1);
+    eq(R.findIndex(even, []), -1);
   });
 
   it('returns -1 in array when no element satisfies the predicate into an array', function() {
-    assert.deepEqual(intoArray(R.findIndex(even), ['zing']), [-1]);
+    eq(intoArray(R.findIndex(even), ['zing']), [-1]);
   });
 
   it('is curried', function() {
-    assert.strictEqual(typeof R.findIndex(even), 'function');
-    assert.strictEqual(R.findIndex(even)(a), 1);
+    eq(typeof R.findIndex(even), 'function');
+    eq(R.findIndex(even)(a), 1);
   });
 });

--- a/test/findLast.js
+++ b/test/findLast.js
@@ -1,6 +1,5 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('findLast', function() {
@@ -14,37 +13,37 @@ describe('findLast', function() {
   var intoArray = R.into([]);
 
   it('returns the index of the last element that satisfies the predicate', function() {
-    assert.strictEqual(R.findLast(even, a), 0);
-    assert.strictEqual(R.findLast(gt100, a), 300);
-    assert.strictEqual(R.findLast(isStr, a), 'cow');
-    assert.strictEqual(R.findLast(xGt100, a), obj2);
+    eq(R.findLast(even, a), 0);
+    eq(R.findLast(gt100, a), 300);
+    eq(R.findLast(isStr, a), 'cow');
+    eq(R.findLast(xGt100, a), obj2);
   });
 
   it('returns the index of the last element that satisfies the predicate into an array', function() {
-    assert.deepEqual(intoArray(R.findLast(even), a), [0]);
-    assert.deepEqual(intoArray(R.findLast(gt100), a), [300]);
-    assert.deepEqual(intoArray(R.findLast(isStr), a), ['cow']);
-    assert.deepEqual(intoArray(R.findLast(xGt100), a), [obj2]);
+    eq(intoArray(R.findLast(even), a), [0]);
+    eq(intoArray(R.findLast(gt100), a), [300]);
+    eq(intoArray(R.findLast(isStr), a), ['cow']);
+    eq(intoArray(R.findLast(xGt100), a), [obj2]);
   });
 
   it('returns `undefined` when no element satisfies the predicate', function() {
-    assert.strictEqual(R.findLast(even, ['zing']), undefined);
+    eq(R.findLast(even, ['zing']), undefined);
   });
 
   it('returns `undefined` into an array when no element satisfies the predicate', function() {
-    assert.deepEqual(intoArray(R.findLast(even), ['zing']), [undefined]);
+    eq(intoArray(R.findLast(even), ['zing']), [undefined]);
   });
 
   it('works when the first element matches', function() {
-    assert.strictEqual(R.findLast(even, [2, 3, 5]), 2);
+    eq(R.findLast(even, [2, 3, 5]), 2);
   });
 
   it('does not go into an infinite loop on an empty array', function() {
-    assert.strictEqual(R.findLast(even, []), undefined);
+    eq(R.findLast(even, []), undefined);
   });
 
   it('is curried', function() {
-    assert.strictEqual(typeof R.findLast(even), 'function');
-    assert.strictEqual(R.findLast(even)(a), 0);
+    eq(typeof R.findLast(even), 'function');
+    eq(R.findLast(even)(a), 0);
   });
 });

--- a/test/findLastIndex.js
+++ b/test/findLastIndex.js
@@ -1,6 +1,5 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('findLastIndex', function() {
@@ -14,37 +13,37 @@ describe('findLastIndex', function() {
   var intoArray = R.into([]);
 
   it('returns the index of the last element that satisfies the predicate', function() {
-    assert.strictEqual(R.findLastIndex(even, a), 15);
-    assert.strictEqual(R.findLastIndex(gt100, a), 9);
-    assert.strictEqual(R.findLastIndex(isStr, a), 3);
-    assert.strictEqual(R.findLastIndex(xGt100, a), 10);
+    eq(R.findLastIndex(even, a), 15);
+    eq(R.findLastIndex(gt100, a), 9);
+    eq(R.findLastIndex(isStr, a), 3);
+    eq(R.findLastIndex(xGt100, a), 10);
   });
 
   it('returns -1 when no element satisfies the predicate', function() {
-    assert.strictEqual(R.findLastIndex(even, ['zing']), -1);
+    eq(R.findLastIndex(even, ['zing']), -1);
   });
 
   it('returns the index of the last element into an array that satisfies the predicate', function() {
-    assert.deepEqual(intoArray(R.findLastIndex(even), a), [15]);
-    assert.deepEqual(intoArray(R.findLastIndex(gt100), a), [9]);
-    assert.deepEqual(intoArray(R.findLastIndex(isStr), a), [3]);
-    assert.deepEqual(intoArray(R.findLastIndex(xGt100), a), [10]);
+    eq(intoArray(R.findLastIndex(even), a), [15]);
+    eq(intoArray(R.findLastIndex(gt100), a), [9]);
+    eq(intoArray(R.findLastIndex(isStr), a), [3]);
+    eq(intoArray(R.findLastIndex(xGt100), a), [10]);
   });
 
   it('returns -1 into an array when no element satisfies the predicate', function() {
-    assert.deepEqual(intoArray(R.findLastIndex(even), ['zing']), [-1]);
+    eq(intoArray(R.findLastIndex(even), ['zing']), [-1]);
   });
 
   it('works when the first element matches', function() {
-    assert.strictEqual(R.findLastIndex(even, [2, 3, 5]), 0);
+    eq(R.findLastIndex(even, [2, 3, 5]), 0);
   });
 
   it('does not go into an infinite loop on an empty array', function() {
-    assert.strictEqual(R.findLastIndex(even, []), -1);
+    eq(R.findLastIndex(even, []), -1);
   });
 
   it('is curried', function() {
-    assert.strictEqual(typeof R.findLastIndex(even), 'function');
-    assert.strictEqual(R.findLastIndex(even)(a), 15);
+    eq(typeof R.findLastIndex(even), 'function');
+    eq(R.findLastIndex(even)(a), 15);
   });
 });

--- a/test/flatten.js
+++ b/test/flatten.js
@@ -1,15 +1,16 @@
 var assert = require('assert');
 
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('flatten', function() {
   it('turns a nested list into one flat list', function() {
     var nest = [1, [2], [3, [4, 5], 6, [[[7], 8]]], 9, 10];
-    assert.deepEqual(R.flatten(nest), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+    eq(R.flatten(nest), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
     nest = [[[[3]], 2, 1], 0, [[-1, -2], -3]];
-    assert.deepEqual(R.flatten(nest), [3, 2, 1, 0, -1, -2, -3]);
-    assert.deepEqual(R.flatten([1, 2, 3, 4, 5]), [1, 2, 3, 4, 5]);
+    eq(R.flatten(nest), [3, 2, 1, 0, -1, -2, -3]);
+    eq(R.flatten([1, 2, 3, 4, 5]), [1, 2, 3, 4, 5]);
   });
 
   it('is not destructive', function() {
@@ -18,16 +19,16 @@ describe('flatten', function() {
   });
 
   it('handles ridiculously large inputs', function() {
-    assert.strictEqual(R.flatten([new Array(1000000), R.range(0, 56000), 5, 1, 3]).length, 1056003);
+    eq(R.flatten([new Array(1000000), R.range(0, 56000), 5, 1, 3]).length, 1056003);
   });
 
   it('handles array-like objects', function() {
     var o = {length: 3, 0: [1, 2, [3]], 1: [], 2: ['a', 'b', 'c', ['d', 'e']]};
-    assert.deepEqual(R.flatten(o), [1, 2, 3, 'a', 'b', 'c', 'd', 'e']);
+    eq(R.flatten(o), [1, 2, 3, 'a', 'b', 'c', 'd', 'e']);
   });
 
   it('flattens an array of empty arrays', function() {
-    assert.deepEqual(R.flatten([[], [], []]), []);
-    assert.deepEqual(R.flatten([]), []);
+    eq(R.flatten([[], [], []]), []);
+    eq(R.flatten([]), []);
   });
 });

--- a/test/flip.js
+++ b/test/flip.js
@@ -1,19 +1,18 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('flip', function() {
   it('returns a function which inverts the first two arguments to the supplied function', function() {
     var f = function(a, b, c) {return a + ' ' + b + ' ' + c;};
     var g = R.flip(f);
-    assert.strictEqual(f('a', 'b', 'c'), 'a b c');
-    assert.strictEqual(g('a', 'b', 'c'), 'b a c');
+    eq(f('a', 'b', 'c'), 'a b c');
+    eq(g('a', 'b', 'c'), 'b a c');
   });
 
   it('returns a curried function', function() {
     var f = function(a, b, c) {return a + ' ' + b + ' ' + c;};
     var g = R.flip(f)('a');
-    assert.strictEqual(g('b', 'c'), 'b a c');
+    eq(g('b', 'c'), 'b a c');
   });
 });

--- a/test/forEach.js
+++ b/test/forEach.js
@@ -1,6 +1,5 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('forEach', function() {
@@ -9,17 +8,17 @@ describe('forEach', function() {
   it('performs the passed in function on each element of the list', function() {
     var sideEffect = {};
     R.forEach(function(elem) { sideEffect[elem.x] = elem.y; }, list);
-    assert.deepEqual(sideEffect, {1: 2, 100: 200, 300: 400, 234: 345});
+    eq(sideEffect, {1: 2, 100: 200, 300: 400, 234: 345});
   });
 
   it('returns the original list', function() {
     var s = '';
-    assert.deepEqual(R.forEach(function(obj) { s += obj.x; }, list), list);
-    assert.strictEqual('1100300234', s);
+    eq(R.forEach(function(obj) { s += obj.x; }, list), list);
+    eq('1100300234', s);
   });
 
   it('handles empty list', function() {
-    assert.deepEqual(R.forEach(function(x) { return x * x; }, []), []);
+    eq(R.forEach(function(x) { return x * x; }, []), []);
   });
 
   it('dispatches to `forEach` method', function() {
@@ -28,17 +27,17 @@ describe('forEach', function() {
     function DummyList() {}
     DummyList.prototype.forEach = function(callback) {
       dispatched = true;
-      assert.strictEqual(callback, fn);
+      eq(callback, fn);
     };
     R.forEach(fn, new DummyList());
-    assert.strictEqual(dispatched, true);
+    eq(dispatched, true);
   });
 
   it('is curried', function() {
     var xStr = '';
     var xe = R.forEach(function(x) { xStr += (x + ' '); });
-    assert.strictEqual(typeof xe, 'function');
+    eq(typeof xe, 'function');
     xe([1, 2, 4]);
-    assert.strictEqual(xStr, '1 2 4 ');
+    eq(xStr, '1 2 4 ');
   });
 });

--- a/test/fromPairs.js
+++ b/test/fromPairs.js
@@ -1,13 +1,12 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('fromPairs', function() {
   it('combines an array of two-element arrays into an object', function() {
-    assert.deepEqual(R.fromPairs([['a', 1], ['b', 2], ['c', 3]]), {a: 1, b: 2, c: 3});
+    eq(R.fromPairs([['a', 1], ['b', 2], ['c', 3]]), {a: 1, b: 2, c: 3});
   });
   it('skips empty Arrays and non-Array elements', function() {
-    assert.deepEqual(R.fromPairs([['a', 1], 'x', [], ['b', 2], {}, ['c', 3]]), {a: 1, b: 2, c: 3});
+    eq(R.fromPairs([['a', 1], 'x', [], ['b', 2], {}, ['c', 3]]), {a: 1, b: 2, c: 3});
   });
 });

--- a/test/functions.js
+++ b/test/functions.js
@@ -1,6 +1,5 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('functions', function() {
@@ -19,13 +18,13 @@ describe('functions', function() {
   var f = new F();
 
   it('returns list of functions without prototype functions', function() {
-    assert.deepEqual(R.functions(f).sort(), ['map', 'sort']);
-    assert.strictEqual(R.functions(f).length, 2);
-    assert.deepEqual(R.functions({add: R.add, reduce: R.reduce}).sort(), ['add', 'reduce']);
+    eq(R.functions(f).sort(), ['map', 'sort']);
+    eq(R.functions(f).length, 2);
+    eq(R.functions({add: R.add, reduce: R.reduce}).sort(), ['add', 'reduce']);
   });
 
   it('returns an empty array if there are no functions on the object or its prototype chain', function() {
     function G() {}
-    assert.deepEqual(R.functions(new G()), []);
+    eq(R.functions(new G()), []);
   });
 });

--- a/test/functionsIn.js
+++ b/test/functionsIn.js
@@ -1,6 +1,5 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('functionsIn', function() {
@@ -19,12 +18,12 @@ describe('functionsIn', function() {
   var f = new F();
 
   it('returns list of functions with prototype functions', function() {
-    assert.deepEqual(R.functionsIn(f).sort(), ['map', 'sort', 'x', 'y']);
-    assert.strictEqual(R.functionsIn(f).length, 4);
+    eq(R.functionsIn(f).sort(), ['map', 'sort', 'x', 'y']);
+    eq(R.functionsIn(f).length, 4);
   });
 
   it('returns an empty array if there are no functions on the object or its prototype chain', function() {
     function G() {}
-    assert.deepEqual(R.functionsIn(new G()), []);
+    eq(R.functionsIn(new G()), []);
   });
 });

--- a/test/groupBy.js
+++ b/test/groupBy.js
@@ -1,6 +1,5 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 var _isTransformer = require('../src/internal/_isTransformer');
 
 
@@ -22,7 +21,7 @@ describe('groupBy', function() {
       {name: 'Jack', score: 69}
     ];
     var byGrade = function(student) {return grade(student.score || 0);};
-    assert.deepEqual(R.groupBy(byGrade, students), {
+    eq(R.groupBy(byGrade, students), {
       A: [{name: 'Dianne', score: 99}, {name: 'Gillian', score: 91}],
       B: [{name: 'Abby', score: 84}, {name: 'Chris', score: 89}, {name: 'Irene', score: 85}],
       C: [{name: 'Brad', score: 73}, {name: 'Hannah', score: 78}],
@@ -33,7 +32,7 @@ describe('groupBy', function() {
 
   it('is curried', function() {
     var splitByType = R.groupBy(R.prop('type'));
-    assert.deepEqual(splitByType([
+    eq(splitByType([
       {type: 'A', val: 10},
       {type: 'B', val: 20},
       {type: 'A', val: 30},
@@ -48,7 +47,7 @@ describe('groupBy', function() {
   });
 
   it('returns an empty object if given an empty array', function() {
-    assert.deepEqual(R.groupBy(R.prop('x'), []), {});
+    eq(R.groupBy(R.prop('x'), []), {});
   });
 
   it('dispatches on transformer objects in list position', function() {
@@ -58,6 +57,6 @@ describe('groupBy', function() {
       '@@transducer/result': function(x) { return x; },
       '@@transducer/step': R.merge
     };
-    assert.strictEqual(_isTransformer(R.groupBy(byType, xf)), true);
+    eq(_isTransformer(R.groupBy(byType, xf)), true);
   });
 });

--- a/test/gt.js
+++ b/test/gt.js
@@ -1,28 +1,27 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('gt', function() {
   it('reports whether one item is less than another', function() {
-    assert.strictEqual(R.gt(3, 5), false);
-    assert.strictEqual(R.gt(6, 4), true);
-    assert.strictEqual(R.gt(7.0, 7.0), false);
-    assert.strictEqual(R.gt('abc', 'xyz'), false);
-    assert.strictEqual(R.gt('abcd', 'abc'), true);
+    eq(R.gt(3, 5), false);
+    eq(R.gt(6, 4), true);
+    eq(R.gt(7.0, 7.0), false);
+    eq(R.gt('abc', 'xyz'), false);
+    eq(R.gt('abcd', 'abc'), true);
   });
 
   it('is curried', function() {
     var lt20 = R.gt(20);
-    assert.strictEqual(lt20(10), true);
-    assert.strictEqual(lt20(20), false);
-    assert.strictEqual(lt20(25), false);
+    eq(lt20(10), true);
+    eq(lt20(20), false);
+    eq(lt20(25), false);
   });
 
   it('behaves right curried when passed `R.__` for its first argument', function() {
     var gt20 = R.gt(R.__, 20);
-    assert.strictEqual(gt20(10), false);
-    assert.strictEqual(gt20(20), false);
-    assert.strictEqual(gt20(25), true);
+    eq(gt20(10), false);
+    eq(gt20(20), false);
+    eq(gt20(25), true);
   });
 });

--- a/test/gte.js
+++ b/test/gte.js
@@ -1,28 +1,27 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('gte', function() {
   it('reports whether one item is less than another', function() {
-    assert.strictEqual(R.gte(3, 5), false);
-    assert.strictEqual(R.gte(6, 4), true);
-    assert.strictEqual(R.gte(7.0, 7.0), true);
-    assert.strictEqual(R.gte('abc', 'xyz'), false);
-    assert.strictEqual(R.gte('abcd', 'abc'), true);
+    eq(R.gte(3, 5), false);
+    eq(R.gte(6, 4), true);
+    eq(R.gte(7.0, 7.0), true);
+    eq(R.gte('abc', 'xyz'), false);
+    eq(R.gte('abcd', 'abc'), true);
   });
 
   it('is curried', function() {
     var lte20 = R.gte(20);
-    assert.strictEqual(lte20(10), true);
-    assert.strictEqual(lte20(20), true);
-    assert.strictEqual(lte20(25), false);
+    eq(lte20(10), true);
+    eq(lte20(20), true);
+    eq(lte20(25), false);
   });
 
   it('behaves right curried when passed `R.__` for its first argument', function() {
     var gte20 = R.gte(R.__, 20);
-    assert.strictEqual(gte20(10), false);
-    assert.strictEqual(gte20(20), true);
-    assert.strictEqual(gte20(25), true);
+    eq(gte20(10), false);
+    eq(gte20(20), true);
+    eq(gte20(25), true);
   });
 });

--- a/test/has.js
+++ b/test/has.js
@@ -1,6 +1,5 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('has', function() {
@@ -8,11 +7,11 @@ describe('has', function() {
   var anon = {age: 99};
 
   it('returns true if the specified property is present', function() {
-    assert.strictEqual(R.has('name', fred), true);
+    eq(R.has('name', fred), true);
   });
 
   it('returns false if the specified property is absent', function() {
-    assert.strictEqual(R.has('name', anon), false);
+    eq(R.has('name', anon), false);
   });
 
   it('does not check properties from the prototype chain', function() {
@@ -20,18 +19,18 @@ describe('has', function() {
     Person.prototype.age = function() {};
 
     var bob = new Person();
-    assert.strictEqual(R.has('age', bob), false);
+    eq(R.has('age', bob), false);
   });
 
   it('is curried, op-style', function() {
     var hasName = R.has('name');
-    assert.strictEqual(hasName(fred), true);
-    assert.strictEqual(hasName(anon), false);
+    eq(hasName(fred), true);
+    eq(hasName(anon), false);
 
     var point = {x: 0, y: 0};
     var pointHas = R.has(R.__, point);
-    assert.strictEqual(pointHas('x'), true);
-    assert.strictEqual(pointHas('y'), true);
-    assert.strictEqual(pointHas('z'), false);
+    eq(pointHas('x'), true);
+    eq(pointHas('y'), true);
+    eq(pointHas('z'), false);
   });
 });

--- a/test/hasIn.js
+++ b/test/hasIn.js
@@ -1,6 +1,5 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('hasIn', function() {
@@ -9,9 +8,9 @@ describe('hasIn', function() {
 
   it('returns a function that checks the appropriate property', function() {
     var nm = R.hasIn('name');
-    assert.strictEqual(typeof nm, 'function');
-    assert.strictEqual(nm(fred), true);
-    assert.strictEqual(nm(anon), false);
+    eq(typeof nm, 'function');
+    eq(nm(fred), true);
+    eq(nm(anon), false);
   });
 
   it('checks properties from the prototype chain', function() {
@@ -19,11 +18,11 @@ describe('hasIn', function() {
     Person.prototype.age = function() {};
 
     var bob = new Person();
-    assert.strictEqual(R.hasIn('age', bob), true);
+    eq(R.hasIn('age', bob), true);
   });
 
   it('works properly when called with two arguments', function() {
-    assert.strictEqual(R.hasIn('name', fred), true);
-    assert.strictEqual(R.hasIn('name', anon), false);
+    eq(R.hasIn('name', fred), true);
+    eq(R.hasIn('name', anon), false);
   });
 });

--- a/test/head.js
+++ b/test/head.js
@@ -1,20 +1,21 @@
 var assert = require('assert');
 
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('head', function() {
 
   it('returns the first element of an ordered collection', function() {
-    assert.strictEqual(R.head([1, 2, 3]), 1);
-    assert.strictEqual(R.head([2, 3]), 2);
-    assert.strictEqual(R.head([3]), 3);
-    assert.strictEqual(R.head([]), undefined);
+    eq(R.head([1, 2, 3]), 1);
+    eq(R.head([2, 3]), 2);
+    eq(R.head([3]), 3);
+    eq(R.head([]), undefined);
 
-    assert.strictEqual(R.head('abc'), 'a');
-    assert.strictEqual(R.head('bc'), 'b');
-    assert.strictEqual(R.head('c'), 'c');
-    assert.strictEqual(R.head(''), '');
+    eq(R.head('abc'), 'a');
+    eq(R.head('bc'), 'b');
+    eq(R.head('c'), 'c');
+    eq(R.head(''), '');
   });
 
   it('throws if applied to null or undefined', function() {

--- a/test/identical.js
+++ b/test/identical.js
@@ -1,36 +1,35 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('identical', function() {
   var a = [];
   var b = a;
   it('has Object.is semantics', function() {
-    assert.strictEqual(R.identical(100, 100), true);
-    assert.strictEqual(R.identical(100, '100'), false);
-    assert.strictEqual(R.identical('string', 'string'), true);
-    assert.strictEqual(R.identical([], []), false);
-    assert.strictEqual(R.identical(a, b), true);
-    assert.strictEqual(R.identical(undefined, undefined), true);
-    assert.strictEqual(R.identical(null, undefined), false);
+    eq(R.identical(100, 100), true);
+    eq(R.identical(100, '100'), false);
+    eq(R.identical('string', 'string'), true);
+    eq(R.identical([], []), false);
+    eq(R.identical(a, b), true);
+    eq(R.identical(undefined, undefined), true);
+    eq(R.identical(null, undefined), false);
 
-    assert.strictEqual(R.identical(-0, 0), false);
-    assert.strictEqual(R.identical(0, -0), false);
-    assert.strictEqual(R.identical(NaN, NaN), true);
+    eq(R.identical(-0, 0), false);
+    eq(R.identical(0, -0), false);
+    eq(R.identical(NaN, NaN), true);
 
-    assert.strictEqual(R.identical(NaN, 42), false);
-    assert.strictEqual(R.identical(42, NaN), false);
+    eq(R.identical(NaN, 42), false);
+    eq(R.identical(42, NaN), false);
 
     /* jshint -W053 */
-    assert.strictEqual(R.identical(0, new Number(0)), false);
-    assert.strictEqual(R.identical(new Number(0), 0), false);
-    assert.strictEqual(R.identical(new Number(0), new Number(0)), false);
+    eq(R.identical(0, new Number(0)), false);
+    eq(R.identical(new Number(0), 0), false);
+    eq(R.identical(new Number(0), new Number(0)), false);
     /* jshint +W053 */
   });
 
   it('is curried', function() {
     var isA = R.identical(a);
-    assert.strictEqual(isA([]), false);
+    eq(isA([]), false);
   });
 });

--- a/test/identity.js
+++ b/test/identity.js
@@ -1,16 +1,15 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('identity', function() {
   it('returns its first argument', function() {
-    assert.strictEqual(R.identity(undefined), undefined);
-    assert.strictEqual(R.identity('foo'), 'foo');
-    assert.strictEqual(R.identity('foo', 'bar'), 'foo');
+    eq(R.identity(undefined), undefined);
+    eq(R.identity('foo'), 'foo');
+    eq(R.identity('foo', 'bar'), 'foo');
   });
 
   it('has length 1', function() {
-    assert.strictEqual(R.identity.length, 1);
+    eq(R.identity.length, 1);
   });
 });

--- a/test/ifElse.js
+++ b/test/ifElse.js
@@ -1,6 +1,5 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('ifElse', function() {
@@ -10,25 +9,25 @@ describe('ifElse', function() {
 
   it('calls the truth case function if the validator returns a truthy value', function() {
     var v = function(a) { return typeof a === 'number'; };
-    assert.strictEqual(R.ifElse(v, t, identity)(10), 11);
+    eq(R.ifElse(v, t, identity)(10), 11);
   });
 
   it('calls the false case function if the validator returns a falsey value', function() {
     var v = function(a) { return typeof a === 'number'; };
-    assert.strictEqual(R.ifElse(v, t, identity)('hello'), 'hello');
+    eq(R.ifElse(v, t, identity)('hello'), 'hello');
   });
 
   it('calls the true case on array items and the false case on non array items', function() {
     var list = [[1, 2, 3, 4, 5], 10, [0, 1], 15];
     var arrayToLength = R.map(R.ifElse(isArray, R.prop('length'), identity));
-    assert.deepEqual(arrayToLength(list), [5, 10, 2, 15]);
+    eq(arrayToLength(list), [5, 10, 2, 15]);
   });
 
   it('passes the arguments to the true case function', function() {
     var v = function() { return true; };
     var onTrue = function(a, b) {
-      assert.strictEqual(a, 123);
-      assert.strictEqual(b, 'abc');
+      eq(a, 123);
+      eq(b, 'abc');
     };
     R.ifElse(v, onTrue, identity)(123, 'abc');
   });
@@ -36,8 +35,8 @@ describe('ifElse', function() {
   it('passes the arguments to the false case function', function() {
     var v = function() { return false; };
     var onFalse = function(a, b) {
-      assert.strictEqual(a, 123);
-      assert.strictEqual(b, 'abc');
+      eq(a, 123);
+      eq(b, 'abc');
     };
     R.ifElse(v, identity, onFalse)(123, 'abc');
   });
@@ -47,24 +46,24 @@ describe('ifElse', function() {
     function a1(x) { return x; }
     function a2(x, y) { return x + y; }
 
-    assert.strictEqual(R.ifElse(a0, a1, a2).length, 2);
-    assert.strictEqual(R.ifElse(a0, a2, a1).length, 2);
-    assert.strictEqual(R.ifElse(a1, a0, a2).length, 2);
-    assert.strictEqual(R.ifElse(a1, a2, a0).length, 2);
-    assert.strictEqual(R.ifElse(a2, a0, a1).length, 2);
-    assert.strictEqual(R.ifElse(a2, a1, a0).length, 2);
+    eq(R.ifElse(a0, a1, a2).length, 2);
+    eq(R.ifElse(a0, a2, a1).length, 2);
+    eq(R.ifElse(a1, a0, a2).length, 2);
+    eq(R.ifElse(a1, a2, a0).length, 2);
+    eq(R.ifElse(a2, a0, a1).length, 2);
+    eq(R.ifElse(a2, a1, a0).length, 2);
   });
 
   it('returns a curried function', function() {
     var v = function(a) { return typeof a === 'number'; };
     var ifIsNumber = R.ifElse(v);
-    assert.strictEqual(ifIsNumber(t, identity)(15), 16);
-    assert.strictEqual(ifIsNumber(t, identity)('hello'), 'hello');
+    eq(ifIsNumber(t, identity)(15), 16);
+    eq(ifIsNumber(t, identity)('hello'), 'hello');
 
     var fn = R.ifElse(R.gt, R.subtract, R.add);
-    assert.strictEqual(fn(2)(7), 9);
-    assert.strictEqual(fn(2, 7), 9);
-    assert.strictEqual(fn(7)(2), 5);
-    assert.strictEqual(fn(7, 2), 5);
+    eq(fn(2)(7), 9);
+    eq(fn(2, 7), 9);
+    eq(fn(7)(2), 5);
+    eq(fn(7, 2), 5);
   });
 });

--- a/test/inc.js
+++ b/test/inc.js
@@ -1,17 +1,16 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('inc', function() {
 
   it('increments its argument', function() {
-    assert.strictEqual(R.inc(-1), 0);
-    assert.strictEqual(R.inc(0), 1);
-    assert.strictEqual(R.inc(1), 2);
-    assert.strictEqual(R.inc(12.34), 13.34);
-    assert.strictEqual(R.inc(-Infinity), -Infinity);
-    assert.strictEqual(R.inc(Infinity), Infinity);
+    eq(R.inc(-1), 0);
+    eq(R.inc(0), 1);
+    eq(R.inc(1), 2);
+    eq(R.inc(12.34), 13.34);
+    eq(R.inc(-Infinity), -Infinity);
+    eq(R.inc(Infinity), Infinity);
   });
 
 });

--- a/test/indexOf.js
+++ b/test/indexOf.js
@@ -1,44 +1,43 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('indexOf', function() {
   it("returns a number indicating an object's position in a list", function() {
     var list = [0, 10, 20, 30];
-    assert.strictEqual(R.indexOf(30, list), 3);
+    eq(R.indexOf(30, list), 3);
   });
   it('returns -1 if the object is not in the list', function() {
     var list = [0, 10, 20, 30];
-    assert.strictEqual(R.indexOf(40, list), -1);
+    eq(R.indexOf(40, list), -1);
   });
 
   var input = [1, 2, 3, 4, 5];
   it('returns the index of the first item', function() {
-    assert.strictEqual(R.indexOf(1, input), 0);
+    eq(R.indexOf(1, input), 0);
   });
   it('returns the index of the last item', function() {
-    assert.strictEqual(R.indexOf(5, input), 4);
+    eq(R.indexOf(5, input), 4);
   });
 
   var list = [1, 2, 3];
   list[-2] = 4; // Throw a wrench in the gears by assigning a non-valid array index as object property.
 
   it('finds 1', function() {
-    assert.strictEqual(R.indexOf(1, list), 0);
+    eq(R.indexOf(1, list), 0);
   });
   it('finds 1 and is result strictly it', function() {
-    assert.strictEqual(R.indexOf(1, list), 0);
+    eq(R.indexOf(1, list), 0);
   });
   it('does not find 4', function() {
-    assert.strictEqual(R.indexOf(4, list), -1);
+    eq(R.indexOf(4, list), -1);
   });
   it('does not consider "1" equal to 1', function() {
-    assert.strictEqual(R.indexOf('1', list), -1);
+    eq(R.indexOf('1', list), -1);
   });
 
   it('returns -1 for an empty array', function() {
-    assert.strictEqual(R.indexOf('x', []), -1);
+    eq(R.indexOf('x', []), -1);
   });
 
   it('has R.equals semantics', function() {
@@ -47,10 +46,10 @@ describe('indexOf', function() {
       return x instanceof Just && R.equals(x.value, this.value);
     };
 
-    assert.strictEqual(R.indexOf(0, [-0]), -1);
-    assert.strictEqual(R.indexOf(-0, [0]), -1);
-    assert.strictEqual(R.indexOf(NaN, [NaN]), 0);
-    assert.strictEqual(R.indexOf(new Just([42]), [new Just([42])]), 0);
+    eq(R.indexOf(0, [-0]), -1);
+    eq(R.indexOf(-0, [0]), -1);
+    eq(R.indexOf(NaN, [NaN]), 0);
+    eq(R.indexOf(new Just([42]), [new Just([42])]), 0);
   });
 
   it('dispatches to `indexOf` method', function() {
@@ -74,14 +73,14 @@ describe('indexOf', function() {
                new List('a',
                new Empty()))))));
 
-    assert.strictEqual(R.indexOf('a', 'banana'), 1);
-    assert.strictEqual(R.indexOf('x', 'banana'), -1);
-    assert.strictEqual(R.indexOf('a', list), 1);
-    assert.strictEqual(R.indexOf('x', list), -1);
+    eq(R.indexOf('a', 'banana'), 1);
+    eq(R.indexOf('x', 'banana'), -1);
+    eq(R.indexOf('a', list), 1);
+    eq(R.indexOf('x', list), -1);
   });
 
   it('is curried', function() {
     var curried = R.indexOf(3);
-    assert.strictEqual(curried(list), 2);
+    eq(curried(list), 2);
   });
 });

--- a/test/init.js
+++ b/test/init.js
@@ -1,20 +1,21 @@
 var assert = require('assert');
 
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('init', function() {
 
   it('returns all but the last element of an ordered collection', function() {
-    assert.deepEqual(R.init([1, 2, 3]), [1, 2]);
-    assert.deepEqual(R.init([2, 3]), [2]);
-    assert.deepEqual(R.init([3]), []);
-    assert.deepEqual(R.init([]), []);
+    eq(R.init([1, 2, 3]), [1, 2]);
+    eq(R.init([2, 3]), [2]);
+    eq(R.init([3]), []);
+    eq(R.init([]), []);
 
-    assert.strictEqual(R.init('abc'), 'ab');
-    assert.strictEqual(R.init('bc'), 'b');
-    assert.strictEqual(R.init('c'), '');
-    assert.strictEqual(R.init(''), '');
+    eq(R.init('abc'), 'ab');
+    eq(R.init('bc'), 'b');
+    eq(R.init('c'), '');
+    eq(R.init(''), '');
   });
 
   it('throws if applied to null or undefined', function() {
@@ -24,7 +25,7 @@ describe('init', function() {
 
   it('handles array-like object', function() {
     var args = (function() { return arguments; }(1, 2, 3, 4, 5));
-    assert.deepEqual(R.init(args), [1, 2, 3, 4]);
+    eq(R.init(args), [1, 2, 3, 4]);
   });
 
 });

--- a/test/insert.js
+++ b/test/insert.js
@@ -1,27 +1,26 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('insert', function() {
   it('inserts an element into the given list', function() {
     var list = ['a', 'b', 'c', 'd', 'e'];
-    assert.deepEqual(R.insert(2, 'x', list), ['a', 'b', 'x', 'c', 'd', 'e']);
+    eq(R.insert(2, 'x', list), ['a', 'b', 'x', 'c', 'd', 'e']);
   });
 
   it('inserts another list as an element', function() {
     var list = ['a', 'b', 'c', 'd', 'e'];
-    assert.deepEqual(R.insert(2, ['s', 't'], list), ['a', 'b', ['s', 't'], 'c', 'd', 'e']);
+    eq(R.insert(2, ['s', 't'], list), ['a', 'b', ['s', 't'], 'c', 'd', 'e']);
   });
 
   it('appends to the end of the list if the index is too large', function() {
     var list = ['a', 'b', 'c', 'd', 'e'];
-    assert.deepEqual(R.insert(8, 'z', list), ['a', 'b', 'c', 'd', 'e', 'z']);
+    eq(R.insert(8, 'z', list), ['a', 'b', 'c', 'd', 'e', 'z']);
   });
 
   it('is curried', function() {
     var list = ['a', 'b', 'c', 'd', 'e'];
-    assert.deepEqual(R.insert(8)('z')(list), ['a', 'b', 'c', 'd', 'e', 'z']);
-    assert.deepEqual(R.insert(8, 'z')(list), ['a', 'b', 'c', 'd', 'e', 'z']);
+    eq(R.insert(8)('z')(list), ['a', 'b', 'c', 'd', 'e', 'z']);
+    eq(R.insert(8, 'z')(list), ['a', 'b', 'c', 'd', 'e', 'z']);
   });
 });

--- a/test/insertAll.js
+++ b/test/insertAll.js
@@ -1,21 +1,20 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('insertAll', function() {
   it('inserts a list of elements into the given list', function() {
     var list = ['a', 'b', 'c', 'd', 'e'];
-    assert.deepEqual(R.insertAll(2, ['x', 'y', 'z'], list), ['a', 'b', 'x', 'y', 'z', 'c', 'd', 'e']);
+    eq(R.insertAll(2, ['x', 'y', 'z'], list), ['a', 'b', 'x', 'y', 'z', 'c', 'd', 'e']);
   });
 
   it('appends to the end of the list if the index is too large', function() {
     var list = ['a', 'b', 'c', 'd', 'e'];
-    assert.deepEqual(R.insertAll(8, ['p', 'q', 'r'], list), ['a', 'b', 'c', 'd', 'e', 'p', 'q', 'r']);
+    eq(R.insertAll(8, ['p', 'q', 'r'], list), ['a', 'b', 'c', 'd', 'e', 'p', 'q', 'r']);
   });
 
   it('is curried', function() {
     var list = ['a', 'b', 'c', 'd', 'e'];
-    assert.deepEqual(R.insertAll(8)(['p', 'q', 'r'], list), ['a', 'b', 'c', 'd', 'e', 'p', 'q', 'r']);
+    eq(R.insertAll(8)(['p', 'q', 'r'], list), ['a', 'b', 'c', 'd', 'e', 'p', 'q', 'r']);
   });
 });

--- a/test/internal/_curry2.js
+++ b/test/internal/_curry2.js
@@ -1,5 +1,4 @@
-var assert = require('assert');
-
+var eq = require('../shared/eq');
 var _ = require('../../src/__');
 var _curry2 = require('../../src/internal/_curry2');
 
@@ -9,15 +8,15 @@ describe('_curry2', function() {
     var f = function(a, b) { return [a, b]; };
     var g = _curry2(f);
 
-    assert.deepEqual(g(1)(2), [1, 2]);
-    assert.deepEqual(g(1, 2), [1, 2]);
+    eq(g(1)(2), [1, 2]);
+    eq(g(1, 2), [1, 2]);
 
-    assert.deepEqual(g(_, 2)(1), [1, 2]);
-    assert.deepEqual(g(1, _)(2), [1, 2]);
+    eq(g(_, 2)(1), [1, 2]);
+    eq(g(1, _)(2), [1, 2]);
 
-    assert.deepEqual(g(_, _)(1)(2), [1, 2]);
-    assert.deepEqual(g(_, _)(1, 2), [1, 2]);
-    assert.deepEqual(g(_, _)(_)(1, 2), [1, 2]);
-    assert.deepEqual(g(_, _)(_, 2)(1), [1, 2]);
+    eq(g(_, _)(1)(2), [1, 2]);
+    eq(g(_, _)(1, 2), [1, 2]);
+    eq(g(_, _)(_)(1, 2), [1, 2]);
+    eq(g(_, _)(_, 2)(1), [1, 2]);
   });
 });

--- a/test/internal/_curry3.js
+++ b/test/internal/_curry3.js
@@ -1,5 +1,4 @@
-var assert = require('assert');
-
+var eq = require('../shared/eq');
 var _ = require('../../src/__');
 var _curry3 = require('../../src/internal/_curry3');
 
@@ -9,28 +8,28 @@ describe('_curry3', function() {
     var f = function(a, b, c) { return [a, b, c]; };
     var g = _curry3(f);
 
-    assert.deepEqual(g(1)(2)(3), [1, 2, 3]);
-    assert.deepEqual(g(1)(2, 3), [1, 2, 3]);
-    assert.deepEqual(g(1, 2)(3), [1, 2, 3]);
-    assert.deepEqual(g(1, 2, 3), [1, 2, 3]);
+    eq(g(1)(2)(3), [1, 2, 3]);
+    eq(g(1)(2, 3), [1, 2, 3]);
+    eq(g(1, 2)(3), [1, 2, 3]);
+    eq(g(1, 2, 3), [1, 2, 3]);
 
-    assert.deepEqual(g(_, 2, 3)(1), [1, 2, 3]);
-    assert.deepEqual(g(1, _, 3)(2), [1, 2, 3]);
-    assert.deepEqual(g(1, 2, _)(3), [1, 2, 3]);
+    eq(g(_, 2, 3)(1), [1, 2, 3]);
+    eq(g(1, _, 3)(2), [1, 2, 3]);
+    eq(g(1, 2, _)(3), [1, 2, 3]);
 
-    assert.deepEqual(g(1, _, _)(2)(3), [1, 2, 3]);
-    assert.deepEqual(g(_, 2, _)(1)(3), [1, 2, 3]);
-    assert.deepEqual(g(_, _, 3)(1)(2), [1, 2, 3]);
+    eq(g(1, _, _)(2)(3), [1, 2, 3]);
+    eq(g(_, 2, _)(1)(3), [1, 2, 3]);
+    eq(g(_, _, 3)(1)(2), [1, 2, 3]);
 
-    assert.deepEqual(g(1, _, _)(2, 3), [1, 2, 3]);
-    assert.deepEqual(g(_, 2, _)(1, 3), [1, 2, 3]);
-    assert.deepEqual(g(_, _, 3)(1, 2), [1, 2, 3]);
+    eq(g(1, _, _)(2, 3), [1, 2, 3]);
+    eq(g(_, 2, _)(1, 3), [1, 2, 3]);
+    eq(g(_, _, 3)(1, 2), [1, 2, 3]);
 
-    assert.deepEqual(g(1, _, _)(_, 3)(2), [1, 2, 3]);
-    assert.deepEqual(g(_, 2, _)(_, 3)(1), [1, 2, 3]);
-    assert.deepEqual(g(_, _, 3)(_, 2)(1), [1, 2, 3]);
+    eq(g(1, _, _)(_, 3)(2), [1, 2, 3]);
+    eq(g(_, 2, _)(_, 3)(1), [1, 2, 3]);
+    eq(g(_, _, 3)(_, 2)(1), [1, 2, 3]);
 
-    assert.deepEqual(g(_, _, _)(_, _)(_)(1, 2, 3), [1, 2, 3]);
-    assert.deepEqual(g(_, _, _)(1, _, _)(_, _)(2, _)(_)(3), [1, 2, 3]);
+    eq(g(_, _, _)(_, _)(_)(1, 2, 3), [1, 2, 3]);
+    eq(g(_, _, _)(1, _, _)(_, _)(2, _)(_)(3), [1, 2, 3]);
   });
 });

--- a/test/intersection.js
+++ b/test/intersection.js
@@ -1,6 +1,5 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('intersection', function() {
@@ -9,11 +8,11 @@ describe('intersection', function() {
   var N = [3, 4, 5, 6];
   var N2 = [3, 3, 4, 4, 5, 5, 6, 6];
   it('combines two lists into the set of common elements', function() {
-    assert.deepEqual(R.intersection(M, N), [3, 4]);
+    eq(R.intersection(M, N), [3, 4]);
   });
 
   it('does not allow duplicates in the output even if the input lists had duplicates', function() {
-    assert.deepEqual(R.intersection(M2, N2), [3, 4]);
+    eq(R.intersection(M2, N2), [3, 4]);
   });
 
   it('has R.equals semantics', function() {
@@ -22,9 +21,9 @@ describe('intersection', function() {
       return x instanceof Just && R.equals(x.value, this.value);
     };
 
-    assert.strictEqual(R.intersection([0], [-0]).length, 0);
-    assert.strictEqual(R.intersection([-0], [0]).length, 0);
-    assert.strictEqual(R.intersection([NaN], [NaN]).length, 1);
-    assert.strictEqual(R.intersection([new Just([42])], [new Just([42])]).length, 1);
+    eq(R.intersection([0], [-0]).length, 0);
+    eq(R.intersection([-0], [0]).length, 0);
+    eq(R.intersection([NaN], [NaN]).length, 1);
+    eq(R.intersection([new Just([42])], [new Just([42])]).length, 1);
   });
 });

--- a/test/intersectionWith.js
+++ b/test/intersectionWith.js
@@ -1,6 +1,5 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('intersectionWith', function() {
@@ -8,6 +7,6 @@ describe('intersectionWith', function() {
   var So = [{a: 3}, {a: 4}, {a: 5}, {a: 6}];
   var eqA = function(r, s) { return r.a === s.a; };
   it('combines two lists into the set of all their elements based on the passed-in equality predicate', function() {
-    assert.deepEqual(R.intersectionWith(eqA, Ro, So), [{a: 3}, {a: 4}]);
+    eq(R.intersectionWith(eqA, Ro, So), [{a: 3}, {a: 4}]);
   });
 });

--- a/test/intersperse.js
+++ b/test/intersperse.js
@@ -1,21 +1,20 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('intersperse', function() {
   it('interposes a separator between list items', function() {
-    assert.deepEqual(R.intersperse('n', ['ba', 'a', 'a']), ['ba', 'n', 'a', 'n', 'a']);
-    assert.deepEqual(R.intersperse('bar', ['foo']), ['foo']);
-    assert.deepEqual(R.intersperse('bar', []), []);
+    eq(R.intersperse('n', ['ba', 'a', 'a']), ['ba', 'n', 'a', 'n', 'a']);
+    eq(R.intersperse('bar', ['foo']), ['foo']);
+    eq(R.intersperse('bar', []), []);
   });
 
   it('dispatches', function() {
     var obj = {intersperse: function(x) { return 'override ' + x; }};
-    assert.strictEqual(R.intersperse('x', obj), 'override x');
+    eq(R.intersperse('x', obj), 'override x');
   });
 
   it('is curried', function() {
-    assert.deepEqual(R.intersperse('n')(['ba', 'a', 'a']), ['ba', 'n', 'a', 'n', 'a']);
+    eq(R.intersperse('n')(['ba', 'a', 'a']), ['ba', 'n', 'a', 'n', 'a']);
   });
 });

--- a/test/into.js
+++ b/test/into.js
@@ -1,6 +1,5 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('into', function() {
@@ -13,44 +12,44 @@ describe('into', function() {
   };
 
   it('transduces into arrays', function() {
-    assert.deepEqual(R.into([], R.map(add(1)), [1, 2, 3, 4]), [2, 3, 4, 5]);
-    assert.deepEqual(R.into([], R.filter(isOdd), [1, 2, 3, 4]), [1, 3]);
-    assert.deepEqual(R.into([], R.compose(R.map(add(1)), R.take(2)), [1, 2, 3, 4]), [2, 3]);
+    eq(R.into([], R.map(add(1)), [1, 2, 3, 4]), [2, 3, 4, 5]);
+    eq(R.into([], R.filter(isOdd), [1, 2, 3, 4]), [1, 3]);
+    eq(R.into([], R.compose(R.map(add(1)), R.take(2)), [1, 2, 3, 4]), [2, 3]);
   });
 
   it('transduces into strings', function() {
-    assert.deepEqual(R.into('', R.map(add(1)), [1, 2, 3, 4]), '2345');
-    assert.deepEqual(R.into('', R.filter(isOdd), [1, 2, 3, 4]), '13');
-    assert.deepEqual(R.into('', R.compose(R.map(add(1)), R.take(2)), [1, 2, 3, 4]), '23');
+    eq(R.into('', R.map(add(1)), [1, 2, 3, 4]), '2345');
+    eq(R.into('', R.filter(isOdd), [1, 2, 3, 4]), '13');
+    eq(R.into('', R.compose(R.map(add(1)), R.take(2)), [1, 2, 3, 4]), '23');
   });
 
   it('transduces into objects', function() {
-    assert.deepEqual(R.into({}, R.identity, [['a', 1], ['b', 2]]), {a: 1, b: 2});
-    assert.deepEqual(R.into({}, R.identity, [{a: 1}, {b: 2, c: 3}]), {a: 1, b: 2, c: 3});
+    eq(R.into({}, R.identity, [['a', 1], ['b', 2]]), {a: 1, b: 2});
+    eq(R.into({}, R.identity, [{a: 1}, {b: 2, c: 3}]), {a: 1, b: 2, c: 3});
   });
 
   it('dispatches to objects that implement `reduce`', function() {
     var obj = {x: [1, 2, 3], reduce: function() { return 'override'; }};
-    assert.deepEqual(R.into([], R.map(add(1)), obj), 'override');
-    assert.deepEqual(R.into([], R.filter(isOdd), obj), 'override');
+    eq(R.into([], R.map(add(1)), obj), 'override');
+    eq(R.into([], R.filter(isOdd), obj), 'override');
   });
 
   it('is curried', function() {
     var intoArray = R.into([]);
     var add2 = R.map(add(2));
     var result = intoArray(add2);
-    assert.deepEqual(result([1, 2, 3, 4]), [3, 4, 5, 6]);
+    eq(result([1, 2, 3, 4]), [3, 4, 5, 6]);
   });
 
   it('allows custom transformer', function() {
     var intoSum = R.into(addXf);
     var add2 = R.map(add(2));
     var result = intoSum(add2);
-    assert.deepEqual(result([1, 2, 3, 4]), 18);
+    eq(result([1, 2, 3, 4]), 18);
   });
 
   it('correctly reports the arity of curried versions', function() {
     var sum = R.into([], R.map(add));
-    assert.strictEqual(sum.length, 1);
+    eq(sum.length, 1);
   });
 });

--- a/test/invariants.js
+++ b/test/invariants.js
@@ -1,6 +1,5 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('invariants', function() {
@@ -9,8 +8,8 @@ describe('invariants', function() {
     for (var prop in R) {
       if (typeof R[prop] === 'function' && R[prop].length > 0) {
         var result = R[prop]();
-        assert.strictEqual(typeof result, 'function');
-        assert.strictEqual(result.length, R[prop].length);
+        eq(typeof result, 'function');
+        eq(result.length, R[prop].length);
       }
     }
   });
@@ -19,8 +18,8 @@ describe('invariants', function() {
     for (var prop in R) {
       if (typeof R[prop] === 'function' && R[prop].length > 0) {
         var result = R[prop](R.__);
-        assert.strictEqual(typeof result, 'function');
-        assert.strictEqual(result.length, R[prop].length);
+        eq(typeof result, 'function');
+        eq(result.length, R[prop].length);
       }
     }
   });
@@ -29,8 +28,8 @@ describe('invariants', function() {
     var testPartialApplication = function(fn, name) {
       if (fn.length > 1) {
         var result = fn(null);
-        assert.strictEqual(typeof result, 'function');
-        assert.strictEqual(result.length, fn.length - 1);
+        eq(typeof result, 'function');
+        eq(result.length, fn.length - 1);
         testPartialApplication(result, name + "'");
       }
     };

--- a/test/invert.js
+++ b/test/invert.js
@@ -1,51 +1,51 @@
-var assert = require('assert');
 var R = require('..');
+var eq = require('./shared/eq');
 
 describe('invert', function() {
 
   it('takes a list or object and returns an object of lists', function() {
-    assert.equal(typeof R.invert([]), 'object');
-    assert.equal(typeof R.invert({}), 'object');
+    eq(typeof R.invert([]), 'object');
+    eq(typeof R.invert({}), 'object');
 
     var inverted = R.invert([0]);
     var keys = R.keys(inverted);
-    assert.strictEqual(R.is(Array, inverted[keys.pop()]), true);
+    eq(R.is(Array, inverted[keys.pop()]), true);
   });
 
   it('returns an empty object when applied to a primitive', function() {
-    assert.deepEqual(R.invert(42), {});
-    assert.deepEqual(R.invert('abc'), {});
+    eq(R.invert(42), {});
+    eq(R.invert('abc'), {});
   });
 
   it('returns an empty object when applied to null/undefined', function() {
-    assert.deepEqual(R.invert(null), {});
-    assert.deepEqual(R.invert(undefined), {});
+    eq(R.invert(null), {});
+    eq(R.invert(undefined), {});
   });
 
   it('returns the input\'s values as keys, and keys as values of an array', function() {
-    assert.deepEqual(R.invert(['a', 'b', 'c']),       {a:['0'], b:['1'], c:['2']});
-    assert.deepEqual(R.invert({x:'a', y:'b', z:'c'}), {a:['x'], b:['y'], c:['z']});
+    eq(R.invert(['a', 'b', 'c']),       {a:['0'], b:['1'], c:['2']});
+    eq(R.invert({x:'a', y:'b', z:'c'}), {a:['x'], b:['y'], c:['z']});
   });
 
   it('puts keys that have the same value into the appropriate an array', function() {
-    assert.deepEqual(R.invert(['a', 'b', 'a']), {a:['0', '2'], b:['1']});
+    eq(R.invert(['a', 'b', 'a']), {a:['0', '2'], b:['1']});
 
     var inverted = R.invert({x:'a', y:'b', z:'a', _id:'a'});
-    assert.strictEqual(R.indexOf('x', inverted.a) >= 0, true);
-    assert.strictEqual(R.indexOf('z', inverted.a) >= 0, true);
-    assert.strictEqual(R.indexOf('_id', inverted.a) >= 0, true);
-    assert.deepEqual(inverted.b, ['y']);
+    eq(R.indexOf('x', inverted.a) >= 0, true);
+    eq(R.indexOf('z', inverted.a) >= 0, true);
+    eq(R.indexOf('_id', inverted.a) >= 0, true);
+    eq(inverted.b, ['y']);
   });
 
   // this one is more of a sanity check
   it('is not destructive', function() {
     var input = {x:'a', y:'b', z:'a', _id:'a'};
     R.invert(input);
-    assert.deepEqual(input, {x:'a', y:'b', z:'a', _id:'a'});
+    eq(input, {x:'a', y:'b', z:'a', _id:'a'});
   });
 
   it('ignores inherited properties', function() {
-    assert.deepEqual(R.invert({x: 'hasOwnProperty'}), {
+    eq(R.invert({x: 'hasOwnProperty'}), {
       /* jshint -W001 */
       hasOwnProperty: ['x']
       /* jshint +W001 */

--- a/test/invertObj.js
+++ b/test/invertObj.js
@@ -1,37 +1,37 @@
-var assert = require('assert');
 var R = require('..');
+var eq = require('./shared/eq');
 
 describe('invertObj', function() {
 
   it('takes a list or object and returns an object', function() {
-    assert.equal(typeof R.invertObj([]), 'object');
-    assert.equal(typeof R.invertObj({}), 'object');
+    eq(typeof R.invertObj([]), 'object');
+    eq(typeof R.invertObj({}), 'object');
   });
 
   it('returns an empty object when applied to a primitive', function() {
-    assert.deepEqual(R.invertObj(42), {});
-    assert.deepEqual(R.invertObj('abc'), {});
+    eq(R.invertObj(42), {});
+    eq(R.invertObj('abc'), {});
   });
 
   it('returns an empty object when applied to null/undefined', function() {
-    assert.deepEqual(R.invertObj(null), {});
-    assert.deepEqual(R.invertObj(undefined), {});
+    eq(R.invertObj(null), {});
+    eq(R.invertObj(undefined), {});
   });
 
   it('returns the input\'s values as keys, and keys as values', function() {
-    assert.deepEqual(R.invertObj(['a', 'b', 'c']),       {a:'0', b:'1', c:'2'});
-    assert.deepEqual(R.invertObj({x:'a', y:'b', z:'c'}), {a:'x', b:'y', c:'z'});
+    eq(R.invertObj(['a', 'b', 'c']),       {a:'0', b:'1', c:'2'});
+    eq(R.invertObj({x:'a', y:'b', z:'c'}), {a:'x', b:'y', c:'z'});
   });
 
   it('prefers the last key found when handling keys with the same value', function() {
-    assert.deepEqual(R.invertObj(['a', 'b', 'a']), {a:'2', b:'1'});
-    assert.deepEqual(R.invertObj({x:'a', y:'b', z:'a', _id:'a'}), {a: '_id', b: 'y'});
+    eq(R.invertObj(['a', 'b', 'a']), {a:'2', b:'1'});
+    eq(R.invertObj({x:'a', y:'b', z:'a', _id:'a'}), {a: '_id', b: 'y'});
   });
 
   // this one is more of a sanity check
   it('is not destructive', function() {
     var input = {x:'a', y:'b', z:'a', _id:'a'};
     R.invertObj(input);
-    assert.deepEqual(input, {x:'a', y:'b', z:'a', _id:'a'});
+    eq(input, {x:'a', y:'b', z:'a', _id:'a'});
   });
 });

--- a/test/invoker.js
+++ b/test/invoker.js
@@ -1,6 +1,7 @@
 var assert = require('assert');
 
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('invoker', function() {
@@ -8,11 +9,11 @@ describe('invoker', function() {
   var concat2 = R.invoker(2, 'concat');
 
   it('returns a function with correct arity', function() {
-    assert.strictEqual(concat2.length, 3);
+    eq(concat2.length, 3);
   });
 
   it('calls the method on the object', function() {
-    assert.deepEqual(concat2(3, 4, [1, 2]), [1, 2, 3, 4]);
+    eq(concat2(3, 4, [1, 2]), [1, 2, 3, 4]);
   });
 
   it('throws a descriptive TypeError if method does not exist', function() {
@@ -40,9 +41,9 @@ describe('invoker', function() {
   });
 
   it('curries the method call', function() {
-    assert.deepEqual(concat2(3)(4)([1, 2]), [1, 2, 3, 4]);
-    assert.deepEqual(concat2(3, 4)([1, 2]), [1, 2, 3, 4]);
-    assert.deepEqual(concat2(3)(4, [1, 2]), [1, 2, 3, 4]);
+    eq(concat2(3)(4)([1, 2]), [1, 2, 3, 4]);
+    eq(concat2(3, 4)([1, 2]), [1, 2, 3, 4]);
+    eq(concat2(3)(4, [1, 2]), [1, 2, 3, 4]);
   });
 
 });

--- a/test/is.js
+++ b/test/is.js
@@ -1,20 +1,19 @@
 /* jshint -W053 */
 
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('is', function() {
   it('works with built-in types', function() {
-    assert.strictEqual(R.is(Array, []), true);
-    assert.strictEqual(R.is(Boolean, new Boolean(false)), true);
-    assert.strictEqual(R.is(Date, new Date()), true);
-    assert.strictEqual(R.is(Function, function() {}), true);
-    assert.strictEqual(R.is(Number, new Number(0)), true);
-    assert.strictEqual(R.is(Object, {}), true);
-    assert.strictEqual(R.is(RegExp, /(?:)/), true);
-    assert.strictEqual(R.is(String, new String('')), true);
+    eq(R.is(Array, []), true);
+    eq(R.is(Boolean, new Boolean(false)), true);
+    eq(R.is(Date, new Date()), true);
+    eq(R.is(Function, function() {}), true);
+    eq(R.is(Number, new Number(0)), true);
+    eq(R.is(Object, {}), true);
+    eq(R.is(RegExp, /(?:)/), true);
+    eq(R.is(String, new String('')), true);
   });
 
   it('works with user-defined types', function() {
@@ -25,16 +24,16 @@ describe('is', function() {
     var foo = new Foo();
     var bar = new Bar();
 
-    assert.strictEqual(R.is(Foo, foo), true);
-    assert.strictEqual(R.is(Bar, bar), true);
-    assert.strictEqual(R.is(Foo, bar), true);
-    assert.strictEqual(R.is(Bar, foo), false);
+    eq(R.is(Foo, foo), true);
+    eq(R.is(Bar, bar), true);
+    eq(R.is(Foo, bar), true);
+    eq(R.is(Bar, foo), false);
   });
 
   it('is curried', function() {
     var isArray = R.is(Array);
-    assert.strictEqual(isArray([]), true);
-    assert.strictEqual(isArray({}), false);
+    eq(isArray([]), true);
+    eq(isArray({}), false);
   });
 
   it('considers almost everything an object', function() {
@@ -42,40 +41,40 @@ describe('is', function() {
     var foo = new Foo();
     var isObject = R.is(Object);
 
-    assert.strictEqual(isObject(foo), true);
-    assert.strictEqual(isObject(function() { return arguments; }()), true);
-    assert.strictEqual(isObject([]), true);
-    assert.strictEqual(isObject(new Boolean(false)), true);
-    assert.strictEqual(isObject(new Date()), true);
-    assert.strictEqual(isObject(function() {}), true);
-    assert.strictEqual(isObject(new Number(0)), true);
-    assert.strictEqual(isObject(/(?:)/), true);
-    assert.strictEqual(isObject(new String('')), true);
+    eq(isObject(foo), true);
+    eq(isObject(function() { return arguments; }()), true);
+    eq(isObject([]), true);
+    eq(isObject(new Boolean(false)), true);
+    eq(isObject(new Date()), true);
+    eq(isObject(function() {}), true);
+    eq(isObject(new Number(0)), true);
+    eq(isObject(/(?:)/), true);
+    eq(isObject(new String('')), true);
 
-    assert.strictEqual(isObject(null), false);
-    assert.strictEqual(isObject(undefined), false);
+    eq(isObject(null), false);
+    eq(isObject(undefined), false);
   });
 
   it('does not coerce', function() {
-    assert.strictEqual(R.is(Boolean, 1), false);
-    assert.strictEqual(R.is(Number, '1'), false);
-    assert.strictEqual(R.is(Number, false), false);
+    eq(R.is(Boolean, 1), false);
+    eq(R.is(Number, '1'), false);
+    eq(R.is(Number, false), false);
   });
 
   it('recognizes primitives as their object equivalents', function() {
-    assert.strictEqual(R.is(Boolean, false), true);
-    assert.strictEqual(R.is(Number, 0), true);
-    assert.strictEqual(R.is(String, ''), true);
+    eq(R.is(Boolean, false), true);
+    eq(R.is(Number, 0), true);
+    eq(R.is(String, ''), true);
   });
 
   it('does not consider primitives to be instances of Object', function() {
-    assert.strictEqual(R.is(Object, false), false);
-    assert.strictEqual(R.is(Object, 0), false);
-    assert.strictEqual(R.is(Object, ''), false);
+    eq(R.is(Object, false), false);
+    eq(R.is(Object, 0), false);
+    eq(R.is(Object, ''), false);
   });
 
   it('is curried', function() {
-    assert.strictEqual(typeof R.is(String), 'function');
-    assert.strictEqual(R.is(String)('s'), true);
+    eq(typeof R.is(String), 'function');
+    eq(R.is(String)('s'), true);
   });
 });

--- a/test/isArrayLike.js
+++ b/test/isArrayLike.js
@@ -1,27 +1,26 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('isArrayLike', function() {
   it('is true for Arrays', function() {
-    assert.strictEqual(R.isArrayLike([]), true);
-    assert.strictEqual(R.isArrayLike([1, 2, 3, 4]), true);
-    assert.strictEqual(R.isArrayLike([null]), true);
+    eq(R.isArrayLike([]), true);
+    eq(R.isArrayLike([1, 2, 3, 4]), true);
+    eq(R.isArrayLike([null]), true);
   });
 
   it('is true for arguments', function() {
     function test() {
       return R.isArrayLike(arguments);
     }
-    assert.strictEqual(test(), true);
-    assert.strictEqual(test(1, 2, 3), true);
-    assert.strictEqual(test(null), true);
+    eq(test(), true);
+    eq(test(1, 2, 3), true);
+    eq(test(null), true);
   });
 
   it('is false for Strings', function() {
-    assert.strictEqual(R.isArrayLike(''), false);
-    assert.strictEqual(R.isArrayLike('abcdefg'), false);
+    eq(R.isArrayLike(''), false);
+    eq(R.isArrayLike('abcdefg'), false);
   });
 
   it('is true for arbitrary objects with numeric length, if extreme indices are defined', function() {
@@ -31,19 +30,19 @@ describe('isArrayLike', function() {
     var obj4 = {0: 'zero', 1: 'one', length: 2};
     var obj5 = {0: 'zero', length: 2};
     var obj6 = {1: 'one', length: 2};
-    assert.strictEqual(R.isArrayLike(obj1), true);
-    assert.strictEqual(R.isArrayLike(obj2), true);
-    assert.strictEqual(R.isArrayLike(obj3), true);
-    assert.strictEqual(R.isArrayLike(obj4), true);
-    assert.strictEqual(R.isArrayLike(obj5), false);
-    assert.strictEqual(R.isArrayLike(obj6), false);
+    eq(R.isArrayLike(obj1), true);
+    eq(R.isArrayLike(obj2), true);
+    eq(R.isArrayLike(obj3), true);
+    eq(R.isArrayLike(obj4), true);
+    eq(R.isArrayLike(obj5), false);
+    eq(R.isArrayLike(obj6), false);
   });
 
   it('is false for everything else', function() {
-    assert.strictEqual(R.isArrayLike(undefined), false);
-    assert.strictEqual(R.isArrayLike(1), false);
-    assert.strictEqual(R.isArrayLike({}), false);
-    assert.strictEqual(R.isArrayLike(false), false);
-    assert.strictEqual(R.isArrayLike(function() {}), false);
+    eq(R.isArrayLike(undefined), false);
+    eq(R.isArrayLike(1), false);
+    eq(R.isArrayLike({}), false);
+    eq(R.isArrayLike(false), false);
+    eq(R.isArrayLike(function() {}), false);
   });
 });

--- a/test/isEmpty.js
+++ b/test/isEmpty.js
@@ -1,42 +1,41 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('isEmpty', function() {
 
   it('returns false for null', function() {
-    assert.strictEqual(R.isEmpty(null), false);
+    eq(R.isEmpty(null), false);
   });
 
   it('returns false for undefined', function() {
-    assert.strictEqual(R.isEmpty(undefined), false);
+    eq(R.isEmpty(undefined), false);
   });
 
   it('returns true for empty string', function() {
-    assert.strictEqual(R.isEmpty(''), true);
-    assert.strictEqual(R.isEmpty(' '), false);
+    eq(R.isEmpty(''), true);
+    eq(R.isEmpty(' '), false);
   });
 
   it('returns true for empty array', function() {
-    assert.strictEqual(R.isEmpty([]), true);
-    assert.strictEqual(R.isEmpty([[]]), false);
+    eq(R.isEmpty([]), true);
+    eq(R.isEmpty([[]]), false);
   });
 
   it('returns true for empty object', function() {
-    assert.strictEqual(R.isEmpty({}), true);
-    assert.strictEqual(R.isEmpty({x: 0}), false);
+    eq(R.isEmpty({}), true);
+    eq(R.isEmpty({x: 0}), false);
   });
 
   it('returns true for empty arguments object', function() {
-    assert.strictEqual(R.isEmpty((function() { return arguments; }())), true);
-    assert.strictEqual(R.isEmpty((function() { return arguments; }(0))), false);
+    eq(R.isEmpty((function() { return arguments; }())), true);
+    eq(R.isEmpty((function() { return arguments; }(0))), false);
   });
 
   it('returns false for every other value', function() {
-    assert.strictEqual(R.isEmpty(0), false);
-    assert.strictEqual(R.isEmpty(NaN), false);
-    assert.strictEqual(R.isEmpty(['']), false);
+    eq(R.isEmpty(0), false);
+    eq(R.isEmpty(NaN), false);
+    eq(R.isEmpty(['']), false);
   });
 
 });

--- a/test/isNil.js
+++ b/test/isNil.js
@@ -1,14 +1,14 @@
-var assert = require('assert');
 var R = require('..');
+var eq = require('./shared/eq');
 
 describe('isNil', function() {
   it('tests a value for `null` or `undefined`', function() {
-    assert.strictEqual(R.isNil(void 0), true);
-    assert.strictEqual(R.isNil(null), true);
-    assert.strictEqual(R.isNil([]), false);
-    assert.strictEqual(R.isNil({}), false);
-    assert.strictEqual(R.isNil(0), false);
-    assert.strictEqual(R.isNil(''), false);
+    eq(R.isNil(void 0), true);
+    eq(R.isNil(null), true);
+    eq(R.isNil([]), false);
+    eq(R.isNil({}), false);
+    eq(R.isNil(0), false);
+    eq(R.isNil(''), false);
   });
 
 });

--- a/test/join.js
+++ b/test/join.js
@@ -1,11 +1,10 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('join', function() {
   it("concatenates a list's elements to a string, with an seperator string between elements", function() {
     var list = [1, 2, 3, 4];
-    assert.strictEqual(R.join('~', list), '1~2~3~4');
+    eq(R.join('~', list), '1~2~3~4');
   });
 });

--- a/test/keys.js
+++ b/test/keys.js
@@ -1,6 +1,5 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('keys', function() {
@@ -11,11 +10,11 @@ describe('keys', function() {
   var cobj = new C();
 
   it("returns an array of the given object's own keys", function() {
-    assert.deepEqual(R.keys(obj).sort(), ['a', 'b', 'c', 'd', 'e', 'f']);
+    eq(R.keys(obj).sort(), ['a', 'b', 'c', 'd', 'e', 'f']);
   });
 
   it('works with hasOwnProperty override', function() {
-    assert.deepEqual(R.keys({
+    eq(R.keys({
       /* jshint -W001 */
       hasOwnProperty: false
       /* jshint +W001 */
@@ -27,10 +26,10 @@ describe('keys', function() {
     var result = R.map(function(val) {
       return R.keys(val);
     }, [null, undefined, 55, '', true, false, NaN, Infinity, , []]);
-    assert.deepEqual(result, R.repeat([], 10));
+    eq(result, R.repeat([], 10));
   });
 
   it("does not include the given object's prototype properties", function() {
-    assert.deepEqual(R.keys(cobj).sort(), ['a', 'b']);
+    eq(R.keys(cobj).sort(), ['a', 'b']);
   });
 });

--- a/test/keysIn.js
+++ b/test/keysIn.js
@@ -1,6 +1,5 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('keysIn', function() {
@@ -11,11 +10,11 @@ describe('keysIn', function() {
   var cobj = new C();
 
   it("returns an array of the given object's keys", function() {
-    assert.deepEqual(R.keysIn(obj).sort(), ['a', 'b', 'c', 'd', 'e', 'f']);
+    eq(R.keysIn(obj).sort(), ['a', 'b', 'c', 'd', 'e', 'f']);
   });
 
   it("includes the given object's prototype properties", function() {
-    assert.deepEqual(R.keysIn(cobj).sort(), ['a', 'b', 'x', 'y']);
+    eq(R.keysIn(cobj).sort(), ['a', 'b', 'x', 'y']);
   });
 
   it('works for primitives', function() {
@@ -23,6 +22,6 @@ describe('keysIn', function() {
     var result = R.map(function(val) {
       return R.keys(val);
     }, [null, undefined, 55, '', true, false, NaN, Infinity, , []]);
-    assert.deepEqual(result, R.repeat([], 10));
+    eq(result, R.repeat([], 10));
   });
 });

--- a/test/last.js
+++ b/test/last.js
@@ -1,20 +1,21 @@
 var assert = require('assert');
 
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('last', function() {
 
   it('returns the first element of an ordered collection', function() {
-    assert.strictEqual(R.last([1, 2, 3]), 3);
-    assert.strictEqual(R.last([1, 2]), 2);
-    assert.strictEqual(R.last([1]), 1);
-    assert.strictEqual(R.last([]), undefined);
+    eq(R.last([1, 2, 3]), 3);
+    eq(R.last([1, 2]), 2);
+    eq(R.last([1]), 1);
+    eq(R.last([]), undefined);
 
-    assert.strictEqual(R.last('abc'), 'c');
-    assert.strictEqual(R.last('ab'), 'b');
-    assert.strictEqual(R.last('a'), 'a');
-    assert.strictEqual(R.last(''), '');
+    eq(R.last('abc'), 'c');
+    eq(R.last('ab'), 'b');
+    eq(R.last('a'), 'a');
+    eq(R.last(''), '');
   });
 
   it('throws if applied to null or undefined', function() {

--- a/test/lastIndexOf.js
+++ b/test/lastIndexOf.js
@@ -1,41 +1,40 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('lastIndexOf', function() {
   it("returns a number indicating an object's last position in a list", function() {
     var list = [0, 10, 20, 30, 0, 10, 20, 30, 0, 10];
-    assert.strictEqual(R.lastIndexOf(30, list), 7);
+    eq(R.lastIndexOf(30, list), 7);
   });
   it('returns -1 if the object is not in the list', function() {
     var list = [0, 10, 20, 30];
-    assert.strictEqual(R.lastIndexOf(40, list), -1);
+    eq(R.lastIndexOf(40, list), -1);
   });
 
   var input = [1, 2, 3, 4, 5, 1];
   it('returns the last index of the first item', function() {
-    assert.strictEqual(R.lastIndexOf(1, input), 5);
+    eq(R.lastIndexOf(1, input), 5);
   });
   it('returns the index of the last item', function() {
-    assert.strictEqual(R.lastIndexOf(5, input), 4);
+    eq(R.lastIndexOf(5, input), 4);
   });
 
   var list = ['a', 1, 'a'];
   list[-2] = 'a'; // Throw a wrench in the gears by assigning a non-valid array index as object property.
 
   it('finds a', function() {
-    assert.strictEqual(R.lastIndexOf('a', list), 2);
+    eq(R.lastIndexOf('a', list), 2);
   });
   it('does not find c', function() {
-    assert.strictEqual(R.lastIndexOf('c', list), -1);
+    eq(R.lastIndexOf('c', list), -1);
   });
   it('does not consider "1" equal to 1', function() {
-    assert.strictEqual(R.lastIndexOf('1', list), -1);
+    eq(R.lastIndexOf('1', list), -1);
   });
   it('returns -1 for an empty array', function() {
-    assert.strictEqual(R.lastIndexOf('x', 2, []), -1);
-    assert.strictEqual(R.lastIndexOf('x', -5, []), -1);
+    eq(R.lastIndexOf('x', 2, []), -1);
+    eq(R.lastIndexOf('x', -5, []), -1);
   });
 
   it('has R.equals semantics', function() {
@@ -44,10 +43,10 @@ describe('lastIndexOf', function() {
       return x instanceof Just && R.equals(x.value, this.value);
     };
 
-    assert.strictEqual(R.lastIndexOf(0, [-0]), -1);
-    assert.strictEqual(R.lastIndexOf(-0, [0]), -1);
-    assert.strictEqual(R.lastIndexOf(NaN, [NaN]), 0);
-    assert.strictEqual(R.lastIndexOf(new Just([42]), [new Just([42])]), 0);
+    eq(R.lastIndexOf(0, [-0]), -1);
+    eq(R.lastIndexOf(-0, [0]), -1);
+    eq(R.lastIndexOf(NaN, [NaN]), 0);
+    eq(R.lastIndexOf(new Just([42]), [new Just([42])]), 0);
   });
 
   it('dispatches to `lastIndexOf` method', function() {
@@ -71,14 +70,14 @@ describe('lastIndexOf', function() {
                new List('a',
                new Empty()))))));
 
-    assert.strictEqual(R.lastIndexOf('a', 'banana'), 5);
-    assert.strictEqual(R.lastIndexOf('x', 'banana'), -1);
-    assert.strictEqual(R.lastIndexOf('a', list), 5);
-    assert.strictEqual(R.lastIndexOf('x', list), -1);
+    eq(R.lastIndexOf('a', 'banana'), 5);
+    eq(R.lastIndexOf('x', 'banana'), -1);
+    eq(R.lastIndexOf('a', list), 5);
+    eq(R.lastIndexOf('x', list), -1);
   });
 
   it('is curried', function() {
     var curried = R.lastIndexOf('a');
-    assert.strictEqual(curried(list), 2);
+    eq(curried(list), 2);
   });
 });

--- a/test/length.js
+++ b/test/length.js
@@ -1,41 +1,40 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('length', function() {
   it('returns the length of a list', function() {
-    assert.strictEqual(R.length([]), 0);
-    assert.strictEqual(R.length(['a', 'b', 'c', 'd']), 4);
+    eq(R.length([]), 0);
+    eq(R.length(['a', 'b', 'c', 'd']), 4);
   });
 
   it('returns the length of a string', function() {
-    assert.strictEqual(R.length(''), 0);
-    assert.strictEqual(R.length('xyz'), 3);
+    eq(R.length(''), 0);
+    eq(R.length('xyz'), 3);
   });
 
   it('returns the length of a function', function() {
-    assert.strictEqual(R.length(function() {}), 0);
-    assert.strictEqual(R.length(function(x, y, z) { return z; }), 3);
+    eq(R.length(function() {}), 0);
+    eq(R.length(function(x, y, z) { return z; }), 3);
   });
 
   it('returns the length of an arguments object', function() {
-    assert.strictEqual(R.length((function() { return arguments; }())), 0);
-    assert.strictEqual(R.length((function() { return arguments; }('x', 'y', 'z'))), 3);
+    eq(R.length((function() { return arguments; }())), 0);
+    eq(R.length((function() { return arguments; }('x', 'y', 'z'))), 3);
   });
 
   it('returns NaN for value of unexpected type', function() {
-    assert.strictEqual(R.identical(NaN, R.length(0)), true);
-    assert.strictEqual(R.identical(NaN, R.length({})), true);
-    assert.strictEqual(R.identical(NaN, R.length(null)), true);
-    assert.strictEqual(R.identical(NaN, R.length(undefined)), true);
+    eq(R.identical(NaN, R.length(0)), true);
+    eq(R.identical(NaN, R.length({})), true);
+    eq(R.identical(NaN, R.length(null)), true);
+    eq(R.identical(NaN, R.length(undefined)), true);
   });
 
   it('returns NaN for length property of unexpected type', function() {
-    assert.strictEqual(R.identical(NaN, R.length({length: ''})), true);
-    assert.strictEqual(R.identical(NaN, R.length({length: '1.23'})), true);
-    assert.strictEqual(R.identical(NaN, R.length({length: null})), true);
-    assert.strictEqual(R.identical(NaN, R.length({length: undefined})), true);
-    assert.strictEqual(R.identical(NaN, R.length({})), true);
+    eq(R.identical(NaN, R.length({length: ''})), true);
+    eq(R.identical(NaN, R.length({length: '1.23'})), true);
+    eq(R.identical(NaN, R.length({length: null})), true);
+    eq(R.identical(NaN, R.length({length: undefined})), true);
+    eq(R.identical(NaN, R.length({})), true);
   });
 });

--- a/test/lenses.js
+++ b/test/lenses.js
@@ -1,13 +1,8 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 var they = it;
-
-var eq = function(actual, expected) {
-  assert.strictEqual(R.toString(actual), R.toString(expected));
-};
 
 
 var alice = {

--- a/test/lift.js
+++ b/test/lift.js
@@ -1,8 +1,7 @@
 /* jshint -W053 */
 
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 var Maybe = require('./shared/Maybe');
 
 
@@ -23,24 +22,24 @@ var madd5 = R.lift(add5);
 describe('lift', function() {
 
   it('returns a function if called with just a function', function() {
-    assert.strictEqual(typeof R.lift(R.add), 'function');
+    eq(typeof R.lift(R.add), 'function');
   });
 
   it('produces a cross-product of array values', function() {
-    assert.deepEqual(madd3([1, 2, 3], [1, 2], [1, 2, 3]), [3, 4, 5, 4, 5, 6, 4, 5, 6, 5, 6, 7, 5, 6, 7, 6, 7, 8]);
-    assert.deepEqual(madd3([1], [2], [3]), [6]);
-    assert.deepEqual(madd3([1, 2], [3, 4], [5, 6]), [9, 10, 10, 11, 10, 11, 11, 12]);
+    eq(madd3([1, 2, 3], [1, 2], [1, 2, 3]), [3, 4, 5, 4, 5, 6, 4, 5, 6, 5, 6, 7, 5, 6, 7, 6, 7, 8]);
+    eq(madd3([1], [2], [3]), [6]);
+    eq(madd3([1, 2], [3, 4], [5, 6]), [9, 10, 10, 11, 10, 11, 11, 12]);
   });
 
   it('can lift functions of any arity', function() {
-    assert.deepEqual(madd3([1, 10], [2], [3]), [6, 15]);
-    assert.deepEqual(madd4([1, 10], [2], [3], [40]), [46, 55]);
-    assert.deepEqual(madd5([1, 10], [2], [3], [40], [500, 1000]), [546, 1046, 555, 1055]);
+    eq(madd3([1, 10], [2], [3]), [6, 15]);
+    eq(madd4([1, 10], [2], [3], [40]), [46, 55]);
+    eq(madd5([1, 10], [2], [3], [40], [500, 1000]), [546, 1046, 555, 1055]);
   });
 
   it('works with other functors such as "Maybe"', function() {
     var addM = R.lift(R.add);
-    assert.deepEqual(addM(Maybe.of(3), Maybe.of(5)), Maybe.of(8));
+    eq(addM(Maybe.of(3), Maybe.of(5)), Maybe.of(8));
   });
 
 });

--- a/test/liftN.js
+++ b/test/liftN.js
@@ -1,8 +1,7 @@
 /* jshint -W053 */
 
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 var Maybe = require('./shared/Maybe');
 
 
@@ -21,47 +20,47 @@ describe('liftN', function() {
   var addN5 = R.liftN(5, addN);
 
   it('returns a function', function() {
-    assert.strictEqual(typeof R.liftN(3, add3), 'function');
+    eq(typeof R.liftN(3, add3), 'function');
   });
 
   it('limits a variadic function to the specified arity', function() {
-    assert.deepEqual(addN3([1, 10], [2], [3]), [6, 15]);
+    eq(addN3([1, 10], [2], [3]), [6, 15]);
   });
 
   it('can lift functions of any arity', function() {
-    assert.deepEqual(addN3([1, 10], [2], [3]), [6, 15]);
-    assert.deepEqual(addN4([1, 10], [2], [3], [40]), [46, 55]);
-    assert.deepEqual(addN5([1, 10], [2], [3], [40], [500, 1000]), [546, 1046, 555, 1055]);
+    eq(addN3([1, 10], [2], [3]), [6, 15]);
+    eq(addN4([1, 10], [2], [3], [40]), [46, 55]);
+    eq(addN5([1, 10], [2], [3], [40], [500, 1000]), [546, 1046, 555, 1055]);
   });
 
   it('is curried', function() {
     var f4 = R.liftN(4);
-    assert.strictEqual(typeof f4, 'function');
-    assert.deepEqual(f4(addN)([1], [2], [3], [4, 5]), [10, 11]);
+    eq(typeof f4, 'function');
+    eq(f4(addN)([1], [2], [3], [4, 5]), [10, 11]);
   });
 
   it('works with other functors such as "Maybe"', function() {
     var addM = R.liftN(2, R.add);
-    assert.deepEqual(addM(Maybe(3), Maybe(5)), Maybe(8));
+    eq(addM(Maybe(3), Maybe(5)), Maybe(8));
   });
 
   it('interprets [a] as a functor', function() {
-    assert.deepEqual(addN3([1, 2, 3], [10, 20], [100, 200, 300]), [111, 211, 311, 121, 221, 321, 112, 212, 312, 122, 222, 322, 113, 213, 313, 123, 223, 323]);
-    assert.deepEqual(addN3([1], [2], [3]), [6]);
-    assert.deepEqual(addN3([1, 2], [10, 20], [100, 200]), [111, 211, 121, 221, 112, 212, 122, 222]);
+    eq(addN3([1, 2, 3], [10, 20], [100, 200, 300]), [111, 211, 311, 121, 221, 321, 112, 212, 312, 122, 222, 322, 113, 213, 313, 123, 223, 323]);
+    eq(addN3([1], [2], [3]), [6]);
+    eq(addN3([1, 2], [10, 20], [100, 200]), [111, 211, 121, 221, 112, 212, 122, 222]);
   });
 
   it('interprets ((->) r) as a functor', function() {
     var convergedOnInt = addN3(R.add(2), R.multiply(3), R.subtract(4));
     var convergedOnBool = R.liftN(2, R.and)(R.gt(R.__, 0), R.lt(R.__, 3));
-    assert.strictEqual(typeof convergedOnInt, 'function');
-    assert.strictEqual(typeof convergedOnBool, 'function');
-    assert.strictEqual(convergedOnInt(10), (10 + 2) + (10 * 3) + (4 - 10));
+    eq(typeof convergedOnInt, 'function');
+    eq(typeof convergedOnBool, 'function');
+    eq(convergedOnInt(10), (10 + 2) + (10 * 3) + (4 - 10));
     // jscs:disable disallowYodaConditions
-    assert.strictEqual(convergedOnBool(0), (0 > 0) && (0 < 3));
-    assert.strictEqual(convergedOnBool(1), (1 > 0) && (1 < 3));
-    assert.strictEqual(convergedOnBool(2), (2 > 0) && (2 < 3));
-    assert.strictEqual(convergedOnBool(3), (3 > 0) && (3 < 3));
+    eq(convergedOnBool(0), (0 > 0) && (0 < 3));
+    eq(convergedOnBool(1), (1 > 0) && (1 < 3));
+    eq(convergedOnBool(2), (2 > 0) && (2 < 3));
+    eq(convergedOnBool(3), (3 > 0) && (3 < 3));
     // jscs:enable disallowYodaConditions
   });
 });

--- a/test/lt.js
+++ b/test/lt.js
@@ -1,28 +1,27 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('lt', function() {
   it('reports whether one item is less than another', function() {
-    assert.strictEqual(R.lt(3, 5), true);
-    assert.strictEqual(R.lt(6, 4), false);
-    assert.strictEqual(R.lt(7.0, 7.0), false);
-    assert.strictEqual(R.lt('abc', 'xyz'), true);
-    assert.strictEqual(R.lt('abcd', 'abc'), false);
+    eq(R.lt(3, 5), true);
+    eq(R.lt(6, 4), false);
+    eq(R.lt(7.0, 7.0), false);
+    eq(R.lt('abc', 'xyz'), true);
+    eq(R.lt('abcd', 'abc'), false);
   });
 
   it('is curried', function() {
     var gt5 = R.lt(5);
-    assert.strictEqual(gt5(10), true);
-    assert.strictEqual(gt5(5), false);
-    assert.strictEqual(gt5(3), false);
+    eq(gt5(10), true);
+    eq(gt5(5), false);
+    eq(gt5(3), false);
   });
 
   it('behaves right curried when passed `R.__` for its first argument', function() {
     var lt5 = R.lt(R.__, 5);
-    assert.strictEqual(lt5(10), false);
-    assert.strictEqual(lt5(5), false);
-    assert.strictEqual(lt5(3), true);
+    eq(lt5(10), false);
+    eq(lt5(5), false);
+    eq(lt5(3), true);
   });
 });

--- a/test/lte.js
+++ b/test/lte.js
@@ -1,28 +1,27 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('lte', function() {
   it('reports whether one item is less than another', function() {
-    assert.strictEqual(R.lte(3, 5), true);
-    assert.strictEqual(R.lte(6, 4), false);
-    assert.strictEqual(R.lte(7.0, 7.0), true);
-    assert.strictEqual(R.lte('abc', 'xyz'), true);
-    assert.strictEqual(R.lte('abcd', 'abc'), false);
+    eq(R.lte(3, 5), true);
+    eq(R.lte(6, 4), false);
+    eq(R.lte(7.0, 7.0), true);
+    eq(R.lte('abc', 'xyz'), true);
+    eq(R.lte('abcd', 'abc'), false);
   });
 
   it('is curried', function() {
     var gte20 = R.lte(20);
-    assert.strictEqual(gte20(10), false);
-    assert.strictEqual(gte20(20), true);
-    assert.strictEqual(gte20(25), true);
+    eq(gte20(10), false);
+    eq(gte20(20), true);
+    eq(gte20(25), true);
   });
 
   it('behaves right curried when passed `R.__` for its first argument', function() {
     var upTo20 = R.lte(R.__, 20);
-    assert.strictEqual(upTo20(10), true);
-    assert.strictEqual(upTo20(20), true);
-    assert.strictEqual(upTo20(25), false);
+    eq(upTo20(10), true);
+    eq(upTo20(20), true);
+    eq(upTo20(25), false);
   });
 });

--- a/test/map.js
+++ b/test/map.js
@@ -1,7 +1,7 @@
-var assert = require('assert');
 var listXf = require('./helpers/listXf');
 
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('map', function() {
@@ -11,27 +11,27 @@ describe('map', function() {
   var intoArray = R.into([]);
 
   it('maps simple functions over arrays', function() {
-    assert.deepEqual(R.map(times2, [1, 2, 3, 4]), [2, 4, 6, 8]);
+    eq(R.map(times2, [1, 2, 3, 4]), [2, 4, 6, 8]);
   });
 
   it('maps simple functions into arrays', function() {
-    assert.deepEqual(intoArray(R.map(times2), [1, 2, 3, 4]), [2, 4, 6, 8]);
+    eq(intoArray(R.map(times2), [1, 2, 3, 4]), [2, 4, 6, 8]);
   });
 
   it('interprets ((->) r) as a functor', function() {
     var f = function(a) { return a - 1; };
     var g = function(b) { return b * 2; };
     var h = R.map(f, g);
-    assert.strictEqual(h(10), (10 * 2) - 1);
+    eq(h(10), (10 * 2) - 1);
   });
 
   it('dispatches to objects that implement `map`', function() {
     var obj = {x: 100, map: function(f) { return f(this.x); }};
-    assert.strictEqual(R.map(add1, obj), 101);
+    eq(R.map(add1, obj), 101);
   });
 
   it('dispatches to transformer objects', function() {
-    assert.deepEqual(R.map(add1, listXf), {
+    eq(R.map(add1, listXf), {
       f: add1,
       xf: listXf
     });
@@ -40,25 +40,25 @@ describe('map', function() {
   it('composes', function() {
     var mdouble = R.map(times2);
     var mdec = R.map(dec);
-    assert.deepEqual(mdec(mdouble([10, 20, 30])), [19, 39, 59]);
+    eq(mdec(mdouble([10, 20, 30])), [19, 39, 59]);
   });
 
   it('can compose transducer-style', function() {
     var mdouble = R.map(times2);
     var mdec = R.map(dec);
     var xcomp = mdec(mdouble(listXf));
-    assert.deepEqual(xcomp.xf, {xf: listXf, f: times2});
-    assert.strictEqual(xcomp.f, dec);
+    eq(xcomp.xf, {xf: listXf, f: times2});
+    eq(xcomp.f, dec);
   });
 
   it('is curried', function() {
     var inc = R.map(add1);
-    assert.deepEqual(inc([1, 2, 3]), [2, 3, 4]);
+    eq(inc([1, 2, 3]), [2, 3, 4]);
   });
 
   it('correctly reports the arity of curried versions', function() {
     var inc = R.map(add1);
-    assert.strictEqual(inc.length, 1);
+    eq(inc.length, 1);
   });
 
 });

--- a/test/mapAccum.js
+++ b/test/mapAccum.js
@@ -1,6 +1,5 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('mapAccum', function() {
@@ -9,26 +8,26 @@ describe('mapAccum', function() {
   var concat = function(a, b) {return [a.concat(b), a.concat(b)];};
 
   it('map and accumulate simple functions over arrays with the supplied accumulator', function() {
-    assert.deepEqual(R.mapAccum(add, 0, [1, 2, 3, 4]), [10, [1, 3, 6, 10]]);
-    assert.deepEqual(R.mapAccum(mult, 1, [1, 2, 3, 4]), [24, [1, 2, 6, 24]]);
+    eq(R.mapAccum(add, 0, [1, 2, 3, 4]), [10, [1, 3, 6, 10]]);
+    eq(R.mapAccum(mult, 1, [1, 2, 3, 4]), [24, [1, 2, 6, 24]]);
   });
 
   it('returns the list and accumulator for an empty array', function() {
-    assert.deepEqual(R.mapAccum(add, 0, []), [0, []]);
-    assert.deepEqual(R.mapAccum(mult, 1, []), [1, []]);
-    assert.deepEqual(R.mapAccum(concat, [], []), [[], []]);
+    eq(R.mapAccum(add, 0, []), [0, []]);
+    eq(R.mapAccum(mult, 1, []), [1, []]);
+    eq(R.mapAccum(concat, [], []), [[], []]);
   });
 
   it('is curried', function() {
     var addOrConcat = R.mapAccum(add);
     var sum = addOrConcat(0);
     var cat = addOrConcat('');
-    assert.deepEqual(sum([1, 2, 3, 4]), [10, [1, 3, 6, 10]]);
-    assert.deepEqual(cat(['1', '2', '3', '4']), ['1234', ['1', '12', '123', '1234']]);
+    eq(sum([1, 2, 3, 4]), [10, [1, 3, 6, 10]]);
+    eq(cat(['1', '2', '3', '4']), ['1234', ['1', '12', '123', '1234']]);
   });
 
   it('correctly reports the arity of curried versions', function() {
     var sum = R.mapAccum(add, 0);
-    assert.strictEqual(sum.length, 1);
+    eq(sum.length, 1);
   });
 });

--- a/test/mapAccumRight.js
+++ b/test/mapAccumRight.js
@@ -1,6 +1,5 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('mapAccumRight', function() {
@@ -8,26 +7,26 @@ describe('mapAccumRight', function() {
   var mult = function(a, b) {return [a * b, a * b];};
 
   it('map and accumulate simple functions over arrays with the supplied accumulator', function() {
-    assert.deepEqual(R.mapAccumRight(add, 0, [1, 2, 3, 4]), [10, [10, 9, 7, 4]]);
-    assert.deepEqual(R.mapAccumRight(mult, 1, [1, 2, 3, 4]), [24, [24, 24, 12, 4]]);
+    eq(R.mapAccumRight(add, 0, [1, 2, 3, 4]), [10, [10, 9, 7, 4]]);
+    eq(R.mapAccumRight(mult, 1, [1, 2, 3, 4]), [24, [24, 24, 12, 4]]);
   });
 
   it('returns the list and accumulator for an empty array', function() {
-    assert.deepEqual(R.mapAccumRight(add, 0, []), [0, []]);
-    assert.deepEqual(R.mapAccumRight(mult, 1, []), [1, []]);
-    assert.deepEqual(R.mapAccumRight(R.concat, [], []), [[], []]);
+    eq(R.mapAccumRight(add, 0, []), [0, []]);
+    eq(R.mapAccumRight(mult, 1, []), [1, []]);
+    eq(R.mapAccumRight(R.concat, [], []), [[], []]);
   });
 
   it('is curried', function() {
     var addOrConcat = R.mapAccumRight(add);
     var sum = addOrConcat(0);
     var cat = addOrConcat('');
-    assert.deepEqual(sum([1, 2, 3, 4]), [10, [10, 9, 7, 4]]);
-    assert.deepEqual(cat(['1', '2', '3', '4']), ['4321', ['4321', '432', '43', '4']]);
+    eq(sum([1, 2, 3, 4]), [10, [10, 9, 7, 4]]);
+    eq(cat(['1', '2', '3', '4']), ['4321', ['4321', '432', '43', '4']]);
   });
 
   it('correctly reports the arity of curried versions', function() {
     var sum = R.mapAccumRight(add, 0);
-    assert.strictEqual(sum.length, 1);
+    eq(sum.length, 1);
   });
 });

--- a/test/mapObj.js
+++ b/test/mapObj.js
@@ -1,6 +1,5 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('mapObj', function() {
@@ -8,6 +7,6 @@ describe('mapObj', function() {
 
   it('runs the given function over each of the object properties', function() {
     var obj = {a: 1, b: 2, c: 3};
-    assert.deepEqual(R.mapObj(square, obj), {a: 1, b: 4, c: 9});
+    eq(R.mapObj(square, obj), {a: 1, b: 4, c: 9});
   });
 });

--- a/test/mapObjIndexed.js
+++ b/test/mapObjIndexed.js
@@ -1,6 +1,5 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('mapObjIndexed', function() {
@@ -12,22 +11,22 @@ describe('mapObjIndexed', function() {
   };
 
   it('works just like a normal mapObj', function() {
-    assert.deepEqual(R.mapObjIndexed(times2, {a: 1, b: 2, c: 3, d: 4}), {a: 2, b: 4, c: 6, d: 8});
+    eq(R.mapObjIndexed(times2, {a: 1, b: 2, c: 3, d: 4}), {a: 2, b: 4, c: 6, d: 8});
   });
 
   it('passes the index as a second parameter to the callback', function() {
-    assert.deepEqual(R.mapObjIndexed(addIndexed, {a: 8, b: 6, c: 7, d: 5, e: 3, f: 0, g: 9}),
-                     {a: '8a', b: '6b', c: '7c', d: '5d', e: '3e', f: '0f', g: '9g'});
+    eq(R.mapObjIndexed(addIndexed, {a: 8, b: 6, c: 7, d: 5, e: 3, f: 0, g: 9}),
+       {a: '8a', b: '6b', c: '7c', d: '5d', e: '3e', f: '0f', g: '9g'});
   });
 
   it('passes the entire list as a third parameter to the callback', function() {
-    assert.deepEqual(R.mapObjIndexed(squareVowels, {a: 8, b: 6, c: 7, d: 5, e: 3, f: 0, g: 9}),
-                     {a: 64, b: 6, c: 7, d: 5, e: 9, f: 0, g: 9});
+    eq(R.mapObjIndexed(squareVowels, {a: 8, b: 6, c: 7, d: 5, e: 3, f: 0, g: 9}),
+       {a: 64, b: 6, c: 7, d: 5, e: 9, f: 0, g: 9});
   });
 
   it('is curried', function() {
     var makeSquareVowels = R.mapObjIndexed(squareVowels);
-    assert.deepEqual(makeSquareVowels({a: 8, b: 6, c: 7, d: 5, e: 3, f: 0, g: 9}),
-                     {a: 64, b: 6, c: 7, d: 5, e: 9, f: 0, g: 9});
+    eq(makeSquareVowels({a: 8, b: 6, c: 7, d: 5, e: 3, f: 0, g: 9}),
+       {a: 64, b: 6, c: 7, d: 5, e: 9, f: 0, g: 9});
   });
 });

--- a/test/match.js
+++ b/test/match.js
@@ -1,6 +1,7 @@
 var assert = require('assert');
 
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('match', function() {
@@ -9,14 +10,14 @@ describe('match', function() {
   var notMatching = 'B1-afn';
 
   it('determines whether a string matches a regex', function() {
-    assert.strictEqual(R.match(re, matching).length, 1);
-    assert.deepEqual(R.match(re, notMatching), []);
+    eq(R.match(re, matching).length, 1);
+    eq(R.match(re, notMatching), []);
   });
 
   it('is curried', function() {
     var format = R.match(re);
-    assert.strictEqual(format(matching).length, 1);
-    assert.deepEqual(format(notMatching), []);
+    eq(format(matching).length, 1);
+    eq(format(notMatching), []);
   });
 
   it('defaults to a different empty array each time', function() {

--- a/test/mathMod.js
+++ b/test/mathMod.js
@@ -1,6 +1,7 @@
 var assert = require('assert');
 
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('mathMod', function() {
@@ -18,22 +19,22 @@ describe('mathMod', function() {
   });
 
   it('computes the true modulo function', function() {
-    assert.strictEqual(R.mathMod(-17, 5), 3);
-    assert.strictEqual(R.identical(NaN, R.mathMod(17, -5)), true);
-    assert.strictEqual(R.identical(NaN, R.mathMod(17, 0)), true);
-    assert.strictEqual(R.identical(NaN, R.mathMod(17.2, 5)), true);
-    assert.strictEqual(R.identical(NaN, R.mathMod(17, 5.5)), true);
+    eq(R.mathMod(-17, 5), 3);
+    eq(R.identical(NaN, R.mathMod(17, -5)), true);
+    eq(R.identical(NaN, R.mathMod(17, 0)), true);
+    eq(R.identical(NaN, R.mathMod(17.2, 5)), true);
+    eq(R.identical(NaN, R.mathMod(17, 5.5)), true);
   });
 
   it('is curried', function() {
     var f = R.mathMod(29);
-    assert.strictEqual(f(6), 5);
+    eq(f(6), 5);
   });
 
 
   it('behaves right curried when passed `R.__` for its first argument', function() {
     var mod5 = R.modulo(R.__, 5);
-    assert.strictEqual(mod5(12), 2);
-    assert.strictEqual(mod5(8), 3);
+    eq(mod5(12), 2);
+    eq(mod5(8), 3);
   });
 });

--- a/test/max.js
+++ b/test/max.js
@@ -1,23 +1,22 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('max', function() {
 
   it('returns the larger of its two arguments', function() {
-    assert.strictEqual(R.max(-7, 7), 7);
-    assert.strictEqual(R.max(7, -7), 7);
+    eq(R.max(-7, 7), 7);
+    eq(R.max(7, -7), 7);
   });
 
   it('works for any orderable type', function() {
     var d1 = new Date('2001-01-01');
     var d2 = new Date('2002-02-02');
 
-    assert.strictEqual(R.max(d1, d2), d2);
-    assert.strictEqual(R.max(d2, d1), d2);
-    assert.strictEqual(R.max('a', 'b'), 'b');
-    assert.strictEqual(R.max('b', 'a'), 'b');
+    eq(R.max(d1, d2), d2);
+    eq(R.max(d2, d1), d2);
+    eq(R.max('a', 'b'), 'b');
+    eq(R.max('b', 'a'), 'b');
   });
 
 });

--- a/test/maxBy.js
+++ b/test/maxBy.js
@@ -1,13 +1,12 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('maxBy', function() {
 
   it('returns the larger value as determined by the function', function() {
-    assert.strictEqual(R.maxBy(function(n) { return n * n; }, -3, 2), -3);
-    assert.deepEqual(R.maxBy(R.prop('x'), {x: 3, y: 1}, {x: 5, y: 10}), {x: 5, y: 10});
+    eq(R.maxBy(function(n) { return n * n; }, -3, 2), -3);
+    eq(R.maxBy(R.prop('x'), {x: 3, y: 1}, {x: 5, y: 10}), {x: 5, y: 10});
   });
 
 });

--- a/test/mean.js
+++ b/test/mean.js
@@ -1,23 +1,22 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('mean', function() {
 
   it('returns mean of a nonempty list', function() {
-    assert.strictEqual(R.mean([2]), 2);
-    assert.strictEqual(R.mean([2, 7]), 4.5);
-    assert.strictEqual(R.mean([2, 7, 9]), 6);
-    assert.strictEqual(R.mean([2, 7, 9, 10]), 7);
+    eq(R.mean([2]), 2);
+    eq(R.mean([2, 7]), 4.5);
+    eq(R.mean([2, 7, 9]), 6);
+    eq(R.mean([2, 7, 9, 10]), 7);
   });
 
   it('returns NaN for an empty list', function() {
-    assert.strictEqual(R.identical(NaN, R.mean([])), true);
+    eq(R.identical(NaN, R.mean([])), true);
   });
 
   it('handles array-like object', function() {
-    assert.strictEqual(R.mean((function() { return arguments; }(1, 2, 3))), 2);
+    eq(R.mean((function() { return arguments; }(1, 2, 3))), 2);
   });
 
 });

--- a/test/median.js
+++ b/test/median.js
@@ -1,26 +1,25 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('median', function() {
 
   it('returns middle value of an odd-length list', function() {
-    assert.strictEqual(R.median([2]), 2);
-    assert.strictEqual(R.median([2, 9, 7]), 7);
+    eq(R.median([2]), 2);
+    eq(R.median([2, 9, 7]), 7);
   });
 
   it('returns mean of two middle values of a nonempty even-length list', function() {
-    assert.strictEqual(R.median([7, 2]), 4.5);
-    assert.strictEqual(R.median([7, 2, 10, 9]), 8);
+    eq(R.median([7, 2]), 4.5);
+    eq(R.median([7, 2, 10, 9]), 8);
   });
 
   it('returns NaN for an empty list', function() {
-    assert.strictEqual(R.identical(NaN, R.median([])), true);
+    eq(R.identical(NaN, R.median([])), true);
   });
 
   it('handles array-like object', function() {
-    assert.strictEqual(R.median((function() { return arguments; }(1, 2, 3))), 2);
+    eq(R.median((function() { return arguments; }(1, 2, 3))), 2);
   });
 
 });

--- a/test/memoize.js
+++ b/test/memoize.js
@@ -1,6 +1,5 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('memoize', function() {
@@ -8,22 +7,22 @@ describe('memoize', function() {
     var ctr = 0;
     var fib = R.memoize(function(n) {ctr += 1; return n < 2 ? n : fib(n - 2) + fib(n - 1);});
     var result = fib(10);
-    assert.strictEqual(result, 55);
-    assert.strictEqual(ctr, 11); // fib(0), fib(1), ... fib(10), no memoization would take 177 iterations.
+    eq(result, 55);
+    eq(ctr, 11); // fib(0), fib(1), ... fib(10), no memoization would take 177 iterations.
   });
 
   it('handles multiple parameters', function() {
     var f = R.memoize(function(a, b, c) {return a + ', ' + b + c;});
-    assert.strictEqual(f('Hello', 'World' , '!'), 'Hello, World!');
-    assert.strictEqual(f('Goodbye', 'Cruel World' , '!!!'), 'Goodbye, Cruel World!!!');
-    assert.strictEqual(f('Hello', 'how are you' , '?'), 'Hello, how are you?');
-    assert.strictEqual(f('Hello', 'World' , '!'), 'Hello, World!');
+    eq(f('Hello', 'World' , '!'), 'Hello, World!');
+    eq(f('Goodbye', 'Cruel World' , '!!!'), 'Goodbye, Cruel World!!!');
+    eq(f('Hello', 'how are you' , '?'), 'Hello, how are you?');
+    eq(f('Hello', 'World' , '!'), 'Hello, World!');
   });
 
   it('does not rely on reported arity', function() {
     var identity = R.memoize(function() { return arguments[0]; });
-    assert.strictEqual(identity('x'), 'x');
-    assert.strictEqual(identity('y'), 'y');
+    eq(identity('x'), 'x');
+    eq(identity('y'), 'y');
   });
 
   it('memoizes "false" return values', function() {
@@ -32,10 +31,10 @@ describe('memoize', function() {
       count += 1;
       return n + 1;
     });
-    assert.strictEqual(inc(-1), 0);
-    assert.strictEqual(inc(-1), 0);
-    assert.strictEqual(inc(-1), 0);
-    assert.strictEqual(count, 1);
+    eq(inc(-1), 0);
+    eq(inc(-1), 0);
+    eq(inc(-1), 0);
+    eq(count, 1);
   });
 
   it('can be applied to nullary function', function() {
@@ -44,10 +43,10 @@ describe('memoize', function() {
       count += 1;
       return 42;
     });
-    assert.strictEqual(f(), 42);
-    assert.strictEqual(f(), 42);
-    assert.strictEqual(f(), 42);
-    assert.strictEqual(count, 1);
+    eq(f(), 42);
+    eq(f(), 42);
+    eq(f(), 42);
+    eq(count, 1);
   });
 
   it('can be applied to function with optional arguments', function() {
@@ -60,18 +59,18 @@ describe('memoize', function() {
       }
       return a + b;
     });
-    assert.strictEqual(f(), 'foobar');
-    assert.strictEqual(f(), 'foobar');
-    assert.strictEqual(f(), 'foobar');
-    assert.strictEqual(count, 1);
+    eq(f(), 'foobar');
+    eq(f(), 'foobar');
+    eq(f(), 'foobar');
+    eq(count, 1);
   });
 
   it('differentiates values with same string representation', function() {
     var f = R.memoize(R.toString);
-    assert.strictEqual(f(42), '42');
-    assert.strictEqual(f('42'), '"42"');
-    assert.strictEqual(f([[42]]), '[[42]]');
-    assert.strictEqual(f([['42']]), '[["42"]]');
+    eq(f(42), '42');
+    eq(f('42'), '"42"');
+    eq(f([[42]]), '[[42]]');
+    eq(f([['42']]), '[["42"]]');
   });
 
   it('respects object equivalence', function() {
@@ -80,9 +79,9 @@ describe('memoize', function() {
       count += 1;
       return R.toString(x);
     });
-    assert.strictEqual(f({x: 1, y: 2}), '{"x": 1, "y": 2}');
-    assert.strictEqual(f({x: 1, y: 2}), '{"x": 1, "y": 2}');
-    assert.strictEqual(f({y: 2, x: 1}), '{"x": 1, "y": 2}');
-    assert.strictEqual(count, 1);
+    eq(f({x: 1, y: 2}), '{"x": 1, "y": 2}');
+    eq(f({x: 1, y: 2}), '{"x": 1, "y": 2}');
+    eq(f({y: 2, x: 1}), '{"x": 1, "y": 2}');
+    eq(count, 1);
   });
 });

--- a/test/merge.js
+++ b/test/merge.js
@@ -1,44 +1,45 @@
 var assert = require('assert');
 
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('merge', function() {
   it('takes two objects, merges their own properties and returns a new object', function() {
     var a = {w: 1, x: 2};
     var b = {y: 3, z: 4};
-    assert.deepEqual(R.merge(a, b), {w: 1, x: 2, y: 3, z: 4});
+    eq(R.merge(a, b), {w: 1, x: 2, y: 3, z: 4});
   });
 
   it('overrides properties in the first object with properties in the second object', function() {
     var a = {w: 1, x: 2};
     var b = {w: 100, y: 3, z: 4};
-    assert.deepEqual(R.merge(a, b), {w: 100, x: 2, y: 3, z: 4});
+    eq(R.merge(a, b), {w: 100, x: 2, y: 3, z: 4});
   });
 
   it('is not destructive', function() {
     var a = {w: 1, x: 2};
     var res = R.merge(a, {x: 5});
     assert.notStrictEqual(a, res);
-    assert.deepEqual(res, {w: 1, x: 5});
+    eq(res, {w: 1, x: 5});
   });
 
   it('reports only own properties', function() {
     var a = {w: 1, x: 2};
     function Cla() {}
     Cla.prototype.x = 5;
-    assert.deepEqual(R.merge(new Cla(), a), {w: 1, x: 2});
-    assert.deepEqual(R.merge(a, new Cla()), {w: 1, x: 2});
+    eq(R.merge(new Cla(), a), {w: 1, x: 2});
+    eq(R.merge(a, new Cla()), {w: 1, x: 2});
   });
 
   it('is curried', function() {
     var curried = R.merge({w: 1, x: 2});
     var b = {y: 3, z: 4};
-    assert.deepEqual(curried(b), {w: 1, x: 2, y: 3, z: 4});
+    eq(curried(b), {w: 1, x: 2, y: 3, z: 4});
   });
 
   it('is curried', function() {
     var curried = R.merge(R.__, {w: 1, x: 2});
-    assert.deepEqual(curried({x: 3, y: 4}), {w: 1, x: 2, y: 4});
+    eq(curried({x: 3, y: 4}), {w: 1, x: 2, y: 4});
   });
 });

--- a/test/mergeAll.js
+++ b/test/mergeAll.js
@@ -1,15 +1,14 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('mergeAll', function() {
   it('merges a list of objects together into one object', function() {
-    assert.deepEqual(R.mergeAll([{foo:1}, {bar:2}, {baz:3}]), {foo:1, bar:2, baz:3});
+    eq(R.mergeAll([{foo:1}, {bar:2}, {baz:3}]), {foo:1, bar:2, baz:3});
   });
 
   it('gives precedence to later objects in the list', function() {
-    assert.deepEqual(R.mergeAll([{foo:1}, {foo:2}, {bar:2}]), {foo:2, bar:2});
+    eq(R.mergeAll([{foo:1}, {foo:2}, {bar:2}]), {foo:2, bar:2});
   });
 
   it('ignores inherited properties', function() {
@@ -17,6 +16,6 @@ describe('mergeAll', function() {
     Foo.prototype.bar = 42;
     var foo = new Foo();
     var res = R.mergeAll([foo, {fizz: 'buzz'}]);
-    assert.deepEqual(res, {fizz: 'buzz'});
+    eq(res, {fizz: 'buzz'});
   });
 });

--- a/test/min.js
+++ b/test/min.js
@@ -1,23 +1,22 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('min', function() {
 
   it('returns the smaller of its two arguments', function() {
-    assert.strictEqual(R.min(-7, 7), -7);
-    assert.strictEqual(R.min(7, -7), -7);
+    eq(R.min(-7, 7), -7);
+    eq(R.min(7, -7), -7);
   });
 
   it('works for any orderable type', function() {
     var d1 = new Date('2001-01-01');
     var d2 = new Date('2002-02-02');
 
-    assert.strictEqual(R.min(d1, d2), d1);
-    assert.strictEqual(R.min(d2, d1), d1);
-    assert.strictEqual(R.min('a', 'b'), 'a');
-    assert.strictEqual(R.min('b', 'a'), 'a');
+    eq(R.min(d1, d2), d1);
+    eq(R.min(d2, d1), d1);
+    eq(R.min('a', 'b'), 'a');
+    eq(R.min('b', 'a'), 'a');
   });
 
 });

--- a/test/minBy.js
+++ b/test/minBy.js
@@ -1,13 +1,12 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('minBy', function() {
 
   it('returns the smaller value as determined by the function', function() {
-    assert.strictEqual(R.minBy(function(n) { return n * n; }, -3, 2), 2);
-    assert.deepEqual(R.minBy(R.prop('x'), {x: 3, y: 1}, {x: 5, y: 10}), {x: 3, y: 1});
+    eq(R.minBy(function(n) { return n * n; }, -3, 2), 2);
+    eq(R.minBy(R.prop('x'), {x: 3, y: 1}, {x: 5, y: 10}), {x: 3, y: 1});
   });
 
 });

--- a/test/modulo.js
+++ b/test/modulo.js
@@ -1,31 +1,30 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('modulo', function() {
   it('divides the first param by the second and returns the remainder', function() {
-    assert.strictEqual(R.modulo(100, 2), 0);
-    assert.strictEqual(R.modulo(100, 3), 1);
-    assert.strictEqual(R.modulo(100, 17), 15);
+    eq(R.modulo(100, 2), 0);
+    eq(R.modulo(100, 3), 1);
+    eq(R.modulo(100, 17), 15);
   });
 
   it('is curried', function() {
     var hundredMod = R.modulo(100);
-    assert.strictEqual(typeof hundredMod, 'function');
-    assert.strictEqual(hundredMod(2), 0);
-    assert.strictEqual(hundredMod(3), 1);
-    assert.strictEqual(hundredMod(17), 15);
+    eq(typeof hundredMod, 'function');
+    eq(hundredMod(2), 0);
+    eq(hundredMod(3), 1);
+    eq(hundredMod(17), 15);
   });
 
   it('behaves right curried when passed `R.__` for its first argument', function() {
     var isOdd = R.modulo(R.__, 2);
-    assert.strictEqual(typeof isOdd, 'function');
-    assert.strictEqual(isOdd(3), 1);
-    assert.strictEqual(isOdd(198), 0);
+    eq(typeof isOdd, 'function');
+    eq(isOdd(3), 1);
+    eq(isOdd(198), 0);
   });
 
   it('preserves javascript-style modulo evaluation for negative numbers', function() {
-    assert.strictEqual(R.modulo(-5, 4), -1);
+    eq(R.modulo(-5, 4), -1);
   });
 });

--- a/test/multiply.js
+++ b/test/multiply.js
@@ -1,15 +1,14 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('multiply', function() {
   it('adds together two numbers', function() {
-    assert.strictEqual(R.multiply(6, 7), 42);
+    eq(R.multiply(6, 7), 42);
   });
 
   it('is curried', function() {
     var dbl = R.multiply(2);
-    assert.strictEqual(dbl(15), 30);
+    eq(dbl(15), 30);
   });
 });

--- a/test/nAry.js
+++ b/test/nAry.js
@@ -1,6 +1,7 @@
 var assert = require('assert');
 
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('nAry', function() {
@@ -9,28 +10,28 @@ describe('nAry', function() {
 
   it('turns multiple-argument function into a nullary one', function() {
     var fn = R.nAry(0, function(x, y, z) { void z; return toArray(arguments); });
-    assert.strictEqual(fn.length, 0);
-    assert.deepEqual(fn(1, 2, 3), []);
+    eq(fn.length, 0);
+    eq(fn(1, 2, 3), []);
   });
 
   it('turns multiple-argument function into a ternary one', function() {
     var fn = R.nAry(3, function(a, b, c, d) { void d; return toArray(arguments); });
-    assert.strictEqual(fn.length, 3);
-    assert.deepEqual(fn(1, 2, 3, 4), [1, 2, 3]);
-    assert.deepEqual(fn(1), [1, undefined, undefined]);
+    eq(fn.length, 3);
+    eq(fn(1, 2, 3, 4), [1, 2, 3]);
+    eq(fn(1), [1, undefined, undefined]);
   });
 
   it('creates functions of arity less than or equal to ten', function() {
     var fn = R.nAry(10, function() { return toArray(arguments); });
-    assert.strictEqual(fn.length, 10);
-    assert.deepEqual(fn.apply(null, R.range(0, 25)), R.range(0, 10));
+    eq(fn.length, 10);
+    eq(fn.apply(null, R.range(0, 25)), R.range(0, 10));
 
     var undefs = fn();
     var ns = R.repeat(undefined, 10);
-    assert.strictEqual(undefs.length, ns.length);
+    eq(undefs.length, ns.length);
     var idx = undefs.length - 1;
     while (idx >= 0) {
-      assert.strictEqual(undefs[idx], ns[idx]);
+      eq(undefs[idx], ns[idx]);
       idx -= 1;
     }
   });

--- a/test/negate.js
+++ b/test/negate.js
@@ -1,16 +1,16 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('negate', function() {
 
   it('negates its argument', function() {
-    assert.strictEqual(R.negate(-Infinity), Infinity);
-    assert.strictEqual(R.negate(-1), 1);
-    assert.strictEqual(R.negate(0), 0);
-    assert.strictEqual(R.negate(1), -1);
-    assert.strictEqual(R.negate(Infinity), -Infinity);
+    eq(R.negate(-Infinity), Infinity);
+    eq(R.negate(-1), 1);
+    eq(R.negate(-0), 0);
+    eq(R.negate(0), -0);
+    eq(R.negate(1), -1);
+    eq(R.negate(Infinity), -Infinity);
   });
 
 });

--- a/test/none.js
+++ b/test/none.js
@@ -1,6 +1,5 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('none', function() {
@@ -8,26 +7,26 @@ describe('none', function() {
   var T = function() {return true;};
 
   it('returns true if no elements satisfy the predicate', function() {
-    assert.strictEqual(R.none(even, [1, 3, 5, 7, 9, 11]), true);
+    eq(R.none(even, [1, 3, 5, 7, 9, 11]), true);
   });
 
   it('returns false if any element satisfies the predicate', function() {
-    assert.strictEqual(R.none(even, [1, 3, 5, 7, 8, 11]), false);
+    eq(R.none(even, [1, 3, 5, 7, 8, 11]), false);
   });
 
   it('returns true for an empty list', function() {
-    assert.strictEqual(R.none(T, []), true);
+    eq(R.none(T, []), true);
   });
 
   it('works with more complex objects', function() {
     var xs = [{x: 'abcd'}, {x: 'adef'}, {x: 'fghiajk'}];
     function len3(o) { return o.x.length === 3; }
     function hasA(o) { return o.x.indexOf('a') >= 0; }
-    assert.strictEqual(R.none(len3, xs), true);
-    assert.strictEqual(R.none(hasA, xs), false);
+    eq(R.none(len3, xs), true);
+    eq(R.none(hasA, xs), false);
   });
 
   it('is curried', function() {
-    assert.strictEqual(R.none(even)([1, 3, 5, 6, 7, 9]), false);
+    eq(R.none(even)([1, 3, 5, 6, 7, 9]), false);
   });
 });

--- a/test/not.js
+++ b/test/not.js
@@ -1,12 +1,11 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('not', function() {
   it('reverses argument', function() {
-    assert.strictEqual(R.not(false), true);
-    assert.strictEqual(R.not(1), false);
-    assert.strictEqual(R.not(''), true);
+    eq(R.not(false), true);
+    eq(R.not(1), false);
+    eq(R.not(''), true);
   });
 });

--- a/test/nth.js
+++ b/test/nth.js
@@ -1,6 +1,7 @@
 var assert = require('assert');
 
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('nth', function() {
@@ -8,29 +9,29 @@ describe('nth', function() {
   var list = ['foo', 'bar', 'baz', 'quux'];
 
   it('accepts positive offsets', function() {
-    assert.strictEqual(R.nth(0, list), 'foo');
-    assert.strictEqual(R.nth(1, list), 'bar');
-    assert.strictEqual(R.nth(2, list), 'baz');
-    assert.strictEqual(R.nth(3, list), 'quux');
-    assert.strictEqual(R.nth(4, list), undefined);
+    eq(R.nth(0, list), 'foo');
+    eq(R.nth(1, list), 'bar');
+    eq(R.nth(2, list), 'baz');
+    eq(R.nth(3, list), 'quux');
+    eq(R.nth(4, list), undefined);
 
-    assert.strictEqual(R.nth(0, 'abc'), 'a');
-    assert.strictEqual(R.nth(1, 'abc'), 'b');
-    assert.strictEqual(R.nth(2, 'abc'), 'c');
-    assert.strictEqual(R.nth(3, 'abc'), '');
+    eq(R.nth(0, 'abc'), 'a');
+    eq(R.nth(1, 'abc'), 'b');
+    eq(R.nth(2, 'abc'), 'c');
+    eq(R.nth(3, 'abc'), '');
   });
 
   it('accepts negative offsets', function() {
-    assert.strictEqual(R.nth(-1, list), 'quux');
-    assert.strictEqual(R.nth(-2, list), 'baz');
-    assert.strictEqual(R.nth(-3, list), 'bar');
-    assert.strictEqual(R.nth(-4, list), 'foo');
-    assert.strictEqual(R.nth(-5, list), undefined);
+    eq(R.nth(-1, list), 'quux');
+    eq(R.nth(-2, list), 'baz');
+    eq(R.nth(-3, list), 'bar');
+    eq(R.nth(-4, list), 'foo');
+    eq(R.nth(-5, list), undefined);
 
-    assert.strictEqual(R.nth(-1, 'abc'), 'c');
-    assert.strictEqual(R.nth(-2, 'abc'), 'b');
-    assert.strictEqual(R.nth(-3, 'abc'), 'a');
-    assert.strictEqual(R.nth(-4, 'abc'), '');
+    eq(R.nth(-1, 'abc'), 'c');
+    eq(R.nth(-2, 'abc'), 'b');
+    eq(R.nth(-3, 'abc'), 'a');
+    eq(R.nth(-4, 'abc'), '');
   });
 
   it('throws if applied to null or undefined', function() {

--- a/test/nthArg.js
+++ b/test/nthArg.js
@@ -1,22 +1,21 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('nthArg', function() {
   it('returns a function which returns its nth argument', function() {
-    assert.strictEqual(R.nthArg(0)('foo', 'bar'), 'foo');
-    assert.strictEqual(R.nthArg(1)('foo', 'bar'), 'bar');
-    assert.strictEqual(R.nthArg(2)('foo', 'bar'), undefined);
+    eq(R.nthArg(0)('foo', 'bar'), 'foo');
+    eq(R.nthArg(1)('foo', 'bar'), 'bar');
+    eq(R.nthArg(2)('foo', 'bar'), undefined);
   });
 
   it('accepts negative offsets', function() {
-    assert.strictEqual(R.nthArg(-1)('foo', 'bar'), 'bar');
-    assert.strictEqual(R.nthArg(-2)('foo', 'bar'), 'foo');
-    assert.strictEqual(R.nthArg(-3)('foo', 'bar'), undefined);
+    eq(R.nthArg(-1)('foo', 'bar'), 'bar');
+    eq(R.nthArg(-2)('foo', 'bar'), 'foo');
+    eq(R.nthArg(-3)('foo', 'bar'), undefined);
   });
 
   it('returns a function with length 0', function() {
-    assert.strictEqual(R.nthArg(2).length, 0);
+    eq(R.nthArg(2).length, 0);
   });
 });

--- a/test/objOf.js
+++ b/test/objOf.js
@@ -1,13 +1,12 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('objOf', function() {
 
   it('creates an object containing a single key:value pair', function() {
-    assert.deepEqual(R.objOf('foo', 42), {foo: 42});
-    assert.deepEqual(R.objOf('foo')(42), {foo: 42});
+    eq(R.objOf('foo', 42), {foo: 42});
+    eq(R.objOf('foo')(42), {foo: 42});
   });
 
 });

--- a/test/of.js
+++ b/test/of.js
@@ -1,14 +1,13 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('of', function() {
   it('returns its argument as an Array', function() {
-    assert.deepEqual(R.of(100), [100]);
-    assert.deepEqual(R.of([100]), [[100]]);
-    assert.deepEqual(R.of(null), [null]);
-    assert.deepEqual(R.of(undefined), [undefined]);
-    assert.deepEqual(R.of([]), [[]]);
+    eq(R.of(100), [100]);
+    eq(R.of([100]), [[100]]);
+    eq(R.of(null), [null]);
+    eq(R.of(undefined), [undefined]);
+    eq(R.of([]), [[]]);
   });
 });

--- a/test/omit.js
+++ b/test/omit.js
@@ -1,13 +1,12 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('omit', function() {
   var obj = {a: 1, b: 2, c: 3, d: 4, e: 5, f: 6};
 
   it('copies an object omitting the listed properties', function() {
-    assert.deepEqual(R.omit(['a', 'c', 'f'], obj), {b: 2, d: 4, e: 5});
+    eq(R.omit(['a', 'c', 'f'], obj), {b: 2, d: 4, e: 5});
   });
 
   it('includes prototype properties', function() {
@@ -15,11 +14,11 @@ describe('omit', function() {
     F.prototype.y = 40; F.prototype.z = 50;
     var obj = new F(30);
     obj.v = 10; obj.w = 20;
-    assert.deepEqual(R.omit(['w', 'x', 'y'], obj), {v: 10, z: 50});
+    eq(R.omit(['w', 'x', 'y'], obj), {v: 10, z: 50});
   });
 
   it('is curried', function() {
     var skipAB = R.omit(['a', 'b']);
-    assert.deepEqual(skipAB(obj), {c: 3, d: 4, e: 5, f: 6});
+    eq(skipAB(obj), {c: 3, d: 4, e: 5, f: 6});
   });
 });

--- a/test/once.js
+++ b/test/once.js
@@ -1,6 +1,5 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('once', function() {
@@ -8,27 +7,27 @@ describe('once', function() {
     var ctr = 0;
     var fn = R.once(function() {ctr += 1;});
     fn();
-    assert.strictEqual(ctr, 1);
+    eq(ctr, 1);
     fn();
-    assert.strictEqual(ctr, 1);
+    eq(ctr, 1);
     fn();
-    assert.strictEqual(ctr, 1);
+    eq(ctr, 1);
   });
 
   it('passes along arguments supplied', function() {
     var fn = R.once(function(a, b) {return a + b;});
     var result = fn(5, 10);
-    assert.strictEqual(result, 15);
+    eq(result, 15);
   });
 
   it('retains and returns the first value calculated, even if different arguments are passed later', function() {
     var ctr = 0;
     var fn = R.once(function(a, b) {ctr += 1; return a + b;});
     var result = fn(5, 10);
-    assert.strictEqual(result, 15);
-    assert.strictEqual(ctr, 1);
+    eq(result, 15);
+    eq(ctr, 1);
     result = fn(20, 30);
-    assert.strictEqual(result, 15);
-    assert.strictEqual(ctr, 1);
+    eq(result, 15);
+    eq(ctr, 1);
   });
 });

--- a/test/or.js
+++ b/test/or.js
@@ -1,18 +1,17 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('or', function() {
   it('compares two values with js &&', function() {
-    assert.strictEqual(R.or(true, true), true);
-    assert.strictEqual(R.or(true, false), true);
-    assert.strictEqual(R.or(false, true), true);
-    assert.strictEqual(R.or(false, false), false);
+    eq(R.or(true, true), true);
+    eq(R.or(true, false), true);
+    eq(R.or(false, true), true);
+    eq(R.or(false, false), false);
   });
 
   it('is curried', function() {
-    assert.strictEqual(R.or(false)(false), false);
-    assert.strictEqual(R.or(false)(true), true);
+    eq(R.or(false)(false), false);
+    eq(R.or(false)(true), true);
   });
 });

--- a/test/pair.js
+++ b/test/pair.js
@@ -1,13 +1,12 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('pair', function() {
 
   it('creates a two-element array', function() {
-    assert.deepEqual(R.pair('foo', 'bar'), ['foo', 'bar']);
-    assert.deepEqual(R.pair('foo')('bar'), ['foo', 'bar']);
+    eq(R.pair('foo', 'bar'), ['foo', 'bar']);
+    eq(R.pair('foo')('bar'), ['foo', 'bar']);
   });
 
 });

--- a/test/partial.js
+++ b/test/partial.js
@@ -1,6 +1,5 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('partial', function() {
@@ -10,15 +9,15 @@ describe('partial', function() {
 
   it('caches the initially supplied left-most parameters in the generated function', function() {
     var f = R.partial(disc, 3);
-    assert.strictEqual(f(7, 4), 1);
+    eq(f(7, 4), 1);
     var g = R.partial(disc, 3, 7);
-    assert.strictEqual(g(4), 1);
+    eq(g(4), 1);
   });
 
   it('correctly reports the arity of the new function', function() {
     var f = R.partial(disc, 3);
-    assert.strictEqual(f.length, 2);
+    eq(f.length, 2);
     var g = R.partial(disc, 3, 7);
-    assert.strictEqual(g.length, 1);
+    eq(g.length, 1);
   });
 });

--- a/test/partialRight.js
+++ b/test/partialRight.js
@@ -1,6 +1,5 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('partialRight', function() {
@@ -10,15 +9,15 @@ describe('partialRight', function() {
 
   it('caches the initially supplied right-most parameters in the generated function', function() {
     var f = R.partialRight(disc, 4);
-    assert.strictEqual(f(3, 7), 1);
+    eq(f(3, 7), 1);
     var g = R.partialRight(disc, 7, 4);
-    assert.strictEqual(g(3), 1);
+    eq(g(3), 1);
   });
 
   it('correctly reports the arity of the new function', function() {
     var f = R.partialRight(disc, 4);
-    assert.strictEqual(f.length, 2);
+    eq(f.length, 2);
     var g = R.partialRight(disc, 7, 4);
-    assert.strictEqual(g.length, 1);
+    eq(g.length, 1);
   });
 });

--- a/test/partition.js
+++ b/test/partition.js
@@ -1,19 +1,18 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('partition', function() {
   it('splits a list into two lists according to a predicate', function() {
     var pred = function(n) { return n % 2; };
-    assert.deepEqual(R.partition(pred, []), [[], []]);
-    assert.deepEqual(R.partition(pred, [0, 2, 4, 6]), [[], [0, 2, 4, 6]]);
-    assert.deepEqual(R.partition(pred, [1, 3, 5, 7]), [[1, 3, 5, 7], []]);
-    assert.deepEqual(R.partition(pred, [0, 1, 2, 3]), [[1, 3], [0, 2]]);
+    eq(R.partition(pred, []), [[], []]);
+    eq(R.partition(pred, [0, 2, 4, 6]), [[], [0, 2, 4, 6]]);
+    eq(R.partition(pred, [1, 3, 5, 7]), [[1, 3, 5, 7], []]);
+    eq(R.partition(pred, [0, 1, 2, 3]), [[1, 3], [0, 2]]);
   });
 
   it('is curried', function() {
     var polarize = R.partition(Boolean);
-    assert.deepEqual(polarize([true, 0, 1, null]), [[true, 1], [0, null]]);
+    eq(polarize([true, 0, 1, null]), [[true, 1], [0, null]]);
   });
 });

--- a/test/path.js
+++ b/test/path.js
@@ -1,6 +1,5 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('path', function() {
@@ -21,34 +20,34 @@ describe('path', function() {
       i: 'I',
       j: ['J']
     };
-    assert.strictEqual(R.path(['a', 'b', 'c'], obj), 100);
-    assert.strictEqual(R.path([], obj), obj);
-    assert.strictEqual(R.path(['a', 'e', 'f', '1'], obj), 101);
-    assert.strictEqual(R.path(['j', '0'], obj), 'J');
-    assert.strictEqual(R.path(['j', '1'], obj), undefined);
-    assert.strictEqual(R.path(['a', 'b', 'c'], null), undefined);
+    eq(R.path(['a', 'b', 'c'], obj), 100);
+    eq(R.path([], obj), obj);
+    eq(R.path(['a', 'e', 'f', '1'], obj), 101);
+    eq(R.path(['j', '0'], obj), 'J');
+    eq(R.path(['j', '1'], obj), undefined);
+    eq(R.path(['a', 'b', 'c'], null), undefined);
   });
 
   it("gets a deep property's value from objects", function() {
-    assert.strictEqual(R.path(['a', 'b', 'c'], deepObject), 'c');
-    assert.strictEqual(R.path(['a'], deepObject), deepObject.a);
+    eq(R.path(['a', 'b', 'c'], deepObject), 'c');
+    eq(R.path(['a'], deepObject), deepObject.a);
   });
 
   it('returns undefined for items not found', function() {
-    assert.strictEqual(R.path(['a', 'b', 'foo'], deepObject), undefined);
-    assert.strictEqual(R.path(['bar'], deepObject), undefined);
+    eq(R.path(['a', 'b', 'foo'], deepObject), undefined);
+    eq(R.path(['bar'], deepObject), undefined);
   });
 
   it('returns undefined for null/undefined', function() {
-    assert.strictEqual(R.path(['toString'], null), undefined);
-    assert.strictEqual(R.path(['toString'], undefined), undefined);
+    eq(R.path(['toString'], null), undefined);
+    eq(R.path(['toString'], undefined), undefined);
   });
 
   it('works with falsy items', function() {
-    assert.strictEqual(R.path(['toString'], false), Boolean.prototype.toString);
+    eq(R.path(['toString'], false), Boolean.prototype.toString);
   });
 
   it('is curried', function() {
-    assert.strictEqual(R.path(['arrayVal', '0'])(deepObject), 'arr');
+    eq(R.path(['arrayVal', '0'])(deepObject), 'arr');
   });
 });

--- a/test/pathEq.js
+++ b/test/pathEq.js
@@ -1,6 +1,5 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('pathEq', function() {
@@ -13,23 +12,23 @@ describe('pathEq', function() {
   };
 
   it('returns true if the path matches the value', function() {
-    assert.strictEqual(R.pathEq(['a'], 1, obj), true);
-    assert.strictEqual(R.pathEq(['b', 'ba'], '2', obj), true);
+    eq(R.pathEq(['a'], 1, obj), true);
+    eq(R.pathEq(['b', 'ba'], '2', obj), true);
   });
 
   it('returns false for non matches', function() {
-    assert.strictEqual(R.pathEq(['a'], '1', obj), false);
-    assert.strictEqual(R.pathEq(['b', 'ba'], 2, obj), false);
+    eq(R.pathEq(['a'], '1', obj), false);
+    eq(R.pathEq(['b', 'ba'], 2, obj), false);
   });
 
   it('returns false for non existing values', function() {
-    assert.strictEqual(R.pathEq(['c'], 'foo', obj), false);
-    assert.strictEqual(R.pathEq(['c', 'd'], 'foo', obj), false);
+    eq(R.pathEq(['c'], 'foo', obj), false);
+    eq(R.pathEq(['c', 'd'], 'foo', obj), false);
   });
 
   it('accepts empty path', function() {
-    assert.strictEqual(R.pathEq([], 42, {a: 1, b: 2}), false);
-    assert.strictEqual(R.pathEq([], obj, obj), true);
+    eq(R.pathEq([], 42, {a: 1, b: 2}), false);
+    eq(R.pathEq([], obj, obj), true);
   });
 
   it('has R.equals semantics', function() {
@@ -38,10 +37,10 @@ describe('pathEq', function() {
       return x instanceof Just && R.equals(x.value, this.value);
     };
 
-    assert.strictEqual(R.pathEq(['value'], 0, {value: -0}), false);
-    assert.strictEqual(R.pathEq(['value'], -0, {value: 0}), false);
-    assert.strictEqual(R.pathEq(['value'], NaN, {value: NaN}), true);
-    assert.strictEqual(R.pathEq(['value'], new Just([42]), {value: new Just([42])}), true);
+    eq(R.pathEq(['value'], 0, {value: -0}), false);
+    eq(R.pathEq(['value'], -0, {value: 0}), false);
+    eq(R.pathEq(['value'], NaN, {value: NaN}), true);
+    eq(R.pathEq(['value'], new Just([42]), {value: new Just([42])}), true);
   });
 
 });

--- a/test/pathOr.js
+++ b/test/pathOr.js
@@ -1,6 +1,5 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('pathOr', function() {
@@ -22,34 +21,34 @@ describe('pathOr', function() {
       i: 'I',
       j: ['J']
     };
-    assert.strictEqual(R.pathOr('Unknown', ['a', 'b', 'c'], obj), 100);
-    assert.strictEqual(R.pathOr('Unknown', [], obj), obj);
-    assert.strictEqual(R.pathOr('Unknown', ['a', 'e', 'f', '1'], obj), 101);
-    assert.strictEqual(R.pathOr('Unknown', ['j', '0'], obj), 'J');
-    assert.strictEqual(R.pathOr('Unknown', ['j', '1'], obj), 'Unknown');
-    assert.strictEqual(R.pathOr('Unknown', ['a', 'b', 'c'], null), 'Unknown');
+    eq(R.pathOr('Unknown', ['a', 'b', 'c'], obj), 100);
+    eq(R.pathOr('Unknown', [], obj), obj);
+    eq(R.pathOr('Unknown', ['a', 'e', 'f', '1'], obj), 101);
+    eq(R.pathOr('Unknown', ['j', '0'], obj), 'J');
+    eq(R.pathOr('Unknown', ['j', '1'], obj), 'Unknown');
+    eq(R.pathOr('Unknown', ['a', 'b', 'c'], null), 'Unknown');
   });
 
   it("gets a deep property's value from objects", function() {
-    assert.strictEqual(R.pathOr('Unknown', ['a', 'b', 'c'], deepObject), 'c');
-    assert.strictEqual(R.pathOr('Unknown', ['a'], deepObject), deepObject.a);
+    eq(R.pathOr('Unknown', ['a', 'b', 'c'], deepObject), 'c');
+    eq(R.pathOr('Unknown', ['a'], deepObject), deepObject.a);
   });
 
   it('returns the default value for items not found', function() {
-    assert.strictEqual(R.pathOr('Unknown', ['a', 'b', 'foo'], deepObject), 'Unknown');
-    assert.strictEqual(R.pathOr('Unknown', ['bar'], deepObject), 'Unknown');
+    eq(R.pathOr('Unknown', ['a', 'b', 'foo'], deepObject), 'Unknown');
+    eq(R.pathOr('Unknown', ['bar'], deepObject), 'Unknown');
   });
 
   it('returns the default value for null/undefined', function() {
-    assert.strictEqual(R.pathOr('Unknown', ['toString'], null), 'Unknown');
-    assert.strictEqual(R.pathOr('Unknown', ['toString'], undefined), 'Unknown');
+    eq(R.pathOr('Unknown', ['toString'], null), 'Unknown');
+    eq(R.pathOr('Unknown', ['toString'], undefined), 'Unknown');
   });
 
   it('works with falsy items', function() {
-    assert.strictEqual(R.pathOr('Unknown', ['toString'], false), Boolean.prototype.toString);
+    eq(R.pathOr('Unknown', ['toString'], false), Boolean.prototype.toString);
   });
 
   it('is curried', function() {
-    assert.strictEqual(R.pathOr('Unknown', ['arrayVal', '0'])(deepObject), 'arr');
+    eq(R.pathOr('Unknown', ['arrayVal', '0'])(deepObject), 'arr');
   });
 });

--- a/test/pick.js
+++ b/test/pick.js
@@ -1,21 +1,20 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('pick', function() {
   var obj = {a: 1, b: 2, c: 3, d: 4, e: 5, f: 6, 1: 7};
 
   it('copies the named properties of an object to the new object', function() {
-    assert.deepEqual(R.pick(['a', 'c', 'f'], obj), {a: 1, c: 3, f: 6});
+    eq(R.pick(['a', 'c', 'f'], obj), {a: 1, c: 3, f: 6});
   });
 
   it('handles numbers as properties', function() {
-    assert.deepEqual(R.pick([1], obj), {1: 7});
+    eq(R.pick([1], obj), {1: 7});
   });
 
   it('ignores properties not included', function() {
-    assert.deepEqual(R.pick(['a', 'c', 'g'], obj), {a: 1, c: 3});
+    eq(R.pick(['a', 'c', 'g'], obj), {a: 1, c: 3});
   });
 
   it('retrieves prototype properties', function() {
@@ -23,11 +22,11 @@ describe('pick', function() {
     F.prototype.y = 40; F.prototype.z = 50;
     var obj = new F(30);
     obj.v = 10; obj.w = 20;
-    assert.deepEqual(R.pick(['w', 'x', 'y'], obj), {w: 20, x: 30, y: 40});
+    eq(R.pick(['w', 'x', 'y'], obj), {w: 20, x: 30, y: 40});
   });
 
   it('is curried', function() {
     var copyAB = R.pick(['a', 'b']);
-    assert.deepEqual(copyAB(obj), {a: 1, b: 2});
+    eq(copyAB(obj), {a: 1, b: 2});
   });
 });

--- a/test/pickAll.js
+++ b/test/pickAll.js
@@ -1,20 +1,19 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('pickAll', function() {
   var obj = {a: 1, b: 2, c: 3, d: 4, e: 5, f: 6};
   it('copies the named properties of an object to the new object', function() {
-    assert.deepEqual(R.pickAll(['a', 'c', 'f'], obj), {a: 1, c: 3, f: 6});
+    eq(R.pickAll(['a', 'c', 'f'], obj), {a: 1, c: 3, f: 6});
   });
 
   it('includes properties not present on the input object', function() {
-    assert.deepEqual(R.pickAll(['a', 'c', 'g'], obj), {a: 1, c: 3, g: undefined});
+    eq(R.pickAll(['a', 'c', 'g'], obj), {a: 1, c: 3, g: undefined});
   });
 
   it('is curried', function() {
     var copyAB = R.pickAll(['a', 'b']);
-    assert.deepEqual(copyAB(obj), {a: 1, b: 2});
+    eq(copyAB(obj), {a: 1, b: 2});
   });
 });

--- a/test/pickBy.js
+++ b/test/pickBy.js
@@ -1,6 +1,7 @@
 var assert = require('assert');
 
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('pickBy', function() {
@@ -11,20 +12,20 @@ describe('pickBy', function() {
   });
 
   it('when returning truthy, keeps the key', function() {
-    assert.deepEqual(R.pickBy(R.T, obj), obj);
-    assert.deepEqual(R.pickBy(R.always({}), obj), obj);
-    assert.deepEqual(R.pickBy(R.always(1), obj), obj);
+    eq(R.pickBy(R.T, obj), obj);
+    eq(R.pickBy(R.always({}), obj), obj);
+    eq(R.pickBy(R.always(1), obj), obj);
   });
 
   it('when returning falsy, keeps the key', function() {
-    assert.deepEqual(R.pickBy(R.always(false), obj), {});
-    assert.deepEqual(R.pickBy(R.always(0), obj), {});
-    assert.deepEqual(R.pickBy(R.always(null), obj), {});
+    eq(R.pickBy(R.always(false), obj), {});
+    eq(R.pickBy(R.always(0), obj), {});
+    eq(R.pickBy(R.always(null), obj), {});
   });
 
   it('is called with (val,key,obj)', function() {
-    assert.deepEqual(R.pickBy(function(val, key, _obj) {
-      assert.strictEqual(_obj, obj);
+    eq(R.pickBy(function(val, key, _obj) {
+      eq(_obj, obj);
       return key === 'd' && val === 4;
     }, obj), {d: 4});
   });
@@ -34,12 +35,12 @@ describe('pickBy', function() {
     F.prototype.y = 40; F.prototype.z = 50;
     var obj = new F(30);
     obj.v = 10; obj.w = 20;
-    assert.deepEqual(R.pickBy(function(val) {return val < 45;}, obj), {v: 10, w: 20, x: 30, y: 40});
+    eq(R.pickBy(function(val) {return val < 45;}, obj), {v: 10, w: 20, x: 30, y: 40});
   });
 
 
   it('is curried', function() {
     var copier = R.pickBy(R.T);
-    assert.deepEqual(copier(obj), obj);
+    eq(copier(obj), obj);
   });
 });

--- a/test/pipe.js
+++ b/test/pipe.js
@@ -1,22 +1,23 @@
 var assert = require('assert');
 
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('pipe', function() {
 
   it('is a variadic function', function() {
-    assert.strictEqual(typeof R.pipe, 'function');
-    assert.strictEqual(R.pipe.length, 0);
+    eq(typeof R.pipe, 'function');
+    eq(R.pipe.length, 0);
   });
 
   it('performs left-to-right function composition', function() {
     //  f :: (String, Number?) -> ([Number] -> [Number])
     var f = R.pipe(parseInt, R.multiply, R.map);
 
-    assert.strictEqual(f.length, 2);
-    assert.deepEqual(f('10')([1, 2, 3]), [10, 20, 30]);
-    assert.deepEqual(f('10', 2)([1, 2, 3]), [2, 4, 6]);
+    eq(f.length, 2);
+    eq(f('10')([1, 2, 3]), [10, 20, 30]);
+    eq(f('10', 2)([1, 2, 3]), [2, 4, 6]);
   });
 
   it('passes context to functions', function() {
@@ -35,7 +36,7 @@ describe('pipe', function() {
       y: 2,
       z: 1
     };
-    assert.strictEqual(context.a(5), 40);
+    eq(context.a(5), 40);
   });
 
   it('throws if given no arguments', function() {
@@ -51,8 +52,8 @@ describe('pipe', function() {
   it('can be applied to one argument', function() {
     var f = function(a, b, c) { return [a, b, c]; };
     var g = R.pipe(f);
-    assert.strictEqual(g.length, 3);
-    assert.deepEqual(g(1, 2, 3), [1, 2, 3]);
+    eq(g.length, 3);
+    eq(g(1, 2, 3), [1, 2, 3]);
   });
 
 });

--- a/test/pipeK.js
+++ b/test/pipeK.js
@@ -1,6 +1,5 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 var Identity = function(x) {
@@ -15,8 +14,8 @@ Identity.prototype.chain = function(f) {
 describe('pipeK', function() {
 
   it('is a variadic function', function() {
-    assert.strictEqual(typeof R.pipeK, 'function');
-    assert.strictEqual(R.pipeK.length, 0);
+    eq(typeof R.pipeK, 'function');
+    eq(R.pipeK.length, 0);
   });
 
   it('performs left-to-right Kleisli composition', function() {
@@ -27,15 +26,15 @@ describe('pipeK', function() {
     var fn = R.pipeK(f, g, h);
     var id = new Identity(8);
 
-    assert.strictEqual(fn(id).value, 50);
-    assert.strictEqual(fn(id).value, R.pipe(R.chain(f), R.chain(g), R.chain(h))(id).value);
+    eq(fn(id).value, 50);
+    eq(fn(id).value, R.pipe(R.chain(f), R.chain(g), R.chain(h))(id).value);
   });
 
   it('returns the identity function given no arguments', function() {
     var identity = R.pipeK();
-    assert.strictEqual(identity.length, 1);
-    assert.strictEqual(identity(R.__).length, 1);
-    assert.strictEqual(identity(42), 42);
+    eq(identity.length, 1);
+    eq(identity(R.__).length, 1);
+    eq(identity(42), 42);
   });
 
 });

--- a/test/pipeP.js
+++ b/test/pipeP.js
@@ -3,37 +3,38 @@ var assert = require('assert');
 var Q = require('q');
 
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('pipeP', function() {
 
   it('is a variadic function', function() {
-    assert.strictEqual(typeof R.pipeP, 'function');
-    assert.strictEqual(R.pipeP.length, 0);
+    eq(typeof R.pipeP, 'function');
+    eq(R.pipeP.length, 0);
   });
 
   it('performs left-to-right composition of Promise-returning functions', function(done) {
     var f = function(a) { return Q.Promise(function(res) { res([a]); }); };
     var g = function(a, b) { return Q.Promise(function(res) { res([a, b]); }); };
 
-    assert.strictEqual(R.pipeP(f).length, 1);
-    assert.strictEqual(R.pipeP(g).length, 2);
-    assert.strictEqual(R.pipeP(f, f).length, 1);
-    assert.strictEqual(R.pipeP(f, g).length, 1);
-    assert.strictEqual(R.pipeP(g, f).length, 2);
-    assert.strictEqual(R.pipeP(g, g).length, 2);
+    eq(R.pipeP(f).length, 1);
+    eq(R.pipeP(g).length, 2);
+    eq(R.pipeP(f, f).length, 1);
+    eq(R.pipeP(f, g).length, 1);
+    eq(R.pipeP(g, f).length, 2);
+    eq(R.pipeP(g, g).length, 2);
 
     R.pipeP(f, g)(1).then(function(result) {
-      assert.deepEqual(result, [[1], undefined]);
+      eq(result, [[1], undefined]);
 
       R.pipeP(g, f)(1).then(function(result) {
-        assert.deepEqual(result, [[1, undefined]]);
+        eq(result, [[1, undefined]]);
 
         R.pipeP(f, g)(1, 2).then(function(result) {
-          assert.deepEqual(result, [[1], undefined]);
+          eq(result, [[1], undefined]);
 
           R.pipeP(g, f)(1, 2).then(function(result) {
-            assert.deepEqual(result, [[1, 2]]);
+            eq(result, [[1, 2]]);
 
             done();
           })['catch'](done);

--- a/test/pluck.js
+++ b/test/pluck.js
@@ -1,6 +1,5 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('pluck', function() {
@@ -12,14 +11,14 @@ describe('pluck', function() {
 
   it('returns a function that maps the appropriate property over an array', function() {
     var nm = R.pluck('name');
-    assert.strictEqual(typeof nm, 'function');
-    assert.deepEqual(nm(people), ['Fred', 'Wilma', 'Pebbles']);
+    eq(typeof nm, 'function');
+    eq(nm(people), ['Fred', 'Wilma', 'Pebbles']);
   });
 
   it('behaves as a transducer when given a transducer in list position', function() {
     var numbers = [{a: 1}, {a: 2}, {a: 3}, {a: 4}];
     var transducer = R.compose(R.pluck('a'), R.map(R.add(1)), R.take(2));
-    assert.deepEqual(R.transduce(transducer, R.flip(R.append), [], numbers), [2, 3]);
+    eq(R.transduce(transducer, R.flip(R.append), [], numbers), [2, 3]);
   });
 
 });

--- a/test/prepend.js
+++ b/test/prepend.js
@@ -1,20 +1,19 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('prepend', function() {
   it('adds the element to the beginning of the list', function() {
-    assert.deepEqual(R.prepend('x', ['y', 'z']), ['x', 'y', 'z']);
-    assert.deepEqual(R.prepend(['a', 'z'], ['x', 'y']), [['a', 'z'], 'x', 'y']);
+    eq(R.prepend('x', ['y', 'z']), ['x', 'y', 'z']);
+    eq(R.prepend(['a', 'z'], ['x', 'y']), [['a', 'z'], 'x', 'y']);
   });
 
   it('works on empty list', function() {
-    assert.deepEqual(R.prepend(1, []), [1]);
+    eq(R.prepend(1, []), [1]);
   });
 
   it('is curried', function() {
-    assert.strictEqual(typeof R.prepend(4), 'function');
-    assert.deepEqual(R.prepend(4)([3, 2, 1]), [4, 3, 2, 1]);
+    eq(typeof R.prepend(4), 'function');
+    eq(R.prepend(4)([3, 2, 1]), [4, 3, 2, 1]);
   });
 });

--- a/test/product.js
+++ b/test/product.js
@@ -1,10 +1,9 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('product', function() {
   it('multiplies together the array of numbers supplied', function() {
-    assert.strictEqual(R.product([1, 2, 3, 4]), 24);
+    eq(R.product([1, 2, 3, 4]), 24);
   });
 });

--- a/test/project.js
+++ b/test/project.js
@@ -1,6 +1,5 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('project', function() {
@@ -12,7 +11,7 @@ describe('project', function() {
   ];
 
   it('selects the chosen properties from each element in a list', function() {
-    assert.deepEqual(R.project(['name', 'age'], kids), [
+    eq(R.project(['name', 'age'], kids), [
       {name: 'Abby', age: 7},
       {name: 'Fred', age: 12},
       {name: 'Rusty', age: 10},
@@ -21,7 +20,7 @@ describe('project', function() {
   });
 
   it('has an undefined property on the output tuple for any input tuple that does not have the property', function() {
-    assert.deepEqual(R.project(['name', 'hair'], kids), [
+    eq(R.project(['name', 'hair'], kids), [
       {name: 'Abby', hair: 'blond'},
       {name: 'Fred', hair: 'brown'},
       {name: 'Rusty', hair: 'brown'},
@@ -31,7 +30,7 @@ describe('project', function() {
 
   it('is curried', function() {
     var myFields = R.project(['name', 'age']);
-    assert.deepEqual(myFields(kids), [
+    eq(myFields(kids), [
       {name: 'Abby', age: 7},
       {name: 'Fred', age: 12},
       {name: 'Rusty', age: 10},

--- a/test/prop.js
+++ b/test/prop.js
@@ -1,6 +1,5 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('prop', function() {
@@ -8,7 +7,7 @@ describe('prop', function() {
 
   it('returns a function that fetches the appropriate property', function() {
     var nm = R.prop('name');
-    assert.strictEqual(typeof nm, 'function');
-    assert.strictEqual(nm(fred), 'Fred');
+    eq(typeof nm, 'function');
+    eq(nm(fred), 'Fred');
   });
 });

--- a/test/propEq.js
+++ b/test/propEq.js
@@ -1,6 +1,5 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('propEq', function() {
@@ -10,9 +9,9 @@ describe('propEq', function() {
   var obj4 = {name: 'Alois', age: 15, disposition: 'surly'};
 
   it('determines whether a particular property matches a given value for a specific object', function() {
-    assert.strictEqual(R.propEq('name', 'Abby', obj1), true);
-    assert.strictEqual(R.propEq('hair', 'brown', obj2), true);
-    assert.strictEqual(R.propEq('hair', 'blond', obj2), false);
+    eq(R.propEq('name', 'Abby', obj1), true);
+    eq(R.propEq('hair', 'brown', obj2), true);
+    eq(R.propEq('hair', 'blond', obj2), false);
   });
 
   it('has R.equals semantics', function() {
@@ -21,20 +20,20 @@ describe('propEq', function() {
       return x instanceof Just && R.equals(x.value, this.value);
     };
 
-    assert.strictEqual(R.propEq('value', 0, {value: -0}), false);
-    assert.strictEqual(R.propEq('value', -0, {value: 0}), false);
-    assert.strictEqual(R.propEq('value', NaN, {value: NaN}), true);
-    assert.strictEqual(R.propEq('value', new Just([42]), {value: new Just([42])}), true);
+    eq(R.propEq('value', 0, {value: -0}), false);
+    eq(R.propEq('value', -0, {value: 0}), false);
+    eq(R.propEq('value', NaN, {value: NaN}), true);
+    eq(R.propEq('value', new Just([42]), {value: new Just([42])}), true);
   });
 
   it('is curried', function() {
     var kids = [obj1, obj2, obj3, obj4];
     var hairMatch = R.propEq('hair');
-    assert.strictEqual(typeof hairMatch, 'function');
+    eq(typeof hairMatch, 'function');
     var brunette = hairMatch('brown');
-    assert.deepEqual(R.filter(brunette, kids), [obj2, obj3]);
+    eq(R.filter(brunette, kids), [obj2, obj3]);
     // more likely usage:
-    assert.deepEqual(R.filter(R.propEq('hair', 'brown'), kids), [obj2, obj3]);
+    eq(R.filter(R.propEq('hair', 'brown'), kids), [obj2, obj3]);
   });
 
 });

--- a/test/propIs.js
+++ b/test/propIs.js
@@ -1,17 +1,16 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('propIs', function() {
 
   it('returns true if the specified object property is of the given type', function() {
-    assert.strictEqual(R.propIs(Number, 'value', {value: 1}), true);
+    eq(R.propIs(Number, 'value', {value: 1}), true);
   });
 
   it('returns false otherwise', function() {
-    assert.strictEqual(R.propIs(String, 'value', {value: 1}), false);
-    assert.strictEqual(R.propIs(String, 'value', {}), false);
+    eq(R.propIs(String, 'value', {value: 1}), false);
+    eq(R.propIs(String, 'value', {}), false);
   });
 
 });

--- a/test/propOr.js
+++ b/test/propOr.js
@@ -1,6 +1,5 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('propOr', function() {
@@ -10,17 +9,17 @@ describe('propOr', function() {
   var nm = R.propOr('Unknown', 'name');
 
   it('returns a function that fetches the appropriate property', function() {
-    assert.strictEqual(typeof nm, 'function');
-    assert.strictEqual(nm(fred), 'Fred');
+    eq(typeof nm, 'function');
+    eq(nm(fred), 'Fred');
   });
 
   it('returns the default value when the property does not exist', function() {
-    assert.strictEqual(nm(anon), 'Unknown');
+    eq(nm(anon), 'Unknown');
   });
 
   it('returns the default value when the object is nil', function() {
-    assert.strictEqual(nm(null), 'Unknown');
-    assert.strictEqual(nm(void 0), 'Unknown');
+    eq(nm(null), 'Unknown');
+    eq(nm(void 0), 'Unknown');
   });
 
   it('does not return properties from the prototype chain', function() {
@@ -28,6 +27,6 @@ describe('propOr', function() {
     Person.prototype.age = function() {};
 
     var bob = new Person();
-    assert.strictEqual(R.propOr(100, 'age', bob), 100);
+    eq(R.propOr(100, 'age', bob), 100);
   });
 });

--- a/test/propSatisfies.js
+++ b/test/propSatisfies.js
@@ -1,6 +1,5 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('propSatisfies', function() {
@@ -8,11 +7,11 @@ describe('propSatisfies', function() {
   var isPositive = function(n) { return n > 0; };
 
   it('returns true if the specified object property satisfies the given predicate', function() {
-    assert.strictEqual(R.propSatisfies(isPositive, 'x', {x: 1, y: 0}), true);
+    eq(R.propSatisfies(isPositive, 'x', {x: 1, y: 0}), true);
   });
 
   it('returns false otherwise', function() {
-    assert.strictEqual(R.propSatisfies(isPositive, 'y', {x: 1, y: 0}), false);
+    eq(R.propSatisfies(isPositive, 'y', {x: 1, y: 0}), false);
   });
 
 });

--- a/test/props.js
+++ b/test/props.js
@@ -1,31 +1,30 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('props', function() {
   var obj = {a: 1, b: 2, c: 3, d: 4, e: 5, f: 6};
 
   it('returns empty array if no properties requested', function() {
-    assert.deepEqual(R.props([], obj), []);
+    eq(R.props([], obj), []);
   });
 
   it('returns values for requested properties', function() {
-    assert.deepEqual(R.props(['a', 'e'], obj), [1, 5]);
+    eq(R.props(['a', 'e'], obj), [1, 5]);
   });
 
   it('preserves order', function() {
-    assert.deepEqual(R.props(['f', 'c', 'e'], obj), [6, 3, 5]);
+    eq(R.props(['f', 'c', 'e'], obj), [6, 3, 5]);
   });
 
   it('returns undefined for nonexistent properties', function() {
     var ps = R.props(['a', 'nonexistent'], obj);
-    assert.strictEqual(ps.length, 2);
-    assert.strictEqual(ps[0], 1);
-    assert.strictEqual(ps[1], void 0);
+    eq(ps.length, 2);
+    eq(ps[0], 1);
+    eq(ps[1], void 0);
   });
 
   it('is curried', function() {
-    assert.deepEqual(R.props(['a', 'b'])(obj), [1, 2]);
+    eq(R.props(['a', 'b'])(obj), [1, 2]);
   });
 });

--- a/test/range.js
+++ b/test/range.js
@@ -1,30 +1,31 @@
 var assert = require('assert');
 
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('range', function() {
 
   it('returns list of numbers', function() {
-    assert.deepEqual(R.range(0, 5), [0, 1, 2, 3, 4]);
-    assert.deepEqual(R.range(4, 7), [4, 5, 6]);
+    eq(R.range(0, 5), [0, 1, 2, 3, 4]);
+    eq(R.range(4, 7), [4, 5, 6]);
   });
 
   it('returns the empty list if the first parameter is not larger than the second', function() {
-    assert.deepEqual(R.range(7, 3), []);
-    assert.deepEqual(R.range(5, 5), []);
+    eq(R.range(7, 3), []);
+    eq(R.range(5, 5), []);
   });
 
   it('is curried', function() {
     var from10 = R.range(10);
-    assert.deepEqual(from10(15), [10, 11, 12, 13, 14]);
+    eq(from10(15), [10, 11, 12, 13, 14]);
   });
 
   it('returns an empty array if from > to', function() {
     var result = R.range(10, 5);
-    assert.deepEqual(result, []);
+    eq(result, []);
     result.push(5);
-    assert.deepEqual(R.range(10, 5), []);
+    eq(R.range(10, 5), []);
   });
 
   it('terminates given bad input', function() {

--- a/test/reduce.js
+++ b/test/reduce.js
@@ -1,38 +1,37 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 describe('reduce', function() {
   var add = function(a, b) {return a + b;};
   var mult = function(a, b) {return a * b;};
 
   it('folds simple functions over arrays with the supplied accumulator', function() {
-    assert.strictEqual(R.reduce(add, 0, [1, 2, 3, 4]), 10);
-    assert.strictEqual(R.reduce(mult, 1, [1, 2, 3, 4]), 24);
+    eq(R.reduce(add, 0, [1, 2, 3, 4]), 10);
+    eq(R.reduce(mult, 1, [1, 2, 3, 4]), 24);
   });
 
   it('dispatches to objects that implement `reduce`', function() {
     var obj = {x: [1, 2, 3], reduce: function() { return 'override'; }};
-    assert.strictEqual(R.reduce(add, 0, obj), 'override');
-    assert.strictEqual(R.reduce(add, 10, obj), 'override');
+    eq(R.reduce(add, 0, obj), 'override');
+    eq(R.reduce(add, 10, obj), 'override');
   });
 
   it('returns the accumulator for an empty array', function() {
-    assert.strictEqual(R.reduce(add, 0, []), 0);
-    assert.strictEqual(R.reduce(mult, 1, []), 1);
-    assert.deepEqual(R.reduce(R.concat, [], []), []);
+    eq(R.reduce(add, 0, []), 0);
+    eq(R.reduce(mult, 1, []), 1);
+    eq(R.reduce(R.concat, [], []), []);
   });
 
   it('is curried', function() {
     var addOrConcat = R.reduce(add);
     var sum = addOrConcat(0);
     var cat = addOrConcat('');
-    assert.strictEqual(sum([1, 2, 3, 4]), 10);
-    assert.strictEqual(cat(['1', '2', '3', '4']), '1234');
+    eq(sum([1, 2, 3, 4]), 10);
+    eq(cat(['1', '2', '3', '4']), '1234');
   });
 
   it('correctly reports the arity of curried versions', function() {
     var sum = R.reduce(add, 0);
-    assert.strictEqual(sum.length, 1);
+    eq(sum.length, 1);
   });
 });

--- a/test/reduceRight.js
+++ b/test/reduceRight.js
@@ -1,32 +1,31 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('reduceRight', function() {
   var avg = function(a, b) {return (a + b) / 2;};
 
   it('folds lists in the right order', function() {
-    assert.strictEqual(R.reduceRight(function(a, b) {return a + b;}, '', ['a', 'b', 'c', 'd']), 'dcba');
+    eq(R.reduceRight(function(a, b) {return a + b;}, '', ['a', 'b', 'c', 'd']), 'dcba');
   });
 
   it('folds simple functions over arrays with the supplied accumulator', function() {
-    assert.strictEqual(R.reduceRight(avg, 54, [12, 4, 10, 6]), 12);
+    eq(R.reduceRight(avg, 54, [12, 4, 10, 6]), 12);
   });
 
   it('returns the accumulator for an empty array', function() {
-    assert.strictEqual(R.reduceRight(avg, 0, []), 0);
+    eq(R.reduceRight(avg, 0, []), 0);
   });
 
   it('is curried', function() {
     var something = R.reduceRight(avg, 54);
     var rcat = R.reduceRight(R.add, '');
-    assert.strictEqual(something([12, 4, 10, 6]), 12);
-    assert.strictEqual(rcat(['1', '2', '3', '4']), '4321');
+    eq(something([12, 4, 10, 6]), 12);
+    eq(rcat(['1', '2', '3', '4']), '4321');
   });
 
   it('correctly reports the arity of curried versions', function() {
     var something = R.reduceRight(avg, 0);
-    assert.strictEqual(something.length, 1);
+    eq(something.length, 1);
   });
 });

--- a/test/reduced.js
+++ b/test/reduced.js
@@ -1,23 +1,22 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('reduced', function() {
   it('wraps a value', function() {
     // white box test.
     var v = {};
-    assert.strictEqual(R.reduced(v)['@@transducer/value'], v);
+    eq(R.reduced(v)['@@transducer/value'], v);
   });
 
   it('flags value as reduced', function() {
     // white box test.
-    assert.strictEqual(R.reduced({})['@@transducer/reduced'], true);
+    eq(R.reduced({})['@@transducer/reduced'], true);
   });
 
   it('short-circuits reduce', function() {
     // black box test.
-    assert.strictEqual(
+    eq(
       R.reduce(
         function(acc, v) {
           var result = acc + v;

--- a/test/reject.js
+++ b/test/reject.js
@@ -1,29 +1,28 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('reject', function() {
   var even = function(x) {return x % 2 === 0;};
 
   it('reduces an array to those not matching a filter', function() {
-    assert.deepEqual(R.reject(even, [1, 2, 3, 4, 5]), [1, 3, 5]);
+    eq(R.reject(even, [1, 2, 3, 4, 5]), [1, 3, 5]);
   });
 
   it('returns an empty array if no element matches', function() {
-    assert.deepEqual(R.reject(function(x) { return x < 100; }, [1, 9, 99]), []);
+    eq(R.reject(function(x) { return x < 100; }, [1, 9, 99]), []);
   });
 
   it('returns an empty array if asked to filter an empty array', function() {
-    assert.deepEqual(R.reject(function(x) { return x > 100; }, []), []);
+    eq(R.reject(function(x) { return x > 100; }, []), []);
   });
 
   it('returns an empty array if no element matches', function() {
-    assert.deepEqual(R.reject(function(x) { return x < 100; }, [1, 9, 99]), []);
+    eq(R.reject(function(x) { return x < 100; }, [1, 9, 99]), []);
   });
 
   it('returns an empty array if asked to filter an empty array', function() {
-    assert.deepEqual(R.reject(function(x) { return x > 100; }, []), []);
+    eq(R.reject(function(x) { return x > 100; }, []), []);
   });
 
   it('dispatches to `filter` method', function() {
@@ -39,14 +38,14 @@ describe('reject', function() {
     };
 
     var m = new Just(42);
-    assert.strictEqual(R.filter(R.T, m), m);
-    assert.strictEqual(R.filter(R.F, m), Nothing.value);
-    assert.strictEqual(R.reject(R.T, m), Nothing.value);
-    assert.strictEqual(R.reject(R.F, m), m);
+    eq(R.filter(R.T, m), m);
+    eq(R.filter(R.F, m), Nothing.value);
+    eq(R.reject(R.T, m), Nothing.value);
+    eq(R.reject(R.F, m), m);
   });
 
   it('is curried', function() {
     var odd = R.reject(even);
-    assert.deepEqual(odd([1, 2, 3, 4, 5, 6, 7]), [1, 3, 5, 7]);
+    eq(odd([1, 2, 3, 4, 5, 6, 7]), [1, 3, 5, 7]);
   });
 });

--- a/test/remove.js
+++ b/test/remove.js
@@ -1,34 +1,33 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('remove', function() {
   it('splices out a sub-list of the given list', function() {
     var list = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j'];
-    assert.deepEqual(R.remove(2, 5, list), ['a', 'b', 'h', 'i', 'j']);
+    eq(R.remove(2, 5, list), ['a', 'b', 'h', 'i', 'j']);
   });
 
   it('returns the appropriate sublist when start == 0', function() {
     var list = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j'];
-    assert.deepEqual(R.remove(0, 5, list), ['f', 'g', 'h', 'i', 'j']);
-    assert.deepEqual(R.remove(0, 1, list), ['b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j']);
-    assert.deepEqual(R.remove(0, list.length, list), []);
+    eq(R.remove(0, 5, list), ['f', 'g', 'h', 'i', 'j']);
+    eq(R.remove(0, 1, list), ['b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j']);
+    eq(R.remove(0, list.length, list), []);
   });
 
   it('removes the end of the list if the count is too large', function() {
     var list = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j'];
-    assert.deepEqual(R.remove(2, 20, list), ['a', 'b']);
+    eq(R.remove(2, 20, list), ['a', 'b']);
   });
 
   it('retains the entire list if the start is too large', function() {
     var list = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j'];
-    assert.deepEqual(R.remove(13, 3, list), ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j']);
+    eq(R.remove(13, 3, list), ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j']);
   });
 
   it('is curried', function() {
     var list = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j'];
-    assert.deepEqual(R.remove(13)(3)(list), ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j']);
-    assert.deepEqual(R.remove(13, 3)(list), ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j']);
+    eq(R.remove(13)(3)(list), ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j']);
+    eq(R.remove(13, 3)(list), ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j']);
   });
 });

--- a/test/repeat.js
+++ b/test/repeat.js
@@ -1,20 +1,19 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('repeat', function() {
   it('returns a lazy list of identical values', function() {
-    assert.deepEqual(R.repeat(0, 5), [0, 0, 0, 0, 0]);
+    eq(R.repeat(0, 5), [0, 0, 0, 0, 0]);
   });
 
   it('can accept any value, including `null`', function() {
-    assert.deepEqual(R.repeat(null, 3), [null, null, null]);
+    eq(R.repeat(null, 3), [null, null, null]);
   });
 
   it('is curried', function() {
     var makeFoos = R.repeat('foo');
-    assert.deepEqual(makeFoos(0), []);
-    assert.deepEqual(makeFoos(3), ['foo', 'foo', 'foo']);
+    eq(makeFoos(0), []);
+    eq(makeFoos(3), ['foo', 'foo', 'foo']);
   });
 });

--- a/test/replace.js
+++ b/test/replace.js
@@ -1,25 +1,24 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('replace', function() {
 
   it('replaces substrings of the input string', function() {
-    assert.strictEqual(R.replace('1', 'one', '1 two three'), 'one two three');
+    eq(R.replace('1', 'one', '1 two three'), 'one two three');
   });
 
   it('replaces regex matches of the input string', function() {
-    assert.strictEqual(R.replace(/\d+/g, 'num', '1 2 three'), 'num num three');
+    eq(R.replace(/\d+/g, 'num', '1 2 three'), 'num num three');
   });
 
   it('is curried up to 3 arguments', function() {
-    assert.strictEqual(R.replace(null).constructor, Function);
-    assert.strictEqual(R.replace(null, null).constructor, Function);
+    eq(R.replace(null).constructor, Function);
+    eq(R.replace(null, null).constructor, Function);
 
     var replaceSemicolon = R.replace(';');
     var removeSemicolon = replaceSemicolon('');
-    assert.strictEqual(removeSemicolon('return 42;'), 'return 42');
+    eq(removeSemicolon('return 42;'), 'return 42');
   });
 
 });

--- a/test/reverse.js
+++ b/test/reverse.js
@@ -1,22 +1,21 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('reverse', function() {
 
   it('reverses arrays', function() {
-    assert.deepEqual(R.reverse([]), []);
-    assert.deepEqual(R.reverse([1]), [1]);
-    assert.deepEqual(R.reverse([1, 2]), [2, 1]);
-    assert.deepEqual(R.reverse([1, 2, 3]), [3, 2, 1]);
+    eq(R.reverse([]), []);
+    eq(R.reverse([1]), [1]);
+    eq(R.reverse([1, 2]), [2, 1]);
+    eq(R.reverse([1, 2, 3]), [3, 2, 1]);
   });
 
   it('reverses strings', function() {
-    assert.strictEqual(R.reverse(''), '');
-    assert.strictEqual(R.reverse('a'), 'a');
-    assert.strictEqual(R.reverse('ab'), 'ba');
-    assert.strictEqual(R.reverse('abc'), 'cba');
+    eq(R.reverse(''), '');
+    eq(R.reverse('a'), 'a');
+    eq(R.reverse('ab'), 'ba');
+    eq(R.reverse('abc'), 'cba');
   });
 
 });

--- a/test/scan.js
+++ b/test/scan.js
@@ -1,6 +1,5 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('scan', function() {
@@ -8,25 +7,25 @@ describe('scan', function() {
   var mult = function(a, b) {return a * b;};
 
   it('scans simple functions over arrays with the supplied accumulator', function() {
-    assert.deepEqual(R.scan(add, 0, [1, 2, 3, 4]), [0, 1, 3, 6, 10]);
-    assert.deepEqual(R.scan(mult, 1, [1, 2, 3, 4]), [1, 1, 2, 6, 24]);
+    eq(R.scan(add, 0, [1, 2, 3, 4]), [0, 1, 3, 6, 10]);
+    eq(R.scan(mult, 1, [1, 2, 3, 4]), [1, 1, 2, 6, 24]);
   });
 
   it('returns the accumulator for an empty array', function() {
-    assert.deepEqual(R.scan(add, 0, []), [0]);
-    assert.deepEqual(R.scan(mult, 1, []), [1]);
+    eq(R.scan(add, 0, []), [0]);
+    eq(R.scan(mult, 1, []), [1]);
   });
 
   it('is curried', function() {
     var addOrConcat = R.scan(add);
     var sum = addOrConcat(0);
     var cat = addOrConcat('');
-    assert.deepEqual(sum([1, 2, 3, 4]), [0, 1, 3, 6, 10]);
-    assert.deepEqual(cat(['1', '2', '3', '4']), ['', '1', '12', '123', '1234']);
+    eq(sum([1, 2, 3, 4]), [0, 1, 3, 6, 10]);
+    eq(cat(['1', '2', '3', '4']), ['', '1', '12', '123', '1234']);
   });
 
   it('correctly reports the arity of curried versions', function() {
     var sum = R.scan(add, 0);
-    assert.strictEqual(sum.length, 1);
+    eq(sum.length, 1);
   });
 });

--- a/test/shared/eq.js
+++ b/test/shared/eq.js
@@ -1,0 +1,9 @@
+var assert = require('assert');
+
+var R = require('../..');
+
+
+module.exports = function(actual, expected) {
+  assert.strictEqual(arguments.length, 2);
+  assert.strictEqual(R.toString(actual), R.toString(expected));
+};

--- a/test/slice.js
+++ b/test/slice.js
@@ -1,37 +1,36 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('slice', function() {
   it('retrieves the proper sublist of a list', function() {
     var list = [8, 6, 7, 5, 3, 0, 9];
-    assert.deepEqual(R.slice(2, 5, list), [7, 5, 3]);
+    eq(R.slice(2, 5, list), [7, 5, 3]);
   });
   it('handles array-like object', function() {
     var args = (function() { return arguments; }(1, 2, 3, 4, 5));
-    assert.deepEqual(R.slice(1, 4, args), [2, 3, 4]);
+    eq(R.slice(1, 4, args), [2, 3, 4]);
   });
   it('can operate on strings', function() {
-    assert.strictEqual(R.slice(0, 0, 'abc'), '');
-    assert.strictEqual(R.slice(0, 1, 'abc'), 'a');
-    assert.strictEqual(R.slice(0, 2, 'abc'), 'ab');
-    assert.strictEqual(R.slice(0, 3, 'abc'), 'abc');
-    assert.strictEqual(R.slice(0, 4, 'abc'), 'abc');
-    assert.strictEqual(R.slice(1, 0, 'abc'), '');
-    assert.strictEqual(R.slice(1, 1, 'abc'), '');
-    assert.strictEqual(R.slice(1, 2, 'abc'), 'b');
-    assert.strictEqual(R.slice(1, 3, 'abc'), 'bc');
-    assert.strictEqual(R.slice(1, 4, 'abc'), 'bc');
-    assert.strictEqual(R.slice(0, -4, 'abc'), '');
-    assert.strictEqual(R.slice(0, -3, 'abc'), '');
-    assert.strictEqual(R.slice(0, -2, 'abc'), 'a');
-    assert.strictEqual(R.slice(0, -1, 'abc'), 'ab');
-    assert.strictEqual(R.slice(0, -0, 'abc'), '');
-    assert.strictEqual(R.slice(-2, -4, 'abc'), '');
-    assert.strictEqual(R.slice(-2, -3, 'abc'), '');
-    assert.strictEqual(R.slice(-2, -2, 'abc'), '');
-    assert.strictEqual(R.slice(-2, -1, 'abc'), 'b');
-    assert.strictEqual(R.slice(-2, -0, 'abc'), '');
+    eq(R.slice(0, 0, 'abc'), '');
+    eq(R.slice(0, 1, 'abc'), 'a');
+    eq(R.slice(0, 2, 'abc'), 'ab');
+    eq(R.slice(0, 3, 'abc'), 'abc');
+    eq(R.slice(0, 4, 'abc'), 'abc');
+    eq(R.slice(1, 0, 'abc'), '');
+    eq(R.slice(1, 1, 'abc'), '');
+    eq(R.slice(1, 2, 'abc'), 'b');
+    eq(R.slice(1, 3, 'abc'), 'bc');
+    eq(R.slice(1, 4, 'abc'), 'bc');
+    eq(R.slice(0, -4, 'abc'), '');
+    eq(R.slice(0, -3, 'abc'), '');
+    eq(R.slice(0, -2, 'abc'), 'a');
+    eq(R.slice(0, -1, 'abc'), 'ab');
+    eq(R.slice(0, -0, 'abc'), '');
+    eq(R.slice(-2, -4, 'abc'), '');
+    eq(R.slice(-2, -3, 'abc'), '');
+    eq(R.slice(-2, -2, 'abc'), '');
+    eq(R.slice(-2, -1, 'abc'), 'b');
+    eq(R.slice(-2, -0, 'abc'), '');
   });
 });

--- a/test/sort.js
+++ b/test/sort.js
@@ -1,22 +1,21 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('sort', function() {
   it('sorts the elements of a list', function() {
-    assert.deepEqual(R.sort(function(a, b) {return a - b;}, [3, 1, 8, 1, 2, 5]), [1, 1, 2, 3, 5, 8]);
+    eq(R.sort(function(a, b) {return a - b;}, [3, 1, 8, 1, 2, 5]), [1, 1, 2, 3, 5, 8]);
   });
 
   it('does not affect the list passed supplied', function() {
     var list = [3, 1, 8, 1, 2, 5];
-    assert.deepEqual(R.sort(function(a, b) {return a - b;}, list), [1, 1, 2, 3, 5, 8]);
-    assert.deepEqual(list, [3, 1, 8, 1, 2, 5]);
+    eq(R.sort(function(a, b) {return a - b;}, list), [1, 1, 2, 3, 5, 8]);
+    eq(list, [3, 1, 8, 1, 2, 5]);
   });
 
   it('is curried', function() {
     var sortByLength = R.sort(function(a, b) {return a.length - b.length;});
-    assert.deepEqual(sortByLength(['one', 'two', 'three', 'four', 'five', 'six']),
-                     ['one', 'two', 'six', 'four', 'five', 'three']);
+    eq(sortByLength(['one', 'two', 'three', 'four', 'five', 'six']),
+       ['one', 'two', 'six', 'four', 'five', 'three']);
   });
 });

--- a/test/sortBy.js
+++ b/test/sortBy.js
@@ -1,6 +1,5 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 var albums = [
@@ -22,32 +21,32 @@ var albums = [
 describe('sortBy', function() {
   it('sorts by a simple property of the objects', function() {
     var sortedAlbums = R.sortBy(R.prop('title'), albums);
-    assert.strictEqual(sortedAlbums.length, albums.length);
-    assert.strictEqual(sortedAlbums[0].title, 'A Farewell to Kings');
-    assert.strictEqual(sortedAlbums[11].title, 'Timeout');
+    eq(sortedAlbums.length, albums.length);
+    eq(sortedAlbums[0].title, 'A Farewell to Kings');
+    eq(sortedAlbums[11].title, 'Timeout');
   });
 
   it('is curried', function() {
     var sorter = R.sortBy(R.prop('title'));
     var sortedAlbums = sorter(albums);
-    assert.strictEqual(sortedAlbums.length, albums.length);
-    assert.strictEqual(sortedAlbums[0].title, 'A Farewell to Kings');
-    assert.strictEqual(sortedAlbums[11].title, 'Timeout');
+    eq(sortedAlbums.length, albums.length);
+    eq(sortedAlbums[0].title, 'A Farewell to Kings');
+    eq(sortedAlbums[11].title, 'Timeout');
   });
 
   it('preserves object identity', function() {
     var a = {value: 'a'};
     var b = {value: 'b'};
     var result = R.sortBy(R.prop('value'), [b, a]);
-    assert.strictEqual(result[0], a);
-    assert.strictEqual(result[1], b);
+    eq(result[0], a);
+    eq(result[1], b);
   });
 
   it('sorts array-like object', function() {
     var args = (function() { return arguments; }('c', 'a', 'b'));
     var result = R.sortBy(R.identity, args);
-    assert.strictEqual(result[0], 'a');
-    assert.strictEqual(result[1], 'b');
-    assert.strictEqual(result[2], 'c');
+    eq(result[0], 'a');
+    eq(result[1], 'b');
+    eq(result[2], 'c');
   });
 });

--- a/test/split.js
+++ b/test/split.js
@@ -1,14 +1,13 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('split', function() {
   it('splits a string into an array', function() {
-    assert.deepEqual(R.split('.', 'a.b.c.xyz.d'), ['a', 'b', 'c', 'xyz', 'd']);
+    eq(R.split('.', 'a.b.c.xyz.d'), ['a', 'b', 'c', 'xyz', 'd']);
   });
 
   it('the split string can be arbitrary', function() {
-    assert.deepEqual(R.split('at', 'The Cat in the Hat sat on the mat'), ['The C', ' in the H', ' s', ' on the m', '']);
+    eq(R.split('at', 'The Cat in the Hat sat on the mat'), ['The C', ' in the H', ' s', ' on the m', '']);
   });
 });

--- a/test/splitEvery.js
+++ b/test/splitEvery.js
@@ -1,23 +1,24 @@
 var assert = require('assert');
 
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('splitEvery', function() {
 
   it('splits a collection into slices of the specified length', function() {
-    assert.deepEqual(R.splitEvery(1, [1, 2, 3, 4]), [[1], [2], [3], [4]]);
-    assert.deepEqual(R.splitEvery(2, [1, 2, 3, 4]), [[1, 2], [3, 4]]);
-    assert.deepEqual(R.splitEvery(3, [1, 2, 3, 4]), [[1, 2, 3], [4]]);
-    assert.deepEqual(R.splitEvery(4, [1, 2, 3, 4]), [[1, 2, 3, 4]]);
-    assert.deepEqual(R.splitEvery(5, [1, 2, 3, 4]), [[1, 2, 3, 4]]);
-    assert.deepEqual(R.splitEvery(3, []), []);
-    assert.deepEqual(R.splitEvery(1, 'abcd'), ['a', 'b', 'c', 'd']);
-    assert.deepEqual(R.splitEvery(2, 'abcd'), ['ab', 'cd']);
-    assert.deepEqual(R.splitEvery(3, 'abcd'), ['abc', 'd']);
-    assert.deepEqual(R.splitEvery(4, 'abcd'), ['abcd']);
-    assert.deepEqual(R.splitEvery(5, 'abcd'), ['abcd']);
-    assert.deepEqual(R.splitEvery(3, ''), []);
+    eq(R.splitEvery(1, [1, 2, 3, 4]), [[1], [2], [3], [4]]);
+    eq(R.splitEvery(2, [1, 2, 3, 4]), [[1, 2], [3, 4]]);
+    eq(R.splitEvery(3, [1, 2, 3, 4]), [[1, 2, 3], [4]]);
+    eq(R.splitEvery(4, [1, 2, 3, 4]), [[1, 2, 3, 4]]);
+    eq(R.splitEvery(5, [1, 2, 3, 4]), [[1, 2, 3, 4]]);
+    eq(R.splitEvery(3, []), []);
+    eq(R.splitEvery(1, 'abcd'), ['a', 'b', 'c', 'd']);
+    eq(R.splitEvery(2, 'abcd'), ['ab', 'cd']);
+    eq(R.splitEvery(3, 'abcd'), ['abc', 'd']);
+    eq(R.splitEvery(4, 'abcd'), ['abcd']);
+    eq(R.splitEvery(5, 'abcd'), ['abcd']);
+    eq(R.splitEvery(3, ''), []);
   });
 
   it('throws if first argument is not positive', function() {

--- a/test/subtract.js
+++ b/test/subtract.js
@@ -1,20 +1,19 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('subtract', function() {
   it('subtracts two numbers', function() {
-    assert.strictEqual(R.subtract(22, 7), 15);
+    eq(R.subtract(22, 7), 15);
   });
 
   it('is curried', function() {
     var ninesCompl = R.subtract(9);
-    assert.strictEqual(ninesCompl(6), 3);
+    eq(ninesCompl(6), 3);
   });
 
   it('behaves right curried when passed `R.__` for its first argument', function() {
     var minus5 = R.subtract(R.__, 5);
-    assert.strictEqual(minus5(17), 12);
+    eq(minus5(17), 12);
   });
 });

--- a/test/sum.js
+++ b/test/sum.js
@@ -1,16 +1,15 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('sum', function() {
   it('adds together the array of numbers supplied', function() {
-    assert.strictEqual(R.sum([1, 2, 3, 4]), 10);
+    eq(R.sum([1, 2, 3, 4]), 10);
   });
 
   it('does not save the state of the accumulator', function() {
-    assert.strictEqual(R.sum([1, 2, 3, 4]), 10);
-    assert.strictEqual(R.sum([1]), 1);
-    assert.strictEqual(R.sum([5, 5, 5, 5, 5]), 25);
+    eq(R.sum([1, 2, 3, 4]), 10);
+    eq(R.sum([1]), 1);
+    eq(R.sum([5, 5, 5, 5, 5]), 25);
   });
 });

--- a/test/tail.js
+++ b/test/tail.js
@@ -1,20 +1,21 @@
 var assert = require('assert');
 
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('tail', function() {
 
   it('returns the tail of an ordered collection', function() {
-    assert.deepEqual(R.tail([1, 2, 3]), [2, 3]);
-    assert.deepEqual(R.tail([2, 3]), [3]);
-    assert.deepEqual(R.tail([3]), []);
-    assert.deepEqual(R.tail([]), []);
+    eq(R.tail([1, 2, 3]), [2, 3]);
+    eq(R.tail([2, 3]), [3]);
+    eq(R.tail([3]), []);
+    eq(R.tail([]), []);
 
-    assert.strictEqual(R.tail('abc'), 'bc');
-    assert.strictEqual(R.tail('bc'), 'c');
-    assert.strictEqual(R.tail('c'), '');
-    assert.strictEqual(R.tail(''), '');
+    eq(R.tail('abc'), 'bc');
+    eq(R.tail('bc'), 'c');
+    eq(R.tail('c'), '');
+    eq(R.tail(''), '');
   });
 
   it('throws if applied to null or undefined', function() {

--- a/test/take.js
+++ b/test/take.js
@@ -1,22 +1,23 @@
 var assert = require('assert');
 
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('take', function() {
 
   it('takes only the first `n` elements from a list', function() {
-    assert.deepEqual(R.take(3, ['a', 'b', 'c', 'd', 'e', 'f', 'g']), ['a', 'b', 'c']);
+    eq(R.take(3, ['a', 'b', 'c', 'd', 'e', 'f', 'g']), ['a', 'b', 'c']);
   });
 
   it('returns only as many as the array can provide', function() {
-    assert.deepEqual(R.take(3, [1, 2]), [1, 2]);
-    assert.deepEqual(R.take(3, []), []);
+    eq(R.take(3, [1, 2]), [1, 2]);
+    eq(R.take(3, []), []);
   });
 
   it('returns an equivalent list if `n` is < 0', function() {
-    assert.deepEqual(R.take(-1, [1, 2, 3]), [1, 2, 3]);
-    assert.deepEqual(R.take(-Infinity, [1, 2, 3]), [1, 2, 3]);
+    eq(R.take(-1, [1, 2, 3]), [1, 2, 3]);
+    eq(R.take(-Infinity, [1, 2, 3]), [1, 2, 3]);
   });
 
   it('never returns the input array', function() {
@@ -28,14 +29,14 @@ describe('take', function() {
   });
 
   it('can operate on strings', function() {
-    assert.strictEqual(R.take(3, 'Ramda'), 'Ram');
-    assert.strictEqual(R.take(2, 'Ramda'), 'Ra');
-    assert.strictEqual(R.take(1, 'Ramda'), 'R');
-    assert.strictEqual(R.take(0, 'Ramda'), '');
+    eq(R.take(3, 'Ramda'), 'Ram');
+    eq(R.take(2, 'Ramda'), 'Ra');
+    eq(R.take(1, 'Ramda'), 'R');
+    eq(R.take(0, 'Ramda'), '');
   });
 
   it('handles zero correctly (#1224)', function() {
-    assert.deepEqual(R.into([], R.take(0), [1, 2, 3]), []);
+    eq(R.into([], R.take(0), [1, 2, 3]), []);
   });
 
 });

--- a/test/takeLast.js
+++ b/test/takeLast.js
@@ -1,22 +1,23 @@
 var assert = require('assert');
 
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('takeLast', function() {
 
   it('takes only the last `n` elements from a list', function() {
-    assert.deepEqual(R.takeLast(3, ['a', 'b', 'c', 'd', 'e', 'f', 'g']), ['e', 'f', 'g']);
+    eq(R.takeLast(3, ['a', 'b', 'c', 'd', 'e', 'f', 'g']), ['e', 'f', 'g']);
   });
 
   it('returns only as many as the array can provide', function() {
-    assert.deepEqual(R.takeLast(3, [1, 2]), [1, 2]);
-    assert.deepEqual(R.takeLast(3, []), []);
+    eq(R.takeLast(3, [1, 2]), [1, 2]);
+    eq(R.takeLast(3, []), []);
   });
 
   it('returns an equivalent list if `n` is < 0', function() {
-    assert.deepEqual(R.takeLast(-1, [1, 2, 3]), [1, 2, 3]);
-    assert.deepEqual(R.takeLast(-Infinity, [1, 2, 3]), [1, 2, 3]);
+    eq(R.takeLast(-1, [1, 2, 3]), [1, 2, 3]);
+    eq(R.takeLast(-Infinity, [1, 2, 3]), [1, 2, 3]);
   });
 
   it('never returns the input array', function() {
@@ -28,17 +29,17 @@ describe('takeLast', function() {
   });
 
   it('can operate on strings', function() {
-    assert.strictEqual(R.takeLast(3, 'Ramda'), 'mda');
+    eq(R.takeLast(3, 'Ramda'), 'mda');
   });
 
   it('handles zero correctly (#1224)', function() {
-    assert.deepEqual(R.takeLast(0, [1, 2, 3]), []);
+    eq(R.takeLast(0, [1, 2, 3]), []);
   });
 
   it('is curried', function() {
     var takeLast3 = R.takeLast(3);
-    assert.deepEqual(takeLast3(['a', 'b', 'c', 'd', 'e', 'f', 'g']), ['e', 'f', 'g']);
-    assert.deepEqual(takeLast3(['w', 'x', 'y', 'z']), ['x', 'y', 'z']);
+    eq(takeLast3(['a', 'b', 'c', 'd', 'e', 'f', 'g']), ['e', 'f', 'g']);
+    eq(takeLast3(['w', 'x', 'y', 'z']), ['x', 'y', 'z']);
   });
 
 });

--- a/test/takeLastWhile.js
+++ b/test/takeLastWhile.js
@@ -1,21 +1,22 @@
 var assert = require('assert');
 
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('takeLastWhile', function() {
   it('continues taking elements while the function reports `true`', function() {
-    assert.deepEqual(R.takeLastWhile(function(x) {return x !== 5;}, [1, 3, 5, 7, 9]), [7, 9]);
+    eq(R.takeLastWhile(function(x) {return x !== 5;}, [1, 3, 5, 7, 9]), [7, 9]);
   });
 
   it('starts at the right arg and acknowledges undefined', function() {
-    assert.deepEqual(R.takeLastWhile(function() { assert(false); }, []), []);
-    assert.deepEqual(R.takeLastWhile(function(x) {return x !== void 0;}, [1, 3, void 0, 5, 7]), [5, 7]);
+    eq(R.takeLastWhile(function() { assert(false); }, []), []);
+    eq(R.takeLastWhile(function(x) {return x !== void 0;}, [1, 3, void 0, 5, 7]), [5, 7]);
   });
 
   it('is curried', function() {
     var takeLastUntil7 = R.takeLastWhile(function(x) {return x !== 7;});
-    assert.deepEqual(takeLastUntil7([1, 3, 5, 7, 9]), [9]);
-    assert.deepEqual(takeLastUntil7([2, 4, 6, 8, 10]), [2, 4, 6, 8, 10]);
+    eq(takeLastUntil7([1, 3, 5, 7, 9]), [9]);
+    eq(takeLastUntil7([2, 4, 6, 8, 10]), [2, 4, 6, 8, 10]);
   });
 });

--- a/test/takeWhile.js
+++ b/test/takeWhile.js
@@ -1,21 +1,22 @@
 var assert = require('assert');
 
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('takeWhile', function() {
   it('continues taking elements while the function reports `true`', function() {
-    assert.deepEqual(R.takeWhile(function(x) {return x !== 5;}, [1, 3, 5, 7, 9]), [1, 3]);
+    eq(R.takeWhile(function(x) {return x !== 5;}, [1, 3, 5, 7, 9]), [1, 3]);
   });
 
   it('starts at the right arg and acknowledges undefined', function() {
-    assert.deepEqual(R.takeWhile(function() { assert(false); }, []), []);
-    assert.deepEqual(R.takeWhile(function(x) {return x !== void 0;}, [1, 3, void 0, 5, 7]), [1, 3]);
+    eq(R.takeWhile(function() { assert(false); }, []), []);
+    eq(R.takeWhile(function(x) {return x !== void 0;}, [1, 3, void 0, 5, 7]), [1, 3]);
   });
 
   it('is curried', function() {
     var takeUntil7 = R.takeWhile(function(x) {return x !== 7;});
-    assert.deepEqual(takeUntil7([1, 3, 5, 7, 9]), [1, 3, 5]);
-    assert.deepEqual(takeUntil7([2, 4, 6, 8, 10]), [2, 4, 6, 8, 10]);
+    eq(takeUntil7([1, 3, 5, 7, 9]), [1, 3, 5]);
+    eq(takeUntil7([2, 4, 6, 8, 10]), [2, 4, 6, 8, 10]);
   });
 });

--- a/test/tap.js
+++ b/test/tap.js
@@ -1,21 +1,20 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('tap', function() {
   it('returns a function that always returns its argument', function() {
     var f = R.tap(R.identity);
-    assert.strictEqual(typeof f, 'function');
-    assert.strictEqual(f(100), 100);
+    eq(typeof f, 'function');
+    eq(f(100), 100);
   });
 
   it("may take a function as the first argument that executes with tap's argument", function() {
     var sideEffect = 0;
-    assert.strictEqual(sideEffect, 0);
+    eq(sideEffect, 0);
     var rv = R.tap(function(x) { sideEffect = 'string ' + x; }, 200);
-    assert.strictEqual(rv, 200);
-    assert.strictEqual(sideEffect, 'string 200');
+    eq(rv, 200);
+    eq(sideEffect, 'string 200');
   });
 
 });

--- a/test/test.js
+++ b/test/test.js
@@ -1,22 +1,21 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('test', function() {
   it('returns true if string matches pattern', function() {
-    assert.strictEqual(R.test(/^x/, 'xyz'), true);
+    eq(R.test(/^x/, 'xyz'), true);
   });
 
   it('returns false if string does not match pattern', function() {
-    assert.strictEqual(R.test(/^y/, 'xyz'), false);
+    eq(R.test(/^y/, 'xyz'), false);
   });
 
   it('is referentially transparent', function() {
     var pattern = /x/g;
-    assert.strictEqual(pattern.lastIndex, 0);
-    assert.strictEqual(R.test(pattern, 'xyz'), true);
-    assert.strictEqual(pattern.lastIndex, 0);
-    assert.strictEqual(R.test(pattern, 'xyz'), true);
+    eq(pattern.lastIndex, 0);
+    eq(R.test(pattern, 'xyz'), true);
+    eq(pattern.lastIndex, 0);
+    eq(R.test(pattern, 'xyz'), true);
   });
 });

--- a/test/times.js
+++ b/test/times.js
@@ -1,19 +1,20 @@
 var assert = require('assert');
 
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('times', function() {
   it('takes a map func', function() {
-    assert.deepEqual(R.times(R.identity, 5), [0, 1, 2, 3, 4]);
-    assert.deepEqual(R.times(function(x) {
+    eq(R.times(R.identity, 5), [0, 1, 2, 3, 4]);
+    eq(R.times(function(x) {
       return x * 2;
     }, 5), [0, 2, 4, 6, 8]);
   });
 
   it('is curried', function() {
     var mapid = R.times(R.identity);
-    assert.deepEqual(mapid(5), [0, 1, 2, 3, 4]);
+    eq(mapid(5), [0, 1, 2, 3, 4]);
   });
 
   it('throws if second argument is not a valid array length', function() {

--- a/test/toLower.js
+++ b/test/toLower.js
@@ -1,10 +1,9 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('toLower', function() {
   it('returns the lower-case equivalent of the input string', function() {
-    assert.strictEqual(R.toLower('XYZ'), 'xyz');
+    eq(R.toLower('XYZ'), 'xyz');
   });
 });

--- a/test/toPairs.js
+++ b/test/toPairs.js
@@ -1,11 +1,10 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('toPairs', function() {
   it('converts an object into an array of two-element [key, value] arrays', function() {
-    assert.deepEqual(R.toPairs({a: 1, b: 2, c: 3}), [['a', 1], ['b', 2], ['c', 3]]);
+    eq(R.toPairs({a: 1, b: 2, c: 3}), [['a', 1], ['b', 2], ['c', 3]]);
   });
   it("only iterates the object's own properties", function() {
     var F = function() {
@@ -14,6 +13,6 @@ describe('toPairs', function() {
     };
     F.prototype.protoProp = 'you can\'t see me';
     var f = new F();
-    assert.deepEqual(R.toPairs(f), [['x', 1], ['y', 2]]);
+    eq(R.toPairs(f), [['x', 1], ['y', 2]]);
   });
 });

--- a/test/toPairsIn.js
+++ b/test/toPairsIn.js
@@ -1,11 +1,10 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('toPairsIn', function() {
   it('converts an object into an array of two-element [key, value] arrays', function() {
-    assert.deepEqual(R.toPairsIn({a: 1, b: 2, c: 3}), [['a', 1], ['b', 2], ['c', 3]]);
+    eq(R.toPairsIn({a: 1, b: 2, c: 3}), [['a', 1], ['b', 2], ['c', 3]]);
   });
   it("iterates properties on the object's prototype chain", function() {
     function sortPairs(a, b) {
@@ -17,6 +16,6 @@ describe('toPairsIn', function() {
     };
     F.prototype.protoProp = 'you can see me';
     var f = new F();
-    assert.deepEqual(R.toPairsIn(f).sort(sortPairs), [['protoProp', 'you can see me'], ['x', 1], ['y', 2]]);
+    eq(R.toPairsIn(f).sort(sortPairs), [['protoProp', 'you can see me'], ['x', 1], ['y', 2]]);
   });
 });

--- a/test/toUpper.js
+++ b/test/toUpper.js
@@ -1,10 +1,9 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('toUpper', function() {
   it('returns the upper-case equivalent of the input string', function() {
-    assert.strictEqual(R.toUpper('abc'), 'ABC');
+    eq(R.toUpper('abc'), 'ABC');
   });
 });

--- a/test/transduce.js
+++ b/test/transduce.js
@@ -1,6 +1,5 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 describe('transduce', function() {
   var add = R.add;
@@ -36,39 +35,39 @@ describe('transduce', function() {
   };
 
   it('transduces into arrays', function() {
-    assert.deepEqual(R.transduce(R.map(add(1)), R.flip(R.append), [], [1, 2, 3, 4]), [2, 3, 4, 5]);
-    assert.deepEqual(R.transduce(R.filter(isOdd), R.flip(R.append), [],  [1, 2, 3, 4]), [1, 3]);
-    assert.deepEqual(R.transduce(R.compose(R.map(add(1)), R.take(2)), R.flip(R.append), [],  [1, 2, 3, 4]), [2, 3]);
+    eq(R.transduce(R.map(add(1)), R.flip(R.append), [], [1, 2, 3, 4]), [2, 3, 4, 5]);
+    eq(R.transduce(R.filter(isOdd), R.flip(R.append), [],  [1, 2, 3, 4]), [1, 3]);
+    eq(R.transduce(R.compose(R.map(add(1)), R.take(2)), R.flip(R.append), [],  [1, 2, 3, 4]), [2, 3]);
   });
 
   it('transduces into strings', function() {
-    assert.deepEqual(R.transduce(R.map(add(1)), add, '', [1, 2, 3, 4]), '2345');
-    assert.deepEqual(R.transduce(R.filter(isOdd), add, '', [1, 2, 3, 4]), '13');
-    assert.deepEqual(R.transduce(R.compose(R.map(add(1)), R.take(2)), add, '', [1, 2, 3, 4]), '23');
+    eq(R.transduce(R.map(add(1)), add, '', [1, 2, 3, 4]), '2345');
+    eq(R.transduce(R.filter(isOdd), add, '', [1, 2, 3, 4]), '13');
+    eq(R.transduce(R.compose(R.map(add(1)), R.take(2)), add, '', [1, 2, 3, 4]), '23');
   });
 
   it('transduces into objects', function() {
-    assert.deepEqual(R.transduce(R.map(R.identity), R.merge, {}, [{a: 1}, {b: 2, c: 3}]), {a: 1, b: 2, c: 3});
+    eq(R.transduce(R.map(R.identity), R.merge, {}, [{a: 1}, {b: 2, c: 3}]), {a: 1, b: 2, c: 3});
   });
 
   it('folds transformer objects over a collection with the supplied accumulator', function() {
-    assert.strictEqual(R.transduce(toxf(add), addxf, 0, [1, 2, 3, 4]), 10);
-    assert.strictEqual(R.transduce(toxf(mult), multxf, 1, [1, 2, 3, 4]), 24);
-    assert.deepEqual(R.transduce(toxf(R.concat), listxf, [0], [1, 2, 3, 4]), [0, 1, 2, 3, 4]);
-    assert.strictEqual(R.transduce(toxf(add), add, 0, [1, 2, 3, 4]), 10);
-    assert.strictEqual(R.transduce(toxf(mult), mult, 1, [1, 2, 3, 4]), 24);
+    eq(R.transduce(toxf(add), addxf, 0, [1, 2, 3, 4]), 10);
+    eq(R.transduce(toxf(mult), multxf, 1, [1, 2, 3, 4]), 24);
+    eq(R.transduce(toxf(R.concat), listxf, [0], [1, 2, 3, 4]), [0, 1, 2, 3, 4]);
+    eq(R.transduce(toxf(add), add, 0, [1, 2, 3, 4]), 10);
+    eq(R.transduce(toxf(mult), mult, 1, [1, 2, 3, 4]), 24);
   });
 
   it('dispatches to objects that implement `reduce`', function() {
     var obj = {x: [1, 2, 3], reduce: function() { return 'override'; }};
-    assert.strictEqual(R.transduce(R.map(add(1)), add, 0, obj), 'override');
-    assert.strictEqual(R.transduce(R.map(add(1)), add, 10, obj), 'override');
+    eq(R.transduce(R.map(add(1)), add, 0, obj), 'override');
+    eq(R.transduce(R.map(add(1)), add, 10, obj), 'override');
   });
 
   it('returns the accumulator for an empty collection', function() {
-    assert.strictEqual(R.transduce(toxf(add), addxf, 0, []), 0);
-    assert.strictEqual(R.transduce(toxf(mult), multxf, 1, []), 1);
-    assert.deepEqual(R.transduce(toxf(R.concat), listxf, [], []), []);
+    eq(R.transduce(toxf(add), addxf, 0, []), 0);
+    eq(R.transduce(toxf(mult), multxf, 1, []), 1);
+    eq(R.transduce(toxf(R.concat), listxf, [], []), []);
   });
 
   it('is curried', function() {
@@ -76,12 +75,12 @@ describe('transduce', function() {
     var addOrCat2 = addOrCat1(addxf);
     var sum = addOrCat2(0);
     var cat = addOrCat2('');
-    assert.strictEqual(sum([1, 2, 3, 4]), 10);
-    assert.strictEqual(cat(['1', '2', '3', '4']), '1234');
+    eq(sum([1, 2, 3, 4]), 10);
+    eq(cat(['1', '2', '3', '4']), '1234');
   });
 
   it('correctly reports the arity of curried versions', function() {
     var sum = R.transduce(toxf(add), addxf, 0);
-    assert.strictEqual(sum.length, 1);
+    eq(sum.length, 1);
   });
 });

--- a/test/trim.js
+++ b/test/trim.js
@@ -1,32 +1,31 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('trim', function() {
   var test = '\x09\x0A\x0B\x0C\x0D\x20\xA0\u1680\u180E\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200A\u202F\u205F\u3000\u2028\u2029\uFEFFHello, World!\x09\x0A\x0B\x0C\x0D\x20\xA0\u1680\u180E\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200A\u202F\u205F\u3000\u2028\u2029\uFEFF';
 
   it('trims a string', function() {
-    assert.strictEqual(R.trim('   xyz  '), 'xyz');
+    eq(R.trim('   xyz  '), 'xyz');
   });
 
   it('trims all ES5 whitespace', function() {
-    assert.strictEqual(R.trim(test), 'Hello, World!');
-    assert.strictEqual(R.trim(test).length, 13);
+    eq(R.trim(test), 'Hello, World!');
+    eq(R.trim(test).length, 13);
   });
 
   it('does not trim the zero-width space', function() {
-    assert.strictEqual(R.trim('\u200b'), '\u200b');
-    assert.strictEqual(R.trim('\u200b').length, 1);
+    eq(R.trim('\u200b'), '\u200b');
+    eq(R.trim('\u200b').length, 1);
   });
 
   if (typeof String.prototype.trim !== 'function') {
     it('falls back to a shim if String.prototype.trim is not present', function() {
-      assert.strictEqual(R.trim('   xyz  '), 'xyz');
-      assert.strictEqual(R.trim(test), 'Hello, World!');
-      assert.strictEqual(R.trim(test).length, 13);
-      assert.strictEqual(R.trim('\u200b'), '\u200b');
-      assert.strictEqual(R.trim('\u200b').length, 1);
+      eq(R.trim('   xyz  '), 'xyz');
+      eq(R.trim(test), 'Hello, World!');
+      eq(R.trim(test).length, 13);
+      eq(R.trim('\u200b'), '\u200b');
+      eq(R.trim('\u200b').length, 1);
     });
   }
 });

--- a/test/type.js
+++ b/test/type.js
@@ -1,49 +1,48 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('type', function() {
 
   it('"Array" if given an array literal', function() {
-    assert.strictEqual(R.type([1, 2, 3]), 'Array');
+    eq(R.type([1, 2, 3]), 'Array');
   });
 
   // it('"Arguments" if given an arguments object', function() {
   //   var args = (function() { return arguments; }());
-  //   assert.strictEqual(R.type(args), 'Arguments');
+  //   eq(R.type(args), 'Arguments');
   // });
 
   it('"Object" if given an object literal', function() {
-    assert.strictEqual(R.type({batman: 'na na na na na na na'}), 'Object');
+    eq(R.type({batman: 'na na na na na na na'}), 'Object');
   });
 
   it('"RegExp" if given a RegExp literal', function() {
-    assert.strictEqual(R.type(/[A-z]/), 'RegExp');
+    eq(R.type(/[A-z]/), 'RegExp');
   });
 
   it('"Number" if given a numeric value', function() {
-    assert.strictEqual(R.type(4), 'Number');
+    eq(R.type(4), 'Number');
   });
 
   it('"Number" if given the NaN value', function() {
-    assert.strictEqual(R.type(NaN), 'Number');
+    eq(R.type(NaN), 'Number');
   });
 
   it('"String" if given a String literal', function() {
-    assert.strictEqual(R.type('Gooooodd Mornning Ramda!!'), 'String');
+    eq(R.type('Gooooodd Mornning Ramda!!'), 'String');
   });
 
   it('"String" if given a String object', function() {
     /*jshint -W053 */
-    assert.strictEqual(R.type(new String('I am a String object')), 'String');
+    eq(R.type(new String('I am a String object')), 'String');
   });
 
   it('"Null" if given the null value', function() {
-    assert.strictEqual(R.type(null), 'Null');
+    eq(R.type(null), 'Null');
   });
 
   it('"Undefined" if given the undefined value', function() {
-    assert.strictEqual(R.type(undefined), 'Undefined');
+    eq(R.type(undefined), 'Undefined');
   });
 });

--- a/test/unapply.js
+++ b/test/unapply.js
@@ -1,28 +1,27 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('unapply', function() {
   it('returns a function which is always passed one argument', function() {
     var fn = R.unapply(function() { return arguments.length; });
-    assert.strictEqual(fn(), 1);
-    assert.strictEqual(fn('x'), 1);
-    assert.strictEqual(fn('x', 'y'), 1);
-    assert.strictEqual(fn('x', 'y', 'z'), 1);
+    eq(fn(), 1);
+    eq(fn('x'), 1);
+    eq(fn('x', 'y'), 1);
+    eq(fn('x', 'y', 'z'), 1);
   });
 
   it('forwards arguments to decorated function as an array', function() {
     var fn = R.unapply(function(xs) { return '[' + xs + ']'; });
-    assert.strictEqual(fn(), '[]');
-    assert.strictEqual(fn(2), '[2]');
-    assert.strictEqual(fn(2, 4), '[2,4]');
-    assert.strictEqual(fn(2, 4, 6), '[2,4,6]');
+    eq(fn(), '[]');
+    eq(fn(2), '[2]');
+    eq(fn(2, 4), '[2,4]');
+    eq(fn(2, 4, 6), '[2,4,6]');
   });
 
   it('returns a function with length 0', function() {
     var fn = R.unapply(R.identity);
-    assert.strictEqual(fn.length, 0);
+    eq(fn.length, 0);
   });
 
   it('is the inverse of R.apply', function() {
@@ -36,7 +35,7 @@ describe('unapply', function() {
     n = 1;
     while (n <= 100) {
       a = rand(); b = rand(); c = rand(); d = rand(); e = rand();
-      assert.strictEqual(f(a, b, c, d, e), g(a, b, c, d, e));
+      eq(f(a, b, c, d, e), g(a, b, c, d, e));
       n += 1;
     }
 
@@ -45,7 +44,7 @@ describe('unapply', function() {
     n = 1;
     while (n <= 100) {
       a = rand(); b = rand(); c = rand(); d = rand(); e = rand();
-      assert.strictEqual(f([a, b, c, d, e]), g([a, b, c, d, e]));
+      eq(f([a, b, c, d, e]), g([a, b, c, d, e]));
       n += 1;
     }
   });

--- a/test/unary.js
+++ b/test/unary.js
@@ -1,20 +1,19 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('unary', function() {
   it('turns multiple-argument function into unary one', function() {
     R.unary(function(x, y, z) {
-      assert.strictEqual(arguments.length, 1);
-      assert.strictEqual(typeof y, 'undefined');
-      assert.strictEqual(typeof z, 'undefined');
+      eq(arguments.length, 1);
+      eq(typeof y, 'undefined');
+      eq(typeof z, 'undefined');
     })(10, 20, 30);
   });
 
   it('initial argument is passed through normally', function() {
     R.unary(function(x, y, z) {
-      assert.strictEqual(x, 10);
+      eq(x, 10);
       void z;
     })(10, 20, 30);
   });

--- a/test/uncurryN.js
+++ b/test/uncurryN.js
@@ -1,6 +1,5 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('uncurryN', function() {
@@ -38,58 +37,58 @@ describe('uncurryN', function() {
 
   it('accepts an arity', function() {
     var uncurried = R.uncurryN(3, a3);
-    assert.strictEqual(uncurried(1, 2, 3), 6);
+    eq(uncurried(1, 2, 3), 6);
   });
 
   it('returns a function of the specified arity', function() {
-    assert.strictEqual(R.uncurryN(2, a2).length, 2);
-    assert.strictEqual(R.uncurryN(3, a3).length, 3);
-    assert.strictEqual(R.uncurryN(4, a4).length, 4);
+    eq(R.uncurryN(2, a2).length, 2);
+    eq(R.uncurryN(3, a3).length, 3);
+    eq(R.uncurryN(4, a4).length, 4);
   });
 
   it('forwards extra arguments', function() {
     var g = R.uncurryN(3, a3b);
 
-    assert.deepEqual(g(1, 2, 3), 6);
-    assert.deepEqual(g(1, 2, 3, 4), 10);
-    assert.deepEqual(g(1, 2, 3, 4, 5), 15);
+    eq(g(1, 2, 3), 6);
+    eq(g(1, 2, 3, 4), 10);
+    eq(g(1, 2, 3, 4, 5), 15);
   });
 
   it('works with ordinary uncurried functions', function() {
-    assert.strictEqual(R.uncurryN(2, function(a, b) { return a + b; })(10, 20), 30);
-    assert.strictEqual(R.uncurryN(3, function(a, b, c) { return a + b + c; })(10, 20, 30), 60);
+    eq(R.uncurryN(2, function(a, b) { return a + b; })(10, 20), 30);
+    eq(R.uncurryN(3, function(a, b, c) { return a + b + c; })(10, 20, 30), 60);
   });
 
   it('works with ramda-curried functions', function() {
-    assert.strictEqual(R.uncurryN(2, R.add)(10, 20), 30);
+    eq(R.uncurryN(2, R.add)(10, 20), 30);
   });
 
   it('returns a function that supports R.__ placeholder', function() {
     var g = R.uncurryN(3, a3);
     var _ = R.__;
 
-    assert.deepEqual(g(1)(2)(3), 6);
-    assert.deepEqual(g(1)(2, 3), 6);
-    assert.deepEqual(g(1, 2)(3), 6);
-    assert.deepEqual(g(1, 2, 3), 6);
+    eq(g(1)(2)(3), 6);
+    eq(g(1)(2, 3), 6);
+    eq(g(1, 2)(3), 6);
+    eq(g(1, 2, 3), 6);
 
-    assert.deepEqual(g(_, 2, 3)(1), 6);
-    assert.deepEqual(g(1, _, 3)(2), 6);
-    assert.deepEqual(g(1, 2, _)(3), 6);
+    eq(g(_, 2, 3)(1), 6);
+    eq(g(1, _, 3)(2), 6);
+    eq(g(1, 2, _)(3), 6);
 
-    assert.deepEqual(g(1, _, _)(2)(3), 6);
-    assert.deepEqual(g(_, 2, _)(1)(3), 6);
-    assert.deepEqual(g(_, _, 3)(1)(2), 6);
+    eq(g(1, _, _)(2)(3), 6);
+    eq(g(_, 2, _)(1)(3), 6);
+    eq(g(_, _, 3)(1)(2), 6);
 
-    assert.deepEqual(g(1, _, _)(2, 3), 6);
-    assert.deepEqual(g(_, 2, _)(1, 3), 6);
-    assert.deepEqual(g(_, _, 3)(1, 2), 6);
+    eq(g(1, _, _)(2, 3), 6);
+    eq(g(_, 2, _)(1, 3), 6);
+    eq(g(_, _, 3)(1, 2), 6);
 
-    assert.deepEqual(g(1, _, _)(_, 3)(2), 6);
-    assert.deepEqual(g(_, 2, _)(_, 3)(1), 6);
-    assert.deepEqual(g(_, _, 3)(_, 2)(1), 6);
+    eq(g(1, _, _)(_, 3)(2), 6);
+    eq(g(_, 2, _)(_, 3)(1), 6);
+    eq(g(_, _, 3)(_, 2)(1), 6);
 
-    assert.deepEqual(g(_, _, _)(_, _)(_)(1, 2, 3), 6);
-    assert.deepEqual(g(_, _, _)(1, _, _)(_, _)(2, _)(_)(3), 6);
+    eq(g(_, _, _)(_, _)(_)(1, 2, 3), 6);
+    eq(g(_, _, _)(1, _, _)(_, _)(2, _)(_)(3), 6);
   });
 });

--- a/test/unfold.js
+++ b/test/unfold.js
@@ -1,11 +1,10 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('unfold', function() {
   it('unfolds simple functions with a starting point to create a list', function() {
-    assert.deepEqual(R.unfold(function(n) {if (n > 0) {return [n, n - 1];}}, 10), [10, 9, 8, 7, 6, 5, 4, 3, 2, 1]);
+    eq(R.unfold(function(n) {if (n > 0) {return [n, n - 1];}}, 10), [10, 9, 8, 7, 6, 5, 4, 3, 2, 1]);
   });
 
   it('is cool!', function() {
@@ -18,7 +17,7 @@ describe('unfold', function() {
         }
       };
     };
-    assert.deepEqual(R.unfold(fib(10), [0, 1]), [0, 1, 1, 2, 3, 5, 8, 13, 21, 34]);
+    eq(R.unfold(fib(10), [0, 1]), [0, 1, 1, 2, 3, 5, 8, 13, 21, 34]);
   });
 
 });

--- a/test/union.js
+++ b/test/union.js
@@ -1,18 +1,17 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('union', function() {
   var M = [1, 2, 3, 4];
   var N = [3, 4, 5, 6];
   it('combines two lists into the set of all their elements', function() {
-    assert.deepEqual(R.union(M, N), [1, 2, 3, 4, 5, 6]);
+    eq(R.union(M, N), [1, 2, 3, 4, 5, 6]);
   });
 
   it('is curried', function() {
-    assert.strictEqual(typeof R.union(M), 'function');
-    assert.deepEqual(R.union(M)(N), [1, 2, 3, 4, 5, 6]);
+    eq(typeof R.union(M), 'function');
+    eq(R.union(M)(N), [1, 2, 3, 4, 5, 6]);
   });
 
   it('has R.equals semantics', function() {
@@ -21,9 +20,9 @@ describe('union', function() {
       return x instanceof Just && R.equals(x.value, this.value);
     };
 
-    assert.strictEqual(R.union([0], [-0]).length, 2);
-    assert.strictEqual(R.union([-0], [0]).length, 2);
-    assert.strictEqual(R.union([NaN], [NaN]).length, 1);
-    assert.strictEqual(R.union([new Just([42])], [new Just([42])]).length, 1);
+    eq(R.union([0], [-0]).length, 2);
+    eq(R.union([-0], [0]).length, 2);
+    eq(R.union([NaN], [NaN]).length, 1);
+    eq(R.union([new Just([42])], [new Just([42])]).length, 1);
   });
 });

--- a/test/unionWith.js
+++ b/test/unionWith.js
@@ -1,6 +1,5 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('unionWith', function() {
@@ -8,6 +7,6 @@ describe('unionWith', function() {
   var So = [{a: 3}, {a: 4}, {a: 5}, {a: 6}];
   var eqA = function(r, s) { return r.a === s.a; };
   it('combines two lists into the set of all their elements based on the passed-in equality predicate', function() {
-    assert.deepEqual(R.unionWith(eqA, Ro, So), [{a: 1}, {a: 2}, {a: 3}, {a: 4}, {a: 5}, {a: 6}]);
+    eq(R.unionWith(eqA, Ro, So), [{a: 1}, {a: 2}, {a: 3}, {a: 4}, {a: 5}, {a: 6}]);
   });
 });

--- a/test/uniq.js
+++ b/test/uniq.js
@@ -1,20 +1,19 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('uniq', function() {
   it('returns a set from any array (i.e. purges duplicate elements)', function() {
     var list = [1, 2, 3, 1, 2, 3, 1, 2, 3];
-    assert.deepEqual(R.uniq(list), [1, 2, 3]);
+    eq(R.uniq(list), [1, 2, 3]);
   });
 
   it('keeps elements from the left', function() {
-    assert.deepEqual(R.uniq([1, 2, 3, 4, 1]), [1, 2, 3, 4]);
+    eq(R.uniq([1, 2, 3, 4, 1]), [1, 2, 3, 4]);
   });
 
   it('returns an empty array for an empty array', function() {
-    assert.deepEqual(R.uniq([]), []);
+    eq(R.uniq([]), []);
   });
 
   it('has R.equals semantics', function() {
@@ -23,13 +22,13 @@ describe('uniq', function() {
       return x instanceof Just && R.equals(x.value, this.value);
     };
 
-    assert.strictEqual(R.uniq([0, -0]).length, 2);
-    assert.strictEqual(R.uniq([NaN, NaN]).length, 1);
-    assert.strictEqual(R.uniq([[1], [1]]).length, 1);
-    assert.strictEqual(R.uniq([new Just([42]), new Just([42])]).length, 1);
+    eq(R.uniq([0, -0]).length, 2);
+    eq(R.uniq([NaN, NaN]).length, 1);
+    eq(R.uniq([[1], [1]]).length, 1);
+    eq(R.uniq([new Just([42]), new Just([42])]).length, 1);
   });
 
   it('handles null and undefined elements', function() {
-    assert.deepEqual(R.uniq([void 0, null, void 0, null]), [void 0, null]);
+    eq(R.uniq([void 0, null, void 0, null]), [void 0, null]);
   });
 });

--- a/test/uniqBy.js
+++ b/test/uniqBy.js
@@ -1,20 +1,19 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('uniqBy', function() {
 
   it('returns a set from any array based on predicate', function() {
-    assert.deepEqual(R.uniqBy(Math.abs, [-2, -1, 0, 1, 2]), [-2, -1, 0]);
+    eq(R.uniqBy(Math.abs, [-2, -1, 0, 1, 2]), [-2, -1, 0]);
   });
 
   it('keeps elements from the left', function() {
-    assert.deepEqual(R.uniqBy(Math.abs, [-1, 2, 4, 3, 1, 3]), [-1, 2, 4, 3]);
+    eq(R.uniqBy(Math.abs, [-1, 2, 4, 3, 1, 3]), [-1, 2, 4, 3]);
   });
 
   it('returns an empty array for an empty array', function() {
-    assert.deepEqual(R.uniqBy(R.identity, []), []);
+    eq(R.uniqBy(R.identity, []), []);
   });
 
   it('has R.equals semantics', function() {
@@ -24,9 +23,9 @@ describe('uniqBy', function() {
     Just.prototype.equals = function(x) {
       return x instanceof Just && R.equals(x.value, this.value);
     };
-    assert.strictEqual(R.uniqBy(R.identity, [-0, 0]).length, 2);
-    assert.strictEqual(R.uniqBy(R.identity, [NaN, NaN]).length, 1);
-    assert.strictEqual(R.uniqBy(R.identity, [new Just([1, 2, 3]), new Just([1, 2, 3])]).length, 1);
+    eq(R.uniqBy(R.identity, [-0, 0]).length, 2);
+    eq(R.uniqBy(R.identity, [NaN, NaN]).length, 1);
+    eq(R.uniqBy(R.identity, [new Just([1, 2, 3]), new Just([1, 2, 3])]).length, 1);
   });
 
 });

--- a/test/uniqWith.js
+++ b/test/uniqWith.js
@@ -1,6 +1,5 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('uniqWith', function() {
@@ -15,21 +14,21 @@ describe('uniqWith', function() {
   function eqI(x, accX) { return x.i === accX.i; }
 
   it('returns a set from any array (i.e. purges duplicate elements) based on predicate', function() {
-    assert.deepEqual(R.uniqWith(eqI, objs), objs);
-    assert.deepEqual(R.uniqWith(eqI, objs2), [{x: R.T, i: 0}, {x: R.F, i: 1}, {x: R.T, i: 2}, {x: R.T, i: 3}]);
+    eq(R.uniqWith(eqI, objs), objs);
+    eq(R.uniqWith(eqI, objs2), [{x: R.T, i: 0}, {x: R.F, i: 1}, {x: R.T, i: 2}, {x: R.T, i: 3}]);
   });
 
   it('keeps elements from the left', function() {
-    assert.deepEqual(R.uniqWith(eqI, [{i: 1}, {i: 2}, {i: 3}, {i: 4}, {i: 1}]), [{i: 1}, {i: 2}, {i: 3}, {i: 4}]);
+    eq(R.uniqWith(eqI, [{i: 1}, {i: 2}, {i: 3}, {i: 4}, {i: 1}]), [{i: 1}, {i: 2}, {i: 3}, {i: 4}]);
   });
 
   it('returns an empty array for an empty array', function() {
-    assert.deepEqual(R.uniqWith(eqI, []), []);
+    eq(R.uniqWith(eqI, []), []);
   });
 
   it('is curried', function() {
-    assert.strictEqual(typeof R.uniqWith(eqI), 'function');
-    assert.deepEqual(R.uniqWith(eqI)(objs), objs);
-    assert.deepEqual(R.uniqWith(eqI)(objs2), [{x: R.T, i: 0}, {x: R.F, i: 1}, {x: R.T, i: 2}, {x: R.T, i: 3}]);
+    eq(typeof R.uniqWith(eqI), 'function');
+    eq(R.uniqWith(eqI)(objs), objs);
+    eq(R.uniqWith(eqI)(objs2), [{x: R.T, i: 0}, {x: R.F, i: 1}, {x: R.T, i: 2}, {x: R.T, i: 3}]);
   });
 });

--- a/test/unless.js
+++ b/test/unless.js
@@ -1,19 +1,18 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('unless', function() {
   it('calls the whenFalse function if the validator returns a falsey value', function() {
-    assert.deepEqual(R.unless(R.isArrayLike, R.of)(10), [10]);
+    eq(R.unless(R.isArrayLike, R.of)(10), [10]);
   });
 
   it('returns the argument unmodified if the validator returns a truthy value', function() {
-    assert.deepEqual(R.unless(R.isArrayLike, R.of)([10]), [10]);
+    eq(R.unless(R.isArrayLike, R.of)([10]), [10]);
   });
 
   it('returns a curried function', function() {
-    assert.deepEqual(R.unless(R.isArrayLike)(R.of)(10), [10]);
-    assert.deepEqual(R.unless(R.isArrayLike)(R.of)([10]), [10]);
+    eq(R.unless(R.isArrayLike)(R.of)(10), [10]);
+    eq(R.unless(R.isArrayLike)(R.of)([10]), [10]);
   });
 });

--- a/test/unnest.js
+++ b/test/unnest.js
@@ -1,6 +1,7 @@
 var assert = require('assert');
 
 var R = require('..');
+var eq = require('./shared/eq');
 var Maybe = require('./shared/Maybe');
 
 
@@ -8,10 +9,10 @@ describe('unnest', function() {
 
   it('only flattens one layer deep of a nested list', function() {
     var nest = [1, [2], [3, [4, 5], 6, [[[7], 8]]], 9, 10];
-    assert.deepEqual(R.unnest(nest), [1, 2, 3, [4, 5], 6, [[[7], 8]], 9, 10]);
+    eq(R.unnest(nest), [1, 2, 3, [4, 5], 6, [[[7], 8]], 9, 10]);
     nest = [[[[3]], 2, 1], 0, [[-1, -2], -3]];
-    assert.deepEqual(R.unnest(nest), [[[3]], 2, 1, 0, [-1, -2], -3]);
-    assert.deepEqual(R.unnest([1, 2, 3, 4, 5]), [1, 2, 3, 4, 5]);
+    eq(R.unnest(nest), [[[3]], 2, 1, 0, [-1, -2], -3]);
+    eq(R.unnest([1, 2, 3, 4, 5]), [1, 2, 3, 4, 5]);
   });
 
   it('is not destructive', function() {
@@ -21,23 +22,23 @@ describe('unnest', function() {
 
   it('handles array-like objects', function() {
     var o = {length: 3, 0: [1, 2, [3]], 1: [], 2: ['a', 'b', 'c', ['d', 'e']]};
-    assert.deepEqual(R.unnest(o), [1, 2, [3], 'a', 'b', 'c', ['d', 'e']]);
+    eq(R.unnest(o), [1, 2, [3], 'a', 'b', 'c', ['d', 'e']]);
   });
 
   it('flattens an array of empty arrays', function() {
-    assert.deepEqual(R.unnest([[], [], []]), []);
-    assert.deepEqual(R.unnest([]), []);
+    eq(R.unnest([[], [], []]), []);
+    eq(R.unnest([]), []);
   });
 
   it('is equivalent to R.chain(R.identity)', function() {
     var Nothing = Maybe.Nothing;
     var Just = Maybe.Just;
 
-    assert.strictEqual(R.toString(R.unnest(Nothing())), 'Nothing()');
-    assert.strictEqual(R.toString(R.unnest(Just(Nothing()))), 'Nothing()');
-    assert.strictEqual(R.toString(R.unnest(Just(Just(Nothing())))), 'Just(Nothing())');
-    assert.strictEqual(R.toString(R.unnest(Just(Just(42)))), 'Just(42)');
-    assert.strictEqual(R.toString(R.unnest(Just(Just(Just(42))))), 'Just(Just(42))');
+    eq(R.unnest(Nothing()), Nothing());
+    eq(R.unnest(Just(Nothing())), Nothing());
+    eq(R.unnest(Just(Just(Nothing()))), Just(Nothing()));
+    eq(R.unnest(Just(Just(42))), Just(42));
+    eq(R.unnest(Just(Just(Just(42)))), Just(Just(42)));
   });
 
 });

--- a/test/update.js
+++ b/test/update.js
@@ -1,36 +1,35 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 describe('update', function() {
   it('updates the value at the given index of the supplied array', function() {
-    assert.deepEqual(R.update(2, 4, [0, 1, 2, 3]), [0, 1, 4, 3]);
+    eq(R.update(2, 4, [0, 1, 2, 3]), [0, 1, 4, 3]);
   });
 
   it('offsets negative indexes from the end of the array', function() {
-    assert.deepEqual(R.update(-3, 4, [0, 1, 2, 3]), [0, 4, 2, 3]);
+    eq(R.update(-3, 4, [0, 1, 2, 3]), [0, 4, 2, 3]);
   });
 
   it('returns the original array if the supplied index is out of bounds', function() {
     var list = [0, 1, 2, 3];
-    assert.deepEqual(R.update(4, 4, list), list);
-    assert.deepEqual(R.update(-5, 4, list), list);
+    eq(R.update(4, 4, list), list);
+    eq(R.update(-5, 4, list), list);
   });
 
   it('does not mutate the original array', function() {
     var list = [0, 1, 2, 3];
-    assert.deepEqual(R.update(2, 4, list), [0, 1, 4, 3]);
-    assert.deepEqual(list, [0, 1, 2, 3]);
+    eq(R.update(2, 4, list), [0, 1, 4, 3]);
+    eq(list, [0, 1, 2, 3]);
   });
 
   it('curries the arguments', function() {
-    assert.deepEqual(R.update(2)(4)([0, 1, 2, 3]), [0, 1, 4, 3]);
+    eq(R.update(2)(4)([0, 1, 2, 3]), [0, 1, 4, 3]);
   });
 
   it('accepts an array-like object', function() {
     function args() {
       return arguments;
     }
-    assert.deepEqual(R.update(2, 4, args(0, 1, 2, 3)), [0, 1, 4, 3]);
+    eq(R.update(2, 4, args(0, 1, 2, 3)), [0, 1, 4, 3]);
   });
 });

--- a/test/useWith.js
+++ b/test/useWith.js
@@ -1,6 +1,5 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('useWith', function() {
@@ -11,22 +10,22 @@ describe('useWith', function() {
   var f = R.useWith(max, [add1, mult2, div3]);
 
   it('takes a list of function and returns a function', function() {
-    assert.strictEqual(typeof R.useWith(max, []), 'function');
-    assert.strictEqual(typeof R.useWith(max, [add1]), 'function');
-    assert.strictEqual(typeof R.useWith(max, [add1, mult2, div3]), 'function');
+    eq(typeof R.useWith(max, []), 'function');
+    eq(typeof R.useWith(max, [add1]), 'function');
+    eq(typeof R.useWith(max, [add1, mult2, div3]), 'function');
   });
 
   it('passes the arguments received to their respective functions', function() {
-    assert.strictEqual(f(7, 8, 9), 16); // max(7 + 1, 8 * 2, 9 / 3);
+    eq(f(7, 8, 9), 16); // max(7 + 1, 8 * 2, 9 / 3);
   });
 
   it('passes additional arguments to the main function', function() {
-    assert.strictEqual(f(7, 8, 9, 10), 16);
-    assert.strictEqual(f(7, 8, 9, 20), 20);
+    eq(f(7, 8, 9, 10), 16);
+    eq(f(7, 8, 9, 20), 20);
   });
 
   it('has the correct arity', function() {
-    assert.strictEqual(f.length, 3);
+    eq(f.length, 3);
   });
 
   it('passes context to its functions', function() {
@@ -35,10 +34,10 @@ describe('useWith', function() {
     var c = function(x, y) { return this.f3(x, y); };
     var d = R.useWith(c, [a, b]);
     var context = {f1: R.add(1), f2: R.add(2), f3: R.add};
-    assert.strictEqual(a.call(context, 1), 2);
-    assert.strictEqual(b.call(context, 1), 3);
-    assert.strictEqual(d.apply(context, [1, 1]), 5);
-    assert.strictEqual(d.apply(context, [2, 3]), 8);
+    eq(a.call(context, 1), 2);
+    eq(b.call(context, 1), 3);
+    eq(d.apply(context, [1, 1]), 5);
+    eq(d.apply(context, [2, 3]), 8);
   });
 
 });

--- a/test/values.js
+++ b/test/values.js
@@ -1,6 +1,5 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('values', function() {
@@ -13,15 +12,15 @@ describe('values', function() {
   it("returns an array of the given object's values", function() {
     var vs = R.values(obj).sort();
     var ts = [[1, 2, 3], 100, 'D', {x: 200, y: 300}, null, undefined];
-    assert.strictEqual(vs.length, ts.length);
-    assert.deepEqual(vs[0], ts[0]);
-    assert.strictEqual(vs[1], ts[1]);
-    assert.strictEqual(vs[2], ts[2]);
-    assert.deepEqual(vs[3], ts[3]);
-    assert.strictEqual(vs[4], ts[4]);
-    assert.strictEqual(vs[5], ts[5]);
+    eq(vs.length, ts.length);
+    eq(vs[0], ts[0]);
+    eq(vs[1], ts[1]);
+    eq(vs[2], ts[2]);
+    eq(vs[3], ts[3]);
+    eq(vs[4], ts[4]);
+    eq(vs[5], ts[5]);
 
-    assert.deepEqual(R.values({
+    eq(R.values({
       /* jshint -W001 */
       hasOwnProperty: false
       /* jshint +W001 */
@@ -29,7 +28,7 @@ describe('values', function() {
   });
 
   it("does not include the given object's prototype properties", function() {
-    assert.deepEqual(R.values(cobj), [100, 200]);
+    eq(R.values(cobj), [100, 200]);
   });
 
   it('works for primitives', function() {
@@ -37,6 +36,6 @@ describe('values', function() {
     var result = R.map(function(val) {
       return R.keys(val);
     }, [null, undefined, 55, '', true, false, NaN, Infinity, , []]);
-    assert.deepEqual(result, R.repeat([], 10));
+    eq(result, R.repeat([], 10));
   });
 });

--- a/test/valuesIn.js
+++ b/test/valuesIn.js
@@ -1,6 +1,5 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('valuesIn', function() {
@@ -12,22 +11,22 @@ describe('valuesIn', function() {
 
   it("returns an array of the given object's values", function() {
     var vs = R.valuesIn(obj);
-    assert.strictEqual(vs.length, 6);
-    assert.strictEqual(R.indexOf(100, vs) >= 0, true);
-    assert.strictEqual(R.indexOf('D', vs) >= 0, true);
-    assert.strictEqual(R.indexOf(null, vs) >= 0, true);
-    assert.strictEqual(R.indexOf(undefined, vs) >= 0, true);
-    assert.strictEqual(R.indexOf(obj.b, vs) >= 0, true);
-    assert.strictEqual(R.indexOf(obj.c, vs) >= 0, true);
+    eq(vs.length, 6);
+    eq(R.indexOf(100, vs) >= 0, true);
+    eq(R.indexOf('D', vs) >= 0, true);
+    eq(R.indexOf(null, vs) >= 0, true);
+    eq(R.indexOf(undefined, vs) >= 0, true);
+    eq(R.indexOf(obj.b, vs) >= 0, true);
+    eq(R.indexOf(obj.c, vs) >= 0, true);
   });
 
   it("includes the given object's prototype properties", function() {
     var vs = R.valuesIn(cobj);
-    assert.strictEqual(vs.length, 4);
-    assert.strictEqual(R.indexOf(100, vs) >= 0, true);
-    assert.strictEqual(R.indexOf(200, vs) >= 0, true);
-    assert.strictEqual(R.indexOf(cobj.x, vs) >= 0, true);
-    assert.strictEqual(R.indexOf('y', vs) >= 0, true);
+    eq(vs.length, 4);
+    eq(R.indexOf(100, vs) >= 0, true);
+    eq(R.indexOf(200, vs) >= 0, true);
+    eq(R.indexOf(cobj.x, vs) >= 0, true);
+    eq(R.indexOf('y', vs) >= 0, true);
   });
 
   it('works for primitives', function() {
@@ -35,6 +34,6 @@ describe('valuesIn', function() {
     var result = R.map(function(val) {
       return R.values(val);
     }, [null, undefined, 55, '', true, false, NaN, Infinity, , []]);
-    assert.deepEqual(result, R.repeat([], 10));
+    eq(result, R.repeat([], 10));
   });
 });

--- a/test/when.js
+++ b/test/when.js
@@ -1,20 +1,19 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('when', function() {
   it('calls the whenTrue function if the validator returns a truthy value', function() {
-    assert.strictEqual(R.when(R.is(Number), R.add(1))(10), 11);
+    eq(R.when(R.is(Number), R.add(1))(10), 11);
   });
 
   it('returns the argument unmodified if the validator returns a falsey value', function() {
-    assert.strictEqual(R.when(R.is(Number), R.add(1))('hello'), 'hello');
+    eq(R.when(R.is(Number), R.add(1))('hello'), 'hello');
   });
 
   it('returns a curried function', function() {
     var ifIsNumber = R.when(R.is(Number));
-    assert.strictEqual(ifIsNumber(R.add(1))(15), 16);
-    assert.strictEqual(ifIsNumber(R.add(1))('hello'), 'hello');
+    eq(ifIsNumber(R.add(1))(15), 16);
+    eq(ifIsNumber(R.add(1))('hello'), 'hello');
   });
 });

--- a/test/where.js
+++ b/test/where.js
@@ -1,6 +1,5 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('where', function() {
@@ -11,10 +10,10 @@ describe('where', function() {
     var test2 = {x: 0, y: 10};
     var test3 = {x: 1, y: 101};
     var test4 = {x: 1, y: 2};
-    assert.strictEqual(R.where(spec, test1), false);
-    assert.strictEqual(R.where(spec, test2), false);
-    assert.strictEqual(R.where(spec, test3), false);
-    assert.strictEqual(R.where(spec, test4), true);
+    eq(R.where(spec, test1), false);
+    eq(R.where(spec, test2), false);
+    eq(R.where(spec, test3), false);
+    eq(R.where(spec, test4), true);
   });
 
   it('does not need the spec and the test object to have the same interface (the test object will have a superset of the specs properties)', function() {
@@ -22,8 +21,8 @@ describe('where', function() {
     var test1 = {x: 20, y: 100, z: 100};
     var test2 = {w: 1, x: 100, y: 100, z: 100};
 
-    assert.strictEqual(R.where(spec, test1), false);
-    assert.strictEqual(R.where(spec, test2), true);
+    eq(R.where(spec, test1), false);
+    eq(R.where(spec, test2), true);
   });
 
   it('matches specs that have undefined properties', function() {
@@ -32,21 +31,21 @@ describe('where', function() {
     var test2 = {x: null};
     var test3 = {x: undefined};
     var test4 = {x: 1};
-    assert.strictEqual(R.where(spec, test1), true);
-    assert.strictEqual(R.where(spec, test2), false);
-    assert.strictEqual(R.where(spec, test3), true);
-    assert.strictEqual(R.where(spec, test4), false);
+    eq(R.where(spec, test1), true);
+    eq(R.where(spec, test2), false);
+    eq(R.where(spec, test3), true);
+    eq(R.where(spec, test4), false);
   });
 
   it('is curried', function() {
     var predicate = R.where({x: R.equals(1), y: R.equals(2)});
-    assert.strictEqual(predicate({x: 1, y: 2, z: 3}), true);
-    assert.strictEqual(predicate({x: 3, y: 2, z: 1}), false);
+    eq(predicate({x: 1, y: 2, z: 3}), true);
+    eq(predicate({x: 3, y: 2, z: 1}), false);
   });
 
   it('is true for an empty spec', function() {
-    assert.strictEqual(R.where({}, {a: 1}), true);
-    assert.strictEqual(R.where(null, {a: 1}), true);
+    eq(R.where({}, {a: 1}), true);
+    eq(R.where(null, {a: 1}), true);
   });
 
   it('matches inherited properties', function() {
@@ -54,7 +53,7 @@ describe('where', function() {
       toString: R.equals(Object.prototype.toString),
       valueOf: R.equals(Object.prototype.valueOf)
     };
-    assert.strictEqual(R.where(spec, {}), true);
+    eq(R.where(spec, {}), true);
   });
 
   it('does not match inherited spec', function() {
@@ -62,8 +61,8 @@ describe('where', function() {
     Spec.prototype.x = R.equals(5);
     var spec = new Spec();
 
-    assert.strictEqual(R.where(spec, {y: 6}), true);
-    assert.strictEqual(R.where(spec, {x: 5}), false);
+    eq(R.where(spec, {y: 6}), true);
+    eq(R.where(spec, {x: 5}), false);
   });
 
 });

--- a/test/whereEq.js
+++ b/test/whereEq.js
@@ -1,6 +1,5 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('whereEq', function() {
@@ -11,10 +10,10 @@ describe('whereEq', function() {
     var test2 = {x: 0, y: 10};
     var test3 = {x: 1, y: 101};
     var test4 = {x: 1, y: 2};
-    assert.strictEqual(R.whereEq(spec, test1), false);
-    assert.strictEqual(R.whereEq(spec, test2), false);
-    assert.strictEqual(R.whereEq(spec, test3), false);
-    assert.strictEqual(R.whereEq(spec, test4), true);
+    eq(R.whereEq(spec, test1), false);
+    eq(R.whereEq(spec, test2), false);
+    eq(R.whereEq(spec, test3), false);
+    eq(R.whereEq(spec, test4), true);
   });
 
   it('does not need the spec and the test object to have the same interface (the test object will have a superset of the specs properties)', function() {
@@ -22,8 +21,8 @@ describe('whereEq', function() {
     var test1 = {x: 20, y: 100, z: 100};
     var test2 = {w: 1, x: 100, y: 100, z: 100};
 
-    assert.strictEqual(R.whereEq(spec, test1), false);
-    assert.strictEqual(R.whereEq(spec, test2), true);
+    eq(R.whereEq(spec, test1), false);
+    eq(R.whereEq(spec, test2), true);
   });
 
   it('matches specs that have undefined properties', function() {
@@ -32,25 +31,25 @@ describe('whereEq', function() {
     var test2 = {x: null};
     var test3 = {x: undefined};
     var test4 = {x: 1};
-    assert.strictEqual(R.whereEq(spec, test1), true);
-    assert.strictEqual(R.whereEq(spec, test2), false);
-    assert.strictEqual(R.whereEq(spec, test3), true);
-    assert.strictEqual(R.whereEq(spec, test4), false);
+    eq(R.whereEq(spec, test1), true);
+    eq(R.whereEq(spec, test2), false);
+    eq(R.whereEq(spec, test3), true);
+    eq(R.whereEq(spec, test4), false);
   });
 
   it('is curried', function() {
     var predicate = R.whereEq({x: 1, y: 2});
-    assert.strictEqual(predicate({x: 1, y: 2, z: 3}), true);
-    assert.strictEqual(predicate({x: 3, y: 2, z: 1}), false);
+    eq(predicate({x: 1, y: 2, z: 3}), true);
+    eq(predicate({x: 3, y: 2, z: 1}), false);
   });
 
   it('is true for an empty spec', function() {
-    assert.strictEqual(R.whereEq({}, {a: 1}), true);
-    assert.strictEqual(R.whereEq(null, {a: 1}), true);
+    eq(R.whereEq({}, {a: 1}), true);
+    eq(R.whereEq(null, {a: 1}), true);
   });
 
   it('reports true when the object equals the spec', function() {
-    assert.strictEqual(R.whereEq(R, R), true);
+    eq(R.whereEq(R, R), true);
   });
 
   function Parent() {
@@ -61,15 +60,15 @@ describe('whereEq', function() {
   var parent = new Parent();
 
   it('matches inherited props', function() {
-    assert.strictEqual(R.whereEq({y: 6}, parent), true);
-    assert.strictEqual(R.whereEq({x: 5}, parent), true);
-    assert.strictEqual(R.whereEq({x: 5, y: 6}, parent), true);
-    assert.strictEqual(R.whereEq({x: 4, y: 6}, parent), false);
+    eq(R.whereEq({y: 6}, parent), true);
+    eq(R.whereEq({x: 5}, parent), true);
+    eq(R.whereEq({x: 5, y: 6}, parent), true);
+    eq(R.whereEq({x: 4, y: 6}, parent), false);
   });
 
   it('does not match inherited spec', function() {
-    assert.strictEqual(R.whereEq(parent, {y: 6}), true);
-    assert.strictEqual(R.whereEq(parent, {x: 5}), false);
+    eq(R.whereEq(parent, {y: 6}), true);
+    eq(R.whereEq(parent, {x: 5}), false);
   });
 
 });

--- a/test/wrap.js
+++ b/test/wrap.js
@@ -1,6 +1,5 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('wrap', function() {
@@ -10,29 +9,29 @@ describe('wrap', function() {
     var extendedGreet = R.wrap(greet, function(gr, name) {
       return gr(name.toUpperCase());
     });
-    assert.strictEqual(greet('joe'), 'Hello joe');
-    assert.strictEqual(extendedGreet('joe'), 'Hello JOE');
+    eq(greet('joe'), 'Hello joe');
+    eq(extendedGreet('joe'), 'Hello JOE');
   });
 
   it('allows you to modify the output', function() {
     var extendedGreet = R.wrap(greet, function(gr, name) {
       return gr(name).toUpperCase();
     });
-    assert.strictEqual(extendedGreet('joe'), 'HELLO JOE');
+    eq(extendedGreet('joe'), 'HELLO JOE');
   });
 
   it('allows you to entirely replace the input function', function() {
     var extendedGreet = R.wrap(greet, function(gr, name) {
       return gr('my dear ' + name) + ', how are you?';
     });
-    assert.strictEqual(extendedGreet('joe'), 'Hello my dear joe, how are you?');
+    eq(extendedGreet('joe'), 'Hello my dear joe, how are you?');
   });
 
   it('maintains the arity of the function that is being wrapped', function() {
     var extendedGreet = R.wrap(greet, function(gr, name) {
       return gr('my dear ' + name) + ', how are you?';
     });
-    assert.strictEqual(greet.length, extendedGreet.length);
+    eq(greet.length, extendedGreet.length);
   });
 
   it('returns a curried function', function() {
@@ -43,8 +42,8 @@ describe('wrap', function() {
       return sideEffect;
     });
     var add10 = wrappedAdd(10);
-    assert.equal(add10(5), 15);
-    assert.equal(sideEffect, 15);
+    eq(add10(5), 15);
+    eq(sideEffect, 15);
   });
 
 });

--- a/test/xprod.js
+++ b/test/xprod.js
@@ -1,27 +1,26 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('xprod', function() {
   var a = [1, 2], b = ['a', 'b', 'c'];
 
   it('returns an empty list if either input list is empty', function() {
-    assert.deepEqual(R.xprod([], [1, 2, 3]), []);
-    assert.deepEqual(R.xprod([1, 2, 3], []), []);
+    eq(R.xprod([], [1, 2, 3]), []);
+    eq(R.xprod([1, 2, 3], []), []);
   });
 
   it('creates the collection of all cross-product pairs of its parameters', function() {
-    assert.deepEqual(R.xprod(a, b), [[1, 'a'], [1, 'b'], [1, 'c'], [2, 'a'], [2, 'b'], [2, 'c']]);
+    eq(R.xprod(a, b), [[1, 'a'], [1, 'b'], [1, 'c'], [2, 'a'], [2, 'b'], [2, 'c']]);
   });
 
   it('is curried', function() {
     var something = R.xprod(b);
-    assert.deepEqual(something(a), [['a', 1], ['a', 2], ['b', 1], ['b', 2], ['c', 1], ['c', 2]]);
+    eq(something(a), [['a', 1], ['a', 2], ['b', 1], ['b', 2], ['c', 1], ['c', 2]]);
   });
 
   it('correctly reports the arity of curried versions', function() {
     var something = R.xprod(a);
-    assert.deepEqual(something.length, 1);
+    eq(something.length, 1);
   });
 });

--- a/test/zip.js
+++ b/test/zip.js
@@ -1,17 +1,16 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('zip', function() {
   it('returns an array of "tuples"', function() {
     var a = [1, 2, 3], b = [100, 200, 300];
-    assert.deepEqual(R.zip(a, b), [[1, 100], [2, 200], [3, 300]]);
+    eq(R.zip(a, b), [[1, 100], [2, 200], [3, 300]]);
   });
 
   it('returns a list as long as the shorter of the lists input', function() {
     var a = [1, 2, 3], b = [100, 200, 300, 400], c = [10, 20];
-    assert.deepEqual(R.zip(a, b), [[1, 100], [2, 200], [3, 300]]);
-    assert.deepEqual(R.zip(a, c), [[1, 10], [2, 20]]);
+    eq(R.zip(a, b), [[1, 100], [2, 200], [3, 300]]);
+    eq(R.zip(a, c), [[1, 10], [2, 20]]);
   });
 });

--- a/test/zipObj.js
+++ b/test/zipObj.js
@@ -1,20 +1,19 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('zipObj', function() {
   it('combines an array of keys with an arrau of values into a single object', function() {
-    assert.deepEqual(R.zipObj(['a', 'b', 'c'], [1, 2, 3]), {a: 1, b: 2, c: 3});
+    eq(R.zipObj(['a', 'b', 'c'], [1, 2, 3]), {a: 1, b: 2, c: 3});
   });
   it('ignores extra values', function() {
-    assert.deepEqual(R.zipObj(['a', 'b', 'c'], [1, 2, 3, 4, 5, 6, 7]), {a: 1, b: 2, c: 3});
+    eq(R.zipObj(['a', 'b', 'c'], [1, 2, 3, 4, 5, 6, 7]), {a: 1, b: 2, c: 3});
   });
   it('extra keys are undefined', function() {
-    assert.deepEqual(R.zipObj(['a', 'b', 'c', 'd', 'e', 'f'], [1, 2, 3]),
-                     {a: 1, b: 2, c: 3, d: undefined, e: undefined, f: undefined});
+    eq(R.zipObj(['a', 'b', 'c', 'd', 'e', 'f'], [1, 2, 3]),
+       {a: 1, b: 2, c: 3, d: undefined, e: undefined, f: undefined});
   });
   it('last one in wins when there are duplicate keys', function() {
-    assert.deepEqual(R.zipObj(['a', 'b', 'c', 'a'], [1, 2, 3, 'LAST']), {a: 'LAST', b: 2, c: 3});
+    eq(R.zipObj(['a', 'b', 'c', 'a'], [1, 2, 3, 'LAST']), {a: 'LAST', b: 2, c: 3});
   });
 });

--- a/test/zipWith.js
+++ b/test/zipWith.js
@@ -1,6 +1,5 @@
-var assert = require('assert');
-
 var R = require('..');
+var eq = require('./shared/eq');
 
 
 describe('zipWith', function() {
@@ -9,12 +8,12 @@ describe('zipWith', function() {
   var x = function(a, b) { return a * b; };
   var s = function(a, b) { return a + ' cow ' + b; };
   it('returns an array created by applying its passed-in function pair-wise on its passed in arrays', function() {
-    assert.deepEqual(R.zipWith(add, a, b), [101, 202, 303]);
-    assert.deepEqual(R.zipWith(x, a, b), [100, 400, 900]);
-    assert.deepEqual(R.zipWith(s, a, b), ['1 cow 100', '2 cow 200', '3 cow 300']);
+    eq(R.zipWith(add, a, b), [101, 202, 303]);
+    eq(R.zipWith(x, a, b), [100, 400, 900]);
+    eq(R.zipWith(s, a, b), ['1 cow 100', '2 cow 200', '3 cow 300']);
   });
 
   it('returns an array whose length is equal to the shorter of its input arrays', function() {
-    assert.strictEqual(R.zipWith(add, a, c).length, a.length);
+    eq(R.zipWith(add, a, c).length, a.length);
   });
 });


### PR DESCRIPTION
https://github.com/ramda/ramda/pull/1409#discussion_r40562734:

> `assert.deepEqual` is horribly broken: `[]` and `{}` are considered equal, as are `[1, 2, 3]` and `['1', '2', '3']`. It's no good for comparing values of ADTs, either, since `Left(42)` and `Right(42)` may have the same internals. In such cases one is forced to use `R.equals` with `assert.strictEqual`, but then in the case of failure one sees
>
>     AssertionError: false === true
>
> rather than a descriptive message such as
>
>     AssertionError: 'Left(42)' === 'Right(42)'

The implementation is straightforward:

```javascript
module.exports = function(actual, expected) {
  assert.strictEqual(arguments.length, 2);
  assert.strictEqual(R.toString(actual), R.toString(expected));
};
```
