### PR TITLE
Update commuteMap sig, impl to use reduceRight

### DIFF
--- a/src/commuteMap.js
+++ b/src/commuteMap.js
@@ -1,9 +1,8 @@
 var _curry3 = require('./internal/_curry3');
-var _of = require('./internal/_of');
-var _reduce = require('./internal/_reduce');
-var concat = require('./concat');
-var lift = require('./lift');
+var ap = require('./ap');
 var map = require('./map');
+var prepend = require('./prepend');
+var reduceRight = require('./reduceRight');
 
 
 /**
@@ -14,23 +13,29 @@ var map = require('./map');
  * @memberOf R
  * @category List
  * @see R.commute
- * @sig Functor f => (f a -> f b) -> (x -> f x) -> [f a] -> f [b]
+ * @sig Functor f => (a -> f b) -> (x -> f x) -> [a] -> f [b]
  * @param {Function} fn The transformation function
  * @param {Function} of A function that returns the data type to return
  * @param {Array} list An array of functors of the same type
  * @return {*}
  * @example
  *
- *      R.commuteMap(R.map(R.add(10)), R.of, [[1], [2, 3]]);   //=> [[11, 12], [11, 13]]
- *      R.commuteMap(R.map(R.add(10)), R.of, [[1, 2], [3]]);   //=> [[11, 13], [12, 13]]
- *      R.commuteMap(R.map(R.add(10)), R.of, [[1], [2], [3]]); //=> [[11, 12, 13]]
- *      R.commuteMap(R.map(R.add(10)), Maybe.of, [Just(1), Just(2), Just(3)]);   //=> Just([11, 12, 13])
- *      R.commuteMap(R.map(R.add(10)), Maybe.of, [Just(1), Just(2), Nothing()]); //=> Nothing()
+ *      var add10 = R.map(R.add(10));
+ *      R.commuteMap(add10, R.of, [[1], [2, 3]]);   //=> [[11, 12], [11, 13]]
+ *      R.commuteMap(add10, R.of, [[1, 2], [3]]);   //=> [[11, 13], [12, 13]]
+ *      R.commuteMap(add10, R.of, [[1], [2], [3]]); //=> [[11, 12, 13]]
+ *      R.commuteMap(add10, Maybe.of, [Just(1), Just(2), Just(3)]);   //=> Just([11, 12, 13])
+ *      R.commuteMap(add10, Maybe.of, [Just(1), Just(2), Nothing()]); //=> Nothing()
+ *
+ *      var fetch = url => Future((rej, res) => http.get(url, res).on('error', rej));
+ *      R.commuteMap(fetch, Future.of, [
+ *        'http://ramdajs.com',
+ *        'http://github.com/ramda'
+ *      ]); //=> Future([IncomingMessage, IncomingMessage])
  */
 module.exports = _curry3(function commuteMap(fn, of, list) {
-  var concatF = lift(concat);
-  function consF(acc, ftor) {
-    return concatF(acc, map(_of, fn(ftor)));
+  function consF(acc, x) {
+    return ap(map(prepend, fn(x)), acc);
   }
-  return _reduce(consF, of([]), list);
+  return reduceRight(consF, of([]), list);
 });


### PR DESCRIPTION
* Updates signature (docs only) of `commuteMap` to remove the `Functor` constraint of the list elements
```
from: Functor f => (f a -> f b) -> (x -> f x) -> [f a] -> f [b]
to:   Functor f =>   (a -> f b) -> (x -> f x) ->   [a] -> f [b]
```
* Switches from `_reduce` and `lift(concat)` to `reduceRight` and `prepend` to fold over the list.