### PR TITLE
define R.map for Object

### DIFF
--- a/src/internal/_map.js
+++ b/src/internal/_map.js
@@ -1,16 +1,10 @@
-var curryN = require('../curryN');
-
 module.exports = function _map(fn, functor) {
-  if (typeof functor === 'function') {
-    return curryN(functor.length, function() {
-      return fn.call(this, functor.apply(this, arguments));
-    });
-  } else {
-    var idx = 0, len = functor.length, result = Array(len);
-    while (idx < len) {
-      result[idx] = fn(functor[idx]);
-      idx += 1;
-    }
-    return result;
+  var idx = 0;
+  var len = functor.length;
+  var result = Array(len);
+  while (idx < len) {
+    result[idx] = fn(functor[idx]);
+    idx += 1;
   }
+  return result;
 };

--- a/src/map.js
+++ b/src/map.js
@@ -1,7 +1,10 @@
 var _curry2 = require('./internal/_curry2');
 var _dispatchable = require('./internal/_dispatchable');
 var _map = require('./internal/_map');
+var _reduce = require('./internal/_reduce');
 var _xmap = require('./internal/_xmap');
+var curryN = require('./curryN');
+var keys = require('./keys');
 
 
 /**
@@ -20,7 +23,7 @@ var _xmap = require('./internal/_xmap');
  * @func
  * @memberOf R
  * @category List
- * @sig (a -> b) -> [a] -> [b]
+ * @sig Functor f => (a -> b) -> f a -> f b
  * @param {Function} fn The function to be called on every element of the input `list`.
  * @param {Array} list The list to be iterated over.
  * @return {Array} The new list.
@@ -29,5 +32,21 @@ var _xmap = require('./internal/_xmap');
  *      var double = x => x * 2;
  *
  *      R.map(double, [1, 2, 3]); //=> [2, 4, 6]
+ *
+ *      R.map(double, {x: 1, y: 2, z: 3}); //=> {x: 2, y: 4, z: 6}
  */
-module.exports = _curry2(_dispatchable('map', _xmap, _map));
+module.exports = _curry2(_dispatchable('map', _xmap, function map(fn, functor) {
+  switch (Object.prototype.toString.call(functor)) {
+    case '[object Function]':
+      return curryN(functor.length, function() {
+        return fn.call(this, functor.apply(this, arguments));
+      });
+    case '[object Object]':
+      return _reduce(function(acc, key) {
+        acc[key] = fn(functor[key]);
+        return acc;
+      }, {}, keys(functor));
+    default:
+      return _map(fn, functor);
+  }
+}));

--- a/src/mapObj.js
+++ b/src/mapObj.js
@@ -17,6 +17,7 @@ var keys = require('./keys');
  * @param {Object} obj The object to iterate over.
  * @return {Object} A new object with the same keys as `obj` and values that are the result
  *         of running each property through `fn`.
+ * @deprecated since v0.18.0
  * @example
  *
  *      var values = { x: 1, y: 2, z: 3 };

--- a/test/map.js
+++ b/test/map.js
@@ -18,6 +18,11 @@ describe('map', function() {
     eq(intoArray(R.map(times2), [1, 2, 3, 4]), [2, 4, 6, 8]);
   });
 
+  it('maps over objects', function() {
+    eq(R.map(dec, {}), {});
+    eq(R.map(dec, {x: 4, y: 5, z: 6}), {x: 3, y: 4, z: 5});
+  });
+
   it('interprets ((->) r) as a functor', function() {
     var f = function(a) { return a - 1; };
     var g = function(b) { return b * 2; };


### PR DESCRIPTION
This one's for you, @paldepind! :smile:

Before anyone freaks out, thinking that Ramda is now making functions do all the things à la Underscore, let me remind you that it's possible to arrive at the same conclusion for two very different reasons. This is not reckless overloading: it makes sense, as I hope to demonstrate.

  - In the early days very few Ramda functions were polymorphic. I imagine this was a reaction to the many useful but unprincipled polymorphic functions in Underscore.

  - Over time various Ramda functions have been granted the ability to dispatch to appropriately named methods, allowing Ramda's list functions to be applied to values which are not necessarily array-like.

  - In recent times Haskell and Fantasy Land have influenced the way certain Ramda contributors view polymorphic functions. Rather than view polymorphic functions as complected, this contingent sees them as useful higher-level abstractions over *groups* of types (*type classes* in Haskell terminology), provided they are principled (i.e. satisfy laws).

  - Thinking in terms of groups of types encouraged us to define `R.empty` for Object and String in #1236, and then to define `R.isEmpty` in terms of `R.empty` in #1242.

  - This same thought process led to define `R.map` for Function in #1408.

`R.map` is no longer a function which operates only on array-like objects. It should operate on any functor. User-defined types such as Maybe can simply provide a `map` method, but Ramda must provide the `map` definition for each built-in type which is a functor: Array, Function, and Object.
