### PR TITLE
define R.filter for Object

### DIFF
--- a/src/filter.js
+++ b/src/filter.js
@@ -1,17 +1,16 @@
 var _curry2 = require('./internal/_curry2');
 var _dispatchable = require('./internal/_dispatchable');
 var _filter = require('./internal/_filter');
+var _isObject = require('./internal/_isObject');
+var _reduce = require('./internal/_reduce');
 var _xfilter = require('./internal/_xfilter');
+var keys = require('./keys');
 
 
 /**
- * Returns a new list containing only those items that match a given predicate
- * function. The predicate function is passed one argument: *(value)*.
- *
- * Note that `R.filter` does not skip deleted or unassigned indices, unlike the
- * native `Array.prototype.filter` method. For more details on this behavior,
- * see:
- * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter#Description
+ * Takes a predicate and a "filterable", and returns a new filterable of the
+ * same type containing the members of the given filterable which satisfy the
+ * given predicate.
  *
  * Dispatches to the `filter` method of the second argument, if present.
  *
@@ -21,15 +20,29 @@ var _xfilter = require('./internal/_xfilter');
  * @memberOf R
  * @since v0.1.0
  * @category List
- * @sig (a -> Boolean) -> [a] -> [a]
- * @param {Function} fn The function called per iteration.
- * @param {Array} list The collection to iterate over.
- * @return {Array} The new filtered array.
+ * @sig Filterable f => (a -> Boolean) -> f a -> f a
+ * @param {Function} pred
+ * @param {Array} filterable
+ * @return {Array}
  * @see R.reject, R.transduce, R.addIndex
  * @example
  *
  *      var isEven = n => n % 2 === 0;
  *
  *      R.filter(isEven, [1, 2, 3, 4]); //=> [2, 4]
+ *
+ *      R.filter(isEven, {a: 1, b: 2, c: 3, d: 4}); //=> {b: 2, d: 4}
  */
-module.exports = _curry2(_dispatchable('filter', _xfilter, _filter));
+module.exports = _curry2(_dispatchable('filter', _xfilter, function(pred, filterable) {
+  return (
+    _isObject(filterable) ?
+      _reduce(function(acc, key) {
+        if (pred(filterable[key])) {
+          acc[key] = filterable[key];
+        }
+        return acc;
+      }, {}, keys(filterable)) :
+    // else
+      _filter(pred, filterable)
+  );
+}));

--- a/src/mapObjIndexed.js
+++ b/src/mapObjIndexed.js
@@ -4,19 +4,19 @@ var keys = require('./keys');
 
 
 /**
- * Like `map` for objects, but passes additional arguments to the predicate function.
- * The predicate function is passed three arguments: *(value, key, obj)*.
+ * An Object-specific version of `map`. The function is applied to three
+ * arguments: *(value, key, obj)*. If only the value is significant, use
+ * `map` instead.
  *
  * @func
  * @memberOf R
  * @since v0.9.0
  * @category Object
- * @sig (v, k, {k: v} -> v) -> {k: v} -> {k: v}
- * @param {Function} fn A function called for each property in `obj`. Its return value will
- *        become a new property on the return object.
- * @param {Object} obj The object to iterate over.
- * @return {Object} A new object with the same keys as `obj` and values that are the result
- *         of running each property through `fn`.
+ * @sig ((*, String, Object) -> *) -> Object -> Object
+ * @param {Function} fn
+ * @param {Object} obj
+ * @return {Object}
+ * @see R.map
  * @example
  *
  *      var values = { x: 1, y: 2, z: 3 };

--- a/src/pickBy.js
+++ b/src/pickBy.js
@@ -15,7 +15,7 @@ var _curry2 = require('./internal/_curry2');
  * @param {Object} obj The object to copy from
  * @return {Object} A new object with only properties that satisfy `pred`
  *         on it.
- * @see R.pick
+ * @see R.pick, R.filter
  * @example
  *
  *      var isUpperCase = (val, key) => key.toUpperCase() === key;

--- a/src/reject.js
+++ b/src/reject.js
@@ -4,9 +4,7 @@ var filter = require('./filter');
 
 
 /**
- * Similar to `filter`, except that it keeps only values for which the given
- * predicate function returns falsy. The predicate function is passed one
- * argument: *(value)*.
+ * The complement of `filter`.
  *
  * Acts as a transducer if a transformer is given in list position.
  *
@@ -14,17 +12,19 @@ var filter = require('./filter');
  * @memberOf R
  * @since v0.1.0
  * @category List
- * @sig (a -> Boolean) -> [a] -> [a]
- * @param {Function} fn The function called per iteration.
- * @param {Array} list The collection to iterate over.
- * @return {Array} The new filtered array.
+ * @sig Filterable f => (a -> Boolean) -> f a -> f a
+ * @param {Function} pred
+ * @param {Array} filterable
+ * @return {Array}
  * @see R.filter, R.transduce, R.addIndex
  * @example
  *
  *      var isOdd = (n) => n % 2 === 1;
  *
  *      R.reject(isOdd, [1, 2, 3, 4]); //=> [2, 4]
+ *
+ *      R.reject(isOdd, {a: 1, b: 2, c: 3, d: 4}); //=> {b: 2, d: 4}
  */
-module.exports = _curry2(function reject(fn, list) {
-  return filter(_complement(fn), list);
+module.exports = _curry2(function reject(pred, filterable) {
+  return filter(_complement(pred), filterable);
 });

--- a/test/filter.js
+++ b/test/filter.js
@@ -17,6 +17,15 @@ describe('filter', function() {
     eq(R.filter(function(x) { return x > 100; }, []), []);
   });
 
+  it('filters objects', function() {
+    var positive = function(x) { return x > 0; };
+    eq(R.filter(positive, {}), {});
+    eq(R.filter(positive, {x: 0, y: 0, z: 0}), {});
+    eq(R.filter(positive, {x: 1, y: 0, z: 0}), {x: 1});
+    eq(R.filter(positive, {x: 1, y: 2, z: 0}), {x: 1, y: 2});
+    eq(R.filter(positive, {x: 1, y: 2, z: 3}), {x: 1, y: 2, z: 3});
+  });
+
   it('dispatches to passed-in non-Array object with a `filter` method', function() {
     var f = {filter: function(f) { return f('called f.filter'); }};
     eq(R.filter(function(s) { return s; }, f), 'called f.filter');

--- a/test/reject.js
+++ b/test/reject.js
@@ -25,6 +25,14 @@ describe('reject', function() {
     eq(R.reject(function(x) { return x > 100; }, []), []);
   });
 
+  it('filters objects', function() {
+    eq(R.reject(R.equals(0), {}), {});
+    eq(R.reject(R.equals(0), {x: 0, y: 0, z: 0}), {});
+    eq(R.reject(R.equals(0), {x: 1, y: 0, z: 0}), {x: 1});
+    eq(R.reject(R.equals(0), {x: 1, y: 2, z: 0}), {x: 1, y: 2});
+    eq(R.reject(R.equals(0), {x: 1, y: 2, z: 3}), {x: 1, y: 2, z: 3});
+  });
+
   it('dispatches to `filter` method', function() {
     function Nothing() {}
     Nothing.value = new Nothing();


### PR DESCRIPTION
This change is warranted by many of the arguments made in #1426.

We have the elegant `R.map`, which applies the given function to exactly one argument, and the inelegant `R.mapObjIndexed` which applies the given function to `(value, key, object)`. [`R.pickBy`][1] falls between these two stools, applying the given function to *two* arguments.

This pull request:

  - <del>deprecates `R.pickBy`;</del>
  - defines `R.filter` for Object<del>; and</del>
  - <del>adds `R.filterObjIndexed`, which mirrors `R.mapObjIndexed`, to replace `R.pickBy` in contexts in which the key is relevant.</del>

I first suggested this change in https://github.com/ramda/ramda/pull/1265#issuecomment-120538941:

> I think `R.pickBy` and `R.omitBy` should only pass the value to the predicate.
>
> I would then go a step further and support objects in `R.filter` (and by extension `R.reject`). We could then deprecate `R.pickBy` and `R.omitBy`.

The time is now right. :)


[1]: http://ramdajs.com/0.17/docs/#pickBy
