### PR TITLE
Added missing dispatch information to docstrings

### DIFF
--- a/src/adjust.js
+++ b/src/adjust.js
@@ -1,6 +1,7 @@
 var _concat = require('./internal/_concat');
 var _curry3 = require('./internal/_curry3');
 
+
 /**
  * Applies a function to the value at the given index of an array,
  * returning a new copy of the array with the element at the given

--- a/src/aperture.js
+++ b/src/aperture.js
@@ -3,6 +3,7 @@ var _curry2 = require('./internal/_curry2');
 var _dispatchable = require('./internal/_dispatchable');
 var _xaperture = require('./internal/_xaperture');
 
+
 /**
  * Returns a new list, composed of n-tuples of consecutive elements
  * If `n` is greater than the length of the list, an empty list is returned.

--- a/src/chain.js
+++ b/src/chain.js
@@ -7,9 +7,9 @@ var map = require('./map');
 
 /**
  * `chain` maps a function over a list and concatenates the results.
- * This implementation is compatible with the
- * Fantasy-land Chain spec, and will work with types that implement that spec.
  * `chain` is also known as `flatMap` in some libraries
+ *
+ * Dispatches to the `chain` method of the second argument, if present.
  *
  * @func
  * @memberOf R

--- a/src/concat.js
+++ b/src/concat.js
@@ -5,6 +5,8 @@ var invoker = require('./invoker');
 /**
  * Returns the result of concatenating the given lists or strings.
  *
+ * Dispatches to the `concat` method of the second argument, if present.
+ *
  * @func
  * @memberOf R
  * @category List

--- a/src/drop.js
+++ b/src/drop.js
@@ -8,6 +8,8 @@ var slice = require('./slice');
  * Returns all but the first `n` elements of the given list, string, or
  * transducer/transformer (or object with a `drop` method).
  *
+ * Dispatches to the `drop` method of the second argument, if present.
+ *
  * @func
  * @memberOf R
  * @category List

--- a/src/dropLast.js
+++ b/src/dropLast.js
@@ -1,6 +1,7 @@
 var _curry2 = require('./internal/_curry2');
 var take = require('./take');
 
+
 /**
  * Returns a list containing all but the last `n` elements of the given `list`.
  *

--- a/src/dropLastWhile.js
+++ b/src/dropLastWhile.js
@@ -1,6 +1,7 @@
 var _curry2 = require('./internal/_curry2');
 var _slice = require('./internal/_slice');
 
+
 /**
  * Returns a new list containing all but last the`n` elements of a given list,
  * passing each value from the right to the supplied predicate function, skipping

--- a/src/dropRepeats.js
+++ b/src/dropRepeats.js
@@ -9,6 +9,8 @@ var equals = require('./equals');
  * Returns a new list without any consecutively repeating elements.
  * `R.equals` is used to determine equality.
  *
+ * Dispatches to the `dropRepeats` method of the first argument, if present.
+ *
  * Acts as a transducer if a transformer is given in list position.
  * @see R.transduce
  *

--- a/src/dropRepeatsWith.js
+++ b/src/dropRepeatsWith.js
@@ -9,6 +9,8 @@ var last = require('./last');
  * determined by applying the supplied predicate two consecutive elements.
  * The first element in a series of equal element is the one being preserved.
  *
+ * Dispatches to the `dropRepeatsWith` method of the second argument, if present.
+ *
  * Acts as a transducer if a transformer is given in list position.
  * @see R.transduce
  *

--- a/src/dropWhile.js
+++ b/src/dropWhile.js
@@ -9,6 +9,8 @@ var _xdropWhile = require('./internal/_xdropWhile');
  * to the supplied predicate function, skipping elements while the predicate function returns
  * `true`. The predicate function is passed one argument: *(value)*.
  *
+ * Dispatches to the `dropWhile` method of the second argument, if present.
+ *
  * Acts as a transducer if a transformer is given in list position.
  * @see R.transduce
  *

--- a/src/empty.js
+++ b/src/empty.js
@@ -11,6 +11,8 @@ var _isString = require('./internal/_isString');
  * Other types are supported if they define `<Type>.empty` and/or
  * `<Type>.prototype.empty`.
  *
+ * Dispatches to the `empty` method of the first argument, if present.
+ *
  * @func
  * @memberOf R
  * @category Function

--- a/src/forEach.js
+++ b/src/forEach.js
@@ -15,6 +15,8 @@ var _curry2 = require('./internal/_curry2');
  * Also note that, unlike `Array.prototype.forEach`, Ramda's `forEach` returns the original
  * array. In some libraries this function is named `each`.
  *
+ * Dispatches to the `forEach` method of the second argument, if present.
+ *
  * @func
  * @memberOf R
  * @category List

--- a/src/intersperse.js
+++ b/src/intersperse.js
@@ -5,6 +5,8 @@ var _curry2 = require('./internal/_curry2');
 /**
  * Creates a new list with the separator interposed between elements.
  *
+ * Dispatches to the `intersperse` method of the second argument, if present.
+ *
  * @func
  * @memberOf R
  * @category List

--- a/src/reduce.js
+++ b/src/reduce.js
@@ -15,6 +15,8 @@ var _reduce = require('./internal/_reduce');
  * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/reduce#Description
  * @see R.reduced
  *
+ * Dispatches to the `reduce` method of the third argument, if present.
+ *
  * @func
  * @memberOf R
  * @category List

--- a/src/slice.js
+++ b/src/slice.js
@@ -6,6 +6,8 @@ var _curry3 = require('./internal/_curry3');
  * Returns the elements of the given list or string (or object with a `slice`
  * method) from `fromIndex` (inclusive) to `toIndex` (exclusive).
  *
+ * Dispatches to the `slice` method of the third argument, if present.
+ *
  * @func
  * @memberOf R
  * @category List

--- a/src/tail.js
+++ b/src/tail.js
@@ -6,6 +6,8 @@ var slice = require('./slice');
  * Returns all but the first element of the given list or string (or object
  * with a `tail` method).
  *
+ * Dispatches to the `slice` method of the first argument, if present.
+ *
  * @func
  * @memberOf R
  * @category List

--- a/src/takeLast.js
+++ b/src/takeLast.js
@@ -1,6 +1,7 @@
 var _curry2 = require('./internal/_curry2');
 var drop = require('./drop');
 
+
 /**
  * Returns a new list containing the last `n` elements of the given list.
  * If `n > list.length`, returns a list of `list.length` elements.

--- a/src/takeLastWhile.js
+++ b/src/takeLastWhile.js
@@ -1,6 +1,7 @@
 var _curry2 = require('./internal/_curry2');
 var _slice = require('./internal/_slice');
 
+
 /**
  * Returns a new list containing the last `n` elements of a given list, passing each value
  * to the supplied predicate function, and terminating when the predicate function returns

--- a/src/update.js
+++ b/src/update.js
@@ -2,6 +2,7 @@ var _curry3 = require('./internal/_curry3');
 var adjust = require('./adjust');
 var always = require('./always');
 
+
 /**
  * Returns a new copy of the array with the element at the
  * provided index replaced with the given value.

--- a/src/useWith.js
+++ b/src/useWith.js
@@ -4,7 +4,7 @@ var _slice = require('./internal/_slice');
 var curry = require('./curry');
 
 
-/*
+/**
  * Accepts a function `fn` and a list of transformer functions and returns a new curried
  * function. When the new function is invoked, it calls the function `fn` with parameters
  * consisting of the result of calling each supplied handler on successive arguments to the


### PR DESCRIPTION
Follow-up for #1417 and #1428. It turns out there are even more functions that dispatch, which didn't have that behaviour specified in their docstrings. I didn't notice them in my previous PR, so here's another one.

I've also fixed some minor codestyle discrepancies; some missing newlines and an incorrect docstring. They're all non-functional changes.