### PR TITLE
add @since annotations

### DIFF
--- a/src/F.js
+++ b/src/F.js
@@ -6,6 +6,7 @@ var always = require('./always');
  *
  * @func
  * @memberOf R
+ * @since v0.9.0
  * @category Function
  * @sig * -> Boolean
  * @param {*}

--- a/src/T.js
+++ b/src/T.js
@@ -6,6 +6,7 @@ var always = require('./always');
  *
  * @func
  * @memberOf R
+ * @since v0.9.0
  * @category Function
  * @sig * -> Boolean
  * @param {*}

--- a/src/__.js
+++ b/src/__.js
@@ -16,6 +16,7 @@
  *
  * @constant
  * @memberOf R
+ * @since v0.6.0
  * @category Function
  * @example
  *

--- a/src/add.js
+++ b/src/add.js
@@ -6,6 +6,7 @@ var _curry2 = require('./internal/_curry2');
  *
  * @func
  * @memberOf R
+ * @since v0.1.0
  * @category Math
  * @sig Number -> Number -> Number
  * @param {Number} a

--- a/src/addIndex.js
+++ b/src/addIndex.js
@@ -15,6 +15,7 @@ var curryN = require('./curryN');
  *
  * @func
  * @memberOf R
+ * @since v0.15.0
  * @category Function
  * @category List
  * @sig ((a ... -> b) ... -> [a] -> *) -> (a ..., Int, [a] -> b) ... -> [a] -> *)

--- a/src/adjust.js
+++ b/src/adjust.js
@@ -10,6 +10,7 @@ var _curry3 = require('./internal/_curry3');
  *
  * @func
  * @memberOf R
+ * @since v0.14.0
  * @category List
  * @sig (a -> a) -> Number -> [a] -> [a]
  * @param {Function} fn The function to apply.

--- a/src/all.js
+++ b/src/all.js
@@ -14,6 +14,7 @@ var _xall = require('./internal/_xall');
  *
  * @func
  * @memberOf R
+ * @since v0.1.0
  * @category List
  * @sig (a -> Boolean) -> [a] -> Boolean
  * @param {Function} fn The predicate function.

--- a/src/allPass.js
+++ b/src/allPass.js
@@ -15,6 +15,7 @@ var reduce = require('./reduce');
  *
  * @func
  * @memberOf R
+ * @since v0.9.0
  * @category Logic
  * @sig [(*... -> Boolean)] -> (*... -> Boolean)
  * @param {Array} preds

--- a/src/allUniq.js
+++ b/src/allUniq.js
@@ -8,6 +8,7 @@ var _indexOf = require('./internal/_indexOf');
  *
  * @func
  * @memberOf R
+ * @since v0.18.0
  * @category List
  * @sig [a] -> Boolean
  * @param {Array} list The array to consider.

--- a/src/always.js
+++ b/src/always.js
@@ -10,6 +10,7 @@ var _curry1 = require('./internal/_curry1');
  *
  * @func
  * @memberOf R
+ * @since v0.1.0
  * @category Function
  * @sig a -> (* -> a)
  * @param {*} val The value to wrap in a function

--- a/src/and.js
+++ b/src/and.js
@@ -6,6 +6,7 @@ var _curry2 = require('./internal/_curry2');
  *
  * @func
  * @memberOf R
+ * @since v0.1.0
  * @category Logic
  * @sig * -> * -> *
  * @param {Boolean} a A boolean value

--- a/src/any.js
+++ b/src/any.js
@@ -14,6 +14,7 @@ var _xany = require('./internal/_xany');
  *
  * @func
  * @memberOf R
+ * @since v0.1.0
  * @category List
  * @sig (a -> Boolean) -> [a] -> Boolean
  * @param {Function} fn The predicate function.

--- a/src/anyPass.js
+++ b/src/anyPass.js
@@ -15,6 +15,7 @@ var reduce = require('./reduce');
  *
  * @func
  * @memberOf R
+ * @since v0.9.0
  * @category Logic
  * @sig [(*... -> Boolean)] -> (*... -> Boolean)
  * @param {Array} preds

--- a/src/ap.js
+++ b/src/ap.js
@@ -13,6 +13,7 @@ var map = require('./map');
  *
  * @func
  * @memberOf R
+ * @since v0.3.0
  * @category Function
  * @sig [f] -> [a] -> [f a]
  * @param {Array} fns An array of functions

--- a/src/aperture.js
+++ b/src/aperture.js
@@ -15,6 +15,7 @@ var _xaperture = require('./internal/_xaperture');
  *
  * @func
  * @memberOf R
+ * @since v0.12.0
  * @category List
  * @sig Number -> [a] -> [[a]]
  * @param {Number} n The size of the tuples to create

--- a/src/append.js
+++ b/src/append.js
@@ -8,6 +8,7 @@ var _curry2 = require('./internal/_curry2');
  *
  * @func
  * @memberOf R
+ * @since v0.1.0
  * @category List
  * @sig a -> [a] -> [a]
  * @param {*} el The element to add to the end of the new list.

--- a/src/apply.js
+++ b/src/apply.js
@@ -8,6 +8,7 @@ var _curry2 = require('./internal/_curry2');
  *
  * @func
  * @memberOf R
+ * @since v0.7.0
  * @category Function
  * @sig (*... -> a) -> [*] -> a
  * @param {Function} fn

--- a/src/assoc.js
+++ b/src/assoc.js
@@ -9,6 +9,7 @@ var _curry3 = require('./internal/_curry3');
  *
  * @func
  * @memberOf R
+ * @since v0.8.0
  * @category Object
  * @sig String -> a -> {k: v} -> {k: v}
  * @param {String} prop the property name to set

--- a/src/assocPath.js
+++ b/src/assocPath.js
@@ -12,6 +12,7 @@ var assoc = require('./assoc');
  *
  * @func
  * @memberOf R
+ * @since v0.8.0
  * @category Object
  * @sig [String] -> a -> {k: v} -> {k: v}
  * @param {Array} path the path to set

--- a/src/binary.js
+++ b/src/binary.js
@@ -8,6 +8,7 @@ var nAry = require('./nAry');
  *
  * @func
  * @memberOf R
+ * @since v0.2.0
  * @category Function
  * @sig (* -> c) -> (a, b -> c)
  * @param {Function} fn The function to wrap.

--- a/src/bind.js
+++ b/src/bind.js
@@ -9,6 +9,7 @@ var _curry2 = require('./internal/_curry2');
  *
  * @func
  * @memberOf R
+ * @since v0.6.0
  * @category Function
  * @category Object
  * @see R.partial

--- a/src/both.js
+++ b/src/both.js
@@ -10,6 +10,7 @@ var lift = require('./lift');
  *
  * @func
  * @memberOf R
+ * @since v0.12.0
  * @category Logic
  * @sig (*... -> Boolean) -> (*... -> Boolean) -> (*... -> Boolean)
  * @param {Function} f a predicate

--- a/src/call.js
+++ b/src/call.js
@@ -10,6 +10,7 @@ var curry = require('./curry');
  *
  * @func
  * @memberOf R
+ * @since v0.9.0
  * @category Function
  * @sig (*... -> a),*... -> a
  * @param {Function} fn The function to apply to the remaining arguments.

--- a/src/chain.js
+++ b/src/chain.js
@@ -13,6 +13,7 @@ var map = require('./map');
  *
  * @func
  * @memberOf R
+ * @since v0.3.0
  * @category List
  * @sig (a -> [b]) -> [a] -> [b]
  * @param {Function} fn

--- a/src/clone.js
+++ b/src/clone.js
@@ -9,6 +9,7 @@ var _curry1 = require('./internal/_curry1');
  *
  * @func
  * @memberOf R
+ * @since v0.1.0
  * @category Object
  * @sig {*} -> {*}
  * @param {*} value The object or array to clone

--- a/src/commute.js
+++ b/src/commute.js
@@ -7,6 +7,7 @@ var identity = require('./identity');
  *
  * @func
  * @memberOf R
+ * @since v0.8.0
  * @category List
  * @see R.commuteMap
  * @sig Functor f => (x -> f x) -> [f a] -> f [a]

--- a/src/commuteMap.js
+++ b/src/commuteMap.js
@@ -11,6 +11,7 @@ var reduceRight = require('./reduceRight');
  *
  * @func
  * @memberOf R
+ * @since v0.8.0
  * @category List
  * @see R.commute
  * @sig Functor f => (a -> f b) -> (x -> f x) -> [a] -> f [b]

--- a/src/comparator.js
+++ b/src/comparator.js
@@ -6,6 +6,7 @@ var _curry1 = require('./internal/_curry1');
  *
  * @func
  * @memberOf R
+ * @since v0.1.0
  * @category Function
  * @sig (a, b -> Boolean) -> (a, b -> Number)
  * @param {Function} pred A predicate function of arity two.

--- a/src/complement.js
+++ b/src/complement.js
@@ -15,6 +15,7 @@ var not = require('./not');
  *
  * @func
  * @memberOf R
+ * @since v0.12.0
  * @category Logic
  * @sig (*... -> *) -> (*... -> Boolean)
  * @param {Function} f

--- a/src/compose.js
+++ b/src/compose.js
@@ -8,6 +8,7 @@ var reverse = require('./reverse');
  *
  * @func
  * @memberOf R
+ * @since v0.1.0
  * @category Function
  * @sig ((y -> z), (x -> y), ..., (o -> p), ((a, b, ..., n) -> o)) -> ((a, b, ..., n) -> z)
  * @param {...Function} functions

--- a/src/composeK.js
+++ b/src/composeK.js
@@ -13,6 +13,7 @@ var prepend = require('./prepend');
  *
  * @func
  * @memberOf R
+ * @since v0.16.0
  * @category Function
  * @see R.pipeK
  * @sig Chain m => ((y -> m z), (x -> m y), ..., (a -> m b)) -> (m a -> m z)

--- a/src/composeP.js
+++ b/src/composeP.js
@@ -9,6 +9,7 @@ var reverse = require('./reverse');
  *
  * @func
  * @memberOf R
+ * @since v0.10.0
  * @category Function
  * @sig ((y -> Promise z), (x -> Promise y), ..., (a -> Promise b)) -> (a -> Promise z)
  * @param {...Function} functions

--- a/src/concat.js
+++ b/src/concat.js
@@ -9,6 +9,7 @@ var invoker = require('./invoker');
  *
  * @func
  * @memberOf R
+ * @since v0.1.0
  * @category List
  * @sig [a] -> [a] -> [a]
  * @sig String -> String -> String

--- a/src/cond.js
+++ b/src/cond.js
@@ -11,6 +11,7 @@ var _curry1 = require('./internal/_curry1');
  *
  * @func
  * @memberOf R
+ * @since v0.6.0
  * @category Logic
  * @sig [[(*... -> Boolean),(*... -> *)]] -> (*... -> *)
  * @param {Array} pairs

--- a/src/construct.js
+++ b/src/construct.js
@@ -8,6 +8,7 @@ var constructN = require('./constructN');
  *
  * @func
  * @memberOf R
+ * @since v0.1.0
  * @category Function
  * @sig (* -> {*}) -> (* -> {*})
  * @param {Function} Fn The constructor function to wrap.

--- a/src/constructN.js
+++ b/src/constructN.js
@@ -10,6 +10,7 @@ var nAry = require('./nAry');
  *
  * @func
  * @memberOf R
+ * @since v0.4.0
  * @category Function
  * @sig Number -> (* -> {*}) -> (* -> {*})
  * @param {Number} n The arity of the constructor function.

--- a/src/contains.js
+++ b/src/contains.js
@@ -8,6 +8,7 @@ var _curry2 = require('./internal/_curry2');
  *
  * @func
  * @memberOf R
+ * @since v0.1.0
  * @category List
  * @sig a -> [a] -> Boolean
  * @param {Object} a The item to compare against.

--- a/src/containsWith.js
+++ b/src/containsWith.js
@@ -8,6 +8,7 @@ var _curry3 = require('./internal/_curry3');
  *
  * @func
  * @memberOf R
+ * @since v0.1.5
  * @category List
  * @sig (a, a -> Boolean) -> a -> [a] -> Boolean
  * @param {Function} pred A predicate used to test whether two items are equal.

--- a/src/converge.js
+++ b/src/converge.js
@@ -12,6 +12,7 @@ var pluck = require('./pluck');
  *
  * @func
  * @memberOf R
+ * @since v0.4.2
  * @category Function
  * @sig (x1 -> x2 -> ... -> z) -> [(a -> b -> ... -> x1), (a -> b -> ... -> x2), ...] -> (a -> b -> ... -> z)
  * @param {Function} after A function. `after` will be invoked with the return values of

--- a/src/countBy.js
+++ b/src/countBy.js
@@ -11,6 +11,7 @@ var _has = require('./internal/_has');
  *
  * @func
  * @memberOf R
+ * @since v0.1.0
  * @category Relation
  * @sig (a -> String) -> [a] -> {*}
  * @param {Function} fn The function used to map values to keys.

--- a/src/createMapEntry.js
+++ b/src/createMapEntry.js
@@ -6,6 +6,7 @@ var objOf = require('./objOf');
  *
  * @func
  * @memberOf R
+ * @since v0.7.0
  * @category Object
  * @sig String -> a -> {String:a}
  * @param {String} key

--- a/src/curry.js
+++ b/src/curry.js
@@ -28,6 +28,7 @@ var curryN = require('./curryN');
  *
  * @func
  * @memberOf R
+ * @since v0.1.0
  * @category Function
  * @sig (* -> a) -> (* -> a)
  * @param {Function} fn The function to curry.

--- a/src/curryN.js
+++ b/src/curryN.js
@@ -30,6 +30,7 @@ var _curryN = require('./internal/_curryN');
  *
  * @func
  * @memberOf R
+ * @since v0.5.0
  * @category Function
  * @sig Number -> (* -> a) -> (* -> a)
  * @param {Number} length The arity for the returned function.

--- a/src/dec.js
+++ b/src/dec.js
@@ -6,6 +6,7 @@ var add = require('./add');
  *
  * @func
  * @memberOf R
+ * @since v0.9.0
  * @category Math
  * @sig Number -> Number
  * @param {Number} n

--- a/src/defaultTo.js
+++ b/src/defaultTo.js
@@ -7,6 +7,7 @@ var _curry2 = require('./internal/_curry2');
  *
  * @func
  * @memberOf R
+ * @since v0.10.0
  * @category Logic
  * @sig a -> b -> a | b
  * @param {a} val The default value.

--- a/src/difference.js
+++ b/src/difference.js
@@ -7,6 +7,7 @@ var _curry2 = require('./internal/_curry2');
  *
  * @func
  * @memberOf R
+ * @since v0.1.0
  * @category Relation
  * @sig [a] -> [a] -> [a]
  * @param {Array} list1 The first list.

--- a/src/differenceWith.js
+++ b/src/differenceWith.js
@@ -9,6 +9,7 @@ var containsWith = require('./containsWith');
  *
  * @func
  * @memberOf R
+ * @since v0.1.0
  * @category Relation
  * @sig (a,a -> Boolean) -> [a] -> [a] -> [a]
  * @param {Function} pred A predicate used to test whether two items are equal.

--- a/src/dissoc.js
+++ b/src/dissoc.js
@@ -6,6 +6,7 @@ var _curry2 = require('./internal/_curry2');
  *
  * @func
  * @memberOf R
+ * @since v0.10.0
  * @category Object
  * @sig String -> {k: v} -> {k: v}
  * @param {String} prop the name of the property to dissociate

--- a/src/dissocPath.js
+++ b/src/dissocPath.js
@@ -12,6 +12,7 @@ var dissoc = require('./dissoc');
  *
  * @func
  * @memberOf R
+ * @since v0.11.0
  * @category Object
  * @sig [String] -> {k: v} -> {k: v}
  * @param {Array} path the path to set

--- a/src/divide.js
+++ b/src/divide.js
@@ -6,6 +6,7 @@ var _curry2 = require('./internal/_curry2');
  *
  * @func
  * @memberOf R
+ * @since v0.1.0
  * @category Math
  * @sig Number -> Number -> Number
  * @param {Number} a The first value.

--- a/src/drop.js
+++ b/src/drop.js
@@ -12,6 +12,7 @@ var slice = require('./slice');
  *
  * @func
  * @memberOf R
+ * @since v0.1.0
  * @category List
  * @see R.transduce
  * @sig Number -> [a] -> [a]

--- a/src/dropLast.js
+++ b/src/dropLast.js
@@ -7,6 +7,7 @@ var take = require('./take');
  *
  * @func
  * @memberOf R
+ * @since v0.16.0
  * @category List
  * @sig Number -> [a] -> [a]
  * @sig Number -> String -> String

--- a/src/dropLastWhile.js
+++ b/src/dropLastWhile.js
@@ -10,6 +10,7 @@ var _slice = require('./internal/_slice');
  *
  * @func
  * @memberOf R
+ * @since v0.16.0
  * @category List
  * @sig (a -> Boolean) -> [a] -> [a]
  * @param {Function} fn The function called per iteration.

--- a/src/dropRepeats.js
+++ b/src/dropRepeats.js
@@ -16,6 +16,7 @@ var equals = require('./equals');
  *
  * @func
  * @memberOf R
+ * @since v0.14.0
  * @category List
  * @sig [a] -> [a]
  * @param {Array} list The array to consider.

--- a/src/dropRepeatsWith.js
+++ b/src/dropRepeatsWith.js
@@ -16,6 +16,7 @@ var last = require('./last');
  *
  * @func
  * @memberOf R
+ * @since v0.14.0
  * @category List
  * @sig (a, a -> Boolean) -> [a] -> [a]
  * @param {Function} pred A predicate used to test whether two items are equal.

--- a/src/dropWhile.js
+++ b/src/dropWhile.js
@@ -16,6 +16,7 @@ var _xdropWhile = require('./internal/_xdropWhile');
  *
  * @func
  * @memberOf R
+ * @since v0.9.0
  * @category List
  * @sig (a -> Boolean) -> [a] -> [a]
  * @param {Function} fn The function called per iteration.

--- a/src/either.js
+++ b/src/either.js
@@ -10,6 +10,7 @@ var or = require('./or');
  *
  * @func
  * @memberOf R
+ * @since v0.12.0
  * @category Logic
  * @sig (*... -> Boolean) -> (*... -> Boolean) -> (*... -> Boolean)
  * @param {Function} f a predicate

--- a/src/empty.js
+++ b/src/empty.js
@@ -15,6 +15,7 @@ var _isString = require('./internal/_isString');
  *
  * @func
  * @memberOf R
+ * @since v0.3.0
  * @category Function
  * @sig a -> a
  * @param {*} x

--- a/src/eqBy.js
+++ b/src/eqBy.js
@@ -8,6 +8,7 @@ var equals = require('./equals');
  *
  * @func
  * @memberOf R
+ * @since v0.18.0
  * @category Relation
  * @sig (a -> b) -> a -> a -> Boolean
  * @param {Function} f

--- a/src/eqProps.js
+++ b/src/eqProps.js
@@ -8,6 +8,7 @@ var equals = require('./equals');
  *
  * @func
  * @memberOf R
+ * @since v0.1.0
  * @category Object
  * @sig k -> {k: v} -> {k: v} -> Boolean
  * @param {String} prop The name of the property to compare

--- a/src/equals.js
+++ b/src/equals.js
@@ -11,6 +11,7 @@ var _equals = require('./internal/_equals');
  *
  * @func
  * @memberOf R
+ * @since v0.15.0
  * @category Relation
  * @sig a -> b -> Boolean
  * @param {*} a

--- a/src/evolve.js
+++ b/src/evolve.js
@@ -10,6 +10,7 @@ var _curry2 = require('./internal/_curry2');
  *
  * @func
  * @memberOf R
+ * @since v0.9.0
  * @category Object
  * @sig {k: (v -> v)} -> {k: v} -> {k: v}
  * @param {Object} transformations The object specifying transformation functions to apply

--- a/src/filter.js
+++ b/src/filter.js
@@ -19,6 +19,7 @@ var _xfilter = require('./internal/_xfilter');
  *
  * @func
  * @memberOf R
+ * @since v0.1.0
  * @category List
  * @sig (a -> Boolean) -> [a] -> [a]
  * @param {Function} fn The function called per iteration.

--- a/src/find.js
+++ b/src/find.js
@@ -14,6 +14,7 @@ var _xfind = require('./internal/_xfind');
  *
  * @func
  * @memberOf R
+ * @since v0.1.0
  * @category List
  * @sig (a -> Boolean) -> [a] -> a | undefined
  * @param {Function} fn The predicate function used to determine if the element is the

--- a/src/findIndex.js
+++ b/src/findIndex.js
@@ -14,6 +14,7 @@ var _xfindIndex = require('./internal/_xfindIndex');
  *
  * @func
  * @memberOf R
+ * @since v0.1.1
  * @category List
  * @sig (a -> Boolean) -> [a] -> Number
  * @param {Function} fn The predicate function used to determine if the element is the

--- a/src/findLast.js
+++ b/src/findLast.js
@@ -14,6 +14,7 @@ var _xfindLast = require('./internal/_xfindLast');
  *
  * @func
  * @memberOf R
+ * @since v0.1.1
  * @category List
  * @sig (a -> Boolean) -> [a] -> a | undefined
  * @param {Function} fn The predicate function used to determine if the element is the

--- a/src/findLastIndex.js
+++ b/src/findLastIndex.js
@@ -14,6 +14,7 @@ var _xfindLastIndex = require('./internal/_xfindLastIndex');
  *
  * @func
  * @memberOf R
+ * @since v0.1.1
  * @category List
  * @sig (a -> Boolean) -> [a] -> Number
  * @param {Function} fn The predicate function used to determine if the element is the

--- a/src/flatten.js
+++ b/src/flatten.js
@@ -8,6 +8,7 @@ var _makeFlat = require('./internal/_makeFlat');
  *
  * @func
  * @memberOf R
+ * @since v0.1.0
  * @category List
  * @sig [a] -> [b]
  * @param {Array} list The array to consider.

--- a/src/flip.js
+++ b/src/flip.js
@@ -9,6 +9,7 @@ var curry = require('./curry');
  *
  * @func
  * @memberOf R
+ * @since v0.1.0
  * @category Function
  * @sig (a -> b -> c -> ... -> z) -> (b -> a -> c -> ... -> z)
  * @param {Function} fn The function to invoke with its first two parameters reversed.

--- a/src/forEach.js
+++ b/src/forEach.js
@@ -19,6 +19,7 @@ var _curry2 = require('./internal/_curry2');
  *
  * @func
  * @memberOf R
+ * @since v0.1.1
  * @category List
  * @sig (a -> *) -> [a] -> [a]
  * @param {Function} fn The function to invoke. Receives one argument, `value`.

--- a/src/fromPairs.js
+++ b/src/fromPairs.js
@@ -7,6 +7,7 @@ var _isArray = require('./internal/_isArray');
  *
  * @func
  * @memberOf R
+ * @since v0.3.0
  * @category List
  * @sig [[k,v]] -> {k: v}
  * @param {Array} pairs An array of two-element arrays that will be the keys and values of the output object.

--- a/src/functions.js
+++ b/src/functions.js
@@ -8,6 +8,7 @@ var keys = require('./keys');
  *
  * @func
  * @memberOf R
+ * @since v0.4.0
  * @category Object
  * @sig {*} -> [String]
  * @param {Object} obj The objects with functions in it

--- a/src/functionsIn.js
+++ b/src/functionsIn.js
@@ -8,6 +8,7 @@ var keysIn = require('./keysIn');
  *
  * @func
  * @memberOf R
+ * @since v0.4.0
  * @category Object
  * @sig {*} -> [String]
  * @param {Object} obj The objects with functions in it

--- a/src/groupBy.js
+++ b/src/groupBy.js
@@ -16,6 +16,7 @@ var append = require('./append');
  *
  * @func
  * @memberOf R
+ * @since v0.1.0
  * @category List
  * @sig (a -> String) -> [a] -> {String: [a]}
  * @param {Function} fn Function :: a -> String

--- a/src/gt.js
+++ b/src/gt.js
@@ -7,6 +7,7 @@ var _curry2 = require('./internal/_curry2');
  *
  * @func
  * @memberOf R
+ * @since v0.1.0
  * @category Relation
  * @sig Ord a => a -> a -> Boolean
  * @param {*} a

--- a/src/gte.js
+++ b/src/gte.js
@@ -7,6 +7,7 @@ var _curry2 = require('./internal/_curry2');
  *
  * @func
  * @memberOf R
+ * @since v0.1.0
  * @category Relation
  * @sig Ord a => a -> a -> Boolean
  * @param {Number} a

--- a/src/has.js
+++ b/src/has.js
@@ -8,6 +8,7 @@ var _has = require('./internal/_has');
  *
  * @func
  * @memberOf R
+ * @since v0.7.0
  * @category Object
  * @sig s -> {s: x} -> Boolean
  * @param {String} prop The name of the property to check for.

--- a/src/hasIn.js
+++ b/src/hasIn.js
@@ -7,6 +7,7 @@ var _curry2 = require('./internal/_curry2');
  *
  * @func
  * @memberOf R
+ * @since v0.7.0
  * @category Object
  * @sig s -> {s: x} -> Boolean
  * @param {String} prop The name of the property to check for.

--- a/src/head.js
+++ b/src/head.js
@@ -7,6 +7,7 @@ var nth = require('./nth');
  *
  * @func
  * @memberOf R
+ * @since v0.1.0
  * @category List
  * @see R.tail, R.init, R.last
  * @sig [a] -> a | Undefined

--- a/src/identical.js
+++ b/src/identical.js
@@ -8,6 +8,7 @@ var _curry2 = require('./internal/_curry2');
  *
  * @func
  * @memberOf R
+ * @since v0.15.0
  * @category Relation
  * @sig a -> a -> Boolean
  * @param {*} a

--- a/src/identity.js
+++ b/src/identity.js
@@ -8,6 +8,7 @@ var _identity = require('./internal/_identity');
  *
  * @func
  * @memberOf R
+ * @since v0.1.0
  * @category Function
  * @sig a -> a
  * @param {*} x The value to return.

--- a/src/ifElse.js
+++ b/src/ifElse.js
@@ -8,6 +8,7 @@ var curryN = require('./curryN');
  *
  * @func
  * @memberOf R
+ * @since v0.8.0
  * @category Logic
  * @see R.unless, R.when
  * @sig (*... -> Boolean) -> (*... -> *) -> (*... -> *) -> (*... -> *)

--- a/src/inc.js
+++ b/src/inc.js
@@ -6,6 +6,7 @@ var add = require('./add');
  *
  * @func
  * @memberOf R
+ * @since v0.9.0
  * @category Math
  * @sig Number -> Number
  * @param {Number} n

--- a/src/indexOf.js
+++ b/src/indexOf.js
@@ -10,6 +10,7 @@ var _isArray = require('./internal/_isArray');
  *
  * @func
  * @memberOf R
+ * @since v0.1.0
  * @category List
  * @sig a -> [a] -> Number
  * @param {*} target The item to find.

--- a/src/init.js
+++ b/src/init.js
@@ -6,6 +6,7 @@ var slice = require('./slice');
  *
  * @func
  * @memberOf R
+ * @since v0.9.0
  * @category List
  * @see R.last, R.head, R.tail
  * @sig [a] -> [a]

--- a/src/insert.js
+++ b/src/insert.js
@@ -9,6 +9,7 @@ var _slice = require('./internal/_slice');
  *
  * @func
  * @memberOf R
+ * @since v0.2.2
  * @category List
  * @sig Number -> a -> [a] -> [a]
  * @param {Number} index The position to insert the element

--- a/src/insertAll.js
+++ b/src/insertAll.js
@@ -10,6 +10,7 @@ var _slice = require('./internal/_slice');
  *
  * @func
  * @memberOf R
+ * @since v0.9.0
  * @category List
  * @sig Number -> [a] -> [a] -> [a]
  * @param {Number} index The position to insert the sub-list

--- a/src/intersection.js
+++ b/src/intersection.js
@@ -10,6 +10,7 @@ var uniq = require('./uniq');
  *
  * @func
  * @memberOf R
+ * @since v0.1.0
  * @category Relation
  * @sig [a] -> [a] -> [a]
  * @param {Array} list1 The first list.

--- a/src/intersectionWith.js
+++ b/src/intersectionWith.js
@@ -11,6 +11,7 @@ var uniqWith = require('./uniqWith');
  *
  * @func
  * @memberOf R
+ * @since v0.1.0
  * @category Relation
  * @sig (a,a -> Boolean) -> [a] -> [a] -> [a]
  * @param {Function} pred A predicate function that determines whether

--- a/src/intersperse.js
+++ b/src/intersperse.js
@@ -9,6 +9,7 @@ var _curry2 = require('./internal/_curry2');
  *
  * @func
  * @memberOf R
+ * @since v0.14.0
  * @category List
  * @sig a -> [a] -> [a]
  * @param {*} separator The element to add to the list.

--- a/src/into.js
+++ b/src/into.js
@@ -22,6 +22,7 @@ var _stepCat = require('./internal/_stepCat');
  *
  * @func
  * @memberOf R
+ * @since v0.12.0
  * @category List
  * @sig a -> (b -> b) -> [c] -> a
  * @param {*} acc The initial accumulator value.

--- a/src/invert.js
+++ b/src/invert.js
@@ -10,6 +10,7 @@ var keys = require('./keys');
  *
  * @func
  * @memberOf R
+ * @since v0.9.0
  * @category Object
  * @sig {s: x} -> {x: [ s, ... ]}
  * @param {Object} obj The object or array to invert

--- a/src/invertObj.js
+++ b/src/invertObj.js
@@ -11,6 +11,7 @@ var keys = require('./keys');
  *
  * @func
  * @memberOf R
+ * @since v0.9.0
  * @category Object
  * @sig {s: x} -> {x: s}
  * @param {Object} obj The object or array to invert

--- a/src/invoker.js
+++ b/src/invoker.js
@@ -14,6 +14,7 @@ var toString = require('./toString');
  *
  * @func
  * @memberOf R
+ * @since v0.1.0
  * @category Function
  * @sig Number -> String -> (a -> b -> ... -> n -> Object -> *)
  * @param {Number} arity Number of arguments the returned function should take

--- a/src/is.js
+++ b/src/is.js
@@ -7,6 +7,7 @@ var _curry2 = require('./internal/_curry2');
  *
  * @func
  * @memberOf R
+ * @since v0.3.0
  * @category Type
  * @sig (* -> {*}) -> a -> Boolean
  * @param {Object} ctor A constructor

--- a/src/isArrayLike.js
+++ b/src/isArrayLike.js
@@ -7,6 +7,7 @@ var _isArray = require('./internal/_isArray');
  *
  * @func
  * @memberOf R
+ * @since v0.5.0
  * @category Type
  * @category List
  * @sig * -> Boolean

--- a/src/isEmpty.js
+++ b/src/isEmpty.js
@@ -9,6 +9,7 @@ var equals = require('./equals');
  *
  * @func
  * @memberOf R
+ * @since v0.1.0
  * @category Logic
  * @sig a -> Boolean
  * @param {*} x

--- a/src/isNil.js
+++ b/src/isNil.js
@@ -6,6 +6,7 @@ var _curry1 = require('./internal/_curry1');
  *
  * @func
  * @memberOf R
+ * @since v0.9.0
  * @category Type
  * @sig * -> Boolean
  * @param {*} x The value to test.

--- a/src/isSet.js
+++ b/src/isSet.js
@@ -7,6 +7,7 @@ var allUniq = require('./allUniq');
  *
  * @func
  * @memberOf R
+ * @since v0.1.1
  * @category List
  * @sig [a] -> Boolean
  * @param {Array} list The array to consider.

--- a/src/join.js
+++ b/src/join.js
@@ -7,6 +7,7 @@ var invoker = require('./invoker');
  *
  * @func
  * @memberOf R
+ * @since v0.1.0
  * @category List
  * @sig String -> [a] -> String
  * @param {Number|String} separator The string used to separate the elements.

--- a/src/keys.js
+++ b/src/keys.js
@@ -10,6 +10,7 @@ var _has = require('./internal/_has');
  *
  * @func
  * @memberOf R
+ * @since v0.1.0
  * @category Object
  * @sig {k: v} -> [k]
  * @param {Object} obj The object to extract properties from

--- a/src/keysIn.js
+++ b/src/keysIn.js
@@ -9,6 +9,7 @@ var _curry1 = require('./internal/_curry1');
  *
  * @func
  * @memberOf R
+ * @since v0.2.0
  * @category Object
  * @sig {k: v} -> [k]
  * @param {Object} obj The object to extract properties from

--- a/src/last.js
+++ b/src/last.js
@@ -6,6 +6,7 @@ var nth = require('./nth');
  *
  * @func
  * @memberOf R
+ * @since v0.1.4
  * @category List
  * @see R.init, R.head, R.tail
  * @sig [a] -> a | Undefined

--- a/src/lastIndexOf.js
+++ b/src/lastIndexOf.js
@@ -10,6 +10,7 @@ var equals = require('./equals');
  *
  * @func
  * @memberOf R
+ * @since v0.1.0
  * @category List
  * @sig a -> [a] -> Number
  * @param {*} target The item to find.

--- a/src/length.js
+++ b/src/length.js
@@ -7,6 +7,7 @@ var is = require('./is');
  *
  * @func
  * @memberOf R
+ * @since v0.3.0
  * @category List
  * @sig [a] -> Number
  * @param {Array} list The array to inspect.

--- a/src/lens.js
+++ b/src/lens.js
@@ -9,6 +9,7 @@ var map = require('./map');
  *
  * @func
  * @memberOf R
+ * @since v0.8.0
  * @category Object
  * @typedefn Lens s a = Functor f => (a -> f a) -> s -> f s
  * @sig (s -> a) -> ((a, s) -> s) -> Lens s a

--- a/src/lensIndex.js
+++ b/src/lensIndex.js
@@ -9,6 +9,7 @@ var update = require('./update');
  *
  * @func
  * @memberOf R
+ * @since v0.14.0
  * @category Object
  * @typedefn Lens s a = Functor f => (a -> f a) -> s -> f s
  * @sig Number -> Lens s a

--- a/src/lensProp.js
+++ b/src/lensProp.js
@@ -9,6 +9,7 @@ var prop = require('./prop');
  *
  * @func
  * @memberOf R
+ * @since v0.14.0
  * @category Object
  * @typedefn Lens s a = Functor f => (a -> f a) -> s -> f s
  * @sig String -> Lens s a

--- a/src/lift.js
+++ b/src/lift.js
@@ -8,6 +8,7 @@ var liftN = require('./liftN');
  *
  * @func
  * @memberOf R
+ * @since v0.7.0
  * @see R.liftN
  * @category Function
  * @sig (*... -> *) -> ([*]... -> [*])

--- a/src/liftN.js
+++ b/src/liftN.js
@@ -12,6 +12,7 @@ var map = require('./map');
  *
  * @func
  * @memberOf R
+ * @since v0.7.0
  * @see R.lift
  * @category Function
  * @sig Number -> (*... -> *) -> ([*]... -> [*])

--- a/src/lt.js
+++ b/src/lt.js
@@ -7,6 +7,7 @@ var _curry2 = require('./internal/_curry2');
  *
  * @func
  * @memberOf R
+ * @since v0.1.0
  * @category Relation
  * @sig Ord a => a -> a -> Boolean
  * @param {*} a

--- a/src/lte.js
+++ b/src/lte.js
@@ -7,6 +7,7 @@ var _curry2 = require('./internal/_curry2');
  *
  * @func
  * @memberOf R
+ * @since v0.1.0
  * @category Relation
  * @sig Ord a => a -> a -> Boolean
  * @param {Number} a

--- a/src/map.js
+++ b/src/map.js
@@ -24,6 +24,7 @@ var keys = require('./keys');
  *
  * @func
  * @memberOf R
+ * @since v0.1.0
  * @category List
  * @sig Functor f => (a -> b) -> f a -> f b
  * @param {Function} fn The function to be called on every element of the input `list`.

--- a/src/mapAccum.js
+++ b/src/mapAccum.js
@@ -11,6 +11,7 @@ var _curry3 = require('./internal/_curry3');
  *
  * @func
  * @memberOf R
+ * @since v0.10.0
  * @category List
  * @sig (acc -> x -> (acc, y)) -> acc -> [x] -> (acc, [y])
  * @param {Function} fn The function to be called on every element of the input `list`.

--- a/src/mapAccumRight.js
+++ b/src/mapAccumRight.js
@@ -14,6 +14,7 @@ var _curry3 = require('./internal/_curry3');
  *
  * @func
  * @memberOf R
+ * @since v0.10.0
  * @category List
  * @sig (acc -> x -> (acc, y)) -> acc -> [x] -> (acc, [y])
  * @param {Function} fn The function to be called on every element of the input `list`.

--- a/src/mapObj.js
+++ b/src/mapObj.js
@@ -10,6 +10,7 @@ var keys = require('./keys');
  *
  * @func
  * @memberOf R
+ * @since v0.1.4
  * @category Object
  * @sig (v -> v) -> {k: v} -> {k: v}
  * @param {Function} fn A function called for each property in `obj`. Its return value will

--- a/src/mapObjIndexed.js
+++ b/src/mapObjIndexed.js
@@ -9,6 +9,7 @@ var keys = require('./keys');
  *
  * @func
  * @memberOf R
+ * @since v0.9.0
  * @category Object
  * @sig (v, k, {k: v} -> v) -> {k: v} -> {k: v}
  * @param {Function} fn A function called for each property in `obj`. Its return value will

--- a/src/match.js
+++ b/src/match.js
@@ -9,6 +9,7 @@ var _curry2 = require('./internal/_curry2');
  *
  * @func
  * @memberOf R
+ * @since v0.1.0
  * @see R.test
  * @category String
  * @sig RegExp -> String -> [String | Undefined]

--- a/src/mathMod.js
+++ b/src/mathMod.js
@@ -10,6 +10,7 @@ var _isInteger = require('./internal/_isInteger');
  *
  * @func
  * @memberOf R
+ * @since v0.3.0
  * @category Math
  * @sig Number -> Number -> Number
  * @param {Number} m The dividend.

--- a/src/max.js
+++ b/src/max.js
@@ -6,6 +6,7 @@ var _curry2 = require('./internal/_curry2');
  *
  * @func
  * @memberOf R
+ * @since v0.1.0
  * @category Relation
  * @sig Ord a => a -> a -> a
  * @param {*} a

--- a/src/maxBy.js
+++ b/src/maxBy.js
@@ -7,6 +7,7 @@ var _curry3 = require('./internal/_curry3');
  *
  * @func
  * @memberOf R
+ * @since v0.8.0
  * @category Relation
  * @sig Ord b => (a -> b) -> a -> a -> a
  * @param {Function} f

--- a/src/mean.js
+++ b/src/mean.js
@@ -7,6 +7,7 @@ var sum = require('./sum');
  *
  * @func
  * @memberOf R
+ * @since v0.14.0
  * @category Math
  * @sig [Number] -> Number
  * @param {Array} list

--- a/src/median.js
+++ b/src/median.js
@@ -8,6 +8,7 @@ var mean = require('./mean');
  *
  * @func
  * @memberOf R
+ * @since v0.14.0
  * @category Math
  * @sig [Number] -> Number
  * @param {Array} list

--- a/src/memoize.js
+++ b/src/memoize.js
@@ -11,6 +11,7 @@ var toString = require('./toString');
  *
  * @func
  * @memberOf R
+ * @since v0.1.0
  * @category Function
  * @sig (*... -> a) -> (*... -> a)
  * @param {Function} fn The function to memoize.

--- a/src/merge.js
+++ b/src/merge.js
@@ -8,6 +8,7 @@ var keys = require('./keys');
  *
  * @func
  * @memberOf R
+ * @since v0.1.0
  * @category Object
  * @sig {k: v} -> {k: v} -> {k: v}
  * @param {Object} a

--- a/src/mergeAll.js
+++ b/src/mergeAll.js
@@ -8,6 +8,7 @@ var reduce = require('./reduce');
  *
  * @func
  * @memberOf R
+ * @since v0.10.0
  * @category List
  * @sig [{k: v}] -> {k: v}
  * @param {Array} list An array of objects

--- a/src/min.js
+++ b/src/min.js
@@ -6,6 +6,7 @@ var _curry2 = require('./internal/_curry2');
  *
  * @func
  * @memberOf R
+ * @since v0.1.0
  * @category Relation
  * @sig Ord a => a -> a -> a
  * @param {*} a

--- a/src/minBy.js
+++ b/src/minBy.js
@@ -7,6 +7,7 @@ var _curry3 = require('./internal/_curry3');
  *
  * @func
  * @memberOf R
+ * @since v0.8.0
  * @category Relation
  * @sig Ord b => (a -> b) -> a -> a -> a
  * @param {Function} f

--- a/src/modulo.js
+++ b/src/modulo.js
@@ -8,6 +8,7 @@ var _curry2 = require('./internal/_curry2');
  *
  * @func
  * @memberOf R
+ * @since v0.1.1
  * @category Math
  * @sig Number -> Number -> Number
  * @param {Number} a The value to the divide.

--- a/src/multiply.js
+++ b/src/multiply.js
@@ -6,6 +6,7 @@ var _curry2 = require('./internal/_curry2');
  *
  * @func
  * @memberOf R
+ * @since v0.1.0
  * @category Math
  * @sig Number -> Number -> Number
  * @param {Number} a The first value.

--- a/src/nAry.js
+++ b/src/nAry.js
@@ -7,6 +7,7 @@ var _curry2 = require('./internal/_curry2');
  *
  * @func
  * @memberOf R
+ * @since v0.1.0
  * @category Function
  * @sig Number -> (* -> a) -> (* -> a)
  * @param {Number} n The desired arity of the new function.

--- a/src/negate.js
+++ b/src/negate.js
@@ -6,6 +6,7 @@ var _curry1 = require('./internal/_curry1');
  *
  * @func
  * @memberOf R
+ * @since v0.9.0
  * @category Math
  * @sig Number -> Number
  * @param {Number} n

--- a/src/none.js
+++ b/src/none.js
@@ -13,6 +13,7 @@ var any = require('./any');
  *
  * @func
  * @memberOf R
+ * @since v0.12.0
  * @category List
  * @sig (a -> Boolean) -> [a] -> Boolean
  * @param {Function} fn The predicate function.

--- a/src/not.js
+++ b/src/not.js
@@ -7,6 +7,7 @@ var _curry1 = require('./internal/_curry1');
  *
  * @func
  * @memberOf R
+ * @since v0.1.0
  * @category Logic
  * @sig * -> Boolean
  * @param {*} a any value

--- a/src/nth.js
+++ b/src/nth.js
@@ -8,6 +8,7 @@ var _isString = require('./internal/_isString');
  *
  * @func
  * @memberOf R
+ * @since v0.1.0
  * @category List
  * @sig Number -> [a] -> a | Undefined
  * @sig Number -> String -> String

--- a/src/nthArg.js
+++ b/src/nthArg.js
@@ -7,6 +7,7 @@ var nth = require('./nth');
  *
  * @func
  * @memberOf R
+ * @since v0.9.0
  * @category Function
  * @sig Number -> *... -> *
  * @param {Number} n

--- a/src/objOf.js
+++ b/src/objOf.js
@@ -6,6 +6,7 @@ var _curry2 = require('./internal/_curry2');
  *
  * @func
  * @memberOf R
+ * @since v0.18.0
  * @category Object
  * @sig String -> a -> {String:a}
  * @param {String} key

--- a/src/of.js
+++ b/src/of.js
@@ -10,6 +10,7 @@ var _of = require('./internal/_of');
  *
  * @func
  * @memberOf R
+ * @since v0.3.0
  * @category Function
  * @sig a -> [a]
  * @param {*} x any value

--- a/src/omit.js
+++ b/src/omit.js
@@ -7,6 +7,7 @@ var _curry2 = require('./internal/_curry2');
  *
  * @func
  * @memberOf R
+ * @since v0.1.0
  * @category Object
  * @sig [String] -> {String: *} -> {String: *}
  * @param {Array} names an array of String property names to omit from the new object

--- a/src/once.js
+++ b/src/once.js
@@ -8,6 +8,7 @@ var _curry1 = require('./internal/_curry1');
  *
  * @func
  * @memberOf R
+ * @since v0.1.0
  * @category Function
  * @sig (a... -> b) -> (a... -> b)
  * @param {Function} fn The function to wrap in a call-only-once wrapper.

--- a/src/or.js
+++ b/src/or.js
@@ -7,6 +7,7 @@ var _curry2 = require('./internal/_curry2');
  *
  * @func
  * @memberOf R
+ * @since v0.1.0
  * @category Logic
  * @sig * -> * -> *
  * @param {Boolean} a A boolean value

--- a/src/over.js
+++ b/src/over.js
@@ -8,6 +8,7 @@ var _curry3 = require('./internal/_curry3');
  *
  * @func
  * @memberOf R
+ * @since v0.16.0
  * @category Object
  * @typedefn Lens s a = Functor f => (a -> f a) -> s -> f s
  * @sig Lens s a -> (a -> a) -> s -> s

--- a/src/pair.js
+++ b/src/pair.js
@@ -6,6 +6,7 @@ var _curry2 = require('./internal/_curry2');
  *
  * @func
  * @memberOf R
+ * @since v0.18.0
  * @category List
  * @sig a -> b -> (a,b)
  * @param {*} fst

--- a/src/partial.js
+++ b/src/partial.js
@@ -9,6 +9,7 @@ var _createPartialApplicator = require('./internal/_createPartialApplicator');
  *
  * @func
  * @memberOf R
+ * @since v0.10.0
  * @category Function
  * @sig ((a, b, c, ..., n) -> x) -> [a, b, c, ...] -> ((d, e, f, ..., n) -> x)
  * @param {Function} f

--- a/src/partialRight.js
+++ b/src/partialRight.js
@@ -10,6 +10,7 @@ var flip = require('./flip');
  *
  * @func
  * @memberOf R
+ * @since v0.10.0
  * @category Function
  * @sig ((a, b, c, ..., n) -> x) -> [d, e, f, ..., n] -> ((a, b, c, ...) -> x)
  * @param {Function} f

--- a/src/partition.js
+++ b/src/partition.js
@@ -8,6 +8,7 @@ var _reduce = require('./internal/_reduce');
  *
  * @func
  * @memberOf R
+ * @since v0.1.4
  * @category List
  * @sig (a -> Boolean) -> [a] -> [[a],[a]]
  * @param {Function} pred A predicate to determine which array the element belongs to.

--- a/src/path.js
+++ b/src/path.js
@@ -6,6 +6,7 @@ var _curry2 = require('./internal/_curry2');
  *
  * @func
  * @memberOf R
+ * @since v0.2.0
  * @category Object
  * @sig [String] -> {k: v} -> v | Undefined
  * @param {Array} path The path to use.

--- a/src/pathEq.js
+++ b/src/pathEq.js
@@ -9,6 +9,7 @@ var path = require('./path');
  *
  * @func
  * @memberOf R
+ * @since v0.7.0
  * @category Relation
  * @sig [String] -> * -> {String: *} -> Boolean
  * @param {Array} path The path of the nested property to use

--- a/src/pathOr.js
+++ b/src/pathOr.js
@@ -9,6 +9,7 @@ var path = require('./path');
  *
  * @func
  * @memberOf R
+ * @since v0.18.0
  * @category Object
  * @sig a -> [String] -> Object -> a
  * @param {*} d The default value.

--- a/src/pick.js
+++ b/src/pick.js
@@ -7,6 +7,7 @@ var _curry2 = require('./internal/_curry2');
  *
  * @func
  * @memberOf R
+ * @since v0.1.0
  * @category Object
  * @sig [k] -> {k: v} -> {k: v}
  * @param {Array} names an array of String property names to copy onto a new object

--- a/src/pickAll.js
+++ b/src/pickAll.js
@@ -6,6 +6,7 @@ var _curry2 = require('./internal/_curry2');
  *
  * @func
  * @memberOf R
+ * @since v0.1.0
  * @category Object
  * @sig [k] -> {k: v} -> {k: v}
  * @param {Array} names an array of String property names to copy onto a new object

--- a/src/pickBy.js
+++ b/src/pickBy.js
@@ -7,6 +7,7 @@ var _curry2 = require('./internal/_curry2');
  *
  * @func
  * @memberOf R
+ * @since v0.8.0
  * @category Object
  * @sig (v, k -> Boolean) -> {k: v} -> {k: v}
  * @param {Function} pred A predicate to determine whether or not a key

--- a/src/pipe.js
+++ b/src/pipe.js
@@ -12,6 +12,7 @@ var tail = require('./tail');
  *
  * @func
  * @memberOf R
+ * @since v0.1.0
  * @category Function
  * @sig (((a, b, ..., n) -> o), (o -> p), ..., (x -> y), (y -> z)) -> ((a, b, ..., n) -> z)
  * @param {...Function} functions

--- a/src/pipeK.js
+++ b/src/pipeK.js
@@ -9,6 +9,7 @@ var reverse = require('./reverse');
  *
  * @func
  * @memberOf R
+ * @since v0.16.0
  * @category Function
  * @see R.composeK
  * @sig Chain m => ((a -> m b), (b -> m c), ..., (y -> m z)) -> (m a -> m z)

--- a/src/pipeP.js
+++ b/src/pipeP.js
@@ -11,6 +11,7 @@ var tail = require('./tail');
  *
  * @func
  * @memberOf R
+ * @since v0.10.0
  * @category Function
  * @sig ((a -> Promise b), (b -> Promise c), ..., (y -> Promise z)) -> (a -> Promise z)
  * @param {...Function} functions

--- a/src/pluck.js
+++ b/src/pluck.js
@@ -8,6 +8,7 @@ var prop = require('./prop');
  *
  * @func
  * @memberOf R
+ * @since v0.1.0
  * @category List
  * @sig k -> [{k: v}] -> [v]
  * @param {Number|String} key The key name to pluck off of each object.

--- a/src/prepend.js
+++ b/src/prepend.js
@@ -8,6 +8,7 @@ var _curry2 = require('./internal/_curry2');
  *
  * @func
  * @memberOf R
+ * @since v0.1.0
  * @category List
  * @sig a -> [a] -> [a]
  * @param {*} el The item to add to the head of the output list.

--- a/src/product.js
+++ b/src/product.js
@@ -7,6 +7,7 @@ var reduce = require('./reduce');
  *
  * @func
  * @memberOf R
+ * @since v0.1.0
  * @category Math
  * @sig [Number] -> Number
  * @param {Array} list An array of numbers

--- a/src/project.js
+++ b/src/project.js
@@ -9,6 +9,7 @@ var useWith = require('./useWith');
  *
  * @func
  * @memberOf R
+ * @since v0.1.0
  * @category Object
  * @category Relation
  * @sig [k] -> [{k: v}] -> [{k: v}]

--- a/src/prop.js
+++ b/src/prop.js
@@ -6,6 +6,7 @@ var _curry2 = require('./internal/_curry2');
  *
  * @func
  * @memberOf R
+ * @since v0.1.0
  * @category Object
  * @sig s -> {s: a} -> a | Undefined
  * @param {String} p The property name

--- a/src/propEq.js
+++ b/src/propEq.js
@@ -9,6 +9,7 @@ var propSatisfies = require('./propSatisfies');
  *
  * @func
  * @memberOf R
+ * @since v0.1.0
  * @category Relation
  * @sig String -> a -> Object -> Boolean
  * @param {String} name

--- a/src/propIs.js
+++ b/src/propIs.js
@@ -9,6 +9,7 @@ var propSatisfies = require('./propSatisfies');
  *
  * @func
  * @memberOf R
+ * @since v0.16.0
  * @category Type
  * @sig Type -> String -> Object -> Boolean
  * @param {Function} type

--- a/src/propOr.js
+++ b/src/propOr.js
@@ -9,6 +9,7 @@ var _has = require('./internal/_has');
  *
  * @func
  * @memberOf R
+ * @since v0.6.0
  * @category Object
  * @sig a -> String -> Object -> a
  * @param {*} val The default value.

--- a/src/propSatisfies.js
+++ b/src/propSatisfies.js
@@ -7,6 +7,7 @@ var _curry3 = require('./internal/_curry3');
  *
  * @func
  * @memberOf R
+ * @since v0.16.0
  * @category Logic
  * @sig (a -> Boolean) -> String -> {String: a} -> Boolean
  * @param {Function} pred

--- a/src/props.js
+++ b/src/props.js
@@ -6,6 +6,7 @@ var _curry2 = require('./internal/_curry2');
  *
  * @func
  * @memberOf R
+ * @since v0.1.0
  * @category Object
  * @sig [k] -> {k: v} -> [v]
  * @param {Array} ps The property names to fetch

--- a/src/range.js
+++ b/src/range.js
@@ -8,6 +8,7 @@ var _isNumber = require('./internal/_isNumber');
  *
  * @func
  * @memberOf R
+ * @since v0.1.0
  * @category List
  * @sig Number -> Number -> [Number]
  * @param {Number} from The first number in the list.

--- a/src/reduce.js
+++ b/src/reduce.js
@@ -19,6 +19,7 @@ var _reduce = require('./internal/_reduce');
  *
  * @func
  * @memberOf R
+ * @since v0.1.0
  * @category List
  * @sig (a,b -> a) -> a -> [b] -> a
  * @param {Function} fn The iterator function. Receives two values, the accumulator and the

--- a/src/reduceRight.js
+++ b/src/reduceRight.js
@@ -16,6 +16,7 @@ var _curry3 = require('./internal/_curry3');
  *
  * @func
  * @memberOf R
+ * @since v0.1.0
  * @category List
  * @sig (a,b -> a) -> a -> [b] -> a
  * @param {Function} fn The iterator function. Receives two values, the accumulator and the

--- a/src/reduced.js
+++ b/src/reduced.js
@@ -13,6 +13,7 @@ var _reduced = require('./internal/_reduced');
  *
  * @func
  * @memberOf R
+ * @since v0.15.0
  * @category List
  * @see R.reduce, R.transduce
  * @sig a -> *

--- a/src/reject.js
+++ b/src/reject.js
@@ -12,6 +12,7 @@ var filter = require('./filter');
  *
  * @func
  * @memberOf R
+ * @since v0.1.0
  * @category List
  * @sig (a -> Boolean) -> [a] -> [a]
  * @param {Function} fn The function called per iteration.

--- a/src/remove.js
+++ b/src/remove.js
@@ -11,6 +11,7 @@ var _slice = require('./internal/_slice');
  *
  * @func
  * @memberOf R
+ * @since v0.2.2
  * @category List
  * @sig Number -> Number -> [a] -> [a]
  * @param {Number} start The position to start removing elements

--- a/src/repeat.js
+++ b/src/repeat.js
@@ -8,6 +8,7 @@ var times = require('./times');
  *
  * @func
  * @memberOf R
+ * @since v0.1.1
  * @category List
  * @sig a -> n -> [a]
  * @param {*} value The value to repeat.

--- a/src/replace.js
+++ b/src/replace.js
@@ -6,6 +6,7 @@ var _curry3 = require('./internal/_curry3');
  *
  * @func
  * @memberOf R
+ * @since v0.7.0
  * @category String
  * @sig RegExp|String -> String -> String -> String
  * @param {RegExp|String} pattern A regular expression or a substring to match.

--- a/src/reverse.js
+++ b/src/reverse.js
@@ -9,6 +9,7 @@ var _slice = require('./internal/_slice');
  *
  * @func
  * @memberOf R
+ * @since v0.1.0
  * @category List
  * @sig [a] -> [a]
  * @sig String -> String

--- a/src/scan.js
+++ b/src/scan.js
@@ -6,6 +6,7 @@ var _curry3 = require('./internal/_curry3');
  *
  * @func
  * @memberOf R
+ * @since v0.10.0
  * @category List
  * @sig (a,b -> a) -> a -> [b] -> [a]
  * @param {Function} fn The iterator function. Receives two values, the accumulator and the

--- a/src/set.js
+++ b/src/set.js
@@ -9,6 +9,7 @@ var over = require('./over');
  *
  * @func
  * @memberOf R
+ * @since v0.16.0
  * @category Object
  * @typedefn Lens s a = Functor f => (a -> f a) -> s -> f s
  * @sig Lens s a -> a -> s -> s

--- a/src/slice.js
+++ b/src/slice.js
@@ -10,6 +10,7 @@ var _curry3 = require('./internal/_curry3');
  *
  * @func
  * @memberOf R
+ * @since v0.1.4
  * @category List
  * @sig Number -> Number -> [a] -> [a]
  * @sig Number -> Number -> String -> String

--- a/src/sort.js
+++ b/src/sort.js
@@ -9,6 +9,7 @@ var _slice = require('./internal/_slice');
  *
  * @func
  * @memberOf R
+ * @since v0.1.0
  * @category List
  * @sig (a,a -> Number) -> [a] -> [a]
  * @param {Function} comparator A sorting function :: a -> b -> Int

--- a/src/sortBy.js
+++ b/src/sortBy.js
@@ -7,6 +7,7 @@ var _slice = require('./internal/_slice');
  *
  * @func
  * @memberOf R
+ * @since v0.1.0
  * @category Relation
  * @sig Ord b => (a -> b) -> [a] -> [a]
  * @param {Function} fn

--- a/src/split.js
+++ b/src/split.js
@@ -7,6 +7,7 @@ var invoker = require('./invoker');
  *
  * @func
  * @memberOf R
+ * @since v0.1.0
  * @category String
  * @sig (String | RegExp) -> String -> [String]
  * @param {String|RegExp} sep The pattern.

--- a/src/splitEvery.js
+++ b/src/splitEvery.js
@@ -7,6 +7,7 @@ var slice = require('./slice');
  *
  * @func
  * @memberOf R
+ * @since v0.16.0
  * @category List
  * @sig Number -> [a] -> [[a]]
  * @sig Number -> String -> [String]

--- a/src/subtract.js
+++ b/src/subtract.js
@@ -6,6 +6,7 @@ var _curry2 = require('./internal/_curry2');
  *
  * @func
  * @memberOf R
+ * @since v0.1.0
  * @category Math
  * @sig Number -> Number -> Number
  * @param {Number} a The first value.

--- a/src/sum.js
+++ b/src/sum.js
@@ -7,6 +7,7 @@ var reduce = require('./reduce');
  *
  * @func
  * @memberOf R
+ * @since v0.1.0
  * @category Math
  * @sig [Number] -> Number
  * @param {Array} list An array of numbers

--- a/src/tail.js
+++ b/src/tail.js
@@ -10,6 +10,7 @@ var slice = require('./slice');
  *
  * @func
  * @memberOf R
+ * @since v0.1.0
  * @category List
  * @see R.head, R.init, R.last
  * @sig [a] -> [a]

--- a/src/take.js
+++ b/src/take.js
@@ -12,6 +12,7 @@ var slice = require('./slice');
  *
  * @func
  * @memberOf R
+ * @since v0.1.0
  * @category List
  * @sig Number -> [a] -> [a]
  * @sig Number -> String -> String

--- a/src/takeLast.js
+++ b/src/takeLast.js
@@ -8,6 +8,7 @@ var drop = require('./drop');
  *
  * @func
  * @memberOf R
+ * @since v0.16.0
  * @category List
  * @sig Number -> [a] -> [a]
  * @sig Number -> String -> String

--- a/src/takeLastWhile.js
+++ b/src/takeLastWhile.js
@@ -10,6 +10,7 @@ var _slice = require('./internal/_slice');
  *
  * @func
  * @memberOf R
+ * @since v0.16.0
  * @category List
  * @sig (a -> Boolean) -> [a] -> [a]
  * @param {Function} fn The function called per iteration.

--- a/src/takeWhile.js
+++ b/src/takeWhile.js
@@ -17,6 +17,7 @@ var _xtakeWhile = require('./internal/_xtakeWhile');
  *
  * @func
  * @memberOf R
+ * @since v0.1.0
  * @category List
  * @sig (a -> Boolean) -> [a] -> [a]
  * @param {Function} fn The function called per iteration.

--- a/src/tap.js
+++ b/src/tap.js
@@ -6,6 +6,7 @@ var _curry2 = require('./internal/_curry2');
  *
  * @func
  * @memberOf R
+ * @since v0.1.0
  * @category Function
  * @sig (a -> *) -> a -> a
  * @param {Function} fn The function to call with `x`. The return value of `fn` will be thrown away.

--- a/src/test.js
+++ b/src/test.js
@@ -9,6 +9,7 @@ var toString = require('./toString');
  *
  * @func
  * @memberOf R
+ * @since v0.12.0
  * @see R.match
  * @category String
  * @sig RegExp -> String -> Boolean

--- a/src/times.js
+++ b/src/times.js
@@ -10,6 +10,7 @@ var _curry2 = require('./internal/_curry2');
  *
  * @func
  * @memberOf R
+ * @since v0.2.3
  * @category List
  * @sig (i -> a) -> i -> [a]
  * @param {Function} fn The function to invoke. Passed one argument, the current value of `n`.

--- a/src/toLower.js
+++ b/src/toLower.js
@@ -6,6 +6,7 @@ var invoker = require('./invoker');
  *
  * @func
  * @memberOf R
+ * @since v0.9.0
  * @category String
  * @sig String -> String
  * @param {String} str The string to lower case.

--- a/src/toPairs.js
+++ b/src/toPairs.js
@@ -10,6 +10,7 @@ var _has = require('./internal/_has');
  *
  * @func
  * @memberOf R
+ * @since v0.4.0
  * @category Object
  * @sig {String: *} -> [[String,*]]
  * @param {Object} obj The object to extract from

--- a/src/toPairsIn.js
+++ b/src/toPairsIn.js
@@ -9,6 +9,7 @@ var _curry1 = require('./internal/_curry1');
  *
  * @func
  * @memberOf R
+ * @since v0.4.0
  * @category Object
  * @sig {String: *} -> [[String,*]]
  * @param {Object} obj The object to extract from

--- a/src/toString.js
+++ b/src/toString.js
@@ -25,6 +25,7 @@ var _toString = require('./internal/_toString');
  *
  * @func
  * @memberOf R
+ * @since v0.14.0
  * @category String
  * @sig * -> String
  * @param {*} val

--- a/src/toUpper.js
+++ b/src/toUpper.js
@@ -6,6 +6,7 @@ var invoker = require('./invoker');
  *
  * @func
  * @memberOf R
+ * @since v0.9.0
  * @category String
  * @sig String -> String
  * @param {String} str The string to upper case.

--- a/src/transduce.js
+++ b/src/transduce.js
@@ -27,6 +27,7 @@ var curryN = require('./curryN');
  *
  * @func
  * @memberOf R
+ * @since v0.12.0
  * @category List
  * @see R.reduce, R.reduced, R.into
  * @sig (c -> c) -> (a,b -> a) -> a -> [b] -> a

--- a/src/trim.js
+++ b/src/trim.js
@@ -6,6 +6,7 @@ var _curry1 = require('./internal/_curry1');
  *
  * @func
  * @memberOf R
+ * @since v0.6.0
  * @category String
  * @sig String -> String
  * @param {String} str The string to trim.

--- a/src/type.js
+++ b/src/type.js
@@ -8,6 +8,7 @@ var _curry1 = require('./internal/_curry1');
  *
  * @func
  * @memberOf R
+ * @since v0.8.0
  * @category Type
  * @sig (* -> {*}) -> String
  * @param {*} val The value to test

--- a/src/unapply.js
+++ b/src/unapply.js
@@ -15,6 +15,7 @@ var _slice = require('./internal/_slice');
  *
  * @func
  * @memberOf R
+ * @since v0.8.0
  * @category Function
  * @sig ([*...] -> a) -> (*... -> a)
  * @param {Function} fn

--- a/src/unary.js
+++ b/src/unary.js
@@ -8,6 +8,7 @@ var nAry = require('./nAry');
  *
  * @func
  * @memberOf R
+ * @since v0.2.0
  * @category Function
  * @sig (* -> b) -> (a -> b)
  * @param {Function} fn The function to wrap.

--- a/src/uncurryN.js
+++ b/src/uncurryN.js
@@ -8,6 +8,7 @@ var curryN = require('./curryN');
  *
  * @func
  * @memberOf R
+ * @since v0.14.0
  * @category Function
  * @sig Number -> (a -> b) -> (a -> c)
  * @param {Number} length The arity for the returned function.

--- a/src/unfold.js
+++ b/src/unfold.js
@@ -10,6 +10,7 @@ var _curry2 = require('./internal/_curry2');
  *
  * @func
  * @memberOf R
+ * @since v0.10.0
  * @category List
  * @sig (a -> [b]) -> * -> [b]
  * @param {Function} fn The iterator function. receives one argument, `seed`, and returns

--- a/src/union.js
+++ b/src/union.js
@@ -10,6 +10,7 @@ var uniq = require('./uniq');
  *
  * @func
  * @memberOf R
+ * @since v0.1.0
  * @category Relation
  * @sig [a] -> [a] -> [a]
  * @param {Array} as The first list.

--- a/src/unionWith.js
+++ b/src/unionWith.js
@@ -9,6 +9,7 @@ var uniqWith = require('./uniqWith');
  *
  * @func
  * @memberOf R
+ * @since v0.1.0
  * @category Relation
  * @sig (a,a -> Boolean) -> [a] -> [a] -> [a]
  * @param {Function} pred A predicate used to test whether two items are equal.

--- a/src/uniq.js
+++ b/src/uniq.js
@@ -8,6 +8,7 @@ var uniqWith = require('./uniqWith');
  *
  * @func
  * @memberOf R
+ * @since v0.1.0
  * @category List
  * @sig [a] -> [a]
  * @param {Array} list The array to consider.

--- a/src/uniqBy.js
+++ b/src/uniqBy.js
@@ -11,6 +11,7 @@ var _curry2 = require('./internal/_curry2');
  *
  * @func
  * @memberOf R
+ * @since v0.16.0
  * @category List
  * @sig (a -> b) -> [a] -> [a]
  * @param {Function} fn A function used to produce a value to use during comparisons.

--- a/src/uniqWith.js
+++ b/src/uniqWith.js
@@ -9,6 +9,7 @@ var _curry2 = require('./internal/_curry2');
  *
  * @func
  * @memberOf R
+ * @since v0.2.0
  * @category List
  * @sig (a, a -> Boolean) -> [a] -> [a]
  * @param {Function} pred A predicate used to test whether two items are equal.

--- a/src/unless.js
+++ b/src/unless.js
@@ -9,6 +9,7 @@ var _curry3 = require('./internal/_curry3');
  *
  * @func
  * @memberOf R
+ * @since v0.18.0
  * @category Logic
  * @see R.ifElse, R.when
  * @sig (a -> Boolean) -> (a -> a) -> a -> a

--- a/src/unnest.js
+++ b/src/unnest.js
@@ -8,6 +8,7 @@ var chain = require('./chain');
  *
  * @func
  * @memberOf R
+ * @since v0.3.0
  * @category List
  * @sig Chain c => c (c a) -> c a
  * @param {*} list

--- a/src/update.js
+++ b/src/update.js
@@ -10,6 +10,7 @@ var always = require('./always');
  *
  * @func
  * @memberOf R
+ * @since v0.14.0
  * @category List
  * @sig Number -> a -> [a] -> [a]
  * @param {Number} idx The index to update.

--- a/src/useWith.js
+++ b/src/useWith.js
@@ -17,6 +17,7 @@ var curry = require('./curry');
  *
  * @func
  * @memberOf R
+ * @since v0.1.0
  * @category Function
  * @sig (x1 -> x2 -> ... -> z) -> [(a -> x1), (b -> x2), ...] -> (a -> b -> ... -> z)
  * @param {Function} fn The function to wrap.

--- a/src/values.js
+++ b/src/values.js
@@ -9,6 +9,7 @@ var keys = require('./keys');
  *
  * @func
  * @memberOf R
+ * @since v0.1.0
  * @category Object
  * @sig {k: v} -> [v]
  * @param {Object} obj The object to extract values from

--- a/src/valuesIn.js
+++ b/src/valuesIn.js
@@ -9,6 +9,7 @@ var _curry1 = require('./internal/_curry1');
  *
  * @func
  * @memberOf R
+ * @since v0.2.0
  * @category Object
  * @sig {k: v} -> [v]
  * @param {Object} obj The object to extract values from

--- a/src/view.js
+++ b/src/view.js
@@ -7,6 +7,7 @@ var _curry2 = require('./internal/_curry2');
  *
  * @func
  * @memberOf R
+ * @since v0.16.0
  * @category Object
  * @typedefn Lens s a = Functor f => (a -> f a) -> s -> f s
  * @sig Lens s a -> s -> a

--- a/src/when.js
+++ b/src/when.js
@@ -9,6 +9,7 @@ var _curry3 = require('./internal/_curry3');
  *
  * @func
  * @memberOf R
+ * @since v0.18.0
  * @category Logic
  * @see R.ifElse, R.unless
  * @sig (a -> Boolean) -> (a -> a) -> a -> a

--- a/src/where.js
+++ b/src/where.js
@@ -14,6 +14,7 @@ var _has = require('./internal/_has');
  *
  * @func
  * @memberOf R
+ * @since v0.1.1
  * @category Object
  * @sig {String: (* -> Boolean)} -> {String: *} -> Boolean
  * @param {Object} spec

--- a/src/whereEq.js
+++ b/src/whereEq.js
@@ -14,6 +14,7 @@ var where = require('./where');
  *
  * @func
  * @memberOf R
+ * @since v0.14.0
  * @category Object
  * @sig {String: *} -> {String: *} -> Boolean
  * @param {Object} spec

--- a/src/wrap.js
+++ b/src/wrap.js
@@ -9,6 +9,7 @@ var curryN = require('./curryN');
  *
  * @func
  * @memberOf R
+ * @since v0.1.0
  * @category Function
  * @sig (a... -> b) -> ((a... -> b) -> a... -> c) -> (a... -> c)
  * @param {Function} fn The function to wrap.

--- a/src/xprod.js
+++ b/src/xprod.js
@@ -7,6 +7,7 @@ var _curry2 = require('./internal/_curry2');
  *
  * @func
  * @memberOf R
+ * @since v0.1.0
  * @category List
  * @sig [a] -> [b] -> [[a,b]]
  * @param {Array} as The first list.

--- a/src/zip.js
+++ b/src/zip.js
@@ -9,6 +9,7 @@ var _curry2 = require('./internal/_curry2');
  *
  * @func
  * @memberOf R
+ * @since v0.1.0
  * @category List
  * @sig [a] -> [b] -> [[a,b]]
  * @param {Array} list1 The first array to consider.

--- a/src/zipObj.js
+++ b/src/zipObj.js
@@ -6,6 +6,7 @@ var _curry2 = require('./internal/_curry2');
  *
  * @func
  * @memberOf R
+ * @since v0.3.0
  * @category List
  * @sig [String] -> [*] -> {String: *}
  * @param {Array} keys The array that will be properties on the output object.

--- a/src/zipWith.js
+++ b/src/zipWith.js
@@ -8,6 +8,7 @@ var _curry3 = require('./internal/_curry3');
  *
  * @function
  * @memberOf R
+ * @since v0.1.0
  * @category List
  * @sig (a,b -> c) -> [a] -> [b] -> [c]
  * @param {Function} fn The function used to combine the two elements into one value.


### PR DESCRIPTION
Closes #1381

Many thanks to @branneman and @kedashoe for their contributions to this pull request.

This is the script I used to add these annotations:

```
#!/usr/bin/env bash
set -e

next_version=v0.18.0
n=$'\n'

tags() {
  git tag --list --sort=version:refname
}

view() {
  git show "refs/tags/$1:$2"
}

for tag in $(tags) ; do
  view "$tag" "$(node -p "($(view "$tag" package.json)).main")" >"ramda-$tag.js"
done

for name in $(node -p "Object.keys(require('./ramda-$(tags | tail -n 1)')).sort().join('\n')") ; do
  for tag in $(tags) ; do
    if [[ "$(node -p "Object.prototype.hasOwnProperty.call(require('./ramda-$tag'), '$name')")" == true ]] ; then
      echo "R.$name was added in $tag"
      if [[ -e "src/$name.js" ]] ; then
        sed -i "" "s/@memberOf R/@memberOf R\\$n * @since $tag/" "src/$name.js"
      fi
      break
    fi
  done
done

for filename in $(find src -depth 1 -name "*.js" | xargs grep --files-without-match "@since v") ; do
  echo "R.$(basename -s .js "$filename") will be added in $next_version"
  sed -i "" "s/@memberOf R/@memberOf R\\$n * @since $next_version/" "$filename"
done

rm ramda-*.js
```

Do you think it's okay to state `@since v0.1.0` for `R.and`, for example, even though the meaning of `R.and` changed at some point between then and now?
