### PR TITLE
use @typedefn rather than @typedef

### DIFF
--- a/src/lens.js
+++ b/src/lens.js
@@ -10,7 +10,7 @@ var map = require('./map');
  * @func
  * @memberOf R
  * @category Object
- * @typedef Lens s a = Functor f => (a -> f a) -> s -> f s
+ * @typedefn Lens s a = Functor f => (a -> f a) -> s -> f s
  * @sig (s -> a) -> ((a, s) -> s) -> Lens s a
  * @param {Function} getter
  * @param {Function} setter

--- a/src/lensIndex.js
+++ b/src/lensIndex.js
@@ -10,7 +10,7 @@ var update = require('./update');
  * @func
  * @memberOf R
  * @category Object
- * @typedef Lens s a = Functor f => (a -> f a) -> s -> f s
+ * @typedefn Lens s a = Functor f => (a -> f a) -> s -> f s
  * @sig Number -> Lens s a
  * @param {Number} n
  * @return {Lens}

--- a/src/lensProp.js
+++ b/src/lensProp.js
@@ -10,7 +10,7 @@ var prop = require('./prop');
  * @func
  * @memberOf R
  * @category Object
- * @typedef Lens s a = Functor f => (a -> f a) -> s -> f s
+ * @typedefn Lens s a = Functor f => (a -> f a) -> s -> f s
  * @sig String -> Lens s a
  * @param {String} k
  * @return {Lens}

--- a/src/over.js
+++ b/src/over.js
@@ -9,7 +9,7 @@ var _curry3 = require('./internal/_curry3');
  * @func
  * @memberOf R
  * @category Object
- * @typedef Lens s a = Functor f => (a -> f a) -> s -> f s
+ * @typedefn Lens s a = Functor f => (a -> f a) -> s -> f s
  * @sig Lens s a -> (a -> a) -> s -> s
  * @param {Lens} lens
  * @param {*} v

--- a/src/set.js
+++ b/src/set.js
@@ -10,7 +10,7 @@ var over = require('./over');
  * @func
  * @memberOf R
  * @category Object
- * @typedef Lens s a = Functor f => (a -> f a) -> s -> f s
+ * @typedefn Lens s a = Functor f => (a -> f a) -> s -> f s
  * @sig Lens s a -> a -> s -> s
  * @param {Lens} lens
  * @param {*} v

--- a/src/view.js
+++ b/src/view.js
@@ -8,7 +8,7 @@ var _curry2 = require('./internal/_curry2');
  * @func
  * @memberOf R
  * @category Object
- * @typedef Lens s a = Functor f => (a -> f a) -> s -> f s
+ * @typedefn Lens s a = Functor f => (a -> f a) -> s -> f s
  * @sig Lens s a -> s -> a
  * @param {Lens} lens
  * @param {*} x


### PR DESCRIPTION
[`@typedef`][1] is a real thing. We should use a different name to avoid confusing JSDoc.


[1]: http://usejsdoc.org/tags-typedef.html
