### PR TITLE
make R.equals return true for equivalent Error objects

### DIFF
--- a/src/internal/_equals.js
+++ b/src/internal/_equals.js
@@ -40,6 +40,11 @@ module.exports = function _equals(a, b, stackA, stackB) {
         return false;
       }
       break;
+    case 'Error':
+      if (!(a.name === b.name && a.message === b.message)) {
+        return false;
+      }
+      break;
     case 'RegExp':
       if (!(a.source === b.source &&
             a.global === b.global &&

--- a/test/equals.js
+++ b/test/equals.js
@@ -111,6 +111,13 @@ describe('equals', function() {
     eq(R.equals(c, a), false);
   });
 
+  it('considers equivalent Error objects equal', function() {
+    eq(R.equals(new Error('XXX'), new Error('XXX')), true);
+    eq(R.equals(new Error('XXX'), new Error('YYY')), false);
+    eq(R.equals(new Error('XXX'), new TypeError('XXX')), false);
+    eq(R.equals(new Error('XXX'), new TypeError('YYY')), false);
+  });
+
   var supportsSticky = false;
   try { RegExp('', 'y'); supportsSticky = true; } catch (e) {}
 


### PR DESCRIPTION
`R.equals` will never be *done*. :stuck_out_tongue_closed_eyes:
