### PR TITLE
Adds mergeWith and mergeWithKey

### DIFF
--- a/src/merge.js
+++ b/src/merge.js
@@ -1,19 +1,20 @@
-var _curry2 = require('./internal/_curry2');
-var keys = require('./keys');
+var mergeWith = require('./mergeWith');
 
 
 /**
- * Create a new object with the own properties of `a` merged with the own
- * properties of object `b`.
+ * Create a new object with the own properties of the first object merged with
+ * the own properties of the second object. If a key exists in both objects,
+ * the value from the second object will be used.
  *
  * @func
  * @memberOf R
  * @since v0.1.0
  * @category Object
  * @sig {k: v} -> {k: v} -> {k: v}
- * @param {Object} a
- * @param {Object} b
+ * @param {Object} l
+ * @param {Object} r
  * @return {Object}
+ * @see R.mergeWith, R.mergeWithKey
  * @example
  *
  *      R.merge({ 'name': 'fred', 'age': 10 }, { 'age': 40 });
@@ -22,19 +23,6 @@ var keys = require('./keys');
  *      var resetToDefault = R.merge(R.__, {x: 0});
  *      resetToDefault({x: 5, y: 2}); //=> {x: 0, y: 2}
  */
-module.exports = _curry2(function merge(a, b) {
-  var result = {};
-  var ks = keys(a);
-  var idx = 0;
-  while (idx < ks.length) {
-    result[ks[idx]] = a[ks[idx]];
-    idx += 1;
-  }
-  ks = keys(b);
-  idx = 0;
-  while (idx < ks.length) {
-    result[ks[idx]] = b[ks[idx]];
-    idx += 1;
-  }
-  return result;
+module.exports = mergeWith(function(l, r) {
+  return r;
 });

--- a/src/mergeWith.js
+++ b/src/mergeWith.js
@@ -1,0 +1,32 @@
+var _curry3 = require('./internal/_curry3');
+var mergeWithKey = require('./mergeWithKey');
+
+
+/**
+ * Creates a new object with the own properties of the two provided objects. If
+ * a key exists in both objects, the provided function is applied to the values
+ * associated with the key in each object, with the result being used as the
+ * value associated with the key in the returned object. The key will be
+ * excluded from the returned object if the resulting value is `undefined`.
+ *
+ * @func
+ * @memberOf R
+ * @category Object
+ * @sig (a -> a -> a) -> {a} -> {a} -> {a}
+ * @param {Function} fn
+ * @param {Object} l
+ * @param {Object} r
+ * @return {Object}
+ * @see R.merge, R.mergeWithKey
+ * @example
+ *
+ *      R.mergeWith(R.concat,
+ *                  { a: true, values: [10, 20] },
+ *                  { b: true, values: [15, 35] });
+ *      //=> { a: true, b: true, values: [10, 20, 15, 35] }
+ */
+module.exports = _curry3(function mergeWith(fn, l, r) {
+  return mergeWithKey(function(_, _l, _r) {
+    return fn(_l, _r);
+  }, l, r);
+});

--- a/src/mergeWithKey.js
+++ b/src/mergeWithKey.js
@@ -1,0 +1,47 @@
+var _curry3 = require('./internal/_curry3');
+var _has = require('./internal/_has');
+
+
+/**
+ * Creates a new object with the own properties of the two provided objects. If
+ * a key exists in both objects, the provided function is applied to the key
+ * and the values associated with the key in each object, with the result being
+ * used as the value associated with the key in the returned object. The key
+ * will be excluded from the returned object if the resulting value is
+ * `undefined`.
+ *
+ * @func
+ * @memberOf R
+ * @category Object
+ * @sig (String -> a -> a -> a) -> {a} -> {a} -> {a}
+ * @param {Function} fn
+ * @param {Object} l
+ * @param {Object} r
+ * @return {Object}
+ * @see R.merge, R.mergeWith
+ * @example
+ *
+ *      let concatValues = (k, l, r) => k == 'values' ? R.concat(l, r) : r
+ *      R.mergeWithKey(concatValues,
+ *                     { a: true, thing: 'foo', values: [10, 20] },
+ *                     { b: true, thing: 'bar', values: [15, 35] });
+ *      //=> { a: true, b: true, thing: 'bar', values: [10, 20, 15, 35] }
+ */
+module.exports = _curry3(function mergeWithKey(fn, l, r) {
+  var result = {};
+  var k;
+
+  for (k in l) {
+    if (_has(k, l)) {
+      result[k] = _has(k, r) ? fn(k, l[k], r[k]) : l[k];
+    }
+  }
+
+  for (k in r) {
+    if (_has(k, r) && !(_has(k, result))) {
+      result[k] = r[k];
+    }
+  }
+
+  return result;
+});

--- a/test/mergeWith.js
+++ b/test/mergeWith.js
@@ -1,0 +1,43 @@
+var assert = require('assert');
+
+var R = require('..');
+var eq = require('./shared/eq');
+
+
+describe('mergeWith', function() {
+  function last(x, y) { return y; }
+
+  it('takes two objects, merges their own properties and returns a new object', function() {
+    var a = {w: 1, x: 2};
+    var b = {y: 3, z: 4};
+    eq(R.mergeWith(last, a, b), {w: 1, x: 2, y: 3, z: 4});
+  });
+
+  it('applies the provided function to the value from the first object and the' +
+    ' value from the second object to determine the value for keys that exist in' +
+    ' both objects', function() {
+    var a = {x: 'a', y: 'c'};
+    var b = {x: 'b', z: 'd'};
+    var c = R.mergeWith(function(a, b) { return a + b; }, a, b);
+    eq(c, {x: 'ab', y: 'c', z: 'd'});
+  });
+
+  it('is not destructive', function() {
+    var a = {w: 1, x: 2};
+    var res = R.mergeWith(last, a, {x: 5});
+    assert.notStrictEqual(a, res);
+    eq(res, {w: 1, x: 5});
+  });
+
+  it('reports only own properties', function() {
+    function Cla() {}
+    Cla.prototype.x = 5;
+    eq(R.mergeWith(last, new Cla(), {w: 1, x: 2}), {w: 1, x: 2});
+    eq(R.mergeWith(last, {w: 1, x: 2}, new Cla()), {w: 1, x: 2});
+    eq(R.mergeWith(last, new Cla(), {w: 1}), {w: 1});
+  });
+
+  it('is curried', function() {
+    eq(R.mergeWith(last)({w: 1, x: 2})({y: 3, z: 4}), {w: 1, x: 2, y: 3, z: 4});
+  });
+});

--- a/test/mergeWithKey.js
+++ b/test/mergeWithKey.js
@@ -1,0 +1,43 @@
+var assert = require('assert');
+
+var R = require('..');
+var eq = require('./shared/eq');
+
+
+describe('mergeWithKey', function() {
+  function last(k, x, y) { return y; }
+
+  it('takes two objects, merges their own properties and returns a new object', function() {
+    var a = {w: 1, x: 2};
+    var b = {y: 3, z: 4};
+    eq(R.mergeWithKey(last, a, b), {w: 1, x: 2, y: 3, z: 4});
+  });
+
+  it('applies the provided function to the key, the value from the first object' +
+    ' and the value from the second object to determine the value for keys that' +
+    ' exist in both objects', function() {
+    var a = {a: 'b', x: 'd'};
+    var b = {a: 'c', y: 'e'};
+    var c = R.mergeWithKey(function(k, a, b) { return k + a + b; }, a, b);
+    eq(c, {a: 'abc', x: 'd', y: 'e'});
+  });
+
+  it('is not destructive', function() {
+    var a = {w: 1, x: 2};
+    var res = R.mergeWithKey(last, a, {x: 5});
+    assert.notStrictEqual(a, res);
+    eq(res, {w: 1, x: 5});
+  });
+
+  it('reports only own properties', function() {
+    var a = {w: 1, x: 2};
+    function Cla() {}
+    Cla.prototype.x = 5;
+    eq(R.mergeWithKey(last, new Cla(), a), {w: 1, x: 2});
+    eq(R.mergeWithKey(last, a, new Cla()), {w: 1, x: 2});
+  });
+
+  it('is curried', function() {
+    eq(R.mergeWithKey(last)({w: 1, x: 2})({y: 3, z: 4}), {w: 1, x: 2, y: 3, z: 4});
+  });
+});


### PR DESCRIPTION
Given the recent discussions again in gitter about merging objects, I thought it might help to throw this up as a concrete example to discuss, if nothing else.

Two new public functions are introduced to allow a custom merging strategy to be provided for merging objects with intersecting keys:
```
// provided with values of each object only
mergeWith :: (a -> a -> a) -> {a} -> {a}
// provided with the key along with the values of each object
mergeWithKey :: (String -> a -> a -> a) -> {a} -> {a} -> {a}
```

The main points of potential contention with this implementation:
* ~~`internal/_mergeWith` provides the non-intersecting keys as objects to the provided `fnL` and `fnR` functions (e.g. `fnL :: {a} -> {a}`) to allow filtering of the resulting object – should these instead operate on individual key/pairs like `fn` (e.g. `(String, a) -> a`)? Doing so would prevent reuse for potential hypothetical functions like `mergeIntersection`.~~

* ~~to support filtering, the implementation currently excludes keys from the resulting object whose values are `undefined` – this feels like it overloads the behaviour of `mergeWith`/`mergeWithKeys` a little.~~

_edit_: I've since removed `internal/_mergeWith`, moving the implementation into `mergeWithKeys` and I've also removed the behaviour of filtering `undefined` values.