### PR TITLE
Corrected dispatching docstrings

### DIFF
--- a/src/clone.js
+++ b/src/clone.js
@@ -5,7 +5,9 @@ var _curry1 = require('./internal/_curry1');
 /**
  * Creates a deep copy of the value which may contain (nested) `Array`s and `Object`s, `Number`s,
  * `String`s, `Boolean`s and `Date`s. `Function`s are not copied, but assigned by their
- * reference. Dispatches to a `clone` method if present.
+ * reference.
+ *
+ * Dispatches to a `clone` method if present.
  *
  * @func
  * @memberOf R

--- a/src/equals.js
+++ b/src/equals.js
@@ -4,10 +4,9 @@ var _equals = require('./internal/_equals');
 
 /**
  * Returns `true` if its arguments are equivalent, `false` otherwise.
- * Dispatches to an `equals` method if present. Handles cyclical data
- * structures.
+ * Handles cyclical data structures.
  *
- * Dispatches to the `equals` method of both arguments, if present.
+ * Dispatches symmetrically to the `equals` methods of both arguments, if present.
  *
  * @func
  * @memberOf R


### PR DESCRIPTION
Fixes:

- [`R.clone()`](http://ramdajs.com/docs/#clone) has a different codestyle for the 'dispatches to...' docstring
- [`R.equals()`](http://ramdajs.com/docs/#equals) has a duplicate sentence