### PR TITLE
Add pathSatisfies

### DIFF
--- a/src/pathSatisfies.js
+++ b/src/pathSatisfies.js
@@ -1,0 +1,24 @@
+var _curry3 = require('./internal/_curry3');
+var path = require('./path');
+
+
+/**
+ * Returns `true` if the specified object property at given path satisfies the
+ * given predicate; `false` otherwise.
+ *
+ * @func
+ * @memberOf R
+ * @category Logic
+ * @sig (a -> Boolean) -> [String] -> Object -> Boolean
+ * @param {Function} pred
+ * @param {Array} propPath
+ * @param {*} obj
+ * @return {Boolean}
+ * @see R.propSatisfies, R.path
+ * @example
+ *
+ *      R.pathSatisfies(y => y > 0, ['x', 'y'], {x: {y: 2}}); //=> true
+ */
+module.exports = _curry3(function pathSatisfies(pred, propPath, obj) {
+  return propPath.length > 0 && pred(path(propPath, obj));
+});

--- a/test/pathSatisfies.js
+++ b/test/pathSatisfies.js
@@ -1,0 +1,25 @@
+var R = require('..');
+var eq = require('./shared/eq');
+
+
+describe('pathSatisfies', function() {
+
+  var isPositive = function(n) { return n > 0; };
+
+  it('returns true if the specified object path satisfies the given predicate', function() {
+    eq(R.pathSatisfies(isPositive, ['x', 'y'], {x: {y: 1}}), true);
+  });
+
+  it('returns false if the specified path does not exist', function() {
+    eq(R.pathSatisfies(isPositive, ['x', 'y'], {x: {z: 42}}), false);
+  });
+
+  it('returns false if the path is empty', function() {
+    eq(R.pathSatisfies(isPositive, [], {x: {z: 42}}), false);
+  });
+
+  it('returns false otherwise', function() {
+    eq(R.pathSatisfies(isPositive, ['x', 'y'], {x: {y: 0}}), false);
+  });
+
+});


### PR DESCRIPTION
pathSatisfies works analogous to propSatisfies but applies
the predicator on a path instead of a property name.