### PR TITLE
Add log method

### DIFF
--- a/src/log.js
+++ b/src/log.js
@@ -1,0 +1,21 @@
+var _curry2 = require('./internal/_curry2');
+
+
+/**
+ * Logs the current result in the console
+ *
+ * @func
+ * @memberOf R
+ * @since v1.8.0
+ * @category List
+ * @sig a -> a
+ * @return {Object|List|String} The argument that was passed.
+ * @example
+ *
+ *      R.pipe(R.toUpper, R.log, R.toLower, R.log)('abc') // logs 'ABC' and then 'abc'
+ */
+module.exports = _curry2(function log(message, value) {
+  console.log(message, value);
+
+  return value;
+});

--- a/test/log.js
+++ b/test/log.js
@@ -1,0 +1,13 @@
+var R = require('..');
+var eq = require('./shared/eq');
+
+
+describe('log', function() {
+  it('doesn\'t affect the return value', function() {
+    eq(R.pipe(R.toUpper, R.log('value after toUpper'))('abc'), 'ABC');
+  });
+
+  it('doesn\'t affect the return value in more complex cases', function() {
+    eq(R.pipe(R.log('Initial value'), R.toUpper, R.log('value after toUpper'), R.toLower, R.log('value after toLower'))('abc'), 'abc');
+  });
+});


### PR DESCRIPTION
I know this is not very functional, but i find the method pretty handy. 
It's easy to get lost when you compose or pipe a lot. R.log just logs the current value and returns it.
When you're new in the FP world (as i am), it can help a lot.

It also affects the output of the tests (i don't know what to do about it):
<img width="575" alt="screenshot 2015-10-21 21 41 03" src="https://cloud.githubusercontent.com/assets/147684/10648047/7ffdebfa-783c-11e5-8c88-bb259550ab35.png">

If you don't like it, just close the pull request, no bad feelings ;)