### PR TITLE
Sorting keys

### DIFF
--- a/src/functions.js
+++ b/src/functions.js
@@ -1,6 +1,6 @@
 var _curry1 = require('./internal/_curry1');
 var _functionsWith = require('./internal/_functionsWith');
-var keys = require('./keys');
+var _sortedKeys = require('./internal/_sortedKeys');
 
 
 /**
@@ -23,4 +23,4 @@ var keys = require('./keys');
  *      F.prototype.a = 100;
  *      R.functions(new F()); //=> ["x"]
  */
-module.exports = _curry1(_functionsWith(keys));
+module.exports = _curry1(_functionsWith(_sortedKeys));

--- a/src/functionsIn.js
+++ b/src/functionsIn.js
@@ -1,6 +1,6 @@
 var _curry1 = require('./internal/_curry1');
 var _functionsWith = require('./internal/_functionsWith');
-var keysIn = require('./keysIn');
+var _sortedKeysIn = require('./internal/_sortedKeysIn');
 
 
 /**
@@ -24,4 +24,4 @@ var keysIn = require('./keysIn');
  *      F.prototype.a = 100;
  *      R.functionsIn(new F()); //=> ["x", "z"]
  */
-module.exports = _curry1(_functionsWith(keysIn));
+module.exports = _curry1(_functionsWith(_sortedKeysIn));

--- a/src/internal/_keys.js
+++ b/src/internal/_keys.js
@@ -1,0 +1,65 @@
+var _curry1 = require('./_curry1');
+var _has = require('./_has');
+
+
+/**
+ * Returns a list containing the names of all the enumerable own
+ * properties of the supplied object.
+ * Note that the order of the output array is not guaranteed to be
+ * consistent across different JS platforms.
+ *
+ * @func
+ * @memberOf R
+ * @since v0.1.0
+ * @category Object
+ * @sig {k: v} -> [k]
+ * @param {Object} obj The object to extract properties from
+ * @return {Array} An array of the object's own properties.
+ * @example
+ *
+ *      R.keys({a: 1, b: 2, c: 3}); //=> ['a', 'b', 'c']
+ */
+module.exports = (function() {
+  // cover IE < 9 keys issues
+  var hasEnumBug = !({toString: null}).propertyIsEnumerable('toString');
+  var nonEnumerableProps = ['constructor', 'valueOf', 'isPrototypeOf', 'toString',
+                            'propertyIsEnumerable', 'hasOwnProperty', 'toLocaleString'];
+
+  var contains = function contains(list, item) {
+    var idx = 0;
+    while (idx < list.length) {
+      if (list[idx] === item) {
+        return true;
+      }
+      idx += 1;
+    }
+    return false;
+  };
+
+  return typeof Object.keys === 'function' ?
+    _curry1(function keys(obj) {
+      return Object(obj) !== obj ? [] : Object.keys(obj);
+    }) :
+    _curry1(function keys(obj) {
+      if (Object(obj) !== obj) {
+        return [];
+      }
+      var prop, ks = [], nIdx;
+      for (prop in obj) {
+        if (_has(prop, obj)) {
+          ks[ks.length] = prop;
+        }
+      }
+      if (hasEnumBug) {
+        nIdx = nonEnumerableProps.length - 1;
+        while (nIdx >= 0) {
+          prop = nonEnumerableProps[nIdx];
+          if (_has(prop, obj) && !contains(ks, prop)) {
+            ks[ks.length] = prop;
+          }
+          nIdx -= 1;
+        }
+      }
+      return ks;
+    });
+}());

--- a/src/internal/_keysIn.js
+++ b/src/internal/_keysIn.js
@@ -1,4 +1,4 @@
-var _sortedKeysIn = require('./internal/_sortedKeysIn');
+var _curry1 = require('./internal/_curry1');
 
 
 /**
@@ -21,4 +21,10 @@ var _sortedKeysIn = require('./internal/_sortedKeysIn');
  *      var f = new F();
  *      R.keysIn(f); //=> ['x', 'y']
  */
-module.exports = _sortedKeysIn;
+module.exports = _curry1(function keysIn(obj) {
+  var prop, ks = [];
+  for (prop in obj) {
+    ks[ks.length] = prop;
+  }
+  return ks;
+});

--- a/src/internal/_sortedKeys.js
+++ b/src/internal/_sortedKeys.js
@@ -1,0 +1,7 @@
+var _curry1 = require('./_curry1');
+var _keys = require('./_keys');
+
+
+module.exports = _curry1(function(obj) {
+  return _keys(obj).sort();
+});

--- a/src/internal/_sortedKeysIn.js
+++ b/src/internal/_sortedKeysIn.js
@@ -1,0 +1,7 @@
+var _curry1 = require('./_curry1');
+var _keysIn = require('./_keysIn');
+
+
+module.exports = _curry1(function(obj) {
+  return _keysIn(obj).sort();
+});

--- a/src/invert.js
+++ b/src/invert.js
@@ -1,6 +1,6 @@
 var _curry1 = require('./internal/_curry1');
 var _has = require('./internal/_has');
-var keys = require('./keys');
+var _sortedKeys = require('./internal/_sortedKeys');
 
 
 /**
@@ -14,8 +14,7 @@ var keys = require('./keys');
  * @category Object
  * @sig {s: x} -> {x: [ s, ... ]}
  * @param {Object} obj The object or array to invert
- * @return {Object} out A new object with keys
- * in an array.
+ * @return {Object} out A new object with keys in an array.
  * @example
  *
  *      var raceResultsByFirstName = {
@@ -27,7 +26,7 @@ var keys = require('./keys');
  *      //=> { 'alice': ['first', 'third'], 'jake':['second'] }
  */
 module.exports = _curry1(function invert(obj) {
-  var props = keys(obj);
+  var props = _sortedKeys(obj);
   var len = props.length;
   var idx = 0;
   var out = {};

--- a/src/invertObj.js
+++ b/src/invertObj.js
@@ -1,5 +1,5 @@
 var _curry1 = require('./internal/_curry1');
-var keys = require('./keys');
+var _sortedKeys = require('./internal/_sortedKeys');
 
 
 /**
@@ -31,7 +31,7 @@ var keys = require('./keys');
  *      //=> { 'alice': '0', 'jake':'1' }
  */
 module.exports = _curry1(function invertObj(obj) {
-  var props = keys(obj);
+  var props = _sortedKeys(obj);
   var len = props.length;
   var idx = 0;
   var out = {};

--- a/src/keys.js
+++ b/src/keys.js
@@ -1,5 +1,4 @@
-var _curry1 = require('./internal/_curry1');
-var _has = require('./internal/_has');
+var _sortedKeys = require('./internal/_sortedKeys');
 
 
 /**
@@ -19,47 +18,4 @@ var _has = require('./internal/_has');
  *
  *      R.keys({a: 1, b: 2, c: 3}); //=> ['a', 'b', 'c']
  */
-module.exports = (function() {
-  // cover IE < 9 keys issues
-  var hasEnumBug = !({toString: null}).propertyIsEnumerable('toString');
-  var nonEnumerableProps = ['constructor', 'valueOf', 'isPrototypeOf', 'toString',
-                            'propertyIsEnumerable', 'hasOwnProperty', 'toLocaleString'];
-
-  var contains = function contains(list, item) {
-    var idx = 0;
-    while (idx < list.length) {
-      if (list[idx] === item) {
-        return true;
-      }
-      idx += 1;
-    }
-    return false;
-  };
-
-  return typeof Object.keys === 'function' ?
-    _curry1(function keys(obj) {
-      return Object(obj) !== obj ? [] : Object.keys(obj);
-    }) :
-    _curry1(function keys(obj) {
-      if (Object(obj) !== obj) {
-        return [];
-      }
-      var prop, ks = [], nIdx;
-      for (prop in obj) {
-        if (_has(prop, obj)) {
-          ks[ks.length] = prop;
-        }
-      }
-      if (hasEnumBug) {
-        nIdx = nonEnumerableProps.length - 1;
-        while (nIdx >= 0) {
-          prop = nonEnumerableProps[nIdx];
-          if (_has(prop, obj) && !contains(ks, prop)) {
-            ks[ks.length] = prop;
-          }
-          nIdx -= 1;
-        }
-      }
-      return ks;
-    });
-}());
+module.exports = _sortedKeys;

--- a/src/map.js
+++ b/src/map.js
@@ -1,10 +1,10 @@
 var _curry2 = require('./internal/_curry2');
 var _dispatchable = require('./internal/_dispatchable');
+var _keys = require('./internal/_keys');
 var _map = require('./internal/_map');
 var _reduce = require('./internal/_reduce');
 var _xmap = require('./internal/_xmap');
 var curryN = require('./curryN');
-var keys = require('./keys');
 
 
 /**
@@ -48,7 +48,7 @@ module.exports = _curry2(_dispatchable('map', _xmap, function map(fn, functor) {
       return _reduce(function(acc, key) {
         acc[key] = fn(functor[key]);
         return acc;
-      }, {}, keys(functor));
+      }, {}, _keys(functor));
     default:
       return _map(fn, functor);
   }

--- a/src/mapObj.js
+++ b/src/mapObj.js
@@ -1,6 +1,6 @@
 var _curry2 = require('./internal/_curry2');
+var _keys = require('./internal/_keys');
 var _reduce = require('./internal/_reduce');
-var keys = require('./keys');
 
 
 /**
@@ -30,5 +30,5 @@ module.exports = _curry2(function mapObj(fn, obj) {
   return _reduce(function(acc, key) {
     acc[key] = fn(obj[key]);
     return acc;
-  }, {}, keys(obj));
+  }, {}, _keys(obj));
 });

--- a/src/mapObjIndexed.js
+++ b/src/mapObjIndexed.js
@@ -1,6 +1,6 @@
 var _curry2 = require('./internal/_curry2');
+var _keys = require('./internal/_keys');
 var _reduce = require('./internal/_reduce');
-var keys = require('./keys');
 
 
 /**
@@ -28,5 +28,5 @@ module.exports = _curry2(function mapObjIndexed(fn, obj) {
   return _reduce(function(acc, key) {
     acc[key] = fn(obj[key], key, obj);
     return acc;
-  }, {}, keys(obj));
+  }, {}, _keys(obj));
 });

--- a/src/merge.js
+++ b/src/merge.js
@@ -1,5 +1,5 @@
 var _curry2 = require('./internal/_curry2');
-var keys = require('./keys');
+var _keys = require('./internal/_keys');
 
 
 /**
@@ -24,13 +24,13 @@ var keys = require('./keys');
  */
 module.exports = _curry2(function merge(a, b) {
   var result = {};
-  var ks = keys(a);
+  var ks = _keys(a);
   var idx = 0;
   while (idx < ks.length) {
     result[ks[idx]] = a[ks[idx]];
     idx += 1;
   }
-  ks = keys(b);
+  ks = _keys(b);
   idx = 0;
   while (idx < ks.length) {
     result[ks[idx]] = b[ks[idx]];

--- a/src/toPairs.js
+++ b/src/toPairs.js
@@ -1,5 +1,7 @@
 var _curry1 = require('./internal/_curry1');
 var _has = require('./internal/_has');
+var head = require('./head');
+var sortBy = require('./sortBy');
 
 
 /**
@@ -27,5 +29,5 @@ module.exports = _curry1(function toPairs(obj) {
       pairs[pairs.length] = [prop, obj[prop]];
     }
   }
-  return pairs;
+  return sortBy(head, pairs);
 });

--- a/src/toPairsIn.js
+++ b/src/toPairsIn.js
@@ -1,4 +1,6 @@
 var _curry1 = require('./internal/_curry1');
+var head = require('./head');
+var sortBy = require('./sortBy');
 
 
 /**
@@ -27,5 +29,5 @@ module.exports = _curry1(function toPairsIn(obj) {
   for (var prop in obj) {
     pairs[pairs.length] = [prop, obj[prop]];
   }
-  return pairs;
+  return sortBy(head, pairs);
 });

--- a/src/values.js
+++ b/src/values.js
@@ -1,5 +1,5 @@
 var _curry1 = require('./internal/_curry1');
-var keys = require('./keys');
+var _sortedKeys = require('./internal/_sortedKeys');
 
 
 /**
@@ -19,7 +19,7 @@ var keys = require('./keys');
  *      R.values({a: 1, b: 2, c: 3}); //=> [1, 2, 3]
  */
 module.exports = _curry1(function values(obj) {
-  var props = keys(obj);
+  var props = _sortedKeys(obj);
   var len = props.length;
   var vals = [];
   var idx = 0;

--- a/test/functions.js
+++ b/test/functions.js
@@ -18,13 +18,19 @@ describe('functions', function() {
   var f = new F();
 
   it('returns list of functions without prototype functions', function() {
-    eq(R.functions(f).sort(), ['map', 'sort']);
+    eq(R.functions(f), ['map', 'sort']);
     eq(R.functions(f).length, 2);
-    eq(R.functions({add: R.add, reduce: R.reduce}).sort(), ['add', 'reduce']);
+    eq(R.functions({add: R.add, reduce: R.reduce}), ['add', 'reduce']);
   });
 
   it('returns an empty array if there are no functions on the object or its prototype chain', function() {
     function G() {}
     eq(R.functions(new G()), []);
+  });
+
+  it('returns the function names sorted by their natural order', function() {
+    var f = function() {};
+    var obj = {first: f, second: f, third: f, fourth: f, fifth: f};
+    eq(R.functions(obj), ['fifth', 'first', 'fourth', 'second', 'third']);
   });
 });

--- a/test/functionsIn.js
+++ b/test/functionsIn.js
@@ -18,8 +18,18 @@ describe('functionsIn', function() {
   var f = new F();
 
   it('returns list of functions with prototype functions', function() {
-    eq(R.functionsIn(f).sort(), ['map', 'sort', 'x', 'y']);
+    eq(R.functionsIn(f), ['map', 'sort', 'x', 'y']);
     eq(R.functionsIn(f).length, 4);
+  });
+
+  it('sorts all the function names', function() {
+    var X = function() {
+      this.s = function() {};
+      this.o = function() {};
+    };
+    X.prototype.r = function() {};
+    X.prototype.t = function() {};
+    eq(R.functionsIn(new X()), ['o', 'r', 's', 't']);
   });
 
   it('returns an empty array if there are no functions on the object or its prototype chain', function() {

--- a/test/invert.js
+++ b/test/invert.js
@@ -27,6 +27,10 @@ describe('invert', function() {
     eq(R.invert({x:'a', y:'b', z:'c'}), {a:['x'], b:['y'], c:['z']});
   });
 
+  it('sorts the resulting array values according the natural sort', function() {
+    eq(R.invert({p: 'a', j: 'b', s: 'b', f: 'a'}),  {a: ['f', 'p'], b: ['j', 's']});
+  });
+
   it('puts keys that have the same value into the appropriate an array', function() {
     eq(R.invert(['a', 'b', 'a']), {a:['0', '2'], b:['1']});
 

--- a/test/invertObj.js
+++ b/test/invertObj.js
@@ -23,9 +23,9 @@ describe('invertObj', function() {
     eq(R.invertObj({x:'a', y:'b', z:'c'}), {a:'x', b:'y', c:'z'});
   });
 
-  it('prefers the last key found when handling keys with the same value', function() {
+  it('prefers the last key in natural sort order when handling keys with the same value', function() {
     eq(R.invertObj(['a', 'b', 'a']), {a:'2', b:'1'});
-    eq(R.invertObj({x:'a', y:'b', z:'a', _id:'a'}), {a: '_id', b: 'y'});
+    eq(R.invertObj({x:'a', y:'b', z:'a', _id:'a'}), {a: 'z', b: 'y'});
   });
 
   // this one is more of a sanity check

--- a/test/keys.js
+++ b/test/keys.js
@@ -10,7 +10,16 @@ describe('keys', function() {
   var cobj = new C();
 
   it("returns an array of the given object's own keys", function() {
-    eq(R.keys(obj).sort(), ['a', 'b', 'c', 'd', 'e', 'f']);
+    eq(R.keys(obj), ['a', 'b', 'c', 'd', 'e', 'f']);
+  });
+
+
+  it('lists the keys in their natural sort order', function() {
+    eq(R.keys({a: 1, d: 2, c: 3, e: 4, b: 5}), ['a', 'b', 'c', 'd', 'e']);
+  });
+
+  it('places numeric indices first, but in lexicographic order', function() {
+    eq(R.keys({a: 1, 20: 2, c: 3, 9: 4, b: 5}), ['20', '9', 'a', 'b', 'c']);
   });
 
   it('works with hasOwnProperty override', function() {
@@ -30,6 +39,6 @@ describe('keys', function() {
   });
 
   it("does not include the given object's prototype properties", function() {
-    eq(R.keys(cobj).sort(), ['a', 'b']);
+    eq(R.keys(cobj), ['a', 'b']);
   });
 });

--- a/test/keysIn.js
+++ b/test/keysIn.js
@@ -10,11 +10,18 @@ describe('keysIn', function() {
   var cobj = new C();
 
   it("returns an array of the given object's keys", function() {
-    eq(R.keysIn(obj).sort(), ['a', 'b', 'c', 'd', 'e', 'f']);
+    eq(R.keysIn(obj), ['a', 'b', 'c', 'd', 'e', 'f']);
   });
 
   it("includes the given object's prototype properties", function() {
-    eq(R.keysIn(cobj).sort(), ['a', 'b', 'x', 'y']);
+    eq(R.keysIn(cobj), ['a', 'b', 'x', 'y']);
+  });
+
+  it('sorts all the property names', function() {
+    function X() { this.x = 100; this.a = 200; }
+    X.prototype.y = function() { return 'y'; };
+    X.prototype.b = 'b';
+    eq(R.keysIn(new X()), ['a', 'b', 'x', 'y']);
   });
 
   it('works for primitives', function() {

--- a/test/toPairs.js
+++ b/test/toPairs.js
@@ -6,6 +6,12 @@ describe('toPairs', function() {
   it('converts an object into an array of two-element [key, value] arrays', function() {
     eq(R.toPairs({a: 1, b: 2, c: 3}), [['a', 1], ['b', 2], ['c', 3]]);
   });
+
+  it('sorts the results according to natural key-order', function() {
+    eq(R.toPairs({c: 3, a: 1, b: 2}), [['a', 1], ['b', 2], ['c', 3]]);
+  });
+
+
   it("only iterates the object's own properties", function() {
     var F = function() {
       this.x = 1;

--- a/test/toPairsIn.js
+++ b/test/toPairsIn.js
@@ -6,6 +6,7 @@ describe('toPairsIn', function() {
   it('converts an object into an array of two-element [key, value] arrays', function() {
     eq(R.toPairsIn({a: 1, b: 2, c: 3}), [['a', 1], ['b', 2], ['c', 3]]);
   });
+
   it("iterates properties on the object's prototype chain", function() {
     function sortPairs(a, b) {
       return a[0] > b[0] ? 1 : a[0] < b[0] ? -1 : 0;
@@ -18,4 +19,16 @@ describe('toPairsIn', function() {
     var f = new F();
     eq(R.toPairsIn(f).sort(sortPairs), [['protoProp', 'you can see me'], ['x', 1], ['y', 2]]);
   });
+
+  it('sorts the results according to natural key-order', function() {
+    var F = function() {
+      this.x = 1;
+      this.y = 2;
+    };
+    F.prototype.a = 'b';
+    F.prototype.z = 'w';
+    var f = new F();
+    eq(R.toPairsIn(f), [['a', 'b'], ['x', 1], ['y', 2], ['z', 'w']]);
+  });
+
 });

--- a/test/values.js
+++ b/test/values.js
@@ -9,6 +9,14 @@ describe('values', function() {
   C.prototype.y = 'y';
   var cobj = new C();
 
+  it('lists the values of an object in the natural sort order of the related keys', function() {
+    eq(R.values({a: 1, d: 2, c: 3, e: 4, b: 5}), [1, 5, 3, 2, 4]); // keys: [a, b, c, d, e]
+  });
+
+  it('places numeric indices first, but in lexicographic order', function() {
+    eq(R.values({a: 1, 20: 2, c: 3, 9: 4, b: 5}), [2, 4, 1, 5, 3]); // keys: [20, 9, a, b, c]
+  });
+
   it("returns an array of the given object's values", function() {
     var vs = R.values(obj).sort();
     var ts = [[1, 2, 3], 100, 'D', {x: 200, y: 300}, null, undefined];


### PR DESCRIPTION
Sorting the output of `keys` and related calls.

This is certain to be controversial.  I'm not going to go over all the rationale for again; we've discussed it a few times, most recently in #1067, especially starting with my long comment, https://github.com/ramda/ramda/issues/1067#issuecomment-135923353.  This at least gives us something concrete to discuss.

There is a perhaps peculiar design decision here.  I'll understand if there are objections; I'm certainly not wedded to it.  Namely, `keys` is simply a reference to `internal/_sortedKeys`.  It adds nothing whatsoever.  The reason for this is that I want to have the `sortedKeys` name used very explicitly.  I want it to be quite clear when we are using that rather than the unsorted version.  But we still want the public API to be `keys`.  There was also one other concern that turned out not to be relevant, but which I always keep in the back of my head.  I really prefer not to have internal modules depend upon the public ones.  I want the dependencies to always run in one direction, the way one might think about layering an application.  It turned out not to be an issue here, as there was no internals that depended on `keys`.  (And of course this same decision applies to `keysIn` / `sortedKeysIn`.) 
