### PR TITLE
add R.sequence and R.traverse

### DIFF
--- a/src/commute.js
+++ b/src/commute.js
@@ -13,7 +13,8 @@ var identity = require('./identity');
  * @param {Function} of A function that returns the data type to return
  * @param {Array} list An array of functors of the same type
  * @return {*}
- * @see R.commuteMap
+ * @see R.sequence
+ * @deprecated since v0.19.0
  * @example
  *
  *      R.commute(R.of, [[1], [2, 3]]);   //=> [[1, 2], [1, 3]]

--- a/src/commuteMap.js
+++ b/src/commuteMap.js
@@ -18,7 +18,8 @@ var reduceRight = require('./reduceRight');
  * @param {Function} of A function that returns the data type to return
  * @param {Array} list An array of functors of the same type
  * @return {*}
- * @see R.commute
+ * @see R.traverse
+ * @deprecated since v0.19.0
  * @example
  *
  *      var add10 = R.map(R.add(10));

--- a/src/sequence.js
+++ b/src/sequence.js
@@ -1,0 +1,37 @@
+var _curry2 = require('./internal/_curry2');
+var ap = require('./ap');
+var map = require('./map');
+var prepend = require('./prepend');
+var reduceRight = require('./reduceRight');
+
+
+/**
+ * Transforms a [Traversable](https://github.com/fantasyland/fantasy-land#traversable)
+ * of [Applicative](https://github.com/fantasyland/fantasy-land#applicative) into an
+ * Applicative of Traversable.
+ *
+ * Dispatches to the `sequence` method of the second argument, if present.
+ *
+ * @func
+ * @memberOf R
+ * @category List
+ * @sig (Applicative f, Traversable t) => (a -> f a) -> t (f a) -> f (t a)
+ * @param {Function} of
+ * @param {*} traversable
+ * @return {*}
+ * @see R.traverse
+ * @example
+ *
+ *      R.sequence(Maybe.of, [Just(1), Just(2), Just(3)]);   //=> Just([1, 2, 3])
+ *      R.sequence(Maybe.of, [Just(1), Just(2), Nothing()]); //=> Nothing()
+ *
+ *      R.sequence(R.of, Just([1, 2, 3])); //=> [Just(1), Just(2), Just(3)]
+ *      R.sequence(R.of, Nothing());       //=> [Nothing()]
+ */
+module.exports = _curry2(function sequence(of, traversable) {
+  return typeof traversable.sequence === 'function' ?
+    traversable.sequence(of) :
+    reduceRight(function(acc, x) { return ap(map(prepend, x), acc); },
+                of([]),
+                traversable);
+});

--- a/src/traverse.js
+++ b/src/traverse.js
@@ -1,0 +1,33 @@
+var _curry3 = require('./internal/_curry3');
+var map = require('./map');
+var sequence = require('./sequence');
+
+
+/**
+ * Maps an [Applicative](https://github.com/fantasyland/fantasy-land#applicative)-returning
+ * function over a [Traversable](https://github.com/fantasyland/fantasy-land#traversable),
+ * then uses [`sequence`](#sequence) to transform the resulting Traversable of Applicative
+ * into an Applicative of Traversable.
+ *
+ * Dispatches to the `sequence` method of the third argument, if present.
+ *
+ * @func
+ * @memberOf R
+ * @category List
+ * @sig (Applicative f, Traversable t) => (a -> f a) -> (a -> f b) -> t a -> f (t b)
+ * @param {Function} of
+ * @param {Function} f
+ * @param {*} traversable
+ * @return {*}
+ * @see R.sequence
+ * @example
+ *
+ *      R.traverse(Maybe.of, R.negate, [Just(1), Just(2), Just(3)]);   //=> Just([-1, -2, -3])
+ *      R.traverse(Maybe.of, R.negate, [Just(1), Just(2), Nothing()]); //=> Nothing()
+ *
+ *      R.traverse(R.of, R.negate, Just([1, 2, 3])); //=> [Just(-1), Just(-2), Just(-3)]
+ *      R.traverse(R.of, R.negate, Nothing());       //=> [Nothing()]
+ */
+module.exports = _curry3(function traverse(of, f, traversable) {
+  return sequence(of, map(f, traversable));
+});

--- a/test/sequence.js
+++ b/test/sequence.js
@@ -1,0 +1,36 @@
+var S = require('sanctuary');
+
+var R = require('..');
+var Id = require('./shared/Id');
+var eq = require('./shared/eq');
+
+
+describe('sequence', function() {
+
+  it('operates on a list of lists', function() {
+    eq(R.sequence(R.of, []), [[]]);
+    eq(R.sequence(R.of, [[], [1, 2, 3, 4]]), []);
+    eq(R.sequence(R.of, [[1], [2, 3, 4]]), [[1, 2], [1, 3], [1, 4]]);
+    eq(R.sequence(R.of, [[1, 2], [3, 4]]), [[1, 3], [1, 4], [2, 3], [2, 4]]);
+    eq(R.sequence(R.of, [[1, 2, 3], [4]]), [[1, 4], [2, 4], [3, 4]]);
+    eq(R.sequence(R.of, [[1, 2, 3, 4], []]), []);
+  });
+
+  it('operates on a list of applicatives', function() {
+    eq(R.sequence(S.Maybe.of, [S.Just(3), S.Just(4), S.Just(5)]), S.Just([3, 4, 5]));
+    eq(R.sequence(S.Maybe.of, [S.Just(3), S.Nothing(), S.Just(5)]), S.Nothing());
+  });
+
+  it('traverses left to right', function() {
+    eq(R.sequence(S.Either.of, [S.Right(1), S.Right(2)]), S.Right([1, 2]));
+    eq(R.sequence(S.Either.of, [S.Right(1), S.Left('XXX')]), S.Left('XXX'));
+    eq(R.sequence(S.Either.of, [S.Left('XXX'), S.Right(1)]), S.Left('XXX'));
+    eq(R.sequence(S.Either.of, [S.Left('XXX'), S.Left('YYY')]), S.Left('XXX'));
+  });
+
+  it('dispatches to `sequence` method', function() {
+    eq(R.sequence(Id, [Id(1), Id(2), Id(3)]), Id([1, 2, 3]));
+    eq(R.sequence(R.of, Id([1, 2, 3])), [Id(1), Id(2), Id(3)]);
+  });
+
+});

--- a/test/shared/Id.js
+++ b/test/shared/Id.js
@@ -1,0 +1,28 @@
+var R = require('../..');
+
+
+function Id(x) {
+  if (!(this instanceof Id)) {
+    return new Id(x);
+  }
+  this.value = x;
+}
+
+Id.prototype.ap = function(id) {
+  return Id(this.value(id.value));
+};
+
+Id.prototype.map = function(f) {
+  return Id(f(this.value));
+};
+
+Id.prototype.sequence = function(of) {
+  void of;
+  return this.value.map(Id);
+};
+
+Id.prototype.toString = function() {
+  return 'Id(' + R.toString(this.value) + ')';
+};
+
+module.exports = Id;

--- a/test/traverse.js
+++ b/test/traverse.js
@@ -1,0 +1,36 @@
+var S = require('sanctuary');
+
+var R = require('..');
+var Id = require('./shared/Id');
+var eq = require('./shared/eq');
+
+
+describe('traverse', function() {
+
+  it('operates on a list of lists', function() {
+    eq(R.traverse(R.of, R.map(R.add(10)), []), [[]]);
+    eq(R.traverse(R.of, R.map(R.add(10)), [[], [1, 2, 3, 4]]), []);
+    eq(R.traverse(R.of, R.map(R.add(10)), [[1], [2, 3, 4]]), [[11, 12], [11, 13], [11, 14]]);
+    eq(R.traverse(R.of, R.map(R.add(10)), [[1, 2], [3, 4]]), [[11, 13], [11, 14], [12, 13], [12, 14]]);
+    eq(R.traverse(R.of, R.map(R.add(10)), [[1, 2, 3], [4]]), [[11, 14], [12, 14], [13, 14]]);
+    eq(R.traverse(R.of, R.map(R.add(10)), [[1, 2, 3, 4], []]), []);
+  });
+
+  it('operates on a list of applicatives', function() {
+    eq(R.traverse(S.Maybe.of, R.map(R.add(10)), [S.Just(3), S.Just(4), S.Just(5)]), S.Just([13, 14, 15]));
+    eq(R.traverse(S.Maybe.of, R.map(R.add(10)), [S.Just(3), S.Nothing(), S.Just(5)]), S.Nothing());
+  });
+
+  it('traverses left to right', function() {
+    eq(R.traverse(S.Either.of, R.identity, [S.Right(1), S.Right(2)]), S.Right([1, 2]));
+    eq(R.traverse(S.Either.of, R.identity, [S.Right(1), S.Left('XXX')]), S.Left('XXX'));
+    eq(R.traverse(S.Either.of, R.identity, [S.Left('XXX'), S.Right(1)]), S.Left('XXX'));
+    eq(R.traverse(S.Either.of, R.identity, [S.Left('XXX'), S.Left('YYY')]), S.Left('XXX'));
+  });
+
+  it('dispatches to `sequence` method', function() {
+    eq(R.traverse(Id, R.map(R.negate), [Id(1), Id(2), Id(3)]), Id([-1, -2, -3]));
+    eq(R.traverse(R.of, R.map(R.negate), Id([1, 2, 3])), [Id(-1), Id(-2), Id(-3)]);
+  });
+
+});


### PR DESCRIPTION
This pull request deprecates `R.commute` and `R.commuteMap` in favour of `R.sequence` and `R.traverse` respectively.

Reasons to rename the functions:

  - My understanding is that `sequence` and `traverse` are the most common names for these functions. I read and reread [Understanding traverse and sequence][1] in order to come to terms with this concept, so I may be biased by the names used there. Is `commute` the name used anywhere but in Ramda?

  - Fantasy Land defines [Traversable][2], which requires that a Traversable provide a `sequence` method. It also shows that `traverse` can be derived from `map` and `sequence`.

  - Currently each Ramda functions which dispatches has the same name as the method to which it dispatches. Having `R.commute` dispatch to `sequence` would break this convention.

Changes:

  - `R.sequence` dispatches; `R.commute` does not.

  - `R.traverse` takes `(of, f, traversable)` rather than `(f, of, traversable)`. It's more likely one would apply several different `f` transformations to a single :twisted_rightwards_arrows: type inversion than apply the same transformation to several different type inversions. I also like having `of` off to the side as it conveys type information that would be unnecessary in the presence of type inference.

I'm particularly interested in hearing from @scott-christopher, who has a better grasp of this than I do. We have discussed these changes (though Scott is happy to keep the names) but I'm not sure that I've done everything correctly.

I'm about to :airplane: from Auckland to San Francisco, so I'll be offline for the next 12 hours or so.


[1]: http://fsharpforfunandprofit.com/posts/elevated-world-4/
[2]: https://github.com/fantasyland/fantasy-land#traversable
