### PR TITLE
Remove excess words in Map documentation

### DIFF
--- a/src/map.js
+++ b/src/map.js
@@ -20,7 +20,7 @@ var keys = require('./keys');
  *
  * Acts as a transducer if a transformer is given in list position.
  *
- * Map treats also treats functions as functors and will compose them together.
+ * Also treats functions as functors and will compose them together.
  *
  * @func
  * @memberOf R


### PR DESCRIPTION
'Map' word was removed to keep it in the same style as in `ap` docs