### PR TITLE
Add juxt function

### DIFF
--- a/src/juxt.js
+++ b/src/juxt.js
@@ -1,0 +1,25 @@
+var __ = require('./__');
+var _curry1 = require('./internal/_curry1');
+var apply = require('./apply');
+var map = require('./map');
+
+
+/**
+ * juxt applies a list of functions to a list of values.
+ *
+ * @func
+ * @memberOf R
+ * @category Function
+ * @sig [(a, b, ..., m) -> n] -> ((a, b, ..., m) -> [n])
+ * @param {Array} fns An array of functions
+ * @return {Function} A function that returns a list of values after applying each of the original `fns` to its parameters.
+ * @example
+ *
+ *      var range = R.juxt([Math.min, Math.max]);
+ *      range(3, 4, 9, -3); //=> [-3, 9]
+ */
+module.exports = _curry1(function juxt(fns) {
+  return function() {
+    return map(apply(__, arguments), fns);
+  };
+});

--- a/test/juxt.js
+++ b/test/juxt.js
@@ -1,0 +1,41 @@
+var R = require('..');
+var eq = require('./shared/eq');
+
+
+describe('juxt', function() {
+  function hello() { return 'hello'; }
+  function bye() { return 'bye'; }
+
+  it('works with no functions and no values', function() {
+    eq(R.juxt([])(), []);
+  });
+
+  it('works with no functions and some values', function() {
+    eq(R.juxt([])(2, 3), []);
+  });
+
+  it('works with 1 function and no values', function() {
+    eq(R.juxt([hello])(), ['hello']);
+  });
+
+  it('works with 1 function and 1 value', function() {
+    eq(R.juxt([R.add(3)])(2), [5]);
+  });
+
+  it('works with 1 function and some values', function() {
+    eq(R.juxt([R.multiply])(2, 3), [6]);
+  });
+
+  it('works with some functions and no values', function() {
+    eq(R.juxt([hello, bye])(), ['hello', 'bye']);
+  });
+
+  it('works with some functions and 1 value', function() {
+    eq(R.juxt([R.multiply(2), R.add(3)])(2), [4, 5]);
+  });
+
+  it('works with some functions and some values', function() {
+    eq(R.juxt([R.add, R.multiply])(2, 3), [5, 6]);
+  });
+
+});


### PR DESCRIPTION
Adding a `juxt` function as discussed in issue #986. This supports passing variadic functions in by passing in the right number of arguments in an array as the second parameter:

```
juxt([noArityFunc], [6])
juxt([arity1Func], [6])
juxt([arity2Func], [6, 7])
juxt([arity3Func], [6, 7, 8])
```