### PR TITLE
Add R.lensPath

### DIFF
--- a/src/lensPath.js
+++ b/src/lensPath.js
@@ -1,0 +1,28 @@
+var _curry1 = require('./internal/_curry1');
+var assocPath = require('./assocPath');
+var lens = require('./lens');
+var path = require('./path');
+
+
+/**
+ * Returns a lens whose focus is the specified path.
+ *
+ * @func
+ * @memberOf R
+ * @category Object
+ * @typedefn Lens s a = Functor f => (a -> f a) -> s -> f s
+ * @sig [String] -> Lens s a
+ * @param {Array} path The path to use.
+ * @return {Lens}
+ * @see R.view, R.set, R.over
+ * @example
+ *
+ *      var xyLens = R.lensPath(['x', 'y']);
+ *
+ *      R.view(xyLens, {x: {y: 2, z: 3}});            //=> 2
+ *      R.set(xyLens, 4, {x: {y: 2, z: 3}});          //=> {x: {y: 4, z: 3}}
+ *      R.over(xyLens, R.negate, {x: {y: 2, z: 3}});  //=> {x: {y: -2, z: 3}}
+ */
+module.exports = _curry1(function lensPath(p) {
+  return lens(path(p), assocPath(p));
+});

--- a/test/lenses.js
+++ b/test/lenses.js
@@ -7,26 +7,34 @@ var they = it;
 
 var alice = {
   name: 'Alice Jones',
-  address: ['22 Walnut St', 'San Francisco', 'CA']
+  address: ['22 Walnut St', 'San Francisco', 'CA'],
+  pets: {dog: 'joker', cat: 'batman'}
 };
 
 var nameLens = R.lens(R.prop('name'), R.assoc('name'));
 var addressLens = R.lensProp('address');
 var headLens = R.lensIndex(0);
+var dogLens = R.lensPath(['pets', 'dog']);
 
 
 describe('view, over, and set', function() {
+
+  they('may be applied to a lens created by `lensPath`', function() {
+    eq(R.view(dogLens, alice), 'joker');
+  });
 
   they('may be applied to a lens created by `lensProp`', function() {
     eq(R.view(nameLens, alice), 'Alice Jones');
 
     eq(R.over(nameLens, R.toUpper, alice),
        {name: 'ALICE JONES',
-        address: ['22 Walnut St', 'San Francisco', 'CA']});
+        address: ['22 Walnut St', 'San Francisco', 'CA'],
+        pets: {dog: 'joker', cat: 'batman'}});
 
     eq(R.set(nameLens, 'Alice Smith', alice),
        {name: 'Alice Smith',
-        address: ['22 Walnut St', 'San Francisco', 'CA']});
+        address: ['22 Walnut St', 'San Francisco', 'CA'],
+        pets: {dog: 'joker', cat: 'batman'}});
   });
 
   they('may be applied to a lens created by `lensIndex`', function() {
@@ -41,16 +49,22 @@ describe('view, over, and set', function() {
 
   they('may be applied to composed lenses', function() {
     var streetLens = R.compose(addressLens, headLens);
+    var dogLens = R.compose(R.lensPath(['pets']), R.lensPath(['dog']));
+
+    eq(R.view(dogLens, alice), R.view(R.lensPath(['pets', 'dog']), alice));
 
     eq(R.view(streetLens, alice), '22 Walnut St');
 
     eq(R.over(streetLens, R.toUpper, alice),
        {name: 'Alice Jones',
-        address: ['22 WALNUT ST', 'San Francisco', 'CA']});
+        address: ['22 WALNUT ST', 'San Francisco', 'CA'],
+        pets: {dog: 'joker', cat: 'batman'}});
 
     eq(R.set(streetLens, '52 Crane Ave', alice),
        {name: 'Alice Jones',
-        address: ['52 Crane Ave', 'San Francisco', 'CA']});
+        address: ['52 Crane Ave', 'San Francisco', 'CA'],
+        pets: {dog: 'joker', cat: 'batman'}});
   });
 
 });
+


### PR DESCRIPTION
This adds a lens focusing on an object property specified by a path. This addition would make the `prop` and `path` set of functions fully "analogous":
 
* `R.prop` - `R.path` 
* `R.propSatisfies` - `R.pathSatisfies` 
* `R.lensProp` - `R.lensPath`.