### PR TITLE
Split lens tests

### DIFF
--- a/test/lensIndex.js
+++ b/test/lensIndex.js
@@ -1,6 +1,7 @@
 var R = require('..');
 var eq = require('./shared/eq');
 
+
 var testList = [{a: 1}, {b: 2}, {c: 3}];
 
 describe('lensIndex', function() {

--- a/test/lensIndex.js
+++ b/test/lensIndex.js
@@ -22,4 +22,12 @@ describe('lensIndex', function() {
       eq(R.over(R.lensIndex(2), R.keys, testList), [{a: 1}, {b: 2}, ['c']]);
     });
   });
+  describe('composability', function() {
+    it('can be composed', function() {
+      var nestedList = [0, [10, 11, 12], 1, 2];
+      var composedLens = R.compose(R.lensIndex(1), R.lensIndex(0));
+
+      eq(R.view(composedLens, nestedList), 10);
+    });
+  });
 });

--- a/test/lensIndex.js
+++ b/test/lensIndex.js
@@ -1,0 +1,25 @@
+var R = require('..');
+var eq = require('./shared/eq');
+
+var testList = [{a: 1}, {b: 2}, {c: 3}];
+
+describe('lensIndex', function() {
+  describe('view', function() {
+    it('focuses list element at the specified index', function() {
+      eq(R.view(R.lensIndex(0), testList), {a: 1});
+    });
+    it('returns undefined if the specified index does not exist', function() {
+      eq(R.view(R.lensIndex(10), testList), undefined);
+    });
+  });
+  describe('set', function() {
+    it('sets the list value at the specified index', function() {
+      eq(R.set(R.lensIndex(0), 0, testList), [0, {b: 2}, {c: 3}]);
+    });
+  });
+  describe('over', function() {
+    it('applies function to the value at the specified list index', function() {
+      eq(R.over(R.lensIndex(2), R.keys, testList), [{a: 1}, {b: 2}, ['c']]);
+    });
+  });
+});

--- a/test/lensIndex.js
+++ b/test/lensIndex.js
@@ -30,4 +30,16 @@ describe('lensIndex', function() {
       eq(R.view(composedLens, nestedList), 10);
     });
   });
+  describe('well behaved lens', function() {
+    it('set s (get s) === s', function() {
+      eq(R.set(R.lensIndex(0), R.view(R.lensIndex(0), testList), testList), testList);
+    });
+    it('get (set s v) === v', function() {
+      eq(R.view(R.lensIndex(0), R.set(R.lensIndex(0), 0, testList)), 0);
+    });
+    it('get (set(set s v1) v2) === v2', function() {
+      eq(R.view(R.lensIndex(0), R.set(R.lensIndex(0), 11, R.set(R.lensIndex(0), 10, testList))),
+         11);
+    });
+  });
 });

--- a/test/lensPath.js
+++ b/test/lensPath.js
@@ -1,0 +1,60 @@
+var R = require('..');
+var eq = require('./shared/eq');
+
+
+var testObj = {
+  a: {
+    b: 2,
+  },
+  d: 3
+};
+
+describe('lensPath', function() {
+  describe('view', function() {
+    it('focuses the specified object property', function() {
+      eq(R.view(R.lensPath(['d']), testObj), 3);
+      eq(R.view(R.lensPath(['a', 'b']), testObj), 2);
+    });
+  });
+  describe('set', function() {
+    it('sets the value of the object property specified', function() {
+      eq(R.set(R.lensPath(['d']), 0, testObj), {a: {b: 2}, d: 0});
+      eq(R.set(R.lensPath(['a', 'b']), 0, testObj), {a: {b: 0}, d: 3});
+    });
+    it('adds the property to the object if it doesn\'t exist', function() {
+      eq(R.set(R.lensPath('d'), 0, testObj), {a: {b: 2}, d: 0});
+      eq(R.set(R.lensPath(['a', 'b']), 0, testObj), {a: {b: 0}, d: 3});
+    });
+  });
+  describe('over', function() {
+    it('applies function to the value of the specified object property', function() {
+      eq(R.over(R.lensPath('d'), R.inc, testObj), {a: {b: 2}, d: 4});
+      eq(R.over(R.lensPath(['a', 'b']), R.inc, testObj), {a: {b: 3}, d: 3});
+    });
+    it('applies function to undefined and adds the property if it doesn\'t exist', function() {
+      eq(R.over(R.lensPath(['X']), R.identity, testObj), {a: {b: 2}, d: 3, X: undefined});
+      eq(R.over(R.lensPath(['a', 'X']), R.identity, testObj), {a: {b: 2, X: undefined}, d: 3});
+    });
+  });
+  describe('composability', function() {
+    it('can be composed', function() {
+      var composedLens = R.compose(R.lensPath('a'), R.lensPath('b'));
+      eq(R.view(composedLens, testObj), 2);
+    });
+  });
+  describe('well behaved lens', function() {
+    it('set s (get s) === s', function() {
+      eq(R.set(R.lensPath('d'), R.view(R.lensPath('d'), testObj), testObj), testObj);
+      eq(R.set(R.lensPath(['a', 'b']), R.view(R.lensPath(['a', 'b']), testObj), testObj), testObj);
+    });
+    it('get (set s v) === v', function() {
+      eq(R.view(R.lensPath('d'), R.set(R.lensPath('d'), 0, testObj)), 0);
+      eq(R.view(R.lensPath(['a', 'b']), R.set(R.lensPath(['a', 'b']), 0, testObj)), 0);
+    });
+    it('get (set(set s v1) v2) === v2', function() {
+      var p = 'd', q = ['a', 'b'];
+      eq(R.view(R.lensPath(p), R.set(R.lensPath(p), 11, R.set(R.lensPath(p), 10, testObj))), 11);
+      eq(R.view(R.lensPath(q), R.set(R.lensPath(q), 11, R.set(R.lensPath(q), 10, testObj))), 11);
+    });
+  });
+});

--- a/test/lensPath.js
+++ b/test/lensPath.js
@@ -14,22 +14,25 @@ describe('lensPath', function() {
     it('focuses the specified object property', function() {
       eq(R.view(R.lensPath(['d']), testObj), 3);
       eq(R.view(R.lensPath(['a', 'b']), testObj), 2);
+      eq(R.view(R.lensPath([]), testObj), testObj);
     });
   });
   describe('set', function() {
     it('sets the value of the object property specified', function() {
       eq(R.set(R.lensPath(['d']), 0, testObj), {a: {b: 2}, d: 0});
       eq(R.set(R.lensPath(['a', 'b']), 0, testObj), {a: {b: 0}, d: 3});
+      eq(R.set(R.lensPath([]), 0, testObj), 0);
     });
     it('adds the property to the object if it doesn\'t exist', function() {
-      eq(R.set(R.lensPath('d'), 0, testObj), {a: {b: 2}, d: 0});
-      eq(R.set(R.lensPath(['a', 'b']), 0, testObj), {a: {b: 0}, d: 3});
+      eq(R.set(R.lensPath('X'), 0, testObj), {a: {b: 2}, d: 3, X: 0});
+      eq(R.set(R.lensPath(['a', 'X']), 0, testObj), {a: {b: 2, X: 0}, d: 3});
     });
   });
   describe('over', function() {
     it('applies function to the value of the specified object property', function() {
       eq(R.over(R.lensPath('d'), R.inc, testObj), {a: {b: 2}, d: 4});
       eq(R.over(R.lensPath(['a', 'b']), R.inc, testObj), {a: {b: 3}, d: 3});
+      eq(R.over(R.lensPath([]), R.toPairs, testObj), [['a', {b: 2}], ['d', 3]]);
     });
     it('applies function to undefined and adds the property if it doesn\'t exist', function() {
       eq(R.over(R.lensPath(['X']), R.identity, testObj), {a: {b: 2}, d: 3, X: undefined});

--- a/test/lensProp.js
+++ b/test/lensProp.js
@@ -1,6 +1,7 @@
 var R = require('..');
 var eq = require('./shared/eq');
 
+
 var testObj = {
   a: 1,
   b: 2,

--- a/test/lensProp.js
+++ b/test/lensProp.js
@@ -28,8 +28,8 @@ describe('lensProp', function() {
     it('applies function to the value of the specified object property', function() {
       eq(R.over(R.lensProp('a'), R.inc, testObj), {a:2, b:2, c:3});
     });
-    it('returns object unchanged if specified property does not exist', function() {
-      eq(R.over(R.lensProp('X'), R.always(0), testObj), {a:1, b:2, c:3, X:0});
+    it('applies function to undefined and adds the property if it doesn\'t exist', function() {
+      eq(R.over(R.lensProp('X'), R.identity, testObj), {a:1, b:2, c:3, X:undefined});
     });
   });
 });

--- a/test/lensProp.js
+++ b/test/lensProp.js
@@ -40,4 +40,16 @@ describe('lensProp', function() {
       eq(R.view(composedLens, nestedObj), 1);
     });
   });
+  describe('well behaved lens', function() {
+    it('set s (get s) === s', function() {
+      eq(R.set(R.lensProp('a'), R.view(R.lensProp('a'), testObj), testObj), testObj);
+    });
+    it('get (set s v) === v', function() {
+      eq(R.view(R.lensProp('a'), R.set(R.lensProp('a'), 0, testObj)), 0);
+    });
+    it('get (set(set s v1) v2) === v2', function() {
+      eq(R.view(R.lensProp('a'), R.set(R.lensProp('a'), 11, R.set(R.lensProp('a'), 10, testObj))),
+         11);
+    });
+  });
 });

--- a/test/lensProp.js
+++ b/test/lensProp.js
@@ -7,7 +7,7 @@ var testObj = {
   c: 3
 };
 
-describe.only('lensProp', function() {
+describe('lensProp', function() {
   describe('view', function() {
     it('focuses object the specified object property', function() {
       eq(R.view(R.lensProp('a'), testObj), 1);

--- a/test/lensProp.js
+++ b/test/lensProp.js
@@ -1,0 +1,35 @@
+var R = require('..');
+var eq = require('./shared/eq');
+
+var testObj = {
+  a: 1,
+  b: 2,
+  c: 3
+};
+
+describe.only('lensProp', function() {
+  describe('view', function() {
+    it('focuses object the specified object property', function() {
+      eq(R.view(R.lensProp('a'), testObj), 1);
+    });
+    it('returns undefined if the specified property does not exist', function() {
+      eq(R.view(R.lensProp('X'), testObj), undefined);
+    });
+  });
+  describe('set', function() {
+    it('sets the value of the object property specified', function() {
+      eq(R.set(R.lensProp('a'), 0, testObj), {a:0, b:2, c:3});
+    });
+    it('adds the property to the object if it doesn\'t exist', function() {
+      eq(R.set(R.lensProp('d'), 4, testObj), {a:1, b:2, c:3, d:4});
+    });
+  });
+  describe('over', function() {
+    it('applies function to the value of the specified object property', function() {
+      eq(R.over(R.lensProp('a'), R.inc, testObj), {a:2, b:2, c:3});
+    });
+    it('returns object unchanged if specified property does not exist', function() {
+      eq(R.over(R.lensProp('X'), R.always(0), testObj), {a:1, b:2, c:3, X:0});
+    });
+  });
+});

--- a/test/lensProp.js
+++ b/test/lensProp.js
@@ -32,4 +32,12 @@ describe('lensProp', function() {
       eq(R.over(R.lensProp('X'), R.identity, testObj), {a:1, b:2, c:3, X:undefined});
     });
   });
+  describe('composability', function() {
+    it('can be composed', function() {
+      var nestedObj = {a: {b: 1}, c:2};
+      var composedLens = R.compose(R.lensProp('a'), R.lensProp('b'));
+
+      eq(R.view(composedLens, nestedObj), 1);
+    });
+  });
 });


### PR DESCRIPTION
This fixes #1509 replacing the combined `lenses.js` test with separate tests for `lensProp` and `lensIndex` each testing the correct behavior for 
* `R.view`
* `R.set`
* `R.over`
* composability
* lens laws