### PR TITLE
Perfomance improvements to `uniq` and `contains`

### DIFF
--- a/lib/bench/uniq.bench.js
+++ b/lib/bench/uniq.bench.js
@@ -1,0 +1,64 @@
+var R = require('../..');
+
+var arr1 = R.times(function() {
+  var n = (Math.random() * 100) >>> 0;
+  if (n < 20) {
+    // integer
+    return n;
+  } else if (n < 40) {
+    // boolean
+    return n < 30;
+  } else if (n < 60) {
+    // string
+    return n.toString(10);
+  } else if (n < 80) {
+    // array
+    return [n % 3, n % 7, n];
+  } else {
+    // object
+    return {
+      a: 'foo',
+      n: n
+    };
+  }
+}, 1000);
+
+var arr2 = R.times(function() { return (Math.random() * 100) >>> 0; }, 1000);
+var arr3 = R.times(function() { return [true]; }, 1000);
+
+function id(x) {
+  return x;
+}
+
+module.exports = {
+  name: 'uniq',
+  tests: {
+    'uniqBy(id, arr1)': function() {
+      R.uniqBy(id, arr1);
+    },
+    'uniqWith(equals, arr1)': function() {
+      R.uniqWith(R.equals, arr1);
+    },
+    'uniq(arr1)': function() {
+      R.uniq(arr1);
+    },
+    'uniqBy(id, arr2)': function() {
+      R.uniqBy(id, arr2);
+    },
+    'uniqWith(equals, arr2)': function() {
+      R.uniqWith(R.equals, arr2);
+    },
+    'uniq(arr2)': function() {
+      R.uniq(arr2);
+    },
+    'uniqBy(id, arr3)': function() {
+      R.uniqBy(id, arr3);
+    },
+    'uniqWith(equals, arr3)': function() {
+      R.uniqWith(R.equals, arr3);
+    },
+    'uniq(arr3)': function() {
+      R.uniq(arr3);
+    }
+  }
+};

--- a/src/internal/_contains.js
+++ b/src/internal/_contains.js
@@ -1,6 +1,48 @@
 var _indexOf = require('./_indexOf');
 
 
-module.exports = function _contains(a, list) {
-  return _indexOf(list, a, 0) >= 0;
-};
+/* globals Set */
+module.exports = typeof Set === 'undefined' ?
+  function _contains(a, list) {
+    return _indexOf(list, a, 0) >= 0;
+  } :
+  function _containsSet(a, list) {
+    var idx, inf, item;
+    switch (typeof a) {
+      case 'number':
+        if (a === 0) {
+          // manually crawl the list to distinguish between +0 and -0
+          idx = 0;
+          inf = 1 / a;
+          while (idx < list.length) {
+            item = list[idx];
+            if (item === 0 && 1 / item === inf) {
+              return true;
+            }
+            idx += 1;
+          }
+          return false;
+        }
+        // non-zero numbers can utilise Set
+        return new Set(list).has(a);
+
+      // all these types can utilise Set
+      case 'string':
+      case 'boolean':
+      case 'function':
+      case 'undefined':
+        return new Set(list).has(a);
+
+      case 'object':
+        if (a === null) {
+          // null can utilise Set
+          return new Set(list).has(a);
+        }
+        // other objects need R.equals for equality
+        return _indexOf(list, a, 0) >= 0;
+
+      default:
+        // anything else not covered above, defer to R.equals
+        return _indexOf(list, a, 0) >= 0;
+    }
+  };

--- a/src/internal/_curry1.js
+++ b/src/internal/_curry1.js
@@ -1,3 +1,6 @@
+var _isPlaceholder = require('./_isPlaceholder');
+
+
 /**
  * Optimized internal one-arity curry function.
  *
@@ -8,9 +11,7 @@
  */
 module.exports = function _curry1(fn) {
   return function f1(a) {
-    if (arguments.length === 0) {
-      return f1;
-    } else if (a != null && a['@@functional/placeholder'] === true) {
+    if (arguments.length === 0 || _isPlaceholder(a)) {
       return f1;
     } else {
       return fn.apply(this, arguments);

--- a/src/internal/_curry2.js
+++ b/src/internal/_curry2.js
@@ -1,4 +1,5 @@
 var _curry1 = require('./_curry1');
+var _isPlaceholder = require('./_isPlaceholder');
 
 
 /**
@@ -11,22 +12,17 @@ var _curry1 = require('./_curry1');
  */
 module.exports = function _curry2(fn) {
   return function f2(a, b) {
-    var n = arguments.length;
-    if (n === 0) {
-      return f2;
-    } else if (n === 1 && a != null && a['@@functional/placeholder'] === true) {
-      return f2;
-    } else if (n === 1) {
-      return _curry1(function(b) { return fn(a, b); });
-    } else if (n === 2 && a != null && a['@@functional/placeholder'] === true &&
-                          b != null && b['@@functional/placeholder'] === true) {
-      return f2;
-    } else if (n === 2 && a != null && a['@@functional/placeholder'] === true) {
-      return _curry1(function(a) { return fn(a, b); });
-    } else if (n === 2 && b != null && b['@@functional/placeholder'] === true) {
-      return _curry1(function(b) { return fn(a, b); });
-    } else {
-      return fn(a, b);
+    switch (arguments.length) {
+      case 0:
+        return f2;
+      case 1:
+        return _isPlaceholder(a) ? f2
+             : _curry1(function(_b) { return fn(a, _b); });
+      default:
+        return _isPlaceholder(a) && _isPlaceholder(b) ? f2
+             : _isPlaceholder(a) ? _curry1(function(_a) { return fn(_a, b); })
+             : _isPlaceholder(b) ? _curry1(function(_b) { return fn(a, _b); })
+             : fn(a, b);
     }
   };
 };

--- a/src/internal/_curry3.js
+++ b/src/internal/_curry3.js
@@ -1,5 +1,6 @@
 var _curry1 = require('./_curry1');
 var _curry2 = require('./_curry2');
+var _isPlaceholder = require('./_isPlaceholder');
 
 
 /**
@@ -12,43 +13,26 @@ var _curry2 = require('./_curry2');
  */
 module.exports = function _curry3(fn) {
   return function f3(a, b, c) {
-    var n = arguments.length;
-    if (n === 0) {
-      return f3;
-    } else if (n === 1 && a != null && a['@@functional/placeholder'] === true) {
-      return f3;
-    } else if (n === 1) {
-      return _curry2(function(b, c) { return fn(a, b, c); });
-    } else if (n === 2 && a != null && a['@@functional/placeholder'] === true &&
-                          b != null && b['@@functional/placeholder'] === true) {
-      return f3;
-    } else if (n === 2 && a != null && a['@@functional/placeholder'] === true) {
-      return _curry2(function(a, c) { return fn(a, b, c); });
-    } else if (n === 2 && b != null && b['@@functional/placeholder'] === true) {
-      return _curry2(function(b, c) { return fn(a, b, c); });
-    } else if (n === 2) {
-      return _curry1(function(c) { return fn(a, b, c); });
-    } else if (n === 3 && a != null && a['@@functional/placeholder'] === true &&
-                          b != null && b['@@functional/placeholder'] === true &&
-                          c != null && c['@@functional/placeholder'] === true) {
-      return f3;
-    } else if (n === 3 && a != null && a['@@functional/placeholder'] === true &&
-                          b != null && b['@@functional/placeholder'] === true) {
-      return _curry2(function(a, b) { return fn(a, b, c); });
-    } else if (n === 3 && a != null && a['@@functional/placeholder'] === true &&
-                          c != null && c['@@functional/placeholder'] === true) {
-      return _curry2(function(a, c) { return fn(a, b, c); });
-    } else if (n === 3 && b != null && b['@@functional/placeholder'] === true &&
-                          c != null && c['@@functional/placeholder'] === true) {
-      return _curry2(function(b, c) { return fn(a, b, c); });
-    } else if (n === 3 && a != null && a['@@functional/placeholder'] === true) {
-      return _curry1(function(a) { return fn(a, b, c); });
-    } else if (n === 3 && b != null && b['@@functional/placeholder'] === true) {
-      return _curry1(function(b) { return fn(a, b, c); });
-    } else if (n === 3 && c != null && c['@@functional/placeholder'] === true) {
-      return _curry1(function(c) { return fn(a, b, c); });
-    } else {
-      return fn(a, b, c);
+    switch (arguments.length) {
+      case 0:
+        return f3;
+      case 1:
+        return _isPlaceholder(a) ? f3
+             : _curry2(function(_b, _c) { return fn(a, _b, _c); });
+      case 2:
+        return _isPlaceholder(a) && _isPlaceholder(b) ? f3
+             : _isPlaceholder(a) ? _curry2(function(_a, _c) { return fn(_a, b, _c); })
+             : _isPlaceholder(b) ? _curry2(function(_b, _c) { return fn(a, _b, _c); })
+             : _curry1(function(_c) { return fn(a, b, _c); });
+      default:
+        return _isPlaceholder(a) && _isPlaceholder(b) && _isPlaceholder(c) ? f3
+             : _isPlaceholder(a) && _isPlaceholder(b) ? _curry2(function(_a, _b) { return fn(_a, _b, c); })
+             : _isPlaceholder(a) && _isPlaceholder(c) ? _curry2(function(_a, _c) { return fn(_a, b, _c); })
+             : _isPlaceholder(b) && _isPlaceholder(c) ? _curry2(function(_b, _c) { return fn(a, _b, _c); })
+             : _isPlaceholder(a) ? _curry1(function(_a) { return fn(_a, b, c); })
+             : _isPlaceholder(b) ? _curry1(function(_b) { return fn(a, _b, c); })
+             : _isPlaceholder(c) ? _curry1(function(_c) { return fn(a, b, _c); })
+             : fn(a, b, c);
     }
   };
 };

--- a/src/internal/_curryN.js
+++ b/src/internal/_curryN.js
@@ -1,4 +1,5 @@
 var _arity = require('./_arity');
+var _isPlaceholder = require('./_isPlaceholder');
 
 
 /**
@@ -7,7 +8,7 @@ var _arity = require('./_arity');
  * @private
  * @category Function
  * @param {Number} length The arity of the curried function.
- * @param {Array} An array of arguments received thus far.
+ * @param {Array} received An array of arguments received thus far.
  * @param {Function} fn The function to curry.
  * @return {Function} The curried function.
  */
@@ -20,8 +21,7 @@ module.exports = function _curryN(length, received, fn) {
     while (combinedIdx < received.length || argsIdx < arguments.length) {
       var result;
       if (combinedIdx < received.length &&
-          (received[combinedIdx] == null ||
-           received[combinedIdx]['@@functional/placeholder'] !== true ||
+          (!_isPlaceholder(received[combinedIdx]) ||
            argsIdx >= arguments.length)) {
         result = received[combinedIdx];
       } else {
@@ -29,11 +29,12 @@ module.exports = function _curryN(length, received, fn) {
         argsIdx += 1;
       }
       combined[combinedIdx] = result;
-      if (result == null || result['@@functional/placeholder'] !== true) {
+      if (!_isPlaceholder(result)) {
         left -= 1;
       }
       combinedIdx += 1;
     }
-    return left <= 0 ? fn.apply(this, combined) : _arity(left, _curryN(length, combined, fn));
+    return left <= 0 ? fn.apply(this, combined)
+                     : _arity(left, _curryN(length, combined, fn));
   };
 };

--- a/src/internal/_isPlaceholder.js
+++ b/src/internal/_isPlaceholder.js
@@ -1,0 +1,5 @@
+module.exports = function _isPlaceholder(a) {
+  return a != null &&
+         typeof a === 'object' &&
+         a['@@functional/placeholder'] === true;
+};

--- a/src/uniq.js
+++ b/src/uniq.js
@@ -1,5 +1,5 @@
-var equals = require('./equals');
-var uniqWith = require('./uniqWith');
+var identity = require('./identity');
+var uniqBy = require('./uniqBy');
 
 
 /**
@@ -19,4 +19,4 @@ var uniqWith = require('./uniqWith');
  *      R.uniq([1, '1']);     //=> [1, '1']
  *      R.uniq([[42], [42]]); //=> [[42]]
  */
-module.exports = uniqWith(equals);
+module.exports = uniqBy(identity);

--- a/src/uniqBy.js
+++ b/src/uniqBy.js
@@ -20,16 +20,72 @@ var _curry2 = require('./internal/_curry2');
  *
  *      R.uniqBy(Math.abs, [-1, -5, 2, 10, 1, 2]); //=> [-1, -5, 2, 10]
  */
-module.exports = _curry2(function uniqBy(fn, list) {
-  var idx = 0, applied = [], result = [], appliedItem, item;
-  while (idx < list.length) {
-    item = list[idx];
-    appliedItem = fn(item);
-    if (!_contains(appliedItem, applied)) {
-      result.push(item);
-      applied.push(appliedItem);
+module.exports = _curry2(/* globals Set */ typeof Set === 'undefined' ?
+  function uniqBy(fn, list) {
+    var idx = 0, applied = [], result = [], appliedItem, item;
+    while (idx < list.length) {
+      item = list[idx];
+      appliedItem = fn(item);
+      if (!_contains(appliedItem, applied)) {
+        result.push(item);
+        applied.push(appliedItem);
+      }
+      idx += 1;
     }
-    idx += 1;
+    return result;
+  } :
+  function uniqBySet(fn, list) {
+    var set           = new Set(),
+        applied       = [], appliedItem, item,
+        prevSetSize   = 0,  newSetSize,
+        result        = [],
+        nullExists    = false,
+        negZeroExists = false,
+        idx           = 0;
+
+    while (idx < list.length) {
+      item = list[idx];
+      appliedItem = fn(item);
+      switch (typeof appliedItem) {
+        case 'number':
+          // distinguishing between +0 and -0 is not supported by Set
+          if (appliedItem === 0 && !negZeroExists && 1 / appliedItem === -Infinity) {
+            negZeroExists = true;
+            result.push(item);
+            break;
+          }
+        /* falls through */
+        case 'string':
+        case 'boolean':
+        case 'function':
+        case 'undefined':
+          // these types can all utilise Set
+          set.add(appliedItem);
+          newSetSize = set.size;
+          if (newSetSize > prevSetSize) {
+            result.push(item);
+            prevSetSize = newSetSize;
+          }
+          break;
+        case 'object':
+          if (appliedItem === null) {
+            if (!nullExists) {
+              // prevent scan for null by tracking as a boolean
+              nullExists = true;
+              result.push(null);
+            }
+            break;
+          }
+        /* falls through */
+        default:
+          // scan through all previously applied items
+          if (!_contains(appliedItem, applied)) {
+            applied.push(appliedItem);
+            result.push(item);
+          }
+      }
+      idx += 1;
+    }
+    return result;
   }
-  return result;
-});
+);


### PR DESCRIPTION
Addresses #1449, #1500, #1503 & #1508 regarding performance concerns with `uniq` and `contains`.

The main changes include:
* Refactoring the various internal currying functions to ensure the args are `Object`s before checking for the placeholder property, preventing unnecessary boxing/unboxing of primitives.
* Some tweaks to the conditional layout of the internal currying functions to reduce redundant conditional tests.
* `_contains` and `uniqBy` now make use of a native `Set` where possible – given the history of this, I'd appreciate people paying close attention here to ensure the existing semantics of `equals` are upheld.

I have also included a simple benchmark script for `uniq`, which produced the following results:

Current HEAD of master:
```
┌────────────────────────┬────────────────────────┬────────────────────────┐
│ uniq                   │ Hertz                  │ Margin of Error        │
├────────────────────────┼────────────────────────┼────────────────────────┤
│ uniqBy(id, arr1)       │ 21.52                  │ 0.60%                  │
├────────────────────────┼────────────────────────┼────────────────────────┤
│ uniqWith(equals, arr1) │ 21.81                  │ 0.68%                  │
├────────────────────────┼────────────────────────┼────────────────────────┤
│ uniq(arr1)             │ 21.66                  │ 0.81%                  │
├────────────────────────┼────────────────────────┼────────────────────────┤
│ uniqBy(id, arr2)       │ 8.73                   │ 0.72%                  │
├────────────────────────┼────────────────────────┼────────────────────────┤
│ uniqWith(equals, arr2) │ 8.72                   │ 0.58%                  │
├────────────────────────┼────────────────────────┼────────────────────────┤
│ uniq(arr2)             │ 8.67                   │ 0.83%                  │
├────────────────────────┼────────────────────────┼────────────────────────┤
│ uniqBy(id, arr3)       │ 692                    │ 0.55%                  │
├────────────────────────┼────────────────────────┼────────────────────────┤
│ uniqWith(equals, arr3) │ 695                    │ 0.60%                  │
├────────────────────────┼────────────────────────┼────────────────────────┤
│ uniq(arr3)             │ 686                    │ 0.72%                  │
└────────────────────────┴────────────────────────┴────────────────────────┘
```
This branch:
```
┌────────────────────────┬────────────────────────┬────────────────────────┐
│ uniq                   │ Hertz                  │ Margin of Error        │
├────────────────────────┼────────────────────────┼────────────────────────┤
│ uniqBy(id, arr1)       │ 94.13                  │ 0.57%                  │
├────────────────────────┼────────────────────────┼────────────────────────┤
│ uniqWith(equals, arr1) │ 40.21                  │ 0.55%                  │
├────────────────────────┼────────────────────────┼────────────────────────┤
│ uniq(arr1)             │ 87.88                  │ 0.62%                  │
├────────────────────────┼────────────────────────┼────────────────────────┤
│ uniqBy(id, arr2)       │ 21,299                 │ 0.45%                  │
├────────────────────────┼────────────────────────┼────────────────────────┤
│ uniqWith(equals, arr2) │ 25.60                  │ 0.46%                  │
├────────────────────────┼────────────────────────┼────────────────────────┤
│ uniq(arr2)             │ 18,967                 │ 0.65%                  │
├────────────────────────┼────────────────────────┼────────────────────────┤
│ uniqBy(id, arr3)       │ 787                    │ 0.51%                  │
├────────────────────────┼────────────────────────┼────────────────────────┤
│ uniqWith(equals, arr3) │ 808                    │ 0.53%                  │
├────────────────────────┼────────────────────────┼────────────────────────┤
│ uniq(arr3)             │ 783                    │ 0.61%                  │
└────────────────────────┴────────────────────────┴────────────────────────┘
```