### PR TITLE
Add JSDoc named parameter to functions using argumens object

### DIFF
--- a/src/compose.js
+++ b/src/compose.js
@@ -20,7 +20,7 @@ var reverse = require('./reverse');
  *
  *      f(3, 4); // -(3^4) + 1
  */
-module.exports = function compose() {
+module.exports = function compose(functions) {
   if (arguments.length === 0) {
     throw new Error('compose requires at least one argument');
   }

--- a/src/composeK.js
+++ b/src/composeK.js
@@ -16,7 +16,7 @@ var prepend = require('./prepend');
  * @since v0.16.0
  * @category Function
  * @sig Chain m => ((y -> m z), (x -> m y), ..., (a -> m b)) -> (m a -> m z)
- * @param {...Function}
+ * @param {...Function} functions
  * @return {Function}
  * @see R.pipeK
  * @example
@@ -38,6 +38,6 @@ var prepend = require('./prepend');
  *      getStateCode(Maybe.of('[Invalid JSON]'));
  *      //=> Nothing()
  */
-module.exports = function composeK() {
+module.exports = function composeK(functions) {
   return compose.apply(this, prepend(identity, map(chain, arguments)));
 };

--- a/src/composeP.js
+++ b/src/composeP.js
@@ -20,7 +20,7 @@ var reverse = require('./reverse');
  *      //  followersForUser :: String -> Promise [User]
  *      var followersForUser = R.composeP(db.getFollowers, db.getUserById);
  */
-module.exports = function composeP() {
+module.exports = function composeP(functions) {
   if (arguments.length === 0) {
     throw new Error('composeP requires at least one argument');
   }

--- a/src/pipe.js
+++ b/src/pipe.js
@@ -24,7 +24,7 @@ var tail = require('./tail');
  *
  *      f(3, 4); // -(3^4) + 1
  */
-module.exports = function pipe() {
+module.exports = function pipe(functions) {
   if (arguments.length === 0) {
     throw new Error('pipe requires at least one argument');
   }

--- a/src/pipeK.js
+++ b/src/pipeK.js
@@ -12,7 +12,7 @@ var reverse = require('./reverse');
  * @since v0.16.0
  * @category Function
  * @sig Chain m => ((a -> m b), (b -> m c), ..., (y -> m z)) -> (m a -> m z)
- * @param {...Function}
+ * @param {...Function} functions
  * @return {Function}
  * @see R.composeK
  * @example
@@ -34,6 +34,6 @@ var reverse = require('./reverse');
  *      getStateCode(Maybe.of('[Invalid JSON]'));
  *      //=> Nothing()
  */
-module.exports = function pipeK() {
+module.exports = function pipeK(functions) {
   return composeK.apply(this, reverse(arguments));
 };

--- a/src/pipeP.js
+++ b/src/pipeP.js
@@ -22,7 +22,7 @@ var tail = require('./tail');
  *      //  followersForUser :: String -> Promise [User]
  *      var followersForUser = R.pipeP(db.getUserById, db.getFollowers);
  */
-module.exports = function pipeP() {
+module.exports = function pipeP(functions) {
   if (arguments.length === 0) {
     throw new Error('pipeP requires at least one argument');
   }


### PR DESCRIPTION
JSDoc needs unused parameter for function declaration and documentation string when functions use the arguments object.

See more: http://usejsdoc.org/tags-param.html#multiple-types-and-repeatable-parameters