### PR TITLE
respect an object's custom "toString" method in R.toString

### DIFF
--- a/src/internal/_functionName.js
+++ b/src/internal/_functionName.js
@@ -1,5 +1,0 @@
-module.exports = function _functionName(f) {
-  // String(x => x) evaluates to "x => x", so the pattern may not match.
-  var match = String(f).match(/^function (\w*)/);
-  return match == null ? '' : match[1];
-};

--- a/src/internal/_toString.js
+++ b/src/internal/_toString.js
@@ -1,5 +1,4 @@
 var _contains = require('./_contains');
-var _functionName = require('./_functionName');
 var _map = require('./_map');
 var _quote = require('./_quote');
 var _toISOString = require('./_toISOString');
@@ -36,9 +35,12 @@ module.exports = function _toString(x, seen) {
     case '[object Undefined]':
       return 'undefined';
     default:
-      return (typeof x.constructor === 'function' && _functionName(x.constructor) !== 'Object' &&
-              typeof x.toString === 'function' && x.toString() !== '[object Object]') ?
-             x.toString() :  // Function, RegExp, user-defined types
-             '{' + mapPairs(x, keys(x)).join(', ') + '}';
+      if (typeof x.toString === 'function') {
+        var repr = x.toString();
+        if (repr !== '[object Object]') {
+          return repr;
+        }
+      }
+      return '{' + mapPairs(x, keys(x)).join(', ') + '}';
   }
 };

--- a/test/toString.js
+++ b/test/toString.js
@@ -151,6 +151,8 @@ describe('toString', function() {
     assert.strictEqual(R.toString(Just(42)), 'Just(42)');
     assert.strictEqual(R.toString(Just([1, 2, 3])), 'Just([1, 2, 3])');
     assert.strictEqual(R.toString(Just(Just(Just('')))), 'Just(Just(Just("")))');
+
+    assert.strictEqual(R.toString({toString: R.always('x')}), 'x');
   });
 
   it('handles object with no `toString` method', function() {


### PR DESCRIPTION
Current behaviour:

```javascript
> R.toString({toString: function() { return 'x'; }})
'{"toString": function () { return \'x\'; }}'
```

New behaviour:

```javascript
> R.toString({toString: function() { return 'x'; }})
'x'
```
