### PR TITLE
R.scan now supports transducers, iterators, and delegates

### DIFF
--- a/src/internal/_scan.js
+++ b/src/internal/_scan.js
@@ -1,0 +1,52 @@
+var _xwrap = require('./_xwrap');
+var bind = require('../bind');
+var isArrayLike = require('../isArrayLike');
+
+module.exports = (function() {
+  function _arrayScan(xf, acc, list) {
+    var idx = 0;
+    var len = list.length;
+    var result = [acc];
+    while (idx < len) {
+      acc = xf['@@transducer/step'](acc, list[idx]);
+      result[idx + 1] = acc;
+      idx += 1;
+    }
+    return xf['@@transducer/result'](result);
+  }
+
+  function _iterableScan(xf, acc, iter) {
+    var step = iter.next();
+    var result = [acc];
+    while (!step.done) {
+      acc = xf['@@transducer/step'](acc, step.value);
+      result.push(acc);
+      step = iter.next();
+    }
+    return xf['@@transducer/result'](result);
+  }
+
+  function _methodScan(xf, acc, obj) {
+    return xf['@@transducer/result'](obj.scan(bind(xf['@@transducer/step'], xf), acc));
+  }
+
+  var symIterator = (typeof Symbol !== 'undefined') ? Symbol.iterator : '@@iterator';
+  return function _scan(fn, acc, list) {
+    if (typeof fn === 'function') {
+      fn = _xwrap(fn);
+    }
+    if (isArrayLike(list)) {
+      return _arrayScan(fn, acc, list);
+    }
+    if (typeof list.scan === 'function') {
+      return _methodScan(fn, acc, list);
+    }
+    if (list[symIterator] != null) {
+      return _iterableScan(fn, acc, list[symIterator]());
+    }
+    if (typeof list.next === 'function') {
+      return _iterableScan(fn, acc, list);
+    }
+    throw new TypeError('scan: list must be array or iterable');
+  };
+})();

--- a/src/scan.js
+++ b/src/scan.js
@@ -1,10 +1,10 @@
 var _curry3 = require('./internal/_curry3');
-
-
+var _scan = require('./internal/_scan');
 /**
  * Scan is similar to reduce, but returns a list of successively reduced values
  * from the left
  *
+ * Dispatches to the `scan` method of the third argument, if present.
  * @func
  * @memberOf R
  * @since v0.10.0
@@ -20,12 +20,4 @@ var _curry3 = require('./internal/_curry3');
  *      var numbers = [1, 2, 3, 4];
  *      var factorials = R.scan(R.multiply, 1, numbers); //=> [1, 1, 2, 6, 24]
  */
-module.exports = _curry3(function scan(fn, acc, list) {
-  var idx = 0, len = list.length, result = [acc];
-  while (idx < len) {
-    acc = fn(acc, list[idx]);
-    result[idx + 1] = acc;
-    idx += 1;
-  }
-  return result;
-});
+module.exports = _curry3(_scan);

--- a/test/reduce.js
+++ b/test/reduce.js
@@ -35,4 +35,13 @@ describe('reduce', function() {
     eq(sum.length, 1);
   });
 
+  it('composes with other transformers', function() {
+    var add1 = function(a) {return a + 1;};
+    var trans = R.compose(
+      R.reduce(add, 1),
+      R.map(add1)
+    );
+    eq(trans([1]), 3);
+    eq(R.transduce(trans, R.flip(R.append), [], [1]), 3);
+  });
 });

--- a/test/scan.js
+++ b/test/scan.js
@@ -29,4 +29,19 @@ describe('scan', function() {
     eq(sum.length, 1);
   });
 
+  it('dispatches to objects that implement `scan`', function() {
+    var obj = {x: 100, scan: function(f, acc) { return f(acc, this.x); }};
+    eq(R.scan(add, 1, obj), 101);
+  });
+
+  it('composes with other transformers', function() {
+    var add1 = function(a) {return a + 1;};
+    var trans = R.compose(
+      R.scan(add, 1),
+      R.map(add1)
+    );
+    eq(trans([1]), [3]);
+    eq(R.transduce(trans, R.flip(R.append), [], [1]), [3]);
+  });
+
 });


### PR DESCRIPTION
Fixes #1179
Implementation now matches R.reduce and should be compatible with other
types that implement `type.scan(reducer, accumulator)` like flyd.