### PR TITLE
Add splitWhen function

### DIFF
--- a/src/splitWhen.js
+++ b/src/splitWhen.js
@@ -1,0 +1,32 @@
+var _curry2 = require('./internal/_curry2');
+var _slice = require('./internal/_slice');
+
+
+/**
+ * Takes a list and a predicate and returns a pair of lists with the following properties:
+ *
+ *  - the result of concatenating the two output lists is equivalent to the input list;
+ *  - none of the elements of the first output list satisfies the predicate; and
+ *  - if the second output list is non-empty, its first element satisfies the predicate.
+ *
+ * @func
+ * @memberOf R
+ * @category List
+ * @sig (a -> Boolean) -> [a] -> [[a], [a]]
+ * @param {Function} pred The predicate that determines where the array is split.
+ * @param {Array} list The array to be split.
+ * @return {Array}
+ * @example
+ *
+ *      R.splitWhen(R.equals(2), [1, 2, 3, 1, 2, 3]);   //=> [[1], [2, 3, 1, 2, 3]]
+ */
+module.exports = _curry2(function splitWhen(pred, list) {
+  var idx = 0, len = list.length, prefix = [];
+
+  while (idx < len && !pred(list[idx])) {
+    prefix.push(list[idx]);
+    idx += 1;
+  }
+
+  return [prefix, _slice(list, idx)];
+});

--- a/test/splitWhen.js
+++ b/test/splitWhen.js
@@ -1,0 +1,22 @@
+var R = require('..');
+var eq = require('./shared/eq');
+
+
+describe('splitWhen', function() {
+  it('splits an array at the first instance to satisfy the predicate', function() {
+    eq(R.splitWhen(R.equals(2), [1, 2, 3]), [[1], [2, 3]]);
+  });
+
+  it('retains all original elements', function() {
+    eq(R.splitWhen(R.T, [1, 1, 1]), [[], [1, 1, 1]]);
+  });
+
+  it('is curried', function() {
+    var splitWhenFoo = R.splitWhen(R.equals('foo'));
+    eq(splitWhenFoo(['foo', 'bar', 'baz']), [[], ['foo', 'bar', 'baz']]);
+  });
+
+  it('only splits once', function() {
+    eq(R.splitWhen(R.equals(2), [1, 2, 3, 1, 2, 3]), [[1], [2, 3, 1, 2, 3]]);
+  });
+});


### PR DESCRIPTION
Inspired by Haskell's `break`:
http://hackage.haskell.org/package/base-4.8.1.0/docs/Prelude.html#v:break

`R.splitWhen(R.equals(2), [1, 2, 3]);   //=> [[1], [2, 3]]`