### PR TITLE
Change assocPath behavior for empty path

### DIFF
--- a/src/assocPath.js
+++ b/src/assocPath.js
@@ -26,7 +26,7 @@ var assoc = require('./assoc');
 module.exports = _curry3(function assocPath(path, val, obj) {
   switch (path.length) {
     case 0:
-      return obj;
+      return val;
     case 1:
       return assoc(path[0], val, obj);
     default:

--- a/test/assocPath.js
+++ b/test/assocPath.js
@@ -37,8 +37,8 @@ describe('assocPath', function() {
     eq(g(obj1), expected);
   });
 
-  it('accepts empty path', function() {
-    eq(R.assocPath([], 3, {a: 1, b: 2}), {a: 1, b: 2});
+  it('empty path replaces the the whole object', function() {
+    eq(R.assocPath([], 3, {a: 1, b: 2}), 3);
   });
 
 });


### PR DESCRIPTION
R.assocPath([], 0, {a:1}) should return 0 not {a:1}

As discussed in #1510 the previous behavior of returning the full object does not quite match the desired logic that would also be required for lensPath. From a lens point of view the focus is on the empty path and thus on the whole object, meaning the whole object is being overwritten and not "nothing is being ovewritten"