### PR TITLE
[perf] Replace Set with indexOf in _contains

### DIFF
--- a/lib/bench/contains.bench.js
+++ b/lib/bench/contains.bench.js
@@ -1,0 +1,23 @@
+var contains = require('../..').contains;
+
+var alphabet = 'abcdefghijklmnopqrstuvwxyz'.split('');
+
+function randomLowerAlpha() {
+  return String.fromCharCode(97 + (Math.random() * 26) >>> 0);
+}
+
+function nativeIndexOf(x, xs) {
+  return xs.indexOf(x) >= 0;
+}
+
+module.exports = {
+  name: 'contains',
+  tests: {
+    'contains(c, cs)': function() {
+      return contains(randomLowerAlpha(), alphabet);
+    },
+    'native indexOf': function() {
+      return nativeIndexOf(randomLowerAlpha(), alphabet);
+    }
+  }
+};

--- a/src/internal/_contains.js
+++ b/src/internal/_contains.js
@@ -1,48 +1,6 @@
 var _indexOf = require('./_indexOf');
 
 
-/* globals Set */
-module.exports = typeof Set === 'undefined' ?
-  function _contains(a, list) {
-    return _indexOf(list, a, 0) >= 0;
-  } :
-  function _containsSet(a, list) {
-    var idx, inf, item;
-    switch (typeof a) {
-      case 'number':
-        if (a === 0) {
-          // manually crawl the list to distinguish between +0 and -0
-          idx = 0;
-          inf = 1 / a;
-          while (idx < list.length) {
-            item = list[idx];
-            if (item === 0 && 1 / item === inf) {
-              return true;
-            }
-            idx += 1;
-          }
-          return false;
-        }
-        // non-zero numbers can utilise Set
-        return new Set(list).has(a);
-
-      // all these types can utilise Set
-      case 'string':
-      case 'boolean':
-      case 'function':
-      case 'undefined':
-        return new Set(list).has(a);
-
-      case 'object':
-        if (a === null) {
-          // null can utilise Set
-          return new Set(list).has(a);
-        }
-        // other objects need R.equals for equality
-        return _indexOf(list, a, 0) >= 0;
-
-      default:
-        // anything else not covered above, defer to R.equals
-        return _indexOf(list, a, 0) >= 0;
-    }
-  };
+module.exports = function _contains(a, list) {
+  return _indexOf(list, a, 0) >= 0;
+};

--- a/src/internal/_indexOf.js
+++ b/src/internal/_indexOf.js
@@ -1,10 +1,54 @@
 var equals = require('../equals');
 
 
-module.exports = function _indexOf(list, item, from) {
-  var idx = from;
+module.exports = function _indexOf(list, a, idx) {
+  var inf, item;
+  // Array.prototype.indexOf doesn't exist below IE9
+  if (typeof list.indexOf === 'function') {
+    switch (typeof a) {
+      case 'number':
+        if (a === 0) {
+          // manually crawl the list to distinguish between +0 and -0
+          inf = 1 / a;
+          while (idx < list.length) {
+            item = list[idx];
+            if (item === 0 && 1 / item === inf) {
+              return idx;
+            }
+            idx += 1;
+          }
+          return -1;
+        } else if (a !== a) {
+          // NaN
+          while (idx < list.length) {
+            item = list[idx];
+            if (typeof item === 'number' && item !== item) {
+              return idx;
+            }
+            idx += 1;
+          }
+          return -1;
+        }
+        // non-zero numbers can utilise Set
+        return list.indexOf(a, idx);
+
+      // all these types can utilise Set
+      case 'string':
+      case 'boolean':
+      case 'function':
+      case 'undefined':
+        return list.indexOf(a, idx);
+
+      case 'object':
+        if (a === null) {
+          // null can utilise Set
+          return list.indexOf(a, idx);
+        }
+    }
+  }
+  // anything else not covered above, defer to R.equals
   while (idx < list.length) {
-    if (equals(list[idx], item)) {
+    if (equals(list[idx], a)) {
       return idx;
     }
     idx += 1;


### PR DESCRIPTION
Addresses #1508

While the use of `Set` in `_contains` provided a nice boost in performance, after further thought I have come to realise that it could be replaced with a simpler `Array.prototype.indexOf` for the instances where `Set` was being utilised (though `NaN` needs to now be handled explicitly), removing the extra insertion cost and memory allocation to create the `Set`. This should remove some extra GC thrashing when used in a tight loop too, such as those often in benchmark code.

I've included a new benchmark file for `R.contains` and run it against the previous implementations, resulting in the following:

Implementation    | Hz         | Margin of Error
------------------|------------|----------------
v0.8              |     73,693 | ±1.31%
Set               |    341,266 | ±0.66%
indexOf (this PR) | 11,372,373 | ±0.84%
nativeIndexOf     | 13,820,992 | ±0.63%
