### PR TITLE
make R.path([k], o) equivalent to R.prop(k, o)

### DIFF
--- a/src/path.js
+++ b/src/path.js
@@ -18,18 +18,14 @@ var _curry2 = require('./internal/_curry2');
  *      R.path(['a', 'b'], {c: {b: 2}}); //=> undefined
  */
 module.exports = _curry2(function path(paths, obj) {
-  if (obj == null) {
-    return;
-  } else {
-    var val = obj;
-    var idx = 0;
-    while (idx < paths.length) {
-      if (val == null) {
-        return;
-      }
-      val = val[paths[idx]];
-      idx += 1;
+  var val = obj;
+  var idx = 0;
+  while (idx < paths.length) {
+    if (val == null) {
+      return;
     }
-    return val;
+    val = val[paths[idx]];
+    idx += 1;
   }
+  return val;
 });

--- a/test/path.js
+++ b/test/path.js
@@ -25,7 +25,6 @@ describe('path', function() {
     eq(R.path(['a', 'e', 'f', '1'], obj), 101);
     eq(R.path(['j', '0'], obj), 'J');
     eq(R.path(['j', '1'], obj), undefined);
-    eq(R.path(['a', 'b', 'c'], null), undefined);
   });
 
   it("gets a deep property's value from objects", function() {
@@ -37,11 +36,6 @@ describe('path', function() {
     eq(R.path(['a', 'b', 'foo'], deepObject), undefined);
     eq(R.path(['bar'], deepObject), undefined);
     eq(R.path(['a', 'b'], {a: null}), undefined);
-  });
-
-  it('returns undefined for null/undefined', function() {
-    eq(R.path(['toString'], null), undefined);
-    eq(R.path(['toString'], undefined), undefined);
   });
 
   it('works with falsy items', function() {


### PR DESCRIPTION
Fixes #1522

Set the query string to __?w=__ when viewing the diff to ignore the indentation change.
