### PR TITLE
RFC : property based tests using jsverify

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "eslint": "^1.10.1",
     "handlebars": "3.0.x",
     "js-yaml": "^3.2.5",
+    "jsverify": "^0.7.1",
     "mocha": "2.x.x",
     "q": "^1.1.1",
     "ramda": "0.17.x",

--- a/test/add.js
+++ b/test/add.js
@@ -1,5 +1,6 @@
 var R = require('..');
 var eq = require('./shared/eq');
+var jsc = require('jsverify');
 
 
 describe('add', function() {
@@ -10,6 +11,20 @@ describe('add', function() {
   it('is curried', function() {
     var incr = R.add(1);
     eq(incr(42), 43);
+  });
+
+  describe('properties', function() {
+    jsc.property('commutative', 'integer', 'integer', function(a, b) {
+      return R.add(a,b) === R.add(b,a);
+    });
+
+    jsc.property('associative', 'integer', 'integer', 'integer', function(a, b, c) {
+      return R.add(a, R.add(b, c)) === R.add(R.add(a, b), c);
+    });
+
+    jsc.property('identity element', 'integer' , function(a) {
+      return R.add(a, 0) === a && R.add(0, a) === a;
+    });
   });
 
 });

--- a/test/adjust.js
+++ b/test/adjust.js
@@ -1,5 +1,6 @@
 var R = require('..');
 var eq = require('./shared/eq');
+var jsc = require('jsverify');
 
 describe('adjust', function() {
   it('applies the given function to the value at the given index of the supplied array', function() {
@@ -31,6 +32,20 @@ describe('adjust', function() {
       return arguments;
     }
     eq(R.adjust(R.add(1), 2, args(0, 1, 2, 3)), [0, 1, 3, 3]);
+  });
+
+  describe('properties', function() {
+    var types = [jsc.number, jsc.bool, jsc.string, jsc.datetime, jsc.falsy, jsc.json];
+    var input = jsc.suchthat(jsc.nearray(jsc.oneof(types)),
+                             jsc.oneof(types),
+                             jsc.nat, function(xs, x, i) {
+                               return i < xs.length;
+                             });
+
+    jsc.property('idempotent', input, function(xs, x, i) {
+      return R.equals(R.adjust(R.always(x), i, xs),
+                      R.adjust(R.always(x), i, R.adjust(R.always(x), i, xs)))
+    });
   });
 
 });

--- a/test/concat.js
+++ b/test/concat.js
@@ -1,4 +1,5 @@
 var assert = require('assert');
+var jsc = require('jsverify');
 
 var R = require('..');
 var eq = require('./shared/eq');
@@ -48,6 +49,18 @@ describe('concat', function() {
 
   it('throws if not an array, String, or object with a concat method', function() {
     assert.throws(function() { return R.concat({}, {}); }, TypeError);
+  });
+
+  describe('properties', function() {
+    var xs = jsc.oneof([jsc.number, jsc.bool, jsc.string, jsc.datetime, jsc.falsy, jsc.json]);
+
+    jsc.property('reflexive', jsc.array(xs), jsc.array(xs), jsc.array(xs), function(a, b, c) {
+      return R.equals(R.concat(R.concat(a, b), c), R.concat(a, R.concat(b, c)));
+    });
+    jsc.property('identity element', jsc.array(xs), function(a) {
+      return R.equals(R.concat(a, []), R.concat([], a));
+    });
+
   });
 
 });

--- a/test/equals.js
+++ b/test/equals.js
@@ -3,6 +3,7 @@
 
 var R = require('..');
 var eq = require('./shared/eq');
+var jsc = require('jsverify');
 
 describe('equals', function() {
   var a = [];
@@ -315,6 +316,26 @@ describe('equals', function() {
   it('is curried', function() {
     var isA = R.equals(a);
     eq(isA([]), true);
+  });
+
+  describe('properties', function() {
+    var arbs = [jsc.number, jsc.bool, jsc.datetime, jsc.falsy, jsc.json];
+
+    jsc.property('reflexive', jsc.oneof(arbs), function(a) {
+      return R.equals(a, a);
+    });
+    jsc.property('symmetry', jsc.oneof(arbs), jsc.oneof(arbs), function(a, b) {
+      return R.equals(a,b) === R.equals(b,a);
+    });
+    jsc.property('transitive', jsc.oneof(arbs), jsc.oneof(arbs), jsc.oneof(arbs), function(a, b, c) {
+      // TODO : this does not look so good. This should be written in a way
+      // that the ocurrance of a == b == c is guanrateed to occur
+      if (R.equals(a,b) && R.equals(b,c)) {
+        return R.equals(a,c) === true;
+      }
+      return true;
+    });
+
   });
 
 });

--- a/test/map.js
+++ b/test/map.js
@@ -2,7 +2,7 @@ var listXf = require('./helpers/listXf');
 
 var R = require('..');
 var eq = require('./shared/eq');
-
+var jsc = require('jsverify');
 
 describe('map', function() {
   var times2 = function(x) {return x * 2;};
@@ -64,6 +64,20 @@ describe('map', function() {
   it('correctly reports the arity of curried versions', function() {
     var inc = R.map(add1);
     eq(inc.length, 1);
+  });
+
+  describe('properties', function() {
+    var functors = jsc.oneof([jsc.array(jsc.number), jsc.dict(jsc.string)]);
+
+    jsc.property('identity', jsc.oneof(functors), function(f) {
+      return R.equals(R.map(R.identity, f), f);
+    });
+
+    jsc.property('composition', jsc.oneof(functors), function(f) {
+      return R.equals(R.map(R.compose(R.add(1), R.multiply(2)), f),
+                      R.map(R.add(1), R.map(R.multiply(2), f)));
+    });
+
   });
 
 });


### PR DESCRIPTION
As mentioned on gitter I would like to look into providing property tests using jsverify (https://github.com/jsverify/jsverify) 

For now this PR only contains a tiny example which tests `R.add` for 

* commutativity
* associativity 
* neutral element 

Writing the tests will in many cases probably not be too hard. I am having more difficulties designating the properties that should hold. I would thus like to ask for some input : What are some functions that you would like to see some properties tested for and which are they. I am happy to implement and then we can see if the outcome is something that can be considered a useful addition to Ramda or not.