### PR TITLE
describe R.map as an operation on a functor

### DIFF
--- a/src/map.js
+++ b/src/map.js
@@ -8,13 +8,13 @@ var keys = require('./keys');
 
 
 /**
- * Returns a new list, constructed by applying the supplied function to every
- * element of the supplied list.
+ * Takes a function and
+ * a [functor](https://github.com/fantasyland/fantasy-land#functor),
+ * applies the function to each of the functor's values, and returns
+ * a functor of the same shape.
  *
- * Note: `R.map` does not skip deleted or unassigned indices (sparse arrays),
- * unlike the native `Array.prototype.map` method. For more details on this
- * behavior, see:
- * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map#Description
+ * Ramda provides suitable `map` implementations for `Array` and `Object`,
+ * so this function may be applied to `[1, 2, 3]` or `{x: 1, y: 2, z: 3}`.
  *
  * Dispatches to the `map` method of the second argument, if present.
  *


### PR DESCRIPTION
This addresses the issue raised by @Xananax in https://github.com/ramda/ramda/pull/1426#issuecomment-164299098.

`R.mapObj` will be removed in the next release, so there's no point updating its docstring as part of this pull request.
