### PR TITLE
Add `indexBy` function

### DIFF
--- a/src/indexBy.js
+++ b/src/indexBy.js
@@ -1,0 +1,30 @@
+var _curry2 = require('./internal/_curry2');
+var _reduce = require('./internal/_reduce');
+
+
+/**
+ * Given a function that generates a key, turns a list of objects into an
+ * object indexing the objects by the given key. Note that if multiple
+ * objects generate the same value for the indexing key only the last value
+ * will be included in the generated object.
+ *
+ * @func
+ * @memberOf R
+ * @category List
+ * @sig (a -> String) -> [{k: v}] -> {k: {k: v}}
+ * @param {Function} fn Function :: a -> String
+ * @param {Array} array The array of objects to index
+ * @return {Object} An object indexing each array element by the given property.
+ * @example
+ *
+ *      var list = [{id: 'xyz', title: 'A'}, {id: 'abc', title: 'B'}];
+ *      R.indexBy(R.prop('id'), list);
+ *      //=> {abc: {id: 'abc', title: 'B'}, xyz: {id: 'xyz', title: 'A'}}
+ */
+module.exports = _curry2(function indexBy(fn, list) {
+  return _reduce(function(acc, elem) {
+    var key = fn(elem);
+    acc[key] = elem;
+    return acc;
+  }, {}, list);
+});

--- a/test/indexBy.js
+++ b/test/indexBy.js
@@ -1,0 +1,25 @@
+var R = require('..');
+var eq = require('./shared/eq');
+
+
+describe('indexBy', function() {
+  it('indexes list by the given property', function() {
+    var list = [{id: 'xyz', title: 'A'}, {id: 'abc', title: 'B'}];
+    var indexed = R.indexBy(R.prop('id'), list);
+    eq(indexed, {abc: {id: 'abc', title: 'B'}, xyz: {id: 'xyz', title: 'A'}});
+  });
+
+  it('indexes list by the given property upper case', function() {
+    var list = [{id: 'xyz', title: 'A'}, {id: 'abc', title: 'B'}];
+    var indexed = R.indexBy(R.compose(R.toUpper, R.prop('id')), list);
+    eq(indexed, {ABC: {id: 'abc', title: 'B'}, XYZ: {id: 'xyz', title: 'A'}});
+  });
+
+
+  it('is curried', function() {
+    var list = [{id: 'xyz', title: 'A'}, {id: 'abc', title: 'B'}];
+    var indexed = R.indexBy(R.prop('id'))(list);
+    eq(indexed, {abc: {id: 'abc', title: 'B'}, xyz: {id: 'xyz', title: 'A'}});
+  });
+
+});


### PR DESCRIPTION
Resolves #1545

This adds a new `indexBy` function. Given a property name to index-by and a list of objects returns an object indexing the objects by the given property. Highly inspired by this [cookbook example](https://github.com/ramda/ramda/wiki/Cookbook#index-objects-by-property-name). 