### PR TITLE
Add node 4.2 (LTS) to travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,6 @@ language: node_js
 node_js:
 - '0.10'
 - '0.12'
-- 'iojs-v1.5.1'
+- '4.2'
 before_script:
 - make clean && make dist/ramda.js


### PR DESCRIPTION
The node 4.2.* branch is LTS. Should be important that Ramda supports these releases. 