### PR TITLE
Fix typos in test descriptions

### DIFF
--- a/test/bind.js
+++ b/test/bind.js
@@ -62,7 +62,7 @@ describe('bind', function() {
     eq(incPojso(), 101);
   });
 
-  it('does not interefere with existing object methods', function() {
+  it('does not interfere with existing object methods', function() {
     var b = new Bar('a', 'b');
     function getX() {
       return this.x;

--- a/test/dropWhile.js
+++ b/test/dropWhile.js
@@ -7,7 +7,7 @@ describe('dropWhile', function() {
     eq(R.dropWhile(function(x) {return x < 5;}, [1, 3, 5, 7, 9]), [5, 7, 9]);
   });
 
-  it('returns an empty list for an ampty list', function() {
+  it('returns an empty list for an empty list', function() {
     eq(R.dropWhile(function() { return false; }, []), []);
     eq(R.dropWhile(function() { return true; }, []), []);
   });

--- a/test/ifElse.js
+++ b/test/ifElse.js
@@ -12,7 +12,7 @@ describe('ifElse', function() {
     eq(R.ifElse(v, t, identity)(10), 11);
   });
 
-  it('calls the false case function if the validator returns a falsey value', function() {
+  it('calls the false case function if the validator returns a falsy value', function() {
     var v = function(a) { return typeof a === 'number'; };
     eq(R.ifElse(v, t, identity)('hello'), 'hello');
   });

--- a/test/join.js
+++ b/test/join.js
@@ -3,7 +3,7 @@ var eq = require('./shared/eq');
 
 
 describe('join', function() {
-  it("concatenates a list's elements to a string, with an seperator string between elements", function() {
+  it("concatenates a list's elements to a string, with an separator string between elements", function() {
     var list = [1, 2, 3, 4];
     eq(R.join('~', list), '1~2~3~4');
   });

--- a/test/unless.js
+++ b/test/unless.js
@@ -3,7 +3,7 @@ var eq = require('./shared/eq');
 
 
 describe('unless', function() {
-  it('calls the whenFalse function if the validator returns a falsey value', function() {
+  it('calls the whenFalse function if the validator returns a falsy value', function() {
     eq(R.unless(R.isArrayLike, R.of)(10), [10]);
   });
 

--- a/test/when.js
+++ b/test/when.js
@@ -7,7 +7,7 @@ describe('when', function() {
     eq(R.when(R.is(Number), R.add(1))(10), 11);
   });
 
-  it('returns the argument unmodified if the validator returns a falsey value', function() {
+  it('returns the argument unmodified if the validator returns a falsy value', function() {
     eq(R.when(R.is(Number), R.add(1))('hello'), 'hello');
   });
 

--- a/test/zipObj.js
+++ b/test/zipObj.js
@@ -3,7 +3,7 @@ var eq = require('./shared/eq');
 
 
 describe('zipObj', function() {
-  it('combines an array of keys with an arrau of values into a single object', function() {
+  it('combines an array of keys with an array of values into a single object', function() {
     eq(R.zipObj(['a', 'b', 'c'], [1, 2, 3]), {a: 1, b: 2, c: 3});
   });
 


### PR DESCRIPTION
Both 'falsy' and 'falsey' were used, so I changed it to just 'falsy'.