### PR TITLE
prepublish: add @since annotations

### DIFF
--- a/scripts/prepublish
+++ b/scripts/prepublish
@@ -7,6 +7,11 @@ README="${README//"${PREVIOUS_VERSION%.*}/ramda.min.js"/"${VERSION%.*}/ramda.min
 echo "$README" >README.md
 git add README.md
 
+for filename in $(find src -depth 1 -name "*.js" | xargs grep --files-without-match "@since v") ; do
+  sed -i "" $'s/@memberOf R/@memberOf R\\\n * @since '"$VERSION/" $filename
+  git add $filename
+done
+
 rm -f dist/ramda{,.min}.js
 make dist/ramda{,.min}.js
 git add dist/ramda{,.min}.js


### PR DESCRIPTION
This is a fragment of the script I wrote for #1434. Adding it to the prepublish script means that each time we run `make release-[major|minor|patch]` we'll add the appropriate `@since` annotation for each function which lacks one.
