### PR TITLE
Remove R.isNaN leftover in documentation

### DIFF
--- a/src/none.js
+++ b/src/none.js
@@ -22,7 +22,9 @@ var any = require('./any');
  * @see R.all, R.any
  * @example
  *
- *      R.none(R.isNaN, [1, 2, 3]); //=> true
- *      R.none(R.isNaN, [1, 2, 3, NaN]); //=> false
+ *      var isEven = n => n % 2 === 0;
+ *
+ *      R.none(isEven, [1, 3, 5, 7, 9, 11]), //=> true
+ *      R.none(isEven, [1, 3, 5, 7, 8, 11]), //=> false
  */
 module.exports = _curry2(_complement(_dispatchable('any', _xany, any)));


### PR DESCRIPTION
The examples for `R.none` are still using `R.isNaN` which was removed in #1112. I’ve replace the examples with actual use-cases from the tests.