### PR TITLE
make both and either respect applicative functors again

### DIFF
--- a/src/both.js
+++ b/src/both.js
@@ -1,4 +1,7 @@
 var _curry2 = require('./internal/_curry2');
+var _isFunction = require('./internal/_isFunction');
+var and = require('./and');
+var lift = require('./lift');
 
 
 /**
@@ -7,6 +10,9 @@ var _curry2 = require('./internal/_curry2');
  * of the second function otherwise. Note that this is short-circuited,
  * meaning that the second function will not be invoked if the first returns a
  * false-y value.
+ *
+ * In addition to functions, `R.both` also accepts any fantasy-land compatible
+ * applicative functor.
  *
  * @func
  * @memberOf R
@@ -26,7 +32,9 @@ var _curry2 = require('./internal/_curry2');
  *      f(101); //=> false
  */
 module.exports = _curry2(function both(f, g) {
-  return function _both() {
-    return f.apply(this, arguments) && g.apply(this, arguments);
-  };
+  return _isFunction(f) ?
+    function _both() {
+      return f.apply(this, arguments) && g.apply(this, arguments);
+    } :
+    lift(and)(f, g);
 });

--- a/src/either.js
+++ b/src/either.js
@@ -1,4 +1,7 @@
 var _curry2 = require('./internal/_curry2');
+var _isFunction = require('./internal/_isFunction');
+var lift = require('./lift');
+var or = require('./or');
 
 
 /**
@@ -7,6 +10,9 @@ var _curry2 = require('./internal/_curry2');
  * of the second function otherwise. Note that this is short-circuited,
  * meaning that the second function will not be invoked if the first returns a
  * truth-y value.
+ *
+ * In addition to functions, `R.either` also accepts any fantasy-land compatible
+ * applicative functor.
  *
  * @func
  * @memberOf R
@@ -26,7 +32,9 @@ var _curry2 = require('./internal/_curry2');
  *      f(8); //=> true
  */
 module.exports = _curry2(function either(f, g) {
-  return function _either() {
-    return f.apply(this, arguments) || g.apply(this, arguments);
-  };
+  return _isFunction(f) ?
+    function _either() {
+      return f.apply(this, arguments) || g.apply(this, arguments);
+    } :
+    lift(or)(f, g);
 });

--- a/src/internal/_isFunction.js
+++ b/src/internal/_isFunction.js
@@ -1,0 +1,3 @@
+module.exports = function _isNumber(x) {
+  return Object.prototype.toString.call(x) === '[object Function]';
+};

--- a/test/both.js
+++ b/test/both.js
@@ -1,3 +1,5 @@
+var S = require('sanctuary');
+
 var R = require('..');
 var eq = require('./shared/eq');
 
@@ -36,6 +38,16 @@ describe('both', function() {
     eq(typeof evenAnd(gt10), 'function');
     eq(evenAnd(gt10)(11), false);
     eq(evenAnd(gt10)(12), true);
+  });
+
+  it('accepts fantasy-land applicative functors', function() {
+    var Just = S.Just;
+    var Nothing = S.Nothing;
+    eq(R.both(Just(true), Just(true)), Just(true));
+    eq(R.both(Just(true), Just(false)), Just(false));
+    eq(R.both(Just(true), Nothing()), Nothing());
+    eq(R.both(Nothing(), Just(false)), Nothing());
+    eq(R.both(Nothing(), Nothing()), Nothing());
   });
 
 });

--- a/test/complement.js
+++ b/test/complement.js
@@ -1,3 +1,5 @@
+var S = require('sanctuary')
+
 var R = require('..');
 var eq = require('./shared/eq');
 
@@ -15,6 +17,14 @@ describe('complement', function() {
     var f = R.complement(between);
     eq(f(4, 5, 11), false);
     eq(f(12, 2, 6), true);
+  });
+
+  it('accepts fantasy-land functors', function() {
+    var Just = S.Just;
+    var Nothing = S.Nothing;
+    eq(R.complement(Just(true)), Just(false));
+    eq(R.complement(Just(false)), Just(true));
+    eq(R.complement(Nothing()), Nothing());
   });
 
 });

--- a/test/either.js
+++ b/test/either.js
@@ -1,3 +1,5 @@
+var S = require('sanctuary');
+
 var R = require('..');
 var eq = require('./shared/eq');
 
@@ -36,6 +38,17 @@ describe('either', function() {
     eq(typeof evenOr(gt10), 'function');
     eq(evenOr(gt10)(11), true);
     eq(evenOr(gt10)(9), false);
+  });
+
+  it('accepts fantasy-land applicative functors', function() {
+    var Just = S.Just;
+    var Nothing = S.Nothing;
+    eq(R.either(Just(true), Just(true)), Just(true));
+    eq(R.either(Just(true), Just(false)), Just(true));
+    eq(R.either(Just(false), Just(false)), Just(false));
+    eq(R.either(Just(true), Nothing()), Nothing());
+    eq(R.either(Nothing(), Just(false)), Nothing());
+    eq(R.either(Nothing(), Nothing()), Nothing());
   });
 
 });


### PR DESCRIPTION
Discussion [here](https://github.com/ramda/ramda/pull/1475). Now `both`/`either` short circuit for functions *and* respect applicative functors.