### PR TITLE
ad hoc type checking for R.add and R.subtract

### DIFF
--- a/src/add.js
+++ b/src/add.js
@@ -1,4 +1,6 @@
 var _curry2 = require('./internal/_curry2');
+var _isNumber = require('./internal/_isNumber');
+var toString = require('./toString');
 
 
 /**
@@ -18,4 +20,14 @@ var _curry2 = require('./internal/_curry2');
  *      R.add(2, 3);       //=>  5
  *      R.add(7)(10);      //=> 17
  */
-module.exports = _curry2(function add(a, b) { return a + b; });
+module.exports = _curry2(function add(a, b) {
+  if (!_isNumber(a)) {
+    throw new TypeError('‘add’ expected a value of type Number ' +
+                        'as its first argument; received ' + toString(a));
+  }
+  if (!_isNumber(b)) {
+    throw new TypeError('‘add’ expected a value of type Number ' +
+                        'as its second argument; received ' + toString(b));
+  }
+  return a + b;
+});

--- a/src/subtract.js
+++ b/src/subtract.js
@@ -1,4 +1,6 @@
 var _curry2 = require('./internal/_curry2');
+var _isNumber = require('./internal/_isNumber');
+var toString = require('./toString');
 
 
 /**
@@ -24,4 +26,14 @@ var _curry2 = require('./internal/_curry2');
  *      complementaryAngle(30); //=> 60
  *      complementaryAngle(72); //=> 18
  */
-module.exports = _curry2(function subtract(a, b) { return a - b; });
+module.exports = _curry2(function subtract(a, b) {
+  if (!_isNumber(a)) {
+    throw new TypeError('‘subtract’ expected a value of type Number ' +
+                        'as its first argument; received ' + toString(a));
+  }
+  if (!_isNumber(b)) {
+    throw new TypeError('‘subtract’ expected a value of type Number ' +
+                        'as its second argument; received ' + toString(b));
+  }
+  return a - b;
+});

--- a/test/add.js
+++ b/test/add.js
@@ -1,3 +1,5 @@
+var assert = require('assert');
+
 var R = require('..');
 var eq = require('./shared/eq');
 
@@ -5,6 +7,25 @@ var eq = require('./shared/eq');
 describe('add', function() {
   it('adds together two numbers', function() {
     eq(R.add(3, 7), 10);
+  });
+
+  it('type checks its arguments', function() {
+    assert.throws(
+      function() { R.add('1', '2'); },
+      function(err) {
+        return err.constructor === TypeError &&
+               err.message === '‘add’ expected a value of type Number ' +
+                               'as its first argument; received "1"';
+      }
+    );
+    assert.throws(
+      function() { R.add(1, '2'); },
+      function(err) {
+        return err.constructor === TypeError &&
+               err.message === '‘add’ expected a value of type Number ' +
+                               'as its second argument; received "2"';
+      }
+    );
   });
 
   it('is curried', function() {

--- a/test/subtract.js
+++ b/test/subtract.js
@@ -1,3 +1,5 @@
+var assert = require('assert');
+
 var R = require('..');
 var eq = require('./shared/eq');
 
@@ -5,6 +7,25 @@ var eq = require('./shared/eq');
 describe('subtract', function() {
   it('subtracts two numbers', function() {
     eq(R.subtract(22, 7), 15);
+  });
+
+  it('type checks its arguments', function() {
+    assert.throws(
+      function() { R.subtract('1', '2'); },
+      function(err) {
+        return err.constructor === TypeError &&
+               err.message === '‘subtract’ expected a value of type Number ' +
+                               'as its first argument; received "1"';
+      }
+    );
+    assert.throws(
+      function() { R.subtract(1, '2'); },
+      function(err) {
+        return err.constructor === TypeError &&
+               err.message === '‘subtract’ expected a value of type Number ' +
+                               'as its second argument; received "2"';
+      }
+    );
   });
 
   it('is curried', function() {

--- a/test/transduce.js
+++ b/test/transduce.js
@@ -41,9 +41,10 @@ describe('transduce', function() {
   });
 
   it('transduces into strings', function() {
-    eq(R.transduce(R.map(add(1)), add, '', [1, 2, 3, 4]), '2345');
-    eq(R.transduce(R.filter(isOdd), add, '', [1, 2, 3, 4]), '13');
-    eq(R.transduce(R.compose(R.map(add(1)), R.take(2)), add, '', [1, 2, 3, 4]), '23');
+    var _add = function(x, y) { return x + y; };
+    eq(R.transduce(R.map(R.inc), _add, '', [1, 2, 3, 4]), '2345');
+    eq(R.transduce(R.filter(isOdd), _add, '', [1, 2, 3, 4]), '13');
+    eq(R.transduce(R.compose(R.map(add(1)), R.take(2)), _add, '', [1, 2, 3, 4]), '23');
   });
 
   it('transduces into objects', function() {


### PR DESCRIPTION
See https://github.com/ramda/ramda/issues/1560#issuecomment-168455854

Current behaviour:

```javascript
R.add(1, 'XXX');
// => '1XXX'

R.subtract(1, 'XXX');
// => NaN

R.inc('XXX');
// => '1XXX'

R.dec('XXX');
// => '-1XXX'
```

New behaviour:

```javascript
R.add(1, 'XXX');
// ! TypeError: ‘add’ expected a value of type Number as its second argument; received "XXX"

R.subtract(1, 'XXX');
// ! TypeError: ‘subtract’ expected a value of type Number as its second argument; received "XXX"

R.inc('XXX');
// ! TypeError: ‘add’ expected a value of type Number as its second argument; received "XXX"

R.dec('XXX');
// ! TypeError: ‘add’ expected a value of type Number as its second argument; received "XXX"
```

I far prefer the new behaviour. I'd like `R.inc` and `R.dec` to throw more appropriate errors, but that change could easily be made in a subsequent pull request.
