### PR TITLE
prepublish: include "v" prefix in @since annotations

### DIFF
--- a/scripts/prepublish
+++ b/scripts/prepublish
@@ -8,7 +8,7 @@ echo "$README" >README.md
 git add README.md
 
 for filename in $(find src -depth 1 -name "*.js" | xargs grep --files-without-match "@since v") ; do
-  sed -i "" $'s/@memberOf R/@memberOf R\\\n * @since '"$VERSION/" $filename
+  sed -i "" $'s/@memberOf R/@memberOf R\\\n * @since v'"$VERSION/" $filename
   git add $filename
 done
 

--- a/src/indexBy.js
+++ b/src/indexBy.js
@@ -10,8 +10,7 @@ var _reduce = require('./internal/_reduce');
  *
  * @func
  * @memberOf R
- * @since 0.19.1
- * @since 0.19.0
+ * @since v0.19.0
  * @category List
  * @sig (a -> String) -> [{k: v}] -> {k: {k: v}}
  * @param {Function} fn Function :: a -> String

--- a/src/juxt.js
+++ b/src/juxt.js
@@ -9,8 +9,7 @@ var map = require('./map');
  *
  * @func
  * @memberOf R
- * @since 0.19.1
- * @since 0.19.0
+ * @since v0.19.0
  * @category Function
  * @sig [(a, b, ..., m) -> n] -> ((a, b, ..., m) -> [n])
  * @param {Array} fns An array of functions

--- a/src/lensPath.js
+++ b/src/lensPath.js
@@ -9,8 +9,7 @@ var path = require('./path');
  *
  * @func
  * @memberOf R
- * @since 0.19.1
- * @since 0.19.0
+ * @since v0.19.0
  * @category Object
  * @typedefn Lens s a = Functor f => (a -> f a) -> s -> f s
  * @sig [String] -> Lens s a

--- a/src/mergeWith.js
+++ b/src/mergeWith.js
@@ -11,8 +11,7 @@ var mergeWithKey = require('./mergeWithKey');
  *
  * @func
  * @memberOf R
- * @since 0.19.1
- * @since 0.19.0
+ * @since v0.19.0
  * @category Object
  * @sig (a -> a -> a) -> {a} -> {a} -> {a}
  * @param {Function} fn

--- a/src/mergeWithKey.js
+++ b/src/mergeWithKey.js
@@ -12,8 +12,7 @@ var _has = require('./internal/_has');
  *
  * @func
  * @memberOf R
- * @since 0.19.1
- * @since 0.19.0
+ * @since v0.19.0
  * @category Object
  * @sig (String -> a -> a -> a) -> {a} -> {a} -> {a}
  * @param {Function} fn

--- a/src/pathSatisfies.js
+++ b/src/pathSatisfies.js
@@ -8,8 +8,7 @@ var path = require('./path');
  *
  * @func
  * @memberOf R
- * @since 0.19.1
- * @since 0.19.0
+ * @since v0.19.0
  * @category Logic
  * @sig (a -> Boolean) -> [String] -> Object -> Boolean
  * @param {Function} pred

--- a/src/sequence.js
+++ b/src/sequence.js
@@ -14,8 +14,7 @@ var reduceRight = require('./reduceRight');
  *
  * @func
  * @memberOf R
- * @since 0.19.1
- * @since 0.19.0
+ * @since v0.19.0
  * @category List
  * @sig (Applicative f, Traversable t) => (a -> f a) -> t (f a) -> f (t a)
  * @param {Function} of

--- a/src/splitAt.js
+++ b/src/splitAt.js
@@ -8,8 +8,7 @@ var slice = require('./slice');
  *
  * @func
  * @memberOf R
- * @since 0.19.1
- * @since 0.19.0
+ * @since v0.19.0
  * @category List
  * @sig Number -> [a] -> [[a], [a]]
  * @sig Number -> String -> [String, String]

--- a/src/splitWhen.js
+++ b/src/splitWhen.js
@@ -11,8 +11,7 @@ var _slice = require('./internal/_slice');
  *
  * @func
  * @memberOf R
- * @since 0.19.1
- * @since 0.19.0
+ * @since v0.19.0
  * @category List
  * @sig (a -> Boolean) -> [a] -> [[a], [a]]
  * @param {Function} pred The predicate that determines where the array is split.

--- a/src/symmetricDifference.js
+++ b/src/symmetricDifference.js
@@ -9,8 +9,7 @@ var difference = require('./difference');
  *
  * @func
  * @memberOf R
- * @since 0.19.1
- * @since 0.19.0
+ * @since v0.19.0
  * @category Relation
  * @sig [*] -> [*] -> [*]
  * @param {Array} list1 The first list.

--- a/src/symmetricDifferenceWith.js
+++ b/src/symmetricDifferenceWith.js
@@ -10,8 +10,7 @@ var differenceWith = require('./differenceWith');
  *
  * @func
  * @memberOf R
- * @since 0.19.1
- * @since 0.19.0
+ * @since v0.19.0
  * @category Relation
  * @sig (a -> a -> Boolean) -> [a] -> [a] -> [a]
  * @param {Function} pred A predicate used to test whether two items are equal.

--- a/src/transpose.js
+++ b/src/transpose.js
@@ -9,8 +9,7 @@ var _curry1 = require('./internal/_curry1');
  *
  * @func
  * @memberOf R
- * @since 0.19.1
- * @since 0.19.0
+ * @since v0.19.0
  * @category List
  * @sig [[a]] -> [[a]]
  * @param {Array} list A 2D list

--- a/src/traverse.js
+++ b/src/traverse.js
@@ -13,8 +13,7 @@ var sequence = require('./sequence');
  *
  * @func
  * @memberOf R
- * @since 0.19.1
- * @since 0.19.0
+ * @since v0.19.0
  * @category List
  * @sig (Applicative f, Traversable t) => (a -> f a) -> (a -> f b) -> t a -> f (t b)
  * @param {Function} of

--- a/src/without.js
+++ b/src/without.js
@@ -12,8 +12,7 @@ var reject = require('./reject');
  *
  * @func
  * @memberOf R
- * @since 0.19.1
- * @since 0.19.0
+ * @since v0.19.0
  * @category List
  * @sig [a] -> [a] -> [a]
  * @param {Array} list1 The values to be removed from `list2`.


### PR DESCRIPTION
I forgot the `v` in #1557.
