### PR TITLE
ad hoc type checking for R.multiply and R.divide

### DIFF
--- a/src/divide.js
+++ b/src/divide.js
@@ -1,4 +1,6 @@
 var _curry2 = require('./internal/_curry2');
+var _isNumber = require('./internal/_isNumber');
+var toString = require('./toString');
 
 
 /**
@@ -23,4 +25,14 @@ var _curry2 = require('./internal/_curry2');
  *      var reciprocal = R.divide(1);
  *      reciprocal(4);   //=> 0.25
  */
-module.exports = _curry2(function divide(a, b) { return a / b; });
+module.exports = _curry2(function divide(a, b) {
+  if (!_isNumber(a)) {
+    throw new TypeError('‘divide’ expected a value of type Number ' +
+                        'as its first argument; received ' + toString(a));
+  }
+  if (!_isNumber(b)) {
+    throw new TypeError('‘divide’ expected a value of type Number ' +
+                        'as its second argument; received ' + toString(b));
+  }
+  return a / b;
+});

--- a/src/multiply.js
+++ b/src/multiply.js
@@ -1,4 +1,6 @@
 var _curry2 = require('./internal/_curry2');
+var _isNumber = require('./internal/_isNumber');
+var toString = require('./toString');
 
 
 /**
@@ -21,4 +23,14 @@ var _curry2 = require('./internal/_curry2');
  *      triple(4);       //=> 12
  *      R.multiply(2, 5);  //=> 10
  */
-module.exports = _curry2(function multiply(a, b) { return a * b; });
+module.exports = _curry2(function multiply(a, b) {
+  if (!_isNumber(a)) {
+    throw new TypeError('‘multiply’ expected a value of type Number ' +
+                        'as its first argument; received ' + toString(a));
+  }
+  if (!_isNumber(b)) {
+    throw new TypeError('‘multiply’ expected a value of type Number ' +
+                        'as its second argument; received ' + toString(b));
+  }
+  return a * b;
+});

--- a/test/divide.js
+++ b/test/divide.js
@@ -1,3 +1,5 @@
+var assert = require('assert');
+
 var R = require('..');
 var eq = require('./shared/eq');
 
@@ -5,6 +7,25 @@ var eq = require('./shared/eq');
 describe('divide', function() {
   it('divides two numbers', function() {
     eq(R.divide(28, 7), 4);
+  });
+
+  it('type checks its arguments', function() {
+    assert.throws(
+      function() { R.divide('1', '2'); },
+      function(err) {
+        return err.constructor === TypeError &&
+               err.message === '‘divide’ expected a value of type Number ' +
+                               'as its first argument; received "1"';
+      }
+    );
+    assert.throws(
+      function() { R.divide(1, '2'); },
+      function(err) {
+        return err.constructor === TypeError &&
+               err.message === '‘divide’ expected a value of type Number ' +
+                               'as its second argument; received "2"';
+      }
+    );
   });
 
   it('is curried', function() {

--- a/test/multiply.js
+++ b/test/multiply.js
@@ -1,3 +1,5 @@
+var assert = require('assert');
+
 var R = require('..');
 var eq = require('./shared/eq');
 
@@ -5,6 +7,25 @@ var eq = require('./shared/eq');
 describe('multiply', function() {
   it('adds together two numbers', function() {
     eq(R.multiply(6, 7), 42);
+  });
+
+  it('type checks its arguments', function() {
+    assert.throws(
+      function() { R.multiply('1', '2'); },
+      function(err) {
+        return err.constructor === TypeError &&
+               err.message === '‘multiply’ expected a value of type Number ' +
+                               'as its first argument; received "1"';
+      }
+    );
+    assert.throws(
+      function() { R.multiply(1, '2'); },
+      function(err) {
+        return err.constructor === TypeError &&
+               err.message === '‘multiply’ expected a value of type Number ' +
+                               'as its second argument; received "2"';
+      }
+    );
   });
 
   it('is curried', function() {


### PR DESCRIPTION
Current behaviour:

```javascript
R.multiply(1, 'XXX');
// => NaN

R.divide(1, 'XXX');
// => NaN
```

New behaviour:

```javascript
R.multiply(1, 'XXX');
// ! TypeError: ‘multiply’ expected a value of type Number as its second argument; received "XXX"

R.divide(1, 'XXX');
// ! TypeError: ‘divide’ expected a value of type Number as its second argument; received "XXX"
```
