### PR TITLE
Optimize intersection and intersectionWith to filter the smaller list

### DIFF
--- a/src/intersection.js
+++ b/src/intersection.js
@@ -23,5 +23,13 @@ var uniq = require('./uniq');
  *      R.intersection([1,2,3,4], [7,6,5,4,3]); //=> [4, 3]
  */
 module.exports = _curry2(function intersection(list1, list2) {
-  return uniq(_filter(flip(_contains)(list1), list2));
+  var lookupList, filteredList;
+  if (list1.length > list2.length) {
+    lookupList = list1;
+    filteredList = list2;
+  } else {
+    lookupList = list2;
+    filteredList = list1;
+  }
+  return uniq(_filter(flip(_contains)(lookupList), filteredList));
 });

--- a/src/intersectionWith.js
+++ b/src/intersectionWith.js
@@ -39,11 +39,19 @@ var uniqWith = require('./uniqWith');
  *      //=> [{id: 456, name: 'Stephen Stills'}, {id: 177, name: 'Neil Young'}]
  */
 module.exports = _curry3(function intersectionWith(pred, list1, list2) {
+  var lookupList, filteredList;
+  if (list1.length > list2.length) {
+    lookupList = list1;
+    filteredList = list2;
+  } else {
+    lookupList = list2;
+    filteredList = list1;
+  }
   var results = [];
   var idx = 0;
-  while (idx < list1.length) {
-    if (_containsWith(pred, list1[idx], list2)) {
-      results[results.length] = list1[idx];
+  while (idx < filteredList.length) {
+    if (_containsWith(pred, filteredList[idx], lookupList)) {
+      results[results.length] = filteredList[idx];
     }
     idx += 1;
   }


### PR DESCRIPTION
Closes #1595

``intersection`` performs much much better. ``intersectionWith`` is almost unchanged (and wasn't as affected to begin with) because most of the time is spent on the predicate execution, apparently.