### PR TITLE
Doc update noting that pipe and compose do not automatically curry

### DIFF
--- a/src/compose.js
+++ b/src/compose.js
@@ -6,6 +6,8 @@ var reverse = require('./reverse');
  * Performs right-to-left function composition. The rightmost function may have
  * any arity; the remaining functions must be unary.
  *
+ * **Note:** The result of compose is not automatically curried.
+ *
  * @func
  * @memberOf R
  * @since v0.1.0

--- a/src/pipe.js
+++ b/src/pipe.js
@@ -10,6 +10,8 @@ var tail = require('./tail');
  *
  * In some libraries this function is named `sequence`.
  *
+ * **Note:** The result of pipe is not automatically curried.
+ *
  * @func
  * @memberOf R
  * @since v0.1.0


### PR DESCRIPTION
As discussed in #1599 these functions are not curried by default and it's helpful to explain this in the documentation .