### PR TITLE
`reduce` now works on objects

### DIFF
--- a/src/internal/_reduce.js
+++ b/src/internal/_reduce.js
@@ -1,6 +1,8 @@
+var _isObject = require('./internal/_isObject');
 var _xwrap = require('./_xwrap');
 var bind = require('../bind');
 var isArrayLike = require('../isArrayLike');
+var values = require('./values');
 
 
 module.exports = (function() {
@@ -36,7 +38,7 @@ module.exports = (function() {
   }
 
   var symIterator = (typeof Symbol !== 'undefined') ? Symbol.iterator : '@@iterator';
-  return function _reduce(fn, acc, list) {
+  function _reduce(fn, acc, list) {
     if (typeof fn === 'function') {
       fn = _xwrap(fn);
     }
@@ -52,6 +54,11 @@ module.exports = (function() {
     if (typeof list.next === 'function') {
       return _iterableReduce(fn, acc, list);
     }
+    if (_isObject(list)) {
+      return _arrayReduce(fn, acc, values(list));
+    }
     throw new TypeError('reduce: list must be array or iterable');
-  };
+  }
+
+  return _reduce;
 }());

--- a/test/reduce.js
+++ b/test/reduce.js
@@ -10,6 +10,10 @@ describe('reduce', function() {
     eq(R.reduce(mult, 1, [1, 2, 3, 4]), 24);
   });
 
+  it('folds over simple objects', function() {
+    eq(R.reduce(add, 0, {a: 1, b: 2, c: 3}), 6);
+  });
+
   it('dispatches to objects that implement `reduce`', function() {
     var obj = {x: [1, 2, 3], reduce: function() { return 'override'; }};
     eq(R.reduce(add, 0, obj), 'override');


### PR DESCRIPTION
Now that simple JS objects are treated as functors, `map` and `filter` works over it, `reduce` should also work over objects.