### PR TITLE
Replace * with Any in all type signatures

### DIFF
--- a/src/F.js
+++ b/src/F.js
@@ -8,8 +8,8 @@ var always = require('./always');
  * @memberOf R
  * @since v0.9.0
  * @category Function
- * @sig * -> Boolean
- * @param {*}
+ * @sig Any -> Boolean
+ * @param {Any}
  * @return {Boolean}
  * @see R.always, R.T
  * @example

--- a/src/T.js
+++ b/src/T.js
@@ -8,8 +8,8 @@ var always = require('./always');
  * @memberOf R
  * @since v0.9.0
  * @category Function
- * @sig * -> Boolean
- * @param {*}
+ * @sig Any -> Boolean
+ * @param {Any}
  * @return {Boolean}
  * @see R.always, R.F
  * @example

--- a/src/addIndex.js
+++ b/src/addIndex.js
@@ -19,7 +19,7 @@ var curryN = require('./curryN');
  * @since v0.15.0
  * @category Function
  * @category List
- * @sig ((a ... -> b) ... -> [a] -> *) -> (a ..., Int, [a] -> b) ... -> [a] -> *)
+ * @sig ((a ... -> b) ... -> [a] -> Any) -> (a ..., Int, [a] -> b) ... -> [a] -> Any)
  * @param {Function} fn A list iteration function that does not pass index or list to its callback
  * @return {Function} An altered list iteration function that passes (item, index, list) to its callback
  * @example

--- a/src/allPass.js
+++ b/src/allPass.js
@@ -17,7 +17,7 @@ var reduce = require('./reduce');
  * @memberOf R
  * @since v0.9.0
  * @category Logic
- * @sig [(*... -> Boolean)] -> (*... -> Boolean)
+ * @sig [(Any... -> Boolean)] -> (Any... -> Boolean)
  * @param {Array} preds
  * @return {Function}
  * @see R.anyPass

--- a/src/always.js
+++ b/src/always.js
@@ -12,9 +12,9 @@ var _curry1 = require('./internal/_curry1');
  * @memberOf R
  * @since v0.1.0
  * @category Function
- * @sig a -> (* -> a)
- * @param {*} val The value to wrap in a function
- * @return {Function} A Function :: * -> val.
+ * @sig a -> (Any -> a)
+ * @param {Any} val The value to wrap in a function
+ * @return {Function} A Function :: Any -> val.
  * @example
  *
  *      var t = R.always('Tee');

--- a/src/and.js
+++ b/src/and.js
@@ -8,7 +8,7 @@ var _curry2 = require('./internal/_curry2');
  * @memberOf R
  * @since v0.1.0
  * @category Logic
- * @sig * -> * -> *
+ * @sig Any -> Any -> Any
  * @param {Boolean} a A boolean value
  * @param {Boolean} b A boolean value
  * @return {Boolean} `true` if both arguments are `true`, `false` otherwise

--- a/src/anyPass.js
+++ b/src/anyPass.js
@@ -17,7 +17,7 @@ var reduce = require('./reduce');
  * @memberOf R
  * @since v0.9.0
  * @category Logic
- * @sig [(*... -> Boolean)] -> (*... -> Boolean)
+ * @sig [(Any... -> Boolean)] -> (Any... -> Boolean)
  * @param {Array} preds
  * @return {Function}
  * @see R.allPass

--- a/src/apply.js
+++ b/src/apply.js
@@ -10,10 +10,10 @@ var _curry2 = require('./internal/_curry2');
  * @memberOf R
  * @since v0.7.0
  * @category Function
- * @sig (*... -> a) -> [*] -> a
+ * @sig (Any... -> a) -> [Any] -> a
  * @param {Function} fn
  * @param {Array} args
- * @return {*}
+ * @return {Any}
  * @see R.call, R.unapply
  * @example
  *

--- a/src/binary.js
+++ b/src/binary.js
@@ -11,7 +11,7 @@ var nAry = require('./nAry');
  * @memberOf R
  * @since v0.2.0
  * @category Function
- * @sig (* -> c) -> (a, b -> c)
+ * @sig (Any -> c) -> (a, b -> c)
  * @param {Function} fn The function to wrap.
  * @return {Function} A new function wrapping `fn`. The new function is guaranteed to be of
  *         arity 2.

--- a/src/bind.js
+++ b/src/bind.js
@@ -12,7 +12,7 @@ var _curry2 = require('./internal/_curry2');
  * @since v0.6.0
  * @category Function
  * @category Object
- * @sig (* -> *) -> {*} -> (* -> *)
+ * @sig (Any -> Any) -> {Any} -> (Any -> Any)
  * @param {Function} fn The function to bind to context
  * @param {Object} thisObj The context to bind `fn` to
  * @return {Function} A function that will execute in the context of `thisObj`.

--- a/src/both.js
+++ b/src/both.js
@@ -18,7 +18,7 @@ var lift = require('./lift');
  * @memberOf R
  * @since v0.12.0
  * @category Logic
- * @sig (*... -> Boolean) -> (*... -> Boolean) -> (*... -> Boolean)
+ * @sig (Any... -> Boolean) -> (Any... -> Boolean) -> (Any... -> Boolean)
  * @param {Function} f a predicate
  * @param {Function} g another predicate
  * @return {Function} a function that applies its arguments to `f` and `g` and `&&`s their outputs together.

--- a/src/call.js
+++ b/src/call.js
@@ -12,10 +12,10 @@ var curry = require('./curry');
  * @memberOf R
  * @since v0.9.0
  * @category Function
- * @sig (*... -> a),*... -> a
+ * @sig (Any... -> a),Any... -> a
  * @param {Function} fn The function to apply to the remaining arguments.
- * @param {...*} args Any number of positional arguments.
- * @return {*}
+ * @param {...Any} args Any number of positional arguments.
+ * @return {Any}
  * @see R.apply
  * @example
  *

--- a/src/clone.js
+++ b/src/clone.js
@@ -13,9 +13,9 @@ var _curry1 = require('./internal/_curry1');
  * @memberOf R
  * @since v0.1.0
  * @category Object
- * @sig {*} -> {*}
- * @param {*} value The object or array to clone
- * @return {*} A new object or array.
+ * @sig {Any} -> {Any}
+ * @param {Any} value The object or array to clone
+ * @return {Any} A new object or array.
  * @example
  *
  *      var objects = [{}, {}, {}];

--- a/src/complement.js
+++ b/src/complement.js
@@ -17,7 +17,7 @@ var not = require('./not');
  * @memberOf R
  * @since v0.12.0
  * @category Logic
- * @sig (*... -> *) -> (*... -> Boolean)
+ * @sig (Any... -> Any) -> (Any... -> Boolean)
  * @param {Function} f
  * @return {Function}
  * @see R.not

--- a/src/cond.js
+++ b/src/cond.js
@@ -17,7 +17,7 @@ var reduce = require('./reduce');
  * @memberOf R
  * @since v0.6.0
  * @category Logic
- * @sig [[(*... -> Boolean),(*... -> *)]] -> (*... -> *)
+ * @sig [[(Any... -> Boolean),(Any... -> Any)]] -> (Any... -> Any)
  * @param {Array} pairs
  * @return {Function}
  * @example

--- a/src/construct.js
+++ b/src/construct.js
@@ -10,7 +10,7 @@ var constructN = require('./constructN');
  * @memberOf R
  * @since v0.1.0
  * @category Function
- * @sig (* -> {*}) -> (* -> {*})
+ * @sig (Any -> {Any}) -> (Any -> {Any})
  * @param {Function} Fn The constructor function to wrap.
  * @return {Function} A wrapped, curried constructor function.
  * @example

--- a/src/constructN.js
+++ b/src/constructN.js
@@ -12,7 +12,7 @@ var nAry = require('./nAry');
  * @memberOf R
  * @since v0.4.0
  * @category Function
- * @sig Number -> (* -> {*}) -> (* -> {*})
+ * @sig Number -> (Any -> {Any}) -> (Any -> {Any})
  * @param {Number} n The arity of the constructor function.
  * @param {Function} Fn The constructor function to wrap.
  * @return {Function} A wrapped, curried constructor function.

--- a/src/countBy.js
+++ b/src/countBy.js
@@ -12,7 +12,7 @@ var _has = require('./internal/_has');
  * @memberOf R
  * @since v0.1.0
  * @category Relation
- * @sig (a -> String) -> [a] -> {*}
+ * @sig (a -> String) -> [a] -> {Any}
  * @param {Function} fn The function used to map values to keys.
  * @param {Array} list The list to count elements from.
  * @return {Object} An object mapping keys to number of occurrences in the list.

--- a/src/curry.js
+++ b/src/curry.js
@@ -30,7 +30,7 @@ var curryN = require('./curryN');
  * @memberOf R
  * @since v0.1.0
  * @category Function
- * @sig (* -> a) -> (* -> a)
+ * @sig (Any -> a) -> (Any -> a)
  * @param {Function} fn The function to curry.
  * @return {Function} A new, curried function.
  * @see R.curryN

--- a/src/curryN.js
+++ b/src/curryN.js
@@ -32,7 +32,7 @@ var _curryN = require('./internal/_curryN');
  * @memberOf R
  * @since v0.5.0
  * @category Function
- * @sig Number -> (* -> a) -> (* -> a)
+ * @sig Number -> (Any -> a) -> (Any -> a)
  * @param {Number} length The arity for the returned function.
  * @param {Function} fn The function to curry.
  * @return {Function} A new, curried function.

--- a/src/either.js
+++ b/src/either.js
@@ -18,7 +18,7 @@ var or = require('./or');
  * @memberOf R
  * @since v0.12.0
  * @category Logic
- * @sig (*... -> Boolean) -> (*... -> Boolean) -> (*... -> Boolean)
+ * @sig (Any... -> Boolean) -> (Any... -> Boolean) -> (Any... -> Boolean)
  * @param {Function} f a predicate
  * @param {Function} g another predicate
  * @return {Function} a function that applies its arguments to `f` and `g` and `||`s their outputs together.

--- a/src/forEach.js
+++ b/src/forEach.js
@@ -22,7 +22,7 @@ var _curry2 = require('./internal/_curry2');
  * @memberOf R
  * @since v0.1.1
  * @category List
- * @sig (a -> *) -> [a] -> [a]
+ * @sig (a -> Any) -> [a] -> [a]
  * @param {Function} fn The function to invoke. Receives one argument, `value`.
  * @param {Array} list The list to iterate over.
  * @return {Array} The original list.

--- a/src/ifElse.js
+++ b/src/ifElse.js
@@ -10,7 +10,7 @@ var curryN = require('./curryN');
  * @memberOf R
  * @since v0.8.0
  * @category Logic
- * @sig (*... -> Boolean) -> (*... -> *) -> (*... -> *) -> (*... -> *)
+ * @sig (Any... -> Boolean) -> (Any... -> Any) -> (Any... -> Any) -> (Any... -> Any)
  * @param {Function} condition A predicate function
  * @param {Function} onTrue A function to invoke when the `condition` evaluates to a truthy value.
  * @param {Function} onFalse A function to invoke when the `condition` evaluates to a falsy value.

--- a/src/invoker.js
+++ b/src/invoker.js
@@ -16,7 +16,7 @@ var toString = require('./toString');
  * @memberOf R
  * @since v0.1.0
  * @category Function
- * @sig Number -> String -> (a -> b -> ... -> n -> Object -> *)
+ * @sig Number -> String -> (a -> b -> ... -> n -> Object -> Any)
  * @param {Number} arity Number of arguments the returned function should take
  *        before the target object.
  * @param {String} method Name of the method to call.

--- a/src/is.js
+++ b/src/is.js
@@ -9,9 +9,9 @@ var _curry2 = require('./internal/_curry2');
  * @memberOf R
  * @since v0.3.0
  * @category Type
- * @sig (* -> {*}) -> a -> Boolean
+ * @sig (Any -> {Any}) -> a -> Boolean
  * @param {Object} ctor A constructor
- * @param {*} val The value to test
+ * @param {Any} val The value to test
  * @return {Boolean}
  * @example
  *

--- a/src/isArrayLike.js
+++ b/src/isArrayLike.js
@@ -11,7 +11,7 @@ var _isArray = require('./internal/_isArray');
  * @category Type
  * @category List
  * @sig * -> Boolean
- * @param {*} x The object to test.
+ * @param {Any} x The object to test.
  * @return {Boolean} `true` if `x` has a numeric length property and extreme indices defined; `false` otherwise.
  * @example
  *

--- a/src/isNil.js
+++ b/src/isNil.js
@@ -8,8 +8,8 @@ var _curry1 = require('./internal/_curry1');
  * @memberOf R
  * @since v0.9.0
  * @category Type
- * @sig * -> Boolean
- * @param {*} x The value to test.
+ * @sig Any -> Boolean
+ * @param {Any} x The value to test.
  * @return {Boolean} `true` if `x` is `undefined` or `null`, otherwise `false`.
  * @example
  *

--- a/src/lift.js
+++ b/src/lift.js
@@ -10,7 +10,7 @@ var liftN = require('./liftN');
  * @memberOf R
  * @since v0.7.0
  * @category Function
- * @sig (*... -> *) -> ([*]... -> [*])
+ * @sig (Any... -> Any) -> ([Any]... -> [Any])
  * @param {Function} fn The function to lift into higher context
  * @return {Function} The lifted function.
  * @see R.liftN

--- a/src/liftN.js
+++ b/src/liftN.js
@@ -14,7 +14,7 @@ var map = require('./map');
  * @memberOf R
  * @since v0.7.0
  * @category Function
- * @sig Number -> (*... -> *) -> ([*]... -> [*])
+ * @sig Number -> (Any... -> Any) -> ([Any]... -> [Any])
  * @param {Function} fn The function to lift into higher context
  * @return {Function} The lifted function.
  * @see R.lift

--- a/src/memoize.js
+++ b/src/memoize.js
@@ -15,7 +15,7 @@ var toString = require('./toString');
  * @memberOf R
  * @since v0.1.0
  * @category Function
- * @sig (*... -> a) -> (*... -> a)
+ * @sig (Any... -> a) -> (Any... -> a)
  * @param {Function} fn The function to memoize.
  * @return {Function} Memoized version of `fn`.
  * @example

--- a/src/nAry.js
+++ b/src/nAry.js
@@ -10,7 +10,7 @@ var _curry2 = require('./internal/_curry2');
  * @memberOf R
  * @since v0.1.0
  * @category Function
- * @sig Number -> (* -> a) -> (* -> a)
+ * @sig Number -> (Any -> a) -> (Any -> a)
  * @param {Number} n The desired arity of the new function.
  * @param {Function} fn The function to wrap.
  * @return {Function} A new function wrapping `fn`. The new function is guaranteed to be of

--- a/src/not.js
+++ b/src/not.js
@@ -9,8 +9,8 @@ var _curry1 = require('./internal/_curry1');
  * @memberOf R
  * @since v0.1.0
  * @category Logic
- * @sig * -> Boolean
- * @param {*} a any value
+ * @sig Any -> Boolean
+ * @param {Any} a any value
  * @return {Boolean} the logical inverse of passed argument.
  * @see R.complement
  * @example

--- a/src/nthArg.js
+++ b/src/nthArg.js
@@ -9,7 +9,7 @@ var nth = require('./nth');
  * @memberOf R
  * @since v0.9.0
  * @category Function
- * @sig Number -> *... -> *
+ * @sig Number -> Any... -> Any
  * @param {Number} n
  * @return {Function}
  * @example

--- a/src/omit.js
+++ b/src/omit.js
@@ -9,7 +9,7 @@ var _curry2 = require('./internal/_curry2');
  * @memberOf R
  * @since v0.1.0
  * @category Object
- * @sig [String] -> {String: *} -> {String: *}
+ * @sig [String] -> {String: Any} -> {String: Any}
  * @param {Array} names an array of String property names to omit from the new object
  * @param {Object} obj The object to copy from
  * @return {Object} A new object with properties from `names` not on it.

--- a/src/or.js
+++ b/src/or.js
@@ -9,7 +9,7 @@ var _curry2 = require('./internal/_curry2');
  * @memberOf R
  * @since v0.1.0
  * @category Logic
- * @sig * -> * -> *
+ * @sig Any -> Any -> Any
  * @param {Boolean} a A boolean value
  * @param {Boolean} b A boolean value
  * @return {Boolean} `true` if one or both arguments are `true`, `false` otherwise

--- a/src/pair.js
+++ b/src/pair.js
@@ -9,8 +9,8 @@ var _curry2 = require('./internal/_curry2');
  * @since v0.18.0
  * @category List
  * @sig a -> b -> (a,b)
- * @param {*} fst
- * @param {*} snd
+ * @param {Any} fst
+ * @param {Any} snd
  * @return {Array}
  * @see R.objOf, R.of
  * @example

--- a/src/pathEq.js
+++ b/src/pathEq.js
@@ -11,9 +11,9 @@ var path = require('./path');
  * @memberOf R
  * @since v0.7.0
  * @category Relation
- * @sig [String] -> * -> {String: *} -> Boolean
+ * @sig [String] -> Any -> {String: Any} -> Boolean
  * @param {Array} path The path of the nested property to use
- * @param {*} val The value to compare the nested property with
+ * @param {Any} val The value to compare the nested property with
  * @param {Object} obj The object to check the nested property in
  * @return {Boolean} `true` if the value equals the nested object property,
  *         `false` otherwise.

--- a/src/reduced.js
+++ b/src/reduced.js
@@ -13,9 +13,9 @@ var _reduced = require('./internal/_reduced');
  * @memberOf R
  * @since v0.15.0
  * @category List
- * @sig a -> *
- * @param {*} x The final value of the reduce.
- * @return {*} The wrapped value.
+ * @sig a -> Any
+ * @param {Any} x The final value of the reduce.
+ * @return {Any} The wrapped value.
  * @see R.reduce, R.transduce
  * @example
  *

--- a/src/tap.js
+++ b/src/tap.js
@@ -8,10 +8,10 @@ var _curry2 = require('./internal/_curry2');
  * @memberOf R
  * @since v0.1.0
  * @category Function
- * @sig (a -> *) -> a -> a
+ * @sig (a -> Any) -> a -> a
  * @param {Function} fn The function to call with `x`. The return value of `fn` will be thrown away.
- * @param {*} x
- * @return {*} `x`.
+ * @param {Any} x
+ * @return {Any} `x`.
  * @example
  *
  *      var sayX = x => console.log('x is ' + x);

--- a/src/toPairs.js
+++ b/src/toPairs.js
@@ -12,7 +12,7 @@ var _has = require('./internal/_has');
  * @memberOf R
  * @since v0.4.0
  * @category Object
- * @sig {String: *} -> [[String,*]]
+ * @sig {String: Any} -> [[String,Any]]
  * @param {Object} obj The object to extract from
  * @return {Array} An array of key, value arrays from the object's own properties.
  * @see R.fromPairs

--- a/src/toPairsIn.js
+++ b/src/toPairsIn.js
@@ -11,7 +11,7 @@ var _curry1 = require('./internal/_curry1');
  * @memberOf R
  * @since v0.4.0
  * @category Object
- * @sig {String: *} -> [[String,*]]
+ * @sig {String: Any} -> [[String,Any]]
  * @param {Object} obj The object to extract from
  * @return {Array} An array of key, value arrays from the object's own
  *         and prototype properties.

--- a/src/toString.js
+++ b/src/toString.js
@@ -28,7 +28,7 @@ var _toString = require('./internal/_toString');
  * @since v0.14.0
  * @category String
  * @sig * -> String
- * @param {*} val
+ * @param {Any} val
  * @return {String}
  * @example
  *

--- a/src/type.js
+++ b/src/type.js
@@ -11,8 +11,8 @@ var _curry1 = require('./internal/_curry1');
  * @memberOf R
  * @since v0.8.0
  * @category Type
- * @sig (* -> {*}) -> String
- * @param {*} val The value to test
+ * @sig (Any -> {Any}) -> String
+ * @param {Any} val The value to test
  * @return {String}
  * @example
  *

--- a/src/unapply.js
+++ b/src/unapply.js
@@ -17,7 +17,7 @@ var _slice = require('./internal/_slice');
  * @memberOf R
  * @since v0.8.0
  * @category Function
- * @sig ([*...] -> a) -> (*... -> a)
+ * @sig ([Any...] -> a) -> (Any... -> a)
  * @param {Function} fn
  * @return {Function}
  * @see R.apply

--- a/src/unary.js
+++ b/src/unary.js
@@ -11,7 +11,7 @@ var nAry = require('./nAry');
  * @memberOf R
  * @since v0.2.0
  * @category Function
- * @sig (* -> b) -> (a -> b)
+ * @sig (Any -> b) -> (a -> b)
  * @param {Function} fn The function to wrap.
  * @return {Function} A new function wrapping `fn`. The new function is guaranteed to be of
  *         arity 1.

--- a/src/unfold.js
+++ b/src/unfold.js
@@ -13,12 +13,12 @@ var _curry2 = require('./internal/_curry2');
  * @memberOf R
  * @since v0.10.0
  * @category List
- * @sig (a -> [b]) -> * -> [b]
+ * @sig (a -> [b]) -> Any -> [b]
  * @param {Function} fn The iterator function. receives one argument, `seed`, and returns
  *        either false to quit iteration or an array of length two to proceed. The element
  *        at index 0 of this array will be added to the resulting array, and the element
  *        at index 1 will be passed to the next call to `fn`.
- * @param {*} seed The seed value.
+ * @param {Any} seed The seed value.
  * @return {Array} The final list.
  * @example
  *

--- a/src/where.js
+++ b/src/where.js
@@ -16,7 +16,7 @@ var _has = require('./internal/_has');
  * @memberOf R
  * @since v0.1.1
  * @category Object
- * @sig {String: (* -> Boolean)} -> {String: *} -> Boolean
+ * @sig {String: (Any -> Boolean)} -> {String: Any} -> Boolean
  * @param {Object} spec
  * @param {Object} testObj
  * @return {Boolean}

--- a/src/whereEq.js
+++ b/src/whereEq.js
@@ -16,7 +16,7 @@ var where = require('./where');
  * @memberOf R
  * @since v0.14.0
  * @category Object
- * @sig {String: *} -> {String: *} -> Boolean
+ * @sig {String: Any} -> {String: Any} -> Boolean
  * @param {Object} spec
  * @param {Object} testObj
  * @return {Boolean}

--- a/src/zipObj.js
+++ b/src/zipObj.js
@@ -8,7 +8,7 @@ var _curry2 = require('./internal/_curry2');
  * @memberOf R
  * @since v0.3.0
  * @category List
- * @sig [String] -> [*] -> {String: *}
+ * @sig [String] -> [Any] -> {String: Any}
  * @param {Array} keys The array that will be properties on the output object.
  * @param {Array} values The list of values on the output object.
  * @return {Object} The object made by pairing up same-indexed elements of `keys` and `values`.


### PR DESCRIPTION
This was discussed in #1554 and seemed to have a reasonable bit of support. I'm happy to do some of the other suggestions made in that issue, like a consistent way to represent dictionaries - as `{a}` - but that seemed to get a more lukewarm reception.
