### PR TITLE
amended docs for lift and liftN 

### DIFF
--- a/src/lift.js
+++ b/src/lift.js
@@ -3,7 +3,7 @@ var liftN = require('./liftN');
 
 
 /**
- * "lifts" a function of arity > 1 so that it may "map over" an Array or other
+ * "lifts" a function of arity > 1 so that it may "map over" a list, Function or other
  * object that satisfies the [FantasyLand Apply spec](https://github.com/fantasyland/fantasy-land#apply).
  *
  * @func
@@ -13,7 +13,7 @@ var liftN = require('./liftN');
  * @sig (*... -> *) -> ([*]... -> [*])
  * @param {Function} fn The function to lift into higher context
  * @return {Function} The lifted function.
- * @see R.liftN
+ * @see R.liftN, R.lift
  * @example
  *
  *      var madd3 = R.lift(R.curry((a, b, c) => a + b + c));

--- a/src/liftN.js
+++ b/src/liftN.js
@@ -8,7 +8,7 @@ var map = require('./map');
 
 /**
  * "lifts" a function to be the specified arity, so that it may "map over" that
- * many lists (or other objects that satisfies the [FantasyLand Apply spec](https://github.com/fantasyland/fantasy-land#apply)).
+ * many lists, Functions or other objects that satisfy the [FantasyLand Apply spec](https://github.com/fantasyland/fantasy-land#apply).
  *
  * @func
  * @memberOf R
@@ -17,7 +17,7 @@ var map = require('./map');
  * @sig Number -> (*... -> *) -> ([*]... -> [*])
  * @param {Function} fn The function to lift into higher context
  * @return {Function} The lifted function.
- * @see R.lift
+ * @see R.lift, R.ap
  * @example
  *
  *      var madd3 = R.liftN(3, R.curryN(3, (...args) => R.sum(args)));


### PR DESCRIPTION
Amended docs for lift and liftN to indicate support for functions-as-applicatives via R.ap
see https://github.com/ramda/ramda/issues/1447

I have also changed  *list* to *Array* in the `liftN` docs; this is consistent with the `lift` docs.


