### PR TITLE
Move Set logic in uniqBy into custom _Set type

### DIFF
--- a/src/internal/_Set.js
+++ b/src/internal/_Set.js
@@ -1,0 +1,162 @@
+var _contains = require('./_contains');
+
+
+// A simple Set type that honours R.equals semantics
+module.exports = (function() {
+  function _Set() {
+    /* globals Set */
+    this._nativeSet = typeof Set === 'function' ? new Set() : null;
+    this._items = {};
+  }
+
+  _Set.prototype.add = function(item) {
+    return hasOrAdd(item, true, this);
+  };
+
+  _Set.prototype.has = function(item) {
+    return hasOrAdd(item, false, this);
+  };
+
+  /**
+   * Combines the logic for checking whether an item is a member of the set and
+   * for adding a new item to the set.
+   *
+   * @param item       The item to check or add to the Set instance.
+   * @param shouldAdd  If true, the item will be added to the set if it doesn't
+   *                   already exist.
+   * @param set        The set instance to check or add to.
+   * @return {boolean} When shouldAdd is true, this will return true when a new
+   *                   item was added otherwise false. When shouldAdd is false,
+   *                   this will return true if the item already exists, otherwise
+   *                   false.
+   */
+  function hasOrAdd(item, shouldAdd, set) {
+    var type = typeof item;
+    var prevSize, newSize;
+    switch (type) {
+      case 'string':
+      case 'number':
+        // distinguish between +0 and -0
+        if (item === 0 && !set._items['-0'] && 1 / item === -Infinity) {
+          if (shouldAdd) {
+            set._items['-0'] = true;
+          }
+          return shouldAdd;
+        }
+        // these types can all utilise Set
+        if (set._nativeSet !== null) {
+          if (shouldAdd) {
+            prevSize = set._nativeSet.size;
+            set._nativeSet.add(item);
+            newSize = set._nativeSet.size;
+            return (newSize > prevSize);
+          } else {
+            return set._nativeSet.has(item);
+          }
+        } else {
+          if (!(type in set._items)) {
+            if (shouldAdd) {
+              set._items[type] = {};
+              set._items[type][item] = true;
+            }
+            return shouldAdd;
+          } else if (item in set._items[type]) {
+            return !shouldAdd;
+          } else {
+            if (shouldAdd) {
+              set._items[type][item] = true;
+            }
+            return shouldAdd;
+          }
+        }
+
+      case 'boolean':
+        // set._items['boolean'] holds a two element array
+        // representing [ falseExists, trueExists ]
+        if (type in set._items) {
+          var bIdx = item ? 1 : 0;
+          if (set._items[type][bIdx]) {
+            return !shouldAdd;
+          } else {
+            if (shouldAdd) {
+              set._items[type][bIdx] = true;
+            }
+            return shouldAdd;
+          }
+        } else {
+          if (shouldAdd) {
+            set._items[type] = item ? [false, true] : [true, false];
+          }
+          return shouldAdd;
+        }
+
+      case 'function':
+        // compare functions for reference equality
+        if (set._nativeSet !== null) {
+          if (shouldAdd) {
+            prevSize = set._nativeSet.size;
+            set._nativeSet.add(item);
+            newSize = set._nativeSet.size;
+            return (newSize > prevSize);
+          } else {
+            return set._nativeSet.has(item);
+          }
+        } else {
+          if (!(type in set._items)) {
+            if (shouldAdd) {
+              set._items[type] = [item];
+            }
+            return shouldAdd;
+          }
+          if (!_contains(item, set._items[type])) {
+            if (shouldAdd) {
+              set._items[type].push(item);
+            }
+            return shouldAdd;
+          }
+        }
+        return !shouldAdd;
+
+      case 'undefined':
+        if (set._items[type]) {
+          return !shouldAdd;
+        } else {
+          if (shouldAdd) {
+            set._items[type] = true;
+          }
+          return shouldAdd;
+        }
+
+      case 'object':
+        if (item === null) {
+          if (!set._items['null']) {
+            if (shouldAdd) {
+              set._items['null'] = true;
+            }
+            return shouldAdd;
+          }
+          return !shouldAdd;
+        }
+      /* falls through */
+      default:
+        // reduce the search size of heterogeneous sets by creating buckets
+        // for each type.
+        type = Object.prototype.toString.call(item);
+        if (!(type in set._items)) {
+          if (shouldAdd) {
+            set._items[type] = [item];
+          }
+          return shouldAdd;
+        }
+        // scan through all previously applied items
+        if (!_contains(item, set._items[type])) {
+          if (shouldAdd) {
+            set._items[type].push(item);
+          }
+          return shouldAdd;
+        }
+        return !shouldAdd;
+    }
+  }
+  return _Set;
+}());

--- a/src/uniqBy.js
+++ b/src/uniqBy.js
@@ -1,4 +1,4 @@
-var _contains = require('./internal/_contains');
+var _Set = require('./internal/_Set');
 var _curry2 = require('./internal/_curry2');
 
 
@@ -20,76 +20,19 @@ var _curry2 = require('./internal/_curry2');
  *
  *      R.uniqBy(Math.abs, [-1, -5, 2, 10, 1, 2]); //=> [-1, -5, 2, 10]
  */
-module.exports = _curry2(/* globals Set */ typeof Set === 'undefined' ?
-  function uniqBy(fn, list) {
-    var idx = 0;
-    var applied = [];
-    var result = [];
-    var appliedItem, item;
-    while (idx < list.length) {
-      item = list[idx];
-      appliedItem = fn(item);
-      if (!_contains(appliedItem, applied)) {
-        result.push(item);
-        applied.push(appliedItem);
-      }
-      idx += 1;
-    }
-    return result;
-  } :
-  function uniqBySet(fn, list) {
-    var set           = new Set();
-    var applied       = [];
-    var prevSetSize   = 0;
-    var result        = [];
-    var nullExists    = false;
-    var negZeroExists = false;
-    var idx           = 0;
-    var appliedItem, item, newSetSize;
+module.exports = _curry2(function uniqBy(fn, list) {
+  var set = new _Set();
+  var result = [];
+  var idx = 0;
+  var appliedItem, item;
 
-    while (idx < list.length) {
-      item = list[idx];
-      appliedItem = fn(item);
-      switch (typeof appliedItem) {
-        case 'number':
-          // distinguishing between +0 and -0 is not supported by Set
-          if (appliedItem === 0 && !negZeroExists && 1 / appliedItem === -Infinity) {
-            negZeroExists = true;
-            result.push(item);
-            break;
-          }
-        /* falls through */
-        case 'string':
-        case 'boolean':
-        case 'function':
-        case 'undefined':
-          // these types can all utilise Set
-          set.add(appliedItem);
-          newSetSize = set.size;
-          if (newSetSize > prevSetSize) {
-            result.push(item);
-            prevSetSize = newSetSize;
-          }
-          break;
-        case 'object':
-          if (appliedItem === null) {
-            if (!nullExists) {
-              // prevent scan for null by tracking as a boolean
-              nullExists = true;
-              result.push(null);
-            }
-            break;
-          }
-        /* falls through */
-        default:
-          // scan through all previously applied items
-          if (!_contains(appliedItem, applied)) {
-            applied.push(appliedItem);
-            result.push(item);
-          }
-      }
-      idx += 1;
+  while (idx < list.length) {
+    item = list[idx];
+    appliedItem = fn(item);
+    if (set.add(appliedItem)) {
+      result.push(item);
     }
-    return result;
+    idx += 1;
   }
-);
+  return result;
+});


### PR DESCRIPTION
This change moves the logic for handling the equality semantics from within `R.uniqBy` into a separate `internal/_Set` type, cleaning up the internals of `R.uniqBy` while making something of a reusable Set type that honours `R.equals` semantics and can also be used in environments where a native `Set` doesn't exist.

Performance gets a nice little boost on earlier versions on Node too :wink:
```
> process.version
'v0.10.36'
> a = R.range(0, 1e6);
> c.time(''); _.uniq(a); c.timeEnd('');
: 156ms
> c.time(''); R.uniq(a); c.timeEnd('');
: 235ms

> process.version
'v5.5.0'
> a = R.range(0, 1e6);
> c.time(''); _.uniq(a); c.timeEnd('');
: 315.964ms
> c.time(''); R.uniq(a); c.timeEnd('');
: 250.782ms
```