### PR TITLE
Fix broken link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Please review the [API documentation](http://ramdajs.com/docs/).
 Introductions
 -------------
 
-* [Introducing Ramda](http://buzzdecafe.github.io/code/2014/05/16/introducing-ramda/) by Buzz de Cafe
+* [Introducing Ramda](http://buzzdecafe.github.io/code/2014/05/16/introducing-ramda) by Buzz de Cafe
 * [Why Ramda?](http://fr.umio.us/why-ramda/) by Scott Sauyet
 * [Favoring Curry](http://fr.umio.us/favoring-curry/) by Scott Sauyet
 


### PR DESCRIPTION
Fixes #1633 - broken link in README.md to "Introducing Ramda" by Buzz de Cafe