### PR TITLE
Curried Function Equality

### DIFF
--- a/src/curryN.js
+++ b/src/curryN.js
@@ -1,4 +1,3 @@
-var _arity = require('./internal/_arity');
 var _curry1 = require('./internal/_curry1');
 var _curry2 = require('./internal/_curry2');
 var _curryN = require('./internal/_curryN');
@@ -50,5 +49,5 @@ module.exports = _curry2(function curryN(length, fn) {
   if (length === 1) {
     return _curry1(fn);
   }
-  return _arity(length, _curryN(length, [], fn));
+  return _curryN(length, [], fn);
 });

--- a/src/internal/_curryN.js
+++ b/src/internal/_curryN.js
@@ -1,6 +1,8 @@
 var _arity = require('./_arity');
+var _complement = require('./_complement');
+var _equals = require('./_equals');
+var _filter = require('./_filter');
 var _isPlaceholder = require('./_isPlaceholder');
-
 
 /**
  * Internal curryN function.
@@ -13,7 +15,8 @@ var _isPlaceholder = require('./_isPlaceholder');
  * @return {Function} The curried function.
  */
 module.exports = function _curryN(length, received, fn) {
-  return function() {
+  var arity = length - _filter(_complement(_isPlaceholder), received).length;
+  var _fn = _arity(arity, function() {
     var combined = [];
     var argsIdx = 0;
     var left = length;
@@ -35,6 +38,17 @@ module.exports = function _curryN(length, received, fn) {
       combinedIdx += 1;
     }
     return left <= 0 ? fn.apply(this, combined)
-                     : _arity(left, _curryN(length, combined, fn));
+                     : _curryN(length, combined, fn);
+  });
+  // keep track of the original function and the combined args
+  _fn.curried = true
+  _fn.fn = fn.curried ? fn.fn : fn
+  _fn.args = received;
+  // compare the original function with the combined args
+  _fn.equals = function(fn2) {
+    return fn2.curried &&
+           _equals(fn2.fn, _fn.fn, [], []) &&
+           _equals(fn2.args, _fn.args, [], []);
   };
+  return _fn
 };

--- a/test/curryN.js
+++ b/test/curryN.js
@@ -105,4 +105,19 @@ describe('curryN', function() {
     eq(g(1)(2)(3, 4), [1, 2, 3, 4]);
   });
 
+  it('equals another curried function', function() {
+    var f = function() { return Array.prototype.slice.call(arguments); };
+    var g = R.curryN(3, f);
+
+    eq(true, R.equals(g(1), g(1)));
+    eq(true, R.equals(g(1, 2), g(1, 2)));
+    eq(true, R.equals(g(), g()));
+
+    eq(false, R.equals(g(1), g(2)));
+    eq(false, R.equals(g(1, 2), g(2)));
+    eq(false, R.equals(g(1, 2), g(2, 1)));
+
+    eq(true, R.equals(g(g(1,2)), g(g(1,2))));
+    eq(false, R.equals(g(g(1,2)), g(g(2,1))));
+  });
 });


### PR DESCRIPTION
This is PR is just an experiment at this point. But I really think it would be useful -- or maybe there's a better way of dealing with my issues. [This discussion](https://github.com/ramda/ramda/issues/1481) didnt get too far, so let me rephrase some things.

In the big picture, I want to find some way of [optimizing a "listOf" higher-order component **in a pure functional way**.](https://github.com/ccorcos/elmish/blob/master/src/ui/listOf.js)  (it may make more sense if you just [browse through these](https://github.com/ccorcos/elmish/tree/master/tutorial)). This consists of (1) being able to lazily build, difference, and evaluate trees in an idiomatic fashion and (2) being able to compare bound functions as if they're referentially transparent to satisfy the first point.

Lets start with the second point. Here's a simple example using React:

```js
const Counter = React.createClass({
  render() {
    const inc = () => this.props.update(this.props.value + 1)
    return (
      <div>
        <span>{this.props.value}</span>
        <button onClick={inc}>inc</button>
      </div>
    )
  }
})

const ListOfCounters = React.createClass({
  getInitialState() {
    return {numbers: [1,2,3,4,5,6,7,8,9,10]}
  },
  update(i, value) {
    this.setState(R.evolve({
      numbers: R.update(i, value)
    }, this.state))
  },
  render() {
    const update = (i) => (value) => this.update(i, value)
    const counter = (value, i) => <Counter value={value} update={update(i)}/>
    return (
      <div>
        {this.state.numbers.map(counter)}
      </div>
    )
  }
})
```

The issue here is that whenever a single counter changes, all counters need to re-render. Thats because the `update` prop to each counter has a new reference. One solution is to make a custom `shouldComponentUpdate` that ignores the comparison of the `update` prop. But there are more complicated scenarios where this isn't a good thing to do, for example, if the list could add and remove counters so the indexes change. What would be amazing though, is if you could use `R.equals` to compare new props and `R.equals` can compare functions *as if they're referentially transparent*. And the only change that would need to be made to the logic (other than changing `shuoldCompnentUpdate` to use `R.equals`) above is:

```js
const update = R.curry(this.update)
```

Thats because we're able to keep track of the original function and any bound arguments thus far. 

Now, `R.curry` isn't the only place you'd want this kind of functionality. Maybe you just want a thunk to call a function with some arguments. For example:

```js
const ListOfCounters = React.createClass({
  getInitialState() {
    return {numbers: [1,2,3,4,5,6,7,8,9,10]}
  },
  update(i) {
    this.setState(R.evolve({
      numbers: R.adjust(i, R.inc)
    }, this.state))
  },
  render() {
    const counter = (value, i) => {
      const inc = () => this.update(i)
      return (
        <div>
          <span>{value}</span>
          <button onClick={inc}>inc</button>
        </div>
      )
    }
    return (
      <div>
        {this.state.numbers.map(counter)}
      </div>
    )
  }
})
```

In this case, you don't exactly want to curry, but you want to return a `thunk`. So perhaps we could have a function called `R.thunk` or maybe we could just use `R.partial`. But the point is that we have a function that is bound to an argument. And so long as we're using pure functional programming patterns, then there should be no harm in partially applied functions being referentially transparent. That is:

```js
R.equals(R.partial(f, 1), R.partial(f, 1))
```

Obviously they won't truely be referentially transparent in JavaScript, but that's why we have Ramda, right?

This leads me back to the first point... React lazily evaluates the virtual dom tree because when you create a component like `<Counter value={value} update={update}/>`, the JSX compiles into `React.createElement(Counter, {value, update})` which in turn returns some sort of object like `{type: Counter, props: {value, update}}`. When React is evaluating the vdom to see if there are any updates, it first sees if we want to render the same component (Counter), and then compares the props to see if a re-render is needed. The thing that bugs me about this is that this format is so specific to React. Sure, we could copy it, but I think theres a much more idiomatic way of accomplishing all of this.

Suppose our components are "stateless components" as React would call it, or just functions. What we really want here is a thunk like we talked about before.

```
const thunk = R.partial(render, props)
```

If we call `thunk()` we'll get back the vdom tree thats returned from render. But if we want to lazily evaluate the vdom tree, we can simply use `R.equals` to compare thunks to determine if anything has changed. 

What I really like about this approach is its more generic feeling--its just a function with bound arguments. In an academic, functional, pure world, there's no reason bound functions shouldnt be referentially transparent. As I've been getting more and more familiar with functional programming, this has always been the limiting factor as far as complexity/performance in javascript, esp in my [elmish](https://github.com/ccorcos/elmish) project where I'm building similar lazy trees for things like http requests and side-effects other than just the vdom.

Maybe I'm just too far down the rabbit hole, but I hope that all makes sense. I'm very interested to hear some of your thoughts.

Cheers