### PR TITLE
Use native Object.assign if available

### DIFF
--- a/src/internal/_assign.js
+++ b/src/internal/_assign.js
@@ -1,0 +1,4 @@
+var _objectAssign = require('./_objectAssign');
+
+module.exports =
+  typeof Object.assign === 'function' ? Object.assign : _objectAssign;

--- a/src/internal/_stepCat.js
+++ b/src/internal/_stepCat.js
@@ -1,6 +1,6 @@
+var _assign = require('./_assign');
 var _identity = require('./_identity');
 var _isTransformer = require('./_isTransformer');
-var _objectAssign = require('./_objectAssign');
 var isArrayLike = require('../isArrayLike');
 var objOf = require('../objOf');
 
@@ -22,7 +22,7 @@ module.exports = (function() {
   var _stepCatObject = {
     '@@transducer/init': Object,
     '@@transducer/step': function(result, input) {
-      return _objectAssign(
+      return _assign(
         result,
         isArrayLike(input) ? objOf(input[0], input[1]) : input
       );

--- a/src/merge.js
+++ b/src/merge.js
@@ -1,5 +1,5 @@
+var _assign = require('./internal/_assign');
 var _curry2 = require('./internal/_curry2');
-var _objectAssign = require('./internal/_objectAssign');
 
 
 /**
@@ -25,5 +25,5 @@ var _objectAssign = require('./internal/_objectAssign');
  *      resetToDefault({x: 5, y: 2}); //=> {x: 0, y: 2}
  */
 module.exports = _curry2(function merge(l, r) {
-  return _objectAssign({}, l, r);
+  return _assign({}, l, r);
 });

--- a/src/mergeAll.js
+++ b/src/mergeAll.js
@@ -1,5 +1,5 @@
+var _assign = require('./internal/_assign');
 var _curry1 = require('./internal/_curry1');
-var _objectAssign = require('./internal/_objectAssign');
 
 
 /**
@@ -19,5 +19,5 @@ var _objectAssign = require('./internal/_objectAssign');
  *      R.mergeAll([{foo:1},{foo:2},{bar:2}]); //=> {foo:2,bar:2}
  */
 module.exports = _curry1(function mergeAll(list) {
-  return _objectAssign.apply(null, [{}].concat(list));
+  return _assign.apply(null, [{}].concat(list));
 });


### PR DESCRIPTION
My fault. It turns out that the polyfill isn’t nearly as fast as the native implementation (at least in Firefox).