### PR TITLE
Fixed category typo in R.clamp documentation

### DIFF
--- a/src/clamp.js
+++ b/src/clamp.js
@@ -8,7 +8,7 @@ var _curry3 = require('./internal/_curry3');
  * @func
  * @memberOf R
  * @since v0.20.0
- * @category Relaction
+ * @category Relation
  * @sig Ord a => a -> a -> a -> a
  * @param {Number} minimum number
  * @param {Number} maximum number


### PR DESCRIPTION
The category in R.clamp was misspelled to 'Relaction'