### PR TITLE
Optimize groupBy to use mutation in reducer

### DIFF
--- a/src/groupBy.js
+++ b/src/groupBy.js
@@ -1,9 +1,7 @@
 var _curry2 = require('./internal/_curry2');
 var _dispatchable = require('./internal/_dispatchable');
-var _reduce = require('./internal/_reduce');
 var _xgroupBy = require('./internal/_xgroupBy');
-var append = require('./append');
-
+var reduceBy = require('./reduceBy');
 
 /**
  * Splits a list into sub-lists stored in an object, based on the result of
@@ -45,10 +43,10 @@ var append = require('./append');
  *      //   'F': [{name: 'Eddy', score: 58}]
  *      // }
  */
-module.exports = _curry2(_dispatchable('groupBy', _xgroupBy, function groupBy(fn, list) {
-  return _reduce(function(acc, elt) {
-    var key = fn(elt);
-    acc[key] = append(elt, acc[key] || (acc[key] = []));
-    return acc;
-  }, {}, list);
-}));
+module.exports = _curry2(_dispatchable('groupBy', _xgroupBy, reduceBy(function(acc, item) {
+  if (acc == null) {
+    acc = [];
+  }
+  acc.push(item);
+  return acc;
+}, null)));


### PR DESCRIPTION
Using `R.groupBy` on large arrays can get pretty slow.

Simply using `arr.push()` instead of `R.append` improves performance significantly. Since the accumulator in the reducer is internal, this mutation shouldn't be a problem.

See [this perf test](http://jsperf.com/ramda-groupby-slow-for-large-arrays/2)

All credit to @davidgtonge

Also, I noticed `_xgroupBy.js`. Should this be updated too as part of this PR? I couldn't immediately see if it was safe to mutate instead of using `append` in that case.