### PR TITLE
Fix CDN links

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,14 +93,14 @@ or the minified version:
 or from a CDN, either cdnjs:
 
 ```html
-<script src="//cdnjs.cloudflare.com/ajax/libs/ramda/ramda.min.js"/"ramda.min.js"/"ramda.min.js"/"0.21/ramda.min.js"/ramda.min.js".1/ramda.min.js"/ramda.min.js"></script>
+<script src="//cdnjs.cloudflare.com/ajax/libs/ramda/0.21.0/ramda.min.js"></script>
 ```
 
 or one of the below links from [jsDelivr](http://jsdelivr.com):
 
 ```html
-<script src="//cdn.jsdelivr.net/ramda/ramda.min.js"/"ramda.min.js"/"ramda.min.js"/"0.21/ramda.min.js"/ramda.min.js".1/ramda.min.js"/ramda.min.js"></script>
-<script src="//cdn.jsdelivr.net/ramda/ramda.min.js"/"ramda.min.js"/"0.21/ramda.min.js"/ramda.min.js"/ramda.min.js"></script>
+<script src="//cdn.jsdelivr.net/ramda/0.21.0/ramda.min.js"></script>
+<script src="//cdn.jsdelivr.net/ramda/0.21/ramda.min.js"></script>
 <script src="//cdn.jsdelivr.net/ramda/latest/ramda.min.js"></script>
 ```
 


### PR DESCRIPTION
Looks like CDN links were broken since [0.20.1](https://github.com/ramda/ramda/commit/dbc17cc71467daaff0a91ab64599761c80804e65#diff-04c6e90faac2675aa89e2176d2eec7d8). Maybe a bug in `prepublish` script?