### PR TITLE
fix handling of function applicatives in R.ap

### DIFF
--- a/src/ap.js
+++ b/src/ap.js
@@ -1,7 +1,6 @@
 var _concat = require('./internal/_concat');
 var _curry2 = require('./internal/_curry2');
 var _reduce = require('./internal/_reduce');
-var curryN = require('./curryN');
 var map = require('./map');
 
 
@@ -9,7 +8,7 @@ var map = require('./map');
  * ap applies a list of functions to a list of values.
  *
  * Dispatches to the `ap` method of the second argument, if present. Also
- * treats functions as applicatives.
+ * treats curried functions as applicatives.
  *
  * @func
  * @memberOf R
@@ -28,9 +27,7 @@ module.exports = _curry2(function ap(applicative, fn) {
     typeof applicative.ap === 'function' ?
       applicative.ap(fn) :
     typeof applicative === 'function' ?
-      curryN(Math.max(applicative.length, fn.length), function() {
-        return applicative.apply(this, arguments)(fn.apply(this, arguments));
-      }) :
+      function(x) { return applicative(x)(fn(x)); } :
     // else
       _reduce(function(acc, f) { return _concat(acc, map(f, fn)); }, [], applicative)
   );

--- a/test/ap.js
+++ b/test/ap.js
@@ -21,6 +21,8 @@ describe('ap', function() {
     // (<*>) :: (r -> a -> b) -> (r -> a) -> (r -> b)
     // f <*> g = \x -> f x (g x)
     eq(h(10), 10 + (10 * 2));
+
+    eq(R.ap(R.add)(g)(10), 10 + (10 * 2));
   });
 
   it('dispatches to the passed object\'s ap method when values is a non-Array object', function() {


### PR DESCRIPTION
When using [`S.lift2`][1], which is defined in terms of `R.map` and `R.ap`, I expected this to work:

```javascript
lift2(map,
      assoc('name'),
      get(Object, _, newDeps))
```

I was forced to write this instead:

```javascript
lift2(map,
      x => assoc('name', x),
      get(Object, _, newDeps))
```

I'm fairly sure the current definition of `R.ap` is unsound.

Haskell:

```haskell
Prelude Control.Applicative> (<*>) (+) (* 2) 10
30
```

Ramda (before):

```javascript
> R.ap(R.add)(R.multiply(2))(10)
«Function»
```

Ramda (after):

```javascript
> R.ap(R.add)(R.multiply(2))(10)
30
```

As a bonus, the new definition is much clearer.

Please review this change, @benperez.


[1]: http://sanctuary.js.org/#lift2
