### PR TITLE
improve perf of propEq and propIs

### DIFF
--- a/lib/bench/propEq.bench.js
+++ b/lib/bench/propEq.bench.js
@@ -1,0 +1,10 @@
+var propEq = require('../..').propEq;
+
+module.exports = {
+  name: 'propEq',
+  tests: {
+    'propEq("value", [1, 2, 3], {value: [1, 2, 3]})': function() {
+      propEq('value', [1, 2, 3], {value: [1, 2, 3]});
+    }
+  }
+};

--- a/scripts/benchRunner
+++ b/scripts/benchRunner
@@ -22,17 +22,17 @@ function prettyMoe(moe) {
 
 fs.readdirSync('./lib/bench').forEach(function(file) {
   var test, table;
-  if (isBench.test(file)) { 
+  if (isBench.test(file)) {
     test = require('../lib/bench/' + file);
     table = getTable(test.name);
     var suite = Benchmark.Suite(test.name, {
-      onComplete: function() { console.log(table.toString()); } 
+      onComplete: function() { console.log(table.toString()); }
     });
     Object.keys(test.tests).forEach(function(k) {
       suite.add(k, test.tests[k], {
         onComplete: function(vo) {
           table.push([
-            vo.target.name, 
+            vo.target.name,
             prettyHz(vo.target.hz),
             prettyMoe(vo.target.stats.rme)
           ]);

--- a/src/propEq.js
+++ b/src/propEq.js
@@ -1,6 +1,5 @@
 var _curry3 = require('./internal/_curry3');
 var equals = require('./equals');
-var propSatisfies = require('./propSatisfies');
 
 
 /**
@@ -28,5 +27,5 @@ var propSatisfies = require('./propSatisfies');
  *      R.filter(hasBrownHair, kids); //=> [fred, rusty]
  */
 module.exports = _curry3(function propEq(name, val, obj) {
-  return propSatisfies(equals(val), name, obj);
+  return equals(val, obj[name]);
 });

--- a/src/propIs.js
+++ b/src/propIs.js
@@ -1,6 +1,5 @@
 var _curry3 = require('./internal/_curry3');
 var is = require('./is');
-var propSatisfies = require('./propSatisfies');
 
 
 /**
@@ -24,5 +23,5 @@ var propSatisfies = require('./propSatisfies');
  *      R.propIs(Number, 'x', {});            //=> false
  */
 module.exports = _curry3(function propIs(type, name, obj) {
-  return propSatisfies(is(type), name, obj);
+  return is(type, obj[name]);
 });


### PR DESCRIPTION
I think defining `propEq` and `propIs` in terms of `propSatisfies` is elegant, but having had problems using these functions on large lists I feel performance is probably more important.

I added a benchmark for `propEq` and had these results running locally:

```
# original definition
propEq("value", [1, 2… │ 368,588Hz │ 2.06% error margin

# new definition
propEq("value", [1, 2… │ 438,435Hz │ 1.79% error margin
```
Could add a benchmark for `propIs` too but I expect the results would be quite similar.

Let me know what you think