### PR TITLE
avoid instanceof checks

### DIFF
--- a/src/invoker.js
+++ b/src/invoker.js
@@ -1,7 +1,7 @@
 var _curry2 = require('./internal/_curry2');
+var _isFunction = require('./internal/_isFunction');
 var _slice = require('./internal/_slice');
 var curryN = require('./curryN');
-var is = require('./is');
 var toString = require('./toString');
 
 
@@ -31,7 +31,7 @@ var toString = require('./toString');
 module.exports = _curry2(function invoker(arity, method) {
   return curryN(arity + 1, function() {
     var target = arguments[arity];
-    if (target != null && is(Function, target[method])) {
+    if (target != null && _isFunction(target[method])) {
       return target[method].apply(target, _slice(arguments, 0, arity));
     }
     throw new TypeError(toString(target) + ' does not have a method named "' + method + '"');

--- a/src/isArrayLike.js
+++ b/src/isArrayLike.js
@@ -1,5 +1,6 @@
 var _curry1 = require('./internal/_curry1');
 var _isArray = require('./internal/_isArray');
+var _isString = require('./internal/_isString');
 
 
 /**
@@ -25,7 +26,7 @@ module.exports = _curry1(function isArrayLike(x) {
   if (_isArray(x)) { return true; }
   if (!x) { return false; }
   if (typeof x !== 'object') { return false; }
-  if (x instanceof String) { return false; }
+  if (_isString(x)) { return false; }
   if (x.nodeType === 1) { return !!x.length; }
   if (x.length === 0) { return true; }
   if (x.length > 0) {

--- a/src/length.js
+++ b/src/length.js
@@ -1,5 +1,5 @@
 var _curry1 = require('./internal/_curry1');
-var is = require('./is');
+var _isNumber = require('./internal/_isNumber');
 
 
 /**
@@ -18,5 +18,5 @@ var is = require('./is');
  *      R.length([1, 2, 3]); //=> 3
  */
 module.exports = _curry1(function length(list) {
-  return list != null && is(Number, list.length) ? list.length : NaN;
+  return list != null && _isNumber(list.length) ? list.length : NaN;
 });

--- a/test/invoker.js
+++ b/test/invoker.js
@@ -1,4 +1,5 @@
 var assert = require('assert');
+var vm = require('vm');
 
 var R = require('..');
 var eq = require('./shared/eq');
@@ -38,6 +39,10 @@ describe('invoker', function() {
                err.message === '[1, 2, 3] does not have a method named "length"';
       }
     );
+  });
+
+  it('does not rely on constructor identity', function() {
+    eq(concat2([2], [3], vm.runInNewContext('[1]')), [1, 2, 3]);
   });
 
   it('curries the method call', function() {


### PR DESCRIPTION
Fixes #1670

I'd like to "fix" `R.is` and `R.propIs` as well, but that can wait for another day.

See sanctuary-js/sanctuary#100 for context.
