### PR TITLE
Remove dependency on R.invoker in R.concat

### DIFF
--- a/src/concat.js
+++ b/src/concat.js
@@ -1,6 +1,6 @@
 var _curry2 = require('./internal/_curry2');
 var _isArray = require('./internal/_isArray');
-var invoker = require('./invoker');
+var _isFunction = require('./internal/_isFunction');
 var toString = require('./toString');
 
 
@@ -30,8 +30,11 @@ var toString = require('./toString');
  *      R.concat('ABC', 'DEF'); // 'ABCDEF'
  */
 module.exports = _curry2(function concat(a, b) {
+  if (a == null || !_isFunction(a.concat)) {
+    throw new TypeError(toString(a) + ' does not have a method named "concat"');
+  }
   if (_isArray(a) && !_isArray(b)) {
     throw new TypeError(toString(b) + ' is not an array');
   }
-  return invoker(1, 'concat')(b, a);
+  return a.concat(b);
 });

--- a/src/internal/_isFunction.js
+++ b/src/internal/_isFunction.js
@@ -1,3 +1,3 @@
-module.exports = function _isNumber(x) {
+module.exports = function _isFunction(x) {
   return Object.prototype.toString.call(x) === '[object Function]';
 };


### PR DESCRIPTION
In [1709](https://github.com/ramda/ramda/issues/1709#issuecomment-205089684) it was mentioned that recently several internal dependencies have crept into the Ramda code base. Looking at the [recent pull request](https://github.com/ramda/ramda/pull/1757) for `R.concat`, I noticed the dependency on `invoker`. While I can appreciate the better error message I can't help but think that a function as fundamental as `concat` should be implemented in its own terms. Also, not that important but on my machine it seems like this version is around 20-30 per cent quicker on arrays with 1000 or less elements:

http://goo.gl/SgU42T