### PR TITLE
Add ES3 test for R.keys

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "postcoverage": "npm run posttest",
     "lint": "eslint scripts/bookmarklet scripts/build src/*.js src/internal/*.js test/*.js test/**/*.js lib/sauce/*.js lib/bench/*.js",
     "pretest": "npm install && npm run lint && npm run clean && npm run build",
-    "test": "mocha --reporter spec",
+    "test": "mocha --reporter spec && mocha test/internal",
     "posttest": "git checkout -- dist",
     "prebrowser_test": "npm run pretest",
     "browser_test": "testem ci",

--- a/src/internal/_keysFallback.js
+++ b/src/internal/_keysFallback.js
@@ -1,0 +1,52 @@
+var _curry1 = require('./_curry1');
+var _has = require('./_has');
+var _isArguments = require('./_isArguments');
+
+
+module.exports = (function() {
+  // cover IE < 9 keys issues
+  var hasEnumBug = !({toString: null}).propertyIsEnumerable('toString');
+  var nonEnumerableProps = ['constructor', 'valueOf', 'isPrototypeOf', 'toString',
+    'propertyIsEnumerable', 'hasOwnProperty', 'toLocaleString'];
+  // Safari bug
+  var hasArgsEnumBug = (function() {
+    'use strict';
+    return arguments.propertyIsEnumerable('length');
+  }());
+
+  var contains = function contains(list, item) {
+    var idx = 0;
+    while (idx < list.length) {
+      if (list[idx] === item) {
+        return true;
+      }
+      idx += 1;
+    }
+    return false;
+  };
+
+  return _curry1(function keys(obj) {
+    if (Object(obj) !== obj) {
+      return [];
+    }
+    var prop, nIdx;
+    var ks = [];
+    var checkArgsLength = hasArgsEnumBug && _isArguments(obj);
+    for (prop in obj) {
+      if (_has(prop, obj) && (!checkArgsLength || prop !== 'length')) {
+        ks[ks.length] = prop;
+      }
+    }
+    if (hasEnumBug) {
+      nIdx = nonEnumerableProps.length - 1;
+      while (nIdx >= 0) {
+        prop = nonEnumerableProps[nIdx];
+        if (_has(prop, obj) && !contains(ks, prop)) {
+          ks[ks.length] = prop;
+        }
+        nIdx -= 1;
+      }
+    }
+    return ks;
+  });
+}());

--- a/src/keys.js
+++ b/src/keys.js
@@ -1,6 +1,5 @@
 var _curry1 = require('./internal/_curry1');
-var _has = require('./internal/_has');
-var _isArguments = require('./internal/_isArguments');
+var _keysFallback = require('./internal/_keysFallback');
 
 
 /**
@@ -21,53 +20,14 @@ var _isArguments = require('./internal/_isArguments');
  *      R.keys({a: 1, b: 2, c: 3}); //=> ['a', 'b', 'c']
  */
 module.exports = (function() {
-  // cover IE < 9 keys issues
-  var hasEnumBug = !({toString: null}).propertyIsEnumerable('toString');
-  var nonEnumerableProps = ['constructor', 'valueOf', 'isPrototypeOf', 'toString',
-                            'propertyIsEnumerable', 'hasOwnProperty', 'toLocaleString'];
   // Safari bug
   var hasArgsEnumBug = (function() {
     'use strict';
     return arguments.propertyIsEnumerable('length');
   }());
 
-  var contains = function contains(list, item) {
-    var idx = 0;
-    while (idx < list.length) {
-      if (list[idx] === item) {
-        return true;
-      }
-      idx += 1;
-    }
-    return false;
-  };
-
   return typeof Object.keys === 'function' && !hasArgsEnumBug ?
     _curry1(function keys(obj) {
       return Object(obj) !== obj ? [] : Object.keys(obj);
-    }) :
-    _curry1(function keys(obj) {
-      if (Object(obj) !== obj) {
-        return [];
-      }
-      var prop, nIdx;
-      var ks = [];
-      var checkArgsLength = hasArgsEnumBug && _isArguments(obj);
-      for (prop in obj) {
-        if (_has(prop, obj) && (!checkArgsLength || prop !== 'length')) {
-          ks[ks.length] = prop;
-        }
-      }
-      if (hasEnumBug) {
-        nIdx = nonEnumerableProps.length - 1;
-        while (nIdx >= 0) {
-          prop = nonEnumerableProps[nIdx];
-          if (_has(prop, obj) && !contains(ks, prop)) {
-            ks[ks.length] = prop;
-          }
-          nIdx -= 1;
-        }
-      }
-      return ks;
-    });
+    }) : _keysFallback
 }());

--- a/test/internal/_keysFallback.js
+++ b/test/internal/_keysFallback.js
@@ -1,0 +1,4 @@
+var _keysFallback = require('../../src/internal/_keysFallback');
+var keys = require('../shared/keys');
+
+keys('keysFallback', _keysFallback);

--- a/test/keys.js
+++ b/test/keys.js
@@ -1,36 +1,5 @@
 var R = require('..');
-var eq = require('./shared/eq');
+var keys = require('./shared/keys');
 
 
-describe('keys', function() {
-  var obj = {a: 100, b: [1, 2, 3], c: {x: 200, y: 300}, d: 'D', e: null, f: undefined};
-  function C() { this.a = 100; this.b = 200; }
-  C.prototype.x = function() { return 'x'; };
-  C.prototype.y = 'y';
-  var cobj = new C();
-
-  it("returns an array of the given object's own keys", function() {
-    eq(R.keys(obj).sort(), ['a', 'b', 'c', 'd', 'e', 'f']);
-  });
-
-  it('works with hasOwnProperty override', function() {
-    eq(R.keys({
-      /* jshint -W001 */
-      hasOwnProperty: false
-      /* jshint +W001 */
-    }), ['hasOwnProperty']);
-  });
-
-  it('works for primitives', function() {
-    /* jshint elision: true */
-    var result = R.map(function(val) {
-      return R.keys(val);
-    }, [null, undefined, 55, '', true, false, NaN, Infinity, , []]);
-    eq(result, R.repeat([], 10));
-  });
-
-  it("does not include the given object's prototype properties", function() {
-    eq(R.keys(cobj).sort(), ['a', 'b']);
-  });
-
-});
+keys('keys', R.keys);

--- a/test/shared/keys.js
+++ b/test/shared/keys.js
@@ -1,0 +1,37 @@
+var R = require('../..');
+var eq = require('./eq');
+
+module.exports = function(testName, keys) {
+  describe(testName, function() {
+    var obj = {a: 100, b: [1, 2, 3], c: {x: 200, y: 300}, d: 'D', e: null, f: undefined};
+    function C() { this.a = 100; this.b = 200; }
+    C.prototype.x = function() { return 'x'; };
+    C.prototype.y = 'y';
+    var cobj = new C();
+
+    it("returns an array of the given object's own keys", function() {
+      eq(keys(obj).sort(), ['a', 'b', 'c', 'd', 'e', 'f']);
+    });
+
+    it('works with hasOwnProperty override', function() {
+      eq(keys({
+        /* jshint -W001 */
+        hasOwnProperty: false
+        /* jshint +W001 */
+      }), ['hasOwnProperty']);
+    });
+
+    it('works for primitives', function() {
+      /* jshint elision: true */
+      var result = R.map(function(val) {
+        return keys(val);
+      }, [null, undefined, 55, '', true, false, NaN, Infinity, , []]);
+      eq(result, R.repeat([], 10));
+    });
+
+    it("does not include the given object's prototype properties", function() {
+      eq(keys(cobj).sort(), ['a', 'b']);
+    });
+
+  });
+};


### PR DESCRIPTION
In the discussion that flowed from sanctuary-js/sanctuary#214 we toyed with the idea of testing the fallback for when `Object.keys` is not present. In the end we decided ES3 support was more hassle than it's worth but if Ramda wants to support such ancient browsers then there really ought to be tests for these fallbacks. 
