### PR TITLE
fix: add correct comments escaping for R.not example

### DIFF
--- a/src/not.js
+++ b/src/not.js
@@ -17,8 +17,8 @@ var _curry1 = require('./internal/_curry1');
  *
  *      R.not(true); //=> false
  *      R.not(false); //=> true
- *      R.not(0); => true
- *      R.not(1); => false
+ *      R.not(0); //=> true
+ *      R.not(1); //=> false
  */
 module.exports = _curry1(function not(a) {
   return !a;


### PR DESCRIPTION
The REPL is broken without this fix.