### PR TITLE
fix signature and example of composeK

### DIFF
--- a/src/composeK.js
+++ b/src/composeK.js
@@ -15,7 +15,7 @@ var prepend = require('./prepend');
  * @memberOf R
  * @since v0.16.0
  * @category Function
- * @sig Chain m => ((y -> m z), (x -> m y), ..., (a -> m b)) -> (m a -> m z)
+ * @sig Chain m => ((y -> m z), (x -> m y), ..., (a -> m b)) -> (a -> m z)
  * @param {...Function}
  * @return {Function}
  * @see R.pipeK
@@ -24,9 +24,8 @@ var prepend = require('./prepend');
  *      //  parseJson :: String -> Maybe *
  *      //  get :: String -> Object -> Maybe *
  *
- *      //  getStateCode :: Maybe String -> Maybe String
+ *      //  getStateCode :: String -> Maybe String
  *      var getStateCode = R.composeK(
- *        R.compose(Maybe.of, R.toUpper),
  *        get('state'),
  *        get('address'),
  *        get('user'),


### PR DESCRIPTION
This looks wrong. From haskell's [Kleisli composition](http://hackage.haskell.org/package/base-4.9.0.0/docs/Control-Monad.html#v:-62--61--62-):

``` haskell
(>=>) :: Monad m => (a -> m b) -> (b -> m c) -> a -> m c
```

This supposed to produce a function which takes as input a normal type and returns a monad. There was also an incorrect function in the example
