### PR TITLE
Updated eslint to v2 

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -86,9 +86,9 @@
     ],
     "space-infix-ops": 2,
     "space-return-throw-case": 0,
-    "space-after-keywords": [
+    "keyword-spacing": [
       2,
-      "always"
+      { "after": true, "before": true }
     ],
     "lines-around-comment": 0,
     "space-before-blocks": [

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,8 @@
 {
   "env": {
     "node": true,
-    "mocha": true
+    "mocha": true,
+    "es6": true
   },
   "globals": {
     "Symbol": true

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "dox": "latest",
     "envvar": "1.x.x",
     "escodegen": "1.4.x",
-    "eslint": "^1.10.1",
+    "eslint": "^2.11.0",
     "handlebars": "3.0.x",
     "istanbul": "^0.4.x",
     "js-yaml": "^3.2.5",


### PR DESCRIPTION
I am not sure if the eslint config is meant to be targeting v2.0 yet so this may not be a desired update. I found the warning about the "space-after-keywords" being replaced in v2.0 and replaced it with its up to date rule "keyword-spacing".