### PR TITLE
Add links between docs for R.difference and related functions

### DIFF
--- a/src/difference.js
+++ b/src/difference.js
@@ -14,7 +14,7 @@ var _curry2 = require('./internal/_curry2');
  * @param {Array} list1 The first list.
  * @param {Array} list2 The second list.
  * @return {Array} The elements in `list1` that are not in `list2`.
- * @see R.differenceWith
+ * @see R.differenceWith, R.symmetricDifference, R.symmetricDifferenceWith
  * @example
  *
  *      R.difference([1,2,3,4], [7,6,5,4,3]); //=> [1,2]

--- a/src/differenceWith.js
+++ b/src/differenceWith.js
@@ -16,7 +16,7 @@ var _curry3 = require('./internal/_curry3');
  * @param {Array} list1 The first list.
  * @param {Array} list2 The second list.
  * @return {Array} The elements in `list1` that are not in `list2`.
- * @see R.difference
+ * @see R.difference, R.symmetricDifference, R.symmetricDifferenceWith
  * @example
  *
  *      var cmp = (x, y) => x.a === y.a;

--- a/src/modulo.js
+++ b/src/modulo.js
@@ -2,7 +2,7 @@ var _curry2 = require('./internal/_curry2');
 
 
 /**
- * Divides the second parameter by the first and returns the remainder. Note
+ * Divides the first parameter by the second and returns the remainder. Note
  * that this function preserves the JavaScript-style behavior for modulo. For
  * mathematical modulo see `mathMod`.
  *

--- a/src/symmetricDifference.js
+++ b/src/symmetricDifference.js
@@ -15,7 +15,7 @@ var difference = require('./difference');
  * @param {Array} list1 The first list.
  * @param {Array} list2 The second list.
  * @return {Array} The elements in `list1` or `list2`, but not both.
- * @see R.symmetricDifferenceWith
+ * @see R.symmetricDifferenceWith, R.difference, R.differenceWith
  * @example
  *
  *      R.symmetricDifference([1,2,3,4], [7,6,5,4,3]); //=> [1,2,7,6,5]

--- a/src/symmetricDifferenceWith.js
+++ b/src/symmetricDifferenceWith.js
@@ -17,7 +17,7 @@ var differenceWith = require('./differenceWith');
  * @param {Array} list1 The first list.
  * @param {Array} list2 The second list.
  * @return {Array} The elements in `list1` or `list2`, but not both.
- * @see R.symmetricDifference
+ * @see R.symmetricDifference, R.difference, R.differenceWith
  * @example
  *
  *      var eqA = R.eqBy(R.prop('a'));


### PR DESCRIPTION
Close ramda/ramda#1806 — Add links between the docs for `R.difference` and related methods.

Adds links between the documentation of the following methods:

- `R.difference`
- `R.differenceWith`
- `R.symmetricDifference`
- `R.symmetricDifferenceWith`

Related to https://github.com/ramda/ramda.github.io/issues/72, as the docs might need to be rebuilt.