### PR TITLE
deprecate R.wrap

### DIFF
--- a/src/wrap.js
+++ b/src/wrap.js
@@ -16,6 +16,7 @@ var curryN = require('./curryN');
  * @param {Function} fn The function to wrap.
  * @param {Function} wrapper The wrapper function.
  * @return {Function} The wrapped function.
+ * @deprecated since v0.22.0
  * @example
  *
  *      var greet = name => 'Hello ' + name;


### PR DESCRIPTION
I've wanted to deprecate this function for a long time, as I've yet to see an example not better expressed *without* `wrap`. Consider the examples in the documentation:

```javascript
var greet = name => 'Hello ' + name;

//  Option 1: R.wrap
var shoutedGreet1 = R.wrap(greet, (gr, name) => gr(name).toUpperCase());

//  Option 2: R.compose
var shoutedGreet2 = R.compose(R.toUpper, greet);

//  Option 3: lambda
var shoutedGreet3 = name => greet(name).toUpperCase();

//  Option 1: R.wrap
var shortenedGreet1 = R.wrap(greet, function(gr, name) {
  return gr(name.substring(0, 3));
});

//  Option 2: R.compose
var shortenedGreet2 = R.compose(greet, R.take(3));

//  Option 3: lambda
var shortenedGreet3 = name => greet(name.substring(0, 3));
```

`wrap` introduces indirection in these cases and gains us nothing. Note that we're providing `greet` as an argument to `wrap` only for `wrap` to then provide it to us as an argument (which we name `gr`). Why not simply reference `greet` directly? :stuck_out_tongue_winking_eye:
