### PR TITLE
Cross-references R.prop with R.path and vice-versa

### DIFF
--- a/src/path.js
+++ b/src/path.js
@@ -12,6 +12,7 @@ var _curry2 = require('./internal/_curry2');
  * @param {Array} path The path to use.
  * @param {Object} obj The object to retrieve the nested property from.
  * @return {*} The data at `path`.
+ * @see R.prop
  * @example
  *
  *      R.path(['a', 'b'], {a: {b: 2}}); //=> 2

--- a/src/prop.js
+++ b/src/prop.js
@@ -13,6 +13,7 @@ var _curry2 = require('./internal/_curry2');
  * @param {String} p The property name
  * @param {Object} obj The object to query
  * @return {*} The value at `obj.p`.
+ * @see R.path
  * @example
  *
  *      R.prop('x', {x: 100}); //=> 100


### PR DESCRIPTION
Cross-references `R.path` and `R.prop`.  Replaces \#1821.