### PR TITLE
deprecate R.unary and R.binary

### DIFF
--- a/src/binary.js
+++ b/src/binary.js
@@ -15,6 +15,7 @@ var nAry = require('./nAry');
  * @param {Function} fn The function to wrap.
  * @return {Function} A new function wrapping `fn`. The new function is guaranteed to be of
  *         arity 2.
+ * @deprecated since v0.23.0
  * @example
  *
  *      var takesThreeArgs = function(a, b, c) {

--- a/src/unary.js
+++ b/src/unary.js
@@ -15,6 +15,7 @@ var nAry = require('./nAry');
  * @param {Function} fn The function to wrap.
  * @return {Function} A new function wrapping `fn`. The new function is guaranteed to be of
  *         arity 1.
+ * @deprecated since v0.23.0
  * @example
  *
  *      var takesTwoArgs = function(a, b) {


### PR DESCRIPTION
:warning: This may be controversial.

I posit that `R.unary(f)` is equally well expressed `x => f(x)`, and that `R.binary(g)` is equally well expressed `(x, y) => g(x, y)`.

Ramda contains several functions for "fixing" inconvenient or poorly designed functions. In most cases a humble wrapper function does the job equally well. When more than one "adjustment" is necessary, a wrapper function is much clearer. Imagine, for example, that we have a function `f` which takes three arguments, the last of which is optional. We'd like to derive from `f` a function, `g`, which takes two arguments and returns the result of applying `f` to these arguments _in reverse order_. Which of the following is clearer?

``` javascript
const g = R.flip(R.binary(f));
```

``` javascript
const g = (x, y) => f(y, x);
```

The `g` defined in the second case is not curried, of course, but this could be achieved by applying `R.curry` to the wrapper function if desired. Still, I find the second case easier to parse.
