### PR TITLE
Update binary predicate signatures as they're not curried.

### DIFF
--- a/src/differenceWith.js
+++ b/src/differenceWith.js
@@ -11,7 +11,7 @@ var _curry3 = require('./internal/_curry3');
  * @memberOf R
  * @since v0.1.0
  * @category Relation
- * @sig (a -> a -> Boolean) -> [*] -> [*] -> [*]
+ * @sig ((a, a) -> Boolean) -> [a] -> [a] -> [a]
  * @param {Function} pred A predicate used to test whether two items are equal.
  * @param {Array} list1 The first list.
  * @param {Array} list2 The second list.

--- a/src/intersectionWith.js
+++ b/src/intersectionWith.js
@@ -12,7 +12,7 @@ var uniqWith = require('./uniqWith');
  * @memberOf R
  * @since v0.1.0
  * @category Relation
- * @sig (a -> a -> Boolean) -> [*] -> [*] -> [*]
+ * @sig ((a, a) -> Boolean) -> [a] -> [a] -> [a]
  * @param {Function} pred A predicate function that determines whether
  *        the two supplied elements are equal.
  * @param {Array} list1 One list of items to compare

--- a/src/symmetricDifferenceWith.js
+++ b/src/symmetricDifferenceWith.js
@@ -12,7 +12,7 @@ var differenceWith = require('./differenceWith');
  * @memberOf R
  * @since v0.19.0
  * @category Relation
- * @sig (a -> a -> Boolean) -> [a] -> [a] -> [a]
+ * @sig ((a, a) -> Boolean) -> [a] -> [a] -> [a]
  * @param {Function} pred A predicate used to test whether two items are equal.
  * @param {Array} list1 The first list.
  * @param {Array} list2 The second list.


### PR DESCRIPTION
This started with `differenceWith`, I noticed that things like
```
R.differenceWith(a => b => ..., xs, ys);
```
don't work as expected.

I tried to propagate the signature changes to all functions that use `internal/_containsWith`.

If updating the signatures is not the right solution, let me know, I'll work on something better (e.g. allowing predicates to be curried).