### PR TITLE
Tidy the curry'ness of doc examples

### DIFF
--- a/src/add.js
+++ b/src/add.js
@@ -16,7 +16,6 @@ var _curry2 = require('./internal/_curry2');
  * @example
  *
  *      R.add(2, 3);       //=>  5
- *      R.add(7)(10);      //=> 17
  */
 module.exports = _curry2(function add(a, b) {
   return Number(a) + Number(b);

--- a/src/adjust.js
+++ b/src/adjust.js
@@ -23,7 +23,6 @@ var _curry3 = require('./internal/_curry3');
  * @example
  *
  *      R.adjust(R.add(10), 1, [0, 1, 2]);     //=> [0, 11, 2]
- *      R.adjust(R.add(10))(1)([0, 1, 2]);     //=> [0, 11, 2]
  */
 module.exports = _curry3(function adjust(fn, idx, list) {
   if (idx >= list.length || idx < -list.length) {

--- a/src/all.js
+++ b/src/all.js
@@ -25,8 +25,8 @@ var _xall = require('./internal/_xall');
  *
  *      var lessThan2 = R.flip(R.lt)(2);
  *      var lessThan3 = R.flip(R.lt)(3);
- *      R.all(lessThan2)([1, 2]); //=> false
- *      R.all(lessThan3)([1, 2]); //=> true
+ *      R.all(lessThan2, [1, 2]); //=> false
+ *      R.all(lessThan3, [1, 2]); //=> true
  */
 module.exports = _curry2(_dispatchable('all', _xall, function all(fn, list) {
   var idx = 0;

--- a/src/any.js
+++ b/src/any.js
@@ -25,8 +25,8 @@ var _xany = require('./internal/_xany');
  *
  *      var lessThan0 = R.flip(R.lt)(0);
  *      var lessThan2 = R.flip(R.lt)(2);
- *      R.any(lessThan0)([1, 2]); //=> false
- *      R.any(lessThan2)([1, 2]); //=> true
+ *      R.any(lessThan0, [1, 2]); //=> false
+ *      R.any(lessThan2, [1, 2]); //=> true
  */
 module.exports = _curry2(_dispatchable('any', _xany, function any(fn, list) {
   var idx = 0;

--- a/src/countBy.js
+++ b/src/countBy.js
@@ -21,7 +21,7 @@ var reduceBy = require('./reduceBy');
  *
  *      var numbers = [1.0, 1.1, 1.2, 2.0, 3.0, 2.2];
  *      var letters = R.split('', 'abcABCaaaBBc');
- *      R.countBy(Math.floor)(numbers);    //=> {'1': 3, '2': 2, '3': 1}
- *      R.countBy(R.toLower)(letters);   //=> {'a': 5, 'b': 4, 'c': 3}
+ *      R.countBy(Math.floor, numbers);    //=> {'1': 3, '2': 2, '3': 1}
+ *      R.countBy(R.toLower, letters);   //=> {'a': 5, 'b': 4, 'c': 3}
  */
 module.exports = reduceBy(function(acc, elem) { return acc + 1; }, 0);

--- a/src/find.js
+++ b/src/find.js
@@ -24,8 +24,8 @@ var _xfind = require('./internal/_xfind');
  * @example
  *
  *      var xs = [{a: 1}, {a: 2}, {a: 3}];
- *      R.find(R.propEq('a', 2))(xs); //=> {a: 2}
- *      R.find(R.propEq('a', 4))(xs); //=> undefined
+ *      R.find(R.propEq('a', 2), xs); //=> {a: 2}
+ *      R.find(R.propEq('a', 4), xs); //=> undefined
  */
 module.exports = _curry2(_dispatchable('find', _xfind, function find(fn, list) {
   var idx = 0;

--- a/src/findIndex.js
+++ b/src/findIndex.js
@@ -24,8 +24,8 @@ var _xfindIndex = require('./internal/_xfindIndex');
  * @example
  *
  *      var xs = [{a: 1}, {a: 2}, {a: 3}];
- *      R.findIndex(R.propEq('a', 2))(xs); //=> 1
- *      R.findIndex(R.propEq('a', 4))(xs); //=> -1
+ *      R.findIndex(R.propEq('a', 2), xs); //=> 1
+ *      R.findIndex(R.propEq('a', 4), xs); //=> -1
  */
 module.exports = _curry2(_dispatchable('findIndex', _xfindIndex, function findIndex(fn, list) {
   var idx = 0;

--- a/src/findLast.js
+++ b/src/findLast.js
@@ -24,8 +24,8 @@ var _xfindLast = require('./internal/_xfindLast');
  * @example
  *
  *      var xs = [{a: 1, b: 0}, {a:1, b: 1}];
- *      R.findLast(R.propEq('a', 1))(xs); //=> {a: 1, b: 1}
- *      R.findLast(R.propEq('a', 4))(xs); //=> undefined
+ *      R.findLast(R.propEq('a', 1), xs); //=> {a: 1, b: 1}
+ *      R.findLast(R.propEq('a', 4), xs); //=> undefined
  */
 module.exports = _curry2(_dispatchable('findLast', _xfindLast, function findLast(fn, list) {
   var idx = list.length - 1;

--- a/src/findLastIndex.js
+++ b/src/findLastIndex.js
@@ -24,8 +24,8 @@ var _xfindLastIndex = require('./internal/_xfindLastIndex');
  * @example
  *
  *      var xs = [{a: 1, b: 0}, {a:1, b: 1}];
- *      R.findLastIndex(R.propEq('a', 1))(xs); //=> 1
- *      R.findLastIndex(R.propEq('a', 4))(xs); //=> -1
+ *      R.findLastIndex(R.propEq('a', 1), xs); //=> 1
+ *      R.findLastIndex(R.propEq('a', 4), xs); //=> -1
  */
 module.exports = _curry2(_dispatchable('findLastIndex', _xfindLastIndex, function findLastIndex(fn, list) {
   var idx = list.length - 1;

--- a/src/pluck.js
+++ b/src/pluck.js
@@ -18,8 +18,8 @@ var prop = require('./prop');
  * @see R.props
  * @example
  *
- *      R.pluck('a')([{a: 1}, {a: 2}]); //=> [1, 2]
- *      R.pluck(0)([[1, 2], [3, 4]]);   //=> [1, 3]
+ *      R.pluck('a', [{a: 1}, {a: 2}]); //=> [1, 2]
+ *      R.pluck(0, [1, 2], [3, 4]]);   //=> [1, 3]
  */
 module.exports = _curry2(function pluck(p, list) {
   return map(prop(p), list);

--- a/src/uniqWith.js
+++ b/src/uniqWith.js
@@ -19,10 +19,10 @@ var _curry2 = require('./internal/_curry2');
  * @example
  *
  *      var strEq = R.eqBy(String);
- *      R.uniqWith(strEq)([1, '1', 2, 1]); //=> [1, 2]
- *      R.uniqWith(strEq)([{}, {}]);       //=> [{}]
- *      R.uniqWith(strEq)([1, '1', 1]);    //=> [1]
- *      R.uniqWith(strEq)(['1', 1, 1]);    //=> ['1']
+ *      R.uniqWith(strEq, [1, '1', 2, 1]); //=> [1, 2]
+ *      R.uniqWith(strEq, [{}, {}]);       //=> [{}]
+ *      R.uniqWith(strEq, [1, '1', 1]);    //=> [1]
+ *      R.uniqWith(strEq, ['1', 1, 1]);    //=> ['1']
  */
 module.exports = _curry2(function uniqWith(pred, list) {
   var idx = 0;

--- a/src/until.js
+++ b/src/until.js
@@ -18,7 +18,7 @@ var _curry3 = require('./internal/_curry3');
  * @return {*} Final value that satisfies predicate
  * @example
  *
- *      R.until(R.gt(R.__, 100), R.multiply(2))(1) // => 128
+ *      R.until(R.gt(R.__, 100), R.multiply(2), 1) // => 128
  */
 module.exports = _curry3(function until(pred, fn, init) {
   var val = init;

--- a/src/update.js
+++ b/src/update.js
@@ -20,7 +20,6 @@ var always = require('./always');
  * @example
  *
  *      R.update(1, 11, [0, 1, 2]);     //=> [0, 11, 2]
- *      R.update(1)(11)([0, 1, 2]);     //=> [0, 11, 2]
  */
 module.exports = _curry3(function update(idx, x, list) {
   return adjust(always(x), idx, list);

--- a/src/useWith.js
+++ b/src/useWith.js
@@ -26,9 +26,7 @@ var curryN = require('./curryN');
  * @example
  *
  *      R.useWith(Math.pow, [R.identity, R.identity])(3, 4); //=> 81
- *      R.useWith(Math.pow, [R.identity, R.identity])(3)(4); //=> 81
  *      R.useWith(Math.pow, [R.dec, R.inc])(3, 4); //=> 32
- *      R.useWith(Math.pow, [R.dec, R.inc])(3)(4); //=> 32
  */
 module.exports = _curry2(function useWith(fn, transformers) {
   return curryN(transformers.length, function() {


### PR DESCRIPTION
- Remove unnecessary examples that add no value other than show curry'ness
- Change ')(' -> ', ' where the parentheses are unnecessary.  It causes confusion because
  there are examples where the parentheses are necessary (e.g. invoker)
