### PR TITLE
deprecate R.composeP and R.pipeP

### DIFF
--- a/src/composeP.js
+++ b/src/composeP.js
@@ -15,6 +15,7 @@ var reverse = require('./reverse');
  * @param {...Function} functions
  * @return {Function}
  * @see R.pipeP
+ * @deprecated since v0.23.0
  * @example
  *
  *      //  followersForUser :: String -> Promise [User]

--- a/src/pipeP.js
+++ b/src/pipeP.js
@@ -17,6 +17,7 @@ var tail = require('./tail');
  * @param {...Function} functions
  * @return {Function}
  * @see R.composeP
+ * @deprecated since v0.23.0
  * @example
  *
  *      //  followersForUser :: String -> Promise [User]


### PR DESCRIPTION
We often advise Ramda users against using promises, yet we provide functions for working with promises. Moreover, such functions are not necessary when working with tasks/futures, which support the regular `compose`/`pipe`/`map`/`chain` operations.

@CrossEye indicated in https://github.com/ramda/ramda/issues/1528#issuecomment-239966677 that he's on board with deprecating `composeP` and `pipeP`. Others have also shown support for the move.
