### PR TITLE
deprecate R.isArrayLike

### DIFF
--- a/src/isArrayLike.js
+++ b/src/isArrayLike.js
@@ -14,6 +14,7 @@ var _isString = require('./internal/_isString');
  * @sig * -> Boolean
  * @param {*} x The object to test.
  * @return {Boolean} `true` if `x` has a numeric length property and extreme indices defined; `false` otherwise.
+ * @deprecated since v0.23.0
  * @example
  *
  *      R.isArrayLike([]); //=> true


### PR DESCRIPTION
Let's deprecate this function. If a glance at the implementation is not sufficient to persuade you that this function should be removed, I'll spend some time writing a case for the deprecation.
