### PR TITLE
Allow dissoc to remove non-string keys

### DIFF
--- a/src/dissoc.js
+++ b/src/dissoc.js
@@ -20,9 +20,8 @@ var _curry2 = require('./internal/_curry2');
 module.exports = _curry2(function dissoc(prop, obj) {
   var result = {};
   for (var p in obj) {
-    if (p !== prop) {
-      result[p] = obj[p];
-    }
+    result[p] = obj[p];
   }
+  delete result[prop]
   return result;
 });

--- a/test/dissoc.js
+++ b/test/dissoc.js
@@ -23,6 +23,12 @@ describe('dissoc', function() {
     eq(R.dissoc('depth', rect), {width: 7, height: 6, area: area});
   });
 
+  it('coerces non-string types', function() {
+    eq(R.dissoc(42, {a: 1, b: 2, 42: 3}), {a: 1, b: 2});
+    eq(R.dissoc(null, {a: 1, b: 2, 'null': 3}), {a: 1, b: 2});
+    eq(R.dissoc(undefined, {a: 1, b: 2, undefined: 3}), {a: 1, b: 2});
+  });
+
   it('is curried', function() {
     eq(R.dissoc('b')({a: 1, b: 2, c: 3}), {a: 1, c: 3});
   });


### PR DESCRIPTION
e.g. numbers, null, undefined, NaN, etc.

Currently ramda behaves like this:
```javascript
const a = {}
const b = R.assoc(42, 'value', a)  // {"42": "value"}
const c = R.dissoc(42, b)  // {"42": "value"}
R.equals(a, c) // false
```

The reason is that values passed to assoc are coerced into string keys (as per the javascript spec),
but dissoc doesn't do a similar conversion.

By principle of least astonishment I'd expect assoc and dissoc to reverse the other's actions 😁

I mostly care about numbers being coerced, but I can see a use-case for undefined or null as well.

I also came across this PR which was merged to solve a very similar problem: https://github.com/ramda/ramda/pull/1122/files

I ran into this exact situation on a side project of mine and it took a while to track down.

Let me know if there's anything else that needs doing, cheers!
