### PR TITLE
Clarify and unify docs

### DIFF
--- a/src/adjust.js
+++ b/src/adjust.js
@@ -22,8 +22,8 @@ var _curry3 = require('./internal/_curry3');
  * @see R.update
  * @example
  *
- *      R.adjust(R.add(10), 1, [0, 1, 2]);     //=> [0, 11, 2]
- *      R.adjust(R.add(10))(1)([0, 1, 2]);     //=> [0, 11, 2]
+ *      R.adjust(R.add(10), 1, [1, 2, 3]);     //=> [1, 12, 3]
+ *      R.adjust(R.add(10))(1)([1, 2, 3]);     //=> [1, 12, 3]
  * @symb R.adjust(f, -1, [a, b]) = [a, f(b)]
  * @symb R.adjust(f, 0, [a, b]) = [f(a), b]
  */

--- a/src/all.js
+++ b/src/all.js
@@ -23,10 +23,9 @@ var _xall = require('./internal/_xall');
  * @see R.any, R.none, R.transduce
  * @example
  *
- *      var lessThan2 = R.flip(R.lt)(2);
- *      var lessThan3 = R.flip(R.lt)(3);
- *      R.all(lessThan2)([1, 2]); //=> false
- *      R.all(lessThan3)([1, 2]); //=> true
+ *      var equals3 = R.equals(3);
+ *      R.all(equals3)([3, 3, 3, 3]); //=> true
+ *      R.all(equals3)([3, 3, 1, 3]); //=> false
  */
 module.exports = _curry2(_dispatchable('all', _xall, function all(fn, list) {
   var idx = 0;

--- a/src/allPass.js
+++ b/src/allPass.js
@@ -18,8 +18,8 @@ var reduce = require('./reduce');
  * @since v0.9.0
  * @category Logic
  * @sig [(*... -> Boolean)] -> (*... -> Boolean)
- * @param {Array} preds
- * @return {Function}
+ * @param {Array} predicates An array of predicates to check
+ * @return {Function} The combined predicate
  * @see R.anyPass
  * @example
  *

--- a/src/anyPass.js
+++ b/src/anyPass.js
@@ -18,8 +18,8 @@ var reduce = require('./reduce');
  * @since v0.9.0
  * @category Logic
  * @sig [(*... -> Boolean)] -> (*... -> Boolean)
- * @param {Array} preds
- * @return {Function}
+ * @param {Array} predicates An array of predicates to check
+ * @return {Function} The combined predicate
  * @see R.allPass
  * @example
  *

--- a/src/ap.js
+++ b/src/ap.js
@@ -22,6 +22,7 @@ var map = require('./map');
  * @example
  *
  *      R.ap([R.multiply(2), R.add(3)], [1,2,3]); //=> [2, 4, 6, 4, 5, 6]
+ *      R.ap([R.concat('tasty '), R.toUpper], ['pizza', 'salad']); //=> ["tasty pizza", "tasty salad", "PIZZA", "SALAD"]
  * @symb R.ap([f, g], [a, b]) = [f(a), f(b), g(a), g(b)]
  */
 module.exports = _curry2(function ap(applicative, fn) {

--- a/src/aperture.js
+++ b/src/aperture.js
@@ -18,8 +18,8 @@ var _xaperture = require('./internal/_xaperture');
  * @category List
  * @sig Number -> [a] -> [[a]]
  * @param {Number} n The size of the tuples to create
- * @param {Array} list The list to split into `n`-tuples
- * @return {Array} The new list.
+ * @param {Array} list The list to split into `n`-length tuples
+ * @return {Array} The resulting list of `n`-length tuples
  * @see R.transduce
  * @example
  *

--- a/src/append.js
+++ b/src/append.js
@@ -12,9 +12,9 @@ var _curry2 = require('./internal/_curry2');
  * @category List
  * @sig a -> [a] -> [a]
  * @param {*} el The element to add to the end of the new list.
- * @param {Array} list The list whose contents will be added to the beginning of the output
+ * @param {Array} list The list of elements to add a new item to.
  *        list.
- * @return {Array} A new list containing the contents of the old list followed by `el`.
+ * @return {Array} A new list containing the elements of the old list followed by `el`.
  * @see R.prepend
  * @example
  *

--- a/src/apply.js
+++ b/src/apply.js
@@ -11,9 +11,9 @@ var _curry2 = require('./internal/_curry2');
  * @since v0.7.0
  * @category Function
  * @sig (*... -> a) -> [*] -> a
- * @param {Function} fn
- * @param {Array} args
- * @return {*}
+ * @param {Function} fn The function which will be called with `args`
+ * @param {Array} args The arguments to call `fn` with
+ * @return {*} result The result, equivalent to `fn(...args)`
  * @see R.call, R.unapply
  * @example
  *

--- a/src/assoc.js
+++ b/src/assoc.js
@@ -12,10 +12,10 @@ var _curry3 = require('./internal/_curry3');
  * @since v0.8.0
  * @category Object
  * @sig String -> a -> {k: v} -> {k: v}
- * @param {String} prop the property name to set
- * @param {*} val the new value
- * @param {Object} obj the object to clone
- * @return {Object} a new object similar to the original except for the specified property.
+ * @param {String} prop The property name to set
+ * @param {*} val The new value
+ * @param {Object} obj The object to clone
+ * @return {Object} A new object equivalent to the original except for the changed property.
  * @see R.dissoc
  * @example
  *

--- a/src/assocPath.js
+++ b/src/assocPath.js
@@ -15,13 +15,16 @@ var assoc = require('./assoc');
  * @category Object
  * @sig [String] -> a -> {k: v} -> {k: v}
  * @param {Array} path the path to set
- * @param {*} val the new value
- * @param {Object} obj the object to clone
- * @return {Object} a new object similar to the original except along the specified path.
+ * @param {*} val The new value
+ * @param {Object} obj The object to clone
+ * @return {Object} A new object equivalent to the original except along the specified path.
  * @see R.dissocPath
  * @example
  *
  *      R.assocPath(['a', 'b', 'c'], 42, {a: {b: {c: 0}}}); //=> {a: {b: {c: 42}}}
+ *
+ *      // Any missing or non-object keys in path will be overridden
+ *      R.assocPath(['a', 'b', 'c'], 42, {a: 5}); //=> {a: {b: {c: 42}}}
  */
 module.exports = _curry3(function assocPath(path, val, obj) {
   switch (path.length) {

--- a/src/both.js
+++ b/src/both.js
@@ -5,8 +5,9 @@ var lift = require('./lift');
 
 
 /**
- * A function wrapping calls to the two functions in an `&&` operation,
- * returning the result of the first function if it is false-y and the result
+ * A function which calls the two provided functions and returns the `&&`
+ * of the results.
+ * It returns the result of the first function if it is false-y and the result
  * of the second function otherwise. Note that this is short-circuited,
  * meaning that the second function will not be invoked if the first returns a
  * false-y value.
@@ -19,17 +20,17 @@ var lift = require('./lift');
  * @since v0.12.0
  * @category Logic
  * @sig (*... -> Boolean) -> (*... -> Boolean) -> (*... -> Boolean)
- * @param {Function} f a predicate
- * @param {Function} g another predicate
+ * @param {Function} f A predicate
+ * @param {Function} g Another predicate
  * @return {Function} a function that applies its arguments to `f` and `g` and `&&`s their outputs together.
  * @see R.and
  * @example
  *
- *      var gt10 = x => x > 10;
- *      var even = x => x % 2 === 0;
- *      var f = R.both(gt10, even);
- *      f(100); //=> true
- *      f(101); //=> false
+ *      var gt10 = R.gt(R.__, 10)
+ *      var lt20 = R.lt(R.__, 20)
+ *      var f = R.both(gt10, lt20);
+ *      f(15); //=> true
+ *      f(30); //=> false
  */
 module.exports = _curry2(function both(f, g) {
   return _isFunction(f) ?

--- a/src/dissoc.js
+++ b/src/dissoc.js
@@ -9,9 +9,9 @@ var _curry2 = require('./internal/_curry2');
  * @since v0.10.0
  * @category Object
  * @sig String -> {k: v} -> {k: v}
- * @param {String} prop the name of the property to dissociate
- * @param {Object} obj the object to clone
- * @return {Object} a new object similar to the original but without the specified property
+ * @param {String} prop The name of the property to dissociate
+ * @param {Object} obj The object to clone
+ * @return {Object} A new object equivalent to the original but without the specified property
  * @see R.assoc
  * @example
  *

--- a/src/dissocPath.js
+++ b/src/dissocPath.js
@@ -14,9 +14,9 @@ var dissoc = require('./dissoc');
  * @since v0.11.0
  * @category Object
  * @sig [String] -> {k: v} -> {k: v}
- * @param {Array} path the path to set
- * @param {Object} obj the object to clone
- * @return {Object} a new object without the property at path
+ * @param {Array} path The path to the value to omit
+ * @param {Object} obj The object to clone
+ * @return {Object} A new object without the property at path
  * @see R.assocPath
  * @example
  *


### PR DESCRIPTION
Hey folks, I've been getting more familiar with the lib lately and I think that the docs are one of Ramda's most valuable assets. For the most part they're very clear, but at parts they get a bit technical (which is fine, but the technical points should accompany simpler explanations).

In particular I've found several examples which would be much clearer if they used slightly different input. There are also several examples that require knowledge of advanced concepts which shouldn't be a requirement to learn that particular function.

To remedy some of this, I've been going through the docs one at a time and have been trying to clarify the docs wherever possible. As I go I'm also adding parameter annotations where they're missing and have been standardizing a few things like capitalization, etc.

Each example is open for debate, I've done each doc as a separate commit for easy editing/exclusion, but once I've finished I'll squash it down. I'm still adding on (I'm going through alphabetically) but feel free to comment along the way.