### PR TITLE
Clarify And Unify doc 2 - Return of the docs

### DIFF
--- a/src/call.js
+++ b/src/call.js
@@ -19,6 +19,8 @@ var curry = require('./curry');
  * @see R.apply
  * @example
  *
+ *      R.call(R.add, 1, 2); //=> 3
+ *
  *      var indentN = R.pipe(R.times(R.always(' ')),
  *                           R.join(''),
  *                           R.replace(/^(?!$)/gm));

--- a/src/chain.js
+++ b/src/chain.js
@@ -17,9 +17,9 @@ var map = require('./map');
  * @since v0.3.0
  * @category List
  * @sig Chain m => (a -> m b) -> m a -> m b
- * @param {Function} fn
- * @param {Array} list
- * @return {Array}
+ * @param {Function} fn The function to map with
+ * @param {Array} list The list to map over
+ * @return {Array} The result of flat-mapping `list` with `fn`
  * @example
  *
  *      var duplicate = n => [n, n];

--- a/src/clamp.js
+++ b/src/clamp.js
@@ -10,14 +10,14 @@ var _curry3 = require('./internal/_curry3');
  * @since v0.20.0
  * @category Relation
  * @sig Ord a => a -> a -> a -> a
- * @param {Number} minimum number
- * @param {Number} maximum number
- * @param {Number} value to be clamped
- * @return {Number} Returns the clamped value
+ * @param {Number} minimum The lower limit of the clamp (inclusive)
+ * @param {Number} maximum The upper limit of the clamp (inclusive)
+ * @param {Number} value Value to be clamped
+ * @return {Number} Returns `minimum` when `val < minimum`, `maximum` when `val > maximum`, returns `val` otherwise
  * @example
  *
- *      R.clamp(1, 10, -1) // => 1
- *      R.clamp(1, 10, 11) // => 10
+ *      R.clamp(1, 10, -5) // => 1
+ *      R.clamp(1, 10, 15) // => 10
  *      R.clamp(1, 10, 4)  // => 4
  */
 module.exports = _curry3(function clamp(min, max, value) {

--- a/src/clone.js
+++ b/src/clone.js
@@ -4,8 +4,8 @@ var _curry1 = require('./internal/_curry1');
 
 /**
  * Creates a deep copy of the value which may contain (nested) `Array`s and
- * `Object`s, `Number`s, `String`s, `Boolean`s and `Date`s. `Function`s are not
- * copied, but assigned by their reference.
+ * `Object`s, `Number`s, `String`s, `Boolean`s and `Date`s. `Function`s are
+ * assigned by reference rather than copied
  *
  * Dispatches to a `clone` method if present.
  *
@@ -15,11 +15,12 @@ var _curry1 = require('./internal/_curry1');
  * @category Object
  * @sig {*} -> {*}
  * @param {*} value The object or array to clone
- * @return {*} A new object or array.
+ * @return {*} A deeply cloned copy of `val`
  * @example
  *
  *      var objects = [{}, {}, {}];
  *      var objectsClone = R.clone(objects);
+ *      objects === objectsClone; //=> false
  *      objects[0] === objectsClone[0]; //=> false
  */
 module.exports = _curry1(function clone(value) {

--- a/src/comparator.js
+++ b/src/comparator.js
@@ -10,15 +10,16 @@ var _curry1 = require('./internal/_curry1');
  * @since v0.1.0
  * @category Function
  * @sig (a, b -> Boolean) -> (a, b -> Number)
- * @param {Function} pred A predicate function of arity two.
- * @return {Function} A Function :: a -> b -> Int that returns `-1` if a < b, `1` if b < a, otherwise `0`.
+ * @param {Function} pred A predicate function of arity two which will return `true` if the first argument
+ * is less than the second, `false` otherwise
+ * @return {Function} A Function :: a -> b -> Int that returns `-1` if a < b, `1` if b < a, otherwise `0`
  * @example
  *
- *      var cmp = R.comparator((a, b) => a.age < b.age);
+ *      var byAge = R.comparator((a, b) => a.age < b.age);
  *      var people = [
  *        // ...
  *      ];
- *      R.sort(cmp, people);
+ *      var peopleByIncreasingAge = R.sort(byAge, people);
  */
 module.exports = _curry1(function comparator(pred) {
   return function(a, b) {

--- a/src/complement.js
+++ b/src/complement.js
@@ -3,15 +3,10 @@ var not = require('./not');
 
 
 /**
- * Takes a function `f` and returns a function `g` such that:
+ * Takes a function `f` and returns a function `g` such that if called with the same arguments
+ * when `f` returns a "truthy" value, `g` returns `false` and when `f` returns a "falsy" value `g` returns `true`.
  *
- *   - applying `g` to zero or more arguments will give __true__ if applying
- *     the same arguments to `f` gives a logical __false__ value; and
- *
- *   - applying `g` to zero or more arguments will give __false__ if applying
- *     the same arguments to `f` gives a logical __true__ value.
- *
- * `R.complement` will work on all other functors as well.
+ * `R.complement` may be applied to any functor
  *
  * @func
  * @memberOf R
@@ -23,9 +18,10 @@ var not = require('./not');
  * @see R.not
  * @example
  *
- *      var isEven = n => n % 2 === 0;
- *      var isOdd = R.complement(isEven);
- *      isOdd(21); //=> true
- *      isOdd(42); //=> false
+ *      var isNotNil = R.complement(R.isNil);
+ *      isNil(null); //=> true
+ *      isNotNil(null); //=> false
+ *      isNil(7); //=> false
+ *      isNotNil(7); //=> true
  */
 module.exports = lift(not);

--- a/src/compose.js
+++ b/src/compose.js
@@ -13,14 +13,17 @@ var reverse = require('./reverse');
  * @since v0.1.0
  * @category Function
  * @sig ((y -> z), (x -> y), ..., (o -> p), ((a, b, ..., n) -> o)) -> ((a, b, ..., n) -> z)
- * @param {...Function} functions
+ * @param {...Function} ...functions The functions to compose
  * @return {Function}
  * @see R.pipe
  * @example
  *
- *      var f = R.compose(R.inc, R.negate, Math.pow);
+ *      var classyGreeting = (firstName, lastName) => "The name's " + lastName + ", " + firstName + " " + lastName
+ *      var yellGreeting = R.compose(R.toUpper, classyGreeting);
+ *      yellGreeting('James', 'Bond'); //=> "THE NAME'S BOND, JAMES BOND"
  *
- *      f(3, 4); // -(3^4) + 1
+ *      R.compose(Math.abs, R.add(1), R.multiply(2))(-4) //=> 7
+ *
  * @symb R.compose(f, g, h)(a, b) = f(g(h(a, b)))
  */
 module.exports = function compose() {

--- a/src/composeK.js
+++ b/src/composeK.js
@@ -16,27 +16,23 @@ var prepend = require('./prepend');
  * @since v0.16.0
  * @category Function
  * @sig Chain m => ((y -> m z), (x -> m y), ..., (a -> m b)) -> (m a -> m z)
- * @param {...Function}
+ * @param {...Function} ...functions The functions to compose
  * @return {Function}
  * @see R.pipeK
  * @example
  *
- *      //  parseJson :: String -> Maybe *
- *      //  get :: String -> Object -> Maybe *
+ *       //  get :: String -> Object -> Maybe *
+ *       var get = R.curry((propName, obj) => Maybe(obj[propName]))
  *
- *      //  getStateCode :: Maybe String -> Maybe String
- *      var getStateCode = R.composeK(
- *        R.compose(Maybe.of, R.toUpper),
- *        get('state'),
- *        get('address'),
- *        get('user'),
- *        parseJson
- *      );
- *
- *      getStateCode(Maybe.of('{"user":{"address":{"state":"ny"}}}'));
- *      //=> Just('NY')
- *      getStateCode(Maybe.of('[Invalid JSON]'));
- *      //=> Nothing()
+ *       //  getStateCode :: Maybe String -> Maybe String
+ *       var getStateCode = R.composeK(
+ *         R.compose(Maybe.of, R.toUpper),
+ *         get('state'),
+ *         get('address'),
+ *         get('user'),
+ *       );
+ *       getStateCode(Maybe.of({"user":{"address":{"state":"ny"}}})); //=> Maybe.Just("NY")
+ *       getStateCode(Maybe.of({})); //=> Maybe.Nothing()
  * @symb R.composeK(f, g, h)(a, b) = R.chain(f, R.chain(g, h(a, b)))
  */
 module.exports = function composeK() {

--- a/src/composeP.js
+++ b/src/composeP.js
@@ -12,13 +12,29 @@ var reverse = require('./reverse');
  * @since v0.10.0
  * @category Function
  * @sig ((y -> Promise z), (x -> Promise y), ..., (a -> Promise b)) -> (a -> Promise z)
- * @param {...Function} functions
+ * @param {...Function} functions The functions to compose
  * @return {Function}
  * @see R.pipeP
  * @example
  *
- *      //  followersForUser :: String -> Promise [User]
- *      var followersForUser = R.composeP(db.getFollowers, db.getUserById);
+ *      var db = {
+ *        users: {
+ *          JOE: {
+ *            name: 'Joe',
+ *            followers: ['STEVE', 'SUZY']
+ *          }
+ *        }
+ *      }
+ *
+ *      // We'll pretend to do a db lookup which returns a promise
+ *      var lookupUser = (userId) => Promise.resolve(db.users[userId])
+ *      var lookupFollowers = (user) => Promise.resolve(user.followers)
+ *      lookupUser('JOE').then(lookupFollowers)
+ *
+ *      //  followersForUser :: String -> Promise [UserId]
+ *      var followersForUser = R.composeP(lookupFollowers, lookupUser);
+ *      followersForUser('JOE').then(followers => console.log('Followers:', followers))
+ *      // Followers: ["STEVE","SUZY"]
  */
 module.exports = function composeP() {
   if (arguments.length === 0) {


### PR DESCRIPTION
See https://github.com/ramda/ramda/pull/1891,
Doing a run over examples clarifying things,

Of note in this batch is that the type signatures for some of the compose functions didn't always show that the first function could take multiple arguments. Quick question on that, is composeK supposed to allow multiple arguments for the first function? I couldn't find it mentioned anywhere.

Also I noticed that the multiple argument functionality of `compose` doesn't seem to be tested 😢 
As usual, I'll squash this down when it's ready to merge.