### PR TITLE
optional type checking

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,9 @@
     "browser_test": "testem ci",
     "postbrowser_test": "npm run posttest"
   },
-  "dependencies": {},
+  "dependencies": {
+    "sanctuary-def": "0.6.x"
+  },
   "devDependencies": {
     "acorn": "0.9.x",
     "benchmark": "~1.0.0",

--- a/scripts/build
+++ b/scripts/build
@@ -122,25 +122,14 @@ var abortIfExportNotLast = R.tap(R.cond([[
 ]]));
 
 //  abortIfDifferentRequireVar :: {*} -> {*}
-var abortIfDifferentRequireVar = R.tap(R.forEach(R.cond([[
-  R.converge(
-    R.complement(R.equals),
-    R.path(['id', 'name']),
-    R.pipe(
-      R.path(['init', 'arguments', '0', 'value']),
-      R.replace(/^[.][/]internal[/]/, './'),
-      R.replace(/^[.]{1,2}[/]/, ''),
-      R.replace(/[.]([a-z])/g, R.pipe(R.nthArg(1), R.toUpper))
-    )
-  ),
-  function(ast) {
+var abortIfDifferentRequireVar = R.tap(R.forEach(function(ast) {
+  var varName = ast.id.name;
+  var depName = ast.init.arguments[0].value;
+  if (/^[.]/.test(depName) && R.last(R.split('/', depName)) !== varName) {
     abort('Dependency declared with different variable name: `' +
-      ast.id.name + '` & `' +
-      ast.init.arguments[0].value +
-      '` in ' + ast.loc.source
-    );
+          varName + '` & `' + depName + '` in ' + ast.loc.source);
   }
-]])));
+}));
 
 //  abortIfEmptyBody :: {*} -> {*}
 var abortIfEmptyBody = R.tap(R.cond([[
@@ -178,8 +167,9 @@ R.pipe(identifierToFilename,
        R.takeWhile(R.both(R.propEq('type', 'VariableDeclaration'),
                           R.pipe(R.prop('declarations'),
                                  R.all(isRequireExpr)))),
-  R.pluck('declarations'),
+       R.pluck('declarations'),
        R.map(R.head),
+       R.reject(R.pathEq(['id', 'name'], '$')),
        abortIfNotSorted,
        abortIfDifferentRequireVar,
        R.map(R.path(['id', 'name'])));

--- a/scripts/template.js
+++ b/scripts/template.js
@@ -1,4 +1,16 @@
-;(function() {
+;(function(f) {
+
+  'use strict';
+
+  if (typeof module === 'object' && typeof module.exports === 'object') {
+    module.exports = f(require('sanctuary-def'));
+  } else if (typeof define === 'function' && define.amd != null) {
+    define(['sanctuary-def'], f);
+  } else {
+    self.R = f(self.sanctuaryDef);
+  }
+
+}(function($) {
 
   'use strict';
 
@@ -7,12 +19,6 @@
 
   /* TEST_ENTRY_POINT */
 
-  if (typeof exports === 'object') {
-    module.exports = R;
-  } else if (typeof define === 'function' && define.amd) {
-    define(function() { return R; });
-  } else {
-    this.R = R;
-  }
+  return R;
 
-}.call(this));
+}));

--- a/src/internal/_def.js
+++ b/src/internal/_def.js
@@ -1,0 +1,3 @@
+var $ = require('sanctuary-def');
+
+module.exports = $.create({checkTypes: true, env: $.env});

--- a/src/internal/_isRegExp.js
+++ b/src/internal/_isRegExp.js
@@ -1,3 +1,0 @@
-module.exports = function _isRegExp(x) {
-  return Object.prototype.toString.call(x) === '[object RegExp]';
-};

--- a/src/match.js
+++ b/src/match.js
@@ -1,4 +1,6 @@
-var _curry2 = require('./internal/_curry2');
+var $ = require('sanctuary-def');
+
+var _def = require('./internal/_def');
 
 
 /**
@@ -20,8 +22,9 @@ var _curry2 = require('./internal/_curry2');
  *
  *      R.match(/([a-z]a)/g, 'bananas'); //=> ['ba', 'na', 'na']
  *      R.match(/a/, 'b'); //=> []
- *      R.match(/a/, null); //=> TypeError: null does not have a method named "match"
  */
-module.exports = _curry2(function match(rx, str) {
-  return str.match(rx) || [];
-});
+module.exports =
+_def('match',
+     {},
+     [$.RegExp, $.String, $.Array($.Any)],
+     function(rx, str) { return str.match(rx) || []; });

--- a/src/test.js
+++ b/src/test.js
@@ -1,7 +1,7 @@
+var $ = require('sanctuary-def');
+
 var _cloneRegExp = require('./internal/_cloneRegExp');
-var _curry2 = require('./internal/_curry2');
-var _isRegExp = require('./internal/_isRegExp');
-var toString = require('./toString');
+var _def = require('./internal/_def');
 
 
 /**
@@ -21,9 +21,8 @@ var toString = require('./toString');
  *      R.test(/^x/, 'xyz'); //=> true
  *      R.test(/^y/, 'xyz'); //=> false
  */
-module.exports = _curry2(function test(pattern, str) {
-  if (!_isRegExp(pattern)) {
-    throw new TypeError('‘test’ requires a value of type RegExp as its first argument; received ' + toString(pattern));
-  }
-  return _cloneRegExp(pattern).test(str);
-});
+module.exports =
+_def('test',
+     {},
+     [$.RegExp, $.String, $.Boolean],
+     function test(pattern, str) { return _cloneRegExp(pattern).test(str); });

--- a/test/invariants.js
+++ b/test/invariants.js
@@ -4,28 +4,31 @@ var eq = require('./shared/eq');
 
 describe('invariants', function() {
 
+  //  toTest :: [String]
+  var toTest = R.without(['match', 'test'], R.keys(R.filter(R.is(Function), R)));
+
   it('-- applying function f with length n (where n > 0) to no arguments gives function with length n', function() {
-    for (var prop in R) {
-      if (typeof R[prop] === 'function' && R[prop].length > 0) {
-        var result = R[prop]();
+    toTest.forEach(function(name) {
+      if (R[name].length > 0) {
+        var result = R[name]();
         eq(typeof result, 'function');
-        eq(result.length, R[prop].length);
+        eq(result.length, R[name].length);
       }
-    }
+    });
   });
 
   it('-- applying function f with length n (where n > 0) to R.__ gives function with length n', function() {
-    for (var prop in R) {
-      if (typeof R[prop] === 'function' && R[prop].length > 0) {
-        var result = R[prop](R.__);
+    toTest.forEach(function(name) {
+      if (R[name].length > 0) {
+        var result = R[name](R.__);
         eq(typeof result, 'function');
-        eq(result.length, R[prop].length);
+        eq(result.length, R[name].length);
       }
-    }
+    });
   });
 
   it('-- applying function f with length n (where n > 1) to any value other than R.__ gives function with length n - 1', function() {
-    var testPartialApplication = function(fn, name) {
+    var testPartialApplication = function testPartialApplication(fn, name) {
       if (fn.length > 1) {
         var result = fn(null);
         eq(typeof result, 'function');
@@ -34,11 +37,9 @@ describe('invariants', function() {
       }
     };
 
-    for (var prop in R) {
-      if (typeof R[prop] === 'function') {
-        testPartialApplication(R[prop], prop);
-      }
-    }
+    toTest.forEach(function(name) {
+      testPartialApplication(R[name], name);
+    });
   });
 
 });

--- a/test/match.js
+++ b/test/match.js
@@ -1,6 +1,7 @@
 var assert = require('assert');
 
 var R = require('..');
+var errorEq = require('./shared/errorEq');
 var eq = require('./shared/eq');
 
 
@@ -27,7 +28,19 @@ describe('match', function() {
   });
 
   it('throws on null input', function() {
-    assert.throws(function shouldThrow() { R.match(re, null); }, TypeError);
+    assert.throws(
+      function shouldThrow() { R.match(re, null); },
+      errorEq(TypeError,
+              'Invalid value\n' +
+              '\n' +
+              'match :: RegExp -> String -> Array Any\n' +
+              '                   ^^^^^^\n' +
+              '                     1\n' +
+              '\n' +
+              '1)  null :: Null\n' +
+              '\n' +
+              'The value at position 1 is not a member of ‘String’.\n')
+    );
   });
 
 });

--- a/test/shared/errorEq.js
+++ b/test/shared/errorEq.js
@@ -1,0 +1,7 @@
+var curry = require('../../src/curry');
+
+
+//  errorEq :: TypeRep a -> String -> Error -> Boolean
+module.exports = curry(function(type, message, error) {
+  return error.constructor === type && error.message === message;
+});

--- a/test/test.js
+++ b/test/test.js
@@ -1,6 +1,7 @@
 var assert = require('assert');
 
 var R = require('..');
+var errorEq = require('./shared/errorEq');
 var eq = require('./shared/eq');
 
 
@@ -25,11 +26,16 @@ describe('test', function() {
   it('throws if first argument is not a regexp', function() {
     assert.throws(
       function() { R.test('foo', 'bar'); },
-      function(err) {
-        return err.constructor === TypeError &&
-               err.message === '‘test’ requires a value of type RegExp ' +
-                               'as its first argument; received "foo"';
-      }
+      errorEq(TypeError,
+              'Invalid value\n' +
+              '\n' +
+              'test :: RegExp -> String -> Boolean\n' +
+              '        ^^^^^^\n' +
+              '          1\n' +
+              '\n' +
+              '1)  "foo" :: String\n' +
+              '\n' +
+              'The value at position 1 is not a member of ‘RegExp’.\n')
     );
   });
 


### PR DESCRIPTION
From discussion in #1910 it seems there's at least some interest in using [sanctuary-def](https://github.com/sanctuary-js/sanctuary-def) in Ramda. I'm opening this pull request simply to provide a couple of concrete examples of how this would look.

If we decide to pursue this we'll need to provide a way for users to opt in to (or opt out of) type checking. Presumably this would work as in [Sanctuary](https://sanctuary.js.org/#type-checking), though we'd likely disable type checking by default.

This could continue to work exactly as it does now:

``` javascript
const R = require('ramda');
```

This would enable type checking to be turned on and off:

``` javascript
const {create, env} = require('ramda');

const R = create({checkTypes: true, env: env});
```
