### PR TITLE
Replace documentation Widget arrow with Constructor Function

### DIFF
--- a/src/construct.js
+++ b/src/construct.js
@@ -16,7 +16,7 @@ var constructN = require('./constructN');
  * @example
  *
  *      // Constructor function
- *      var Widget = config => {
+ *      var Widget = function (config) {
  *        // ...
  *      };
  *      Widget.prototype = {

--- a/src/constructN.js
+++ b/src/constructN.js
@@ -19,7 +19,7 @@ var nAry = require('./nAry');
  * @example
  *
  *      // Variadic constructor function
- *      var Widget = () => {
+ *      var Widget = function () {
  *        this.children = Array.prototype.slice.call(arguments);
  *        // ...
  *      };


### PR DESCRIPTION
Arrow functions are not constructable.