### PR TITLE
Add support for integer path segments in assocPath

### DIFF
--- a/src/assocPath.js
+++ b/src/assocPath.js
@@ -1,4 +1,7 @@
 var _curry3 = require('./internal/_curry3');
+var _has = require('./internal/_has');
+var _isArray = require('./internal/_isArray');
+var _isInteger = require('./internal/_isInteger');
 var assoc = require('./assoc');
 
 
@@ -27,12 +30,19 @@ var assoc = require('./assoc');
  *      R.assocPath(['a', 'b', 'c'], 42, {a: 5}); //=> {a: {b: {c: 42}}}
  */
 module.exports = _curry3(function assocPath(path, val, obj) {
-  switch (path.length) {
-    case 0:
-      return val;
-    case 1:
-      return assoc(path[0], val, obj);
-    default:
-      return assoc(path[0], assocPath(Array.prototype.slice.call(path, 1), val, Object(obj[path[0]])), obj);
+  if (path.length === 0) {
+    return val;
+  }
+  var idx = path[0];
+  if (path.length > 1) {
+    var nextObj = _has(idx, obj) ? obj[idx] : _isInteger(path[1]) ? [] : {};
+    val = assocPath(Array.prototype.slice.call(path, 1), val, nextObj);
+  }
+  if (_isInteger(idx) && _isArray(obj)) {
+    var arr = [].concat(obj);
+    arr[idx] = val;
+    return arr;
+  } else {
+    return assoc(idx, val, obj);
   }
 });

--- a/src/assocPath.js
+++ b/src/assocPath.js
@@ -12,7 +12,8 @@ var assoc = require('./assoc');
  * @memberOf R
  * @since v0.8.0
  * @category Object
- * @sig [String] -> a -> {k: v} -> {k: v}
+ * @typedefn Idx = String | Int
+ * @sig [Idx] -> a -> {a} -> {a}
  * @param {Array} path the path to set
  * @param {*} val The new value
  * @param {Object} obj The object to clone

--- a/src/lensPath.js
+++ b/src/lensPath.js
@@ -11,18 +11,22 @@ var path = require('./path');
  * @memberOf R
  * @since v0.19.0
  * @category Object
+ * @typedefn Idx = String | Int
  * @typedefn Lens s a = Functor f => (a -> f a) -> s -> f s
- * @sig [String] -> Lens s a
+ * @sig [Idx] -> Lens s a
  * @param {Array} path The path to use.
  * @return {Lens}
  * @see R.view, R.set, R.over
  * @example
  *
- *      var xyLens = R.lensPath(['x', 'y']);
+ *      var xHeadYLens = R.lensPath(['x', 0, 'y']);
  *
- *      R.view(xyLens, {x: {y: 2, z: 3}});            //=> 2
- *      R.set(xyLens, 4, {x: {y: 2, z: 3}});          //=> {x: {y: 4, z: 3}}
- *      R.over(xyLens, R.negate, {x: {y: 2, z: 3}});  //=> {x: {y: -2, z: 3}}
+ *      R.view(xHeadYLens, {x: [{y: 2, z: 3}, {y: 4, z: 5}]});
+ *      //=> 2
+ *      R.set(xHeadYLens, 1, {x: [{y: 2, z: 3}, {y: 4, z: 5}]});
+ *      //=> {x: [{y: 1, z: 3}, {y: 4, z: 5}]}
+ *      R.over(xHeadYLens, R.negate, {x: [{y: 2, z: 3}, {y: 4, z: 5}]});
+ *      //=> {x: [{y: -2, z: 3}, {y: 4, z: 5}]}
  */
 module.exports = _curry1(function lensPath(p) {
   return lens(path(p), assocPath(p));

--- a/src/path.js
+++ b/src/path.js
@@ -8,7 +8,8 @@ var _curry2 = require('./internal/_curry2');
  * @memberOf R
  * @since v0.2.0
  * @category Object
- * @sig [String] -> {k: v} -> v | Undefined
+ * @typedefn Idx = String | Int
+ * @sig [Idx] -> {a} -> a | Undefined
  * @param {Array} path The path to use.
  * @param {Object} obj The object to retrieve the nested property from.
  * @return {*} The data at `path`.

--- a/src/pathEq.js
+++ b/src/pathEq.js
@@ -11,7 +11,8 @@ var path = require('./path');
  * @memberOf R
  * @since v0.7.0
  * @category Relation
- * @sig [String] -> * -> {String: *} -> Boolean
+ * @typedefn Idx = String | Int
+ * @sig [Idx] -> a -> {a} -> Boolean
  * @param {Array} path The path of the nested property to use
  * @param {*} val The value to compare the nested property with
  * @param {Object} obj The object to check the nested property in

--- a/src/pathOr.js
+++ b/src/pathOr.js
@@ -11,7 +11,8 @@ var path = require('./path');
  * @memberOf R
  * @since v0.18.0
  * @category Object
- * @sig a -> [String] -> Object -> a
+ * @typedefn Idx = String | Int
+ * @sig a -> [Idx] -> {a} -> a
  * @param {*} d The default value.
  * @param {Array} p The path to use.
  * @param {Object} obj The object to retrieve the nested property from.

--- a/src/pathSatisfies.js
+++ b/src/pathSatisfies.js
@@ -10,7 +10,8 @@ var path = require('./path');
  * @memberOf R
  * @since v0.19.0
  * @category Logic
- * @sig (a -> Boolean) -> [String] -> Object -> Boolean
+ * @typedefn Idx = String | Int
+ * @sig (a -> Boolean) -> [Idx] -> {a} -> Boolean
  * @param {Function} pred
  * @param {Array} propPath
  * @param {*} obj

--- a/test/assocPath.js
+++ b/test/assocPath.js
@@ -2,15 +2,14 @@ var assert = require('assert');
 
 var R = require('..');
 var eq = require('./shared/eq');
+var assocPath = require('../src/assocPath');
 
 
 describe('assocPath', function() {
   it('makes a shallow clone of an object, overriding only what is necessary for the path', function() {
-    var obj1 = {a: {b: 1, c: 2, d: {e: 3}}, f: {g: {h: 4, i: 5, j: {k: 6, l: 7}}}, m: 8};
-    var obj2 = R.assocPath(['f', 'g', 'i'], {x: 42}, obj1);
-    eq(obj2,
-      {a: {b: 1, c: 2, d: {e: 3}}, f: {g: {h: 4, i: {x: 42}, j: {k: 6, l: 7}}}, m: 8}
-    );
+    var obj1 = {a: {b: 1, c: 2, d: {e: 3}}, f: {g: {h: 4, i: [5, 6, 7], j: {k: 6, l: 7}}}, m: 8};
+    var obj2 = R.assocPath(['f', 'g', 'i', 1], 42, obj1);
+    eq(obj2.f.g.i, [5, 42, 7]);
     // Note: reference equality below!
     assert.strictEqual(obj2.a, obj1.a);
     assert.strictEqual(obj2.m, obj1.m);
@@ -20,11 +19,12 @@ describe('assocPath', function() {
 
   it('is the equivalent of clone and setPath if the property is not on the original', function() {
     var obj1 = {a: 1, b: {c: 2, d: 3}, e: 4, f: 5};
-    var obj2 = R.assocPath(['x', 'y', 'z'], {w: 42}, obj1);
-    eq(obj2, {a: 1, b: {c: 2, d: 3}, e: 4, f: 5, x: {y: {z: {w: 42}}}});
+    var obj2 = assocPath(['x', 0, 'y'], 42, obj1);
+    eq(obj2, {a: 1, b: {c: 2, d: 3}, e: 4, f: 5, x: [{y: 42}]});
     // Note: reference equality below!
     assert.strictEqual(obj2.a, obj1.a);
     assert.strictEqual(obj2.b, obj1.b);
+    assert.strictEqual(obj2.e, obj1.e);
     assert.strictEqual(obj2.f, obj1.f);
   });
 

--- a/test/lensPath.js
+++ b/test/lensPath.js
@@ -3,9 +3,11 @@ var eq = require('./shared/eq');
 
 
 var testObj = {
-  a: {
+  a: [{
+    b: 1
+  }, {
     b: 2
-  },
+  }],
   d: 3
 };
 
@@ -13,50 +15,50 @@ describe('lensPath', function() {
   describe('view', function() {
     it('focuses the specified object property', function() {
       eq(R.view(R.lensPath(['d']), testObj), 3);
-      eq(R.view(R.lensPath(['a', 'b']), testObj), 2);
+      eq(R.view(R.lensPath(['a', 1, 'b']), testObj), 2);
       eq(R.view(R.lensPath([]), testObj), testObj);
     });
   });
   describe('set', function() {
     it('sets the value of the object property specified', function() {
-      eq(R.set(R.lensPath(['d']), 0, testObj), {a: {b: 2}, d: 0});
-      eq(R.set(R.lensPath(['a', 'b']), 0, testObj), {a: {b: 0}, d: 3});
+      eq(R.set(R.lensPath(['d']), 0, testObj), {a: [{b: 1}, {b: 2}], d: 0});
+      eq(R.set(R.lensPath(['a', 0, 'b']), 0, testObj), {a: [{b: 0}, {b: 2}], d: 3});
       eq(R.set(R.lensPath([]), 0, testObj), 0);
     });
     it('adds the property to the object if it doesn\'t exist', function() {
-      eq(R.set(R.lensPath(['X']), 0, testObj), {a: {b: 2}, d: 3, X: 0});
-      eq(R.set(R.lensPath(['a', 'X']), 0, testObj), {a: {b: 2, X: 0}, d: 3});
+      eq(R.set(R.lensPath(['X']), 0, testObj), {a: [{b: 1}, {b: 2}], d: 3, X: 0});
+      eq(R.set(R.lensPath(['a', 0, 'X']), 0, testObj), {a: [{b: 1, X: 0}, {b: 2}], d: 3});
     });
   });
   describe('over', function() {
     it('applies function to the value of the specified object property', function() {
-      eq(R.over(R.lensPath(['d']), R.inc, testObj), {a: {b: 2}, d: 4});
-      eq(R.over(R.lensPath(['a', 'b']), R.inc, testObj), {a: {b: 3}, d: 3});
-      eq(R.over(R.lensPath([]), R.toPairs, testObj), [['a', {b: 2}], ['d', 3]]);
+      eq(R.over(R.lensPath(['d']), R.inc, testObj), {a: [{b: 1}, {b: 2}], d: 4});
+      eq(R.over(R.lensPath(['a', 1, 'b']), R.inc, testObj), {a: [{b: 1}, {b: 3}], d: 3});
+      eq(R.over(R.lensPath([]), R.toPairs, testObj), [['a', [{b: 1}, {b: 2}]], ['d', 3]]);
     });
     it('applies function to undefined and adds the property if it doesn\'t exist', function() {
-      eq(R.over(R.lensPath(['X']), R.identity, testObj), {a: {b: 2}, d: 3, X: undefined});
-      eq(R.over(R.lensPath(['a', 'X']), R.identity, testObj), {a: {b: 2, X: undefined}, d: 3});
+      eq(R.over(R.lensPath(['X']), R.identity, testObj), {a: [{b: 1}, {b: 2}], d: 3, X: undefined});
+      eq(R.over(R.lensPath(['a', 0, 'X']), R.identity, testObj), {a: [{b: 1, X: undefined}, {b: 2}], d: 3});
     });
   });
   describe('composability', function() {
     it('can be composed', function() {
-      var composedLens = R.compose(R.lensPath(['a']), R.lensPath(['b']));
+      var composedLens = R.compose(R.lensPath(['a']), R.lensPath([1, 'b']));
       eq(R.view(composedLens, testObj), 2);
     });
   });
   describe('well behaved lens', function() {
     it('set s (get s) === s', function() {
       eq(R.set(R.lensPath(['d']), R.view(R.lensPath(['d']), testObj), testObj), testObj);
-      eq(R.set(R.lensPath(['a', 'b']), R.view(R.lensPath(['a', 'b']), testObj), testObj), testObj);
+      eq(R.set(R.lensPath(['a', 0, 'b']), R.view(R.lensPath(['a', 0, 'b']), testObj), testObj), testObj);
     });
     it('get (set s v) === v', function() {
       eq(R.view(R.lensPath(['d']), R.set(R.lensPath(['d']), 0, testObj)), 0);
-      eq(R.view(R.lensPath(['a', 'b']), R.set(R.lensPath(['a', 'b']), 0, testObj)), 0);
+      eq(R.view(R.lensPath(['a', 0, 'b']), R.set(R.lensPath(['a', 0, 'b']), 0, testObj)), 0);
     });
     it('get (set(set s v1) v2) === v2', function() {
       var p = ['d'];
-      var q = ['a', 'b'];
+      var q = ['a', 0, 'b'];
       eq(R.view(R.lensPath(p), R.set(R.lensPath(p), 11, R.set(R.lensPath(p), 10, testObj))), 11);
       eq(R.view(R.lensPath(q), R.set(R.lensPath(q), 11, R.set(R.lensPath(q), 10, testObj))), 11);
     });

--- a/test/path.js
+++ b/test/path.js
@@ -22,9 +22,9 @@ describe('path', function() {
     };
     eq(R.path(['a', 'b', 'c'], obj), 100);
     eq(R.path([], obj), obj);
-    eq(R.path(['a', 'e', 'f', '1'], obj), 101);
-    eq(R.path(['j', '0'], obj), 'J');
-    eq(R.path(['j', '1'], obj), undefined);
+    eq(R.path(['a', 'e', 'f', 1], obj), 101);
+    eq(R.path(['j', 0], obj), 'J');
+    eq(R.path(['j', 1], obj), undefined);
   });
 
   it("gets a deep property's value from objects", function() {

--- a/test/pathEq.js
+++ b/test/pathEq.js
@@ -6,19 +6,21 @@ describe('pathEq', function() {
 
   var obj = {
     a: 1,
-    b: {
-      ba: '2'
-    }
+    b: [{
+      ba: 2
+    }, {
+      ba: 3
+    }]
   };
 
   it('returns true if the path matches the value', function() {
     eq(R.pathEq(['a'], 1, obj), true);
-    eq(R.pathEq(['b', 'ba'], '2', obj), true);
+    eq(R.pathEq(['b', 1, 'ba'], 3, obj), true);
   });
 
   it('returns false for non matches', function() {
     eq(R.pathEq(['a'], '1', obj), false);
-    eq(R.pathEq(['b', 'ba'], 2, obj), false);
+    eq(R.pathEq(['b', 0, 'ba'], 3, obj), false);
   });
 
   it('returns false for non existing values', function() {

--- a/test/pathOr.js
+++ b/test/pathOr.js
@@ -23,9 +23,9 @@ describe('pathOr', function() {
     };
     eq(R.pathOr('Unknown', ['a', 'b', 'c'], obj), 100);
     eq(R.pathOr('Unknown', [], obj), obj);
-    eq(R.pathOr('Unknown', ['a', 'e', 'f', '1'], obj), 101);
-    eq(R.pathOr('Unknown', ['j', '0'], obj), 'J');
-    eq(R.pathOr('Unknown', ['j', '1'], obj), 'Unknown');
+    eq(R.pathOr('Unknown', ['a', 'e', 'f', 1], obj), 101);
+    eq(R.pathOr('Unknown', ['j', 0], obj), 'J');
+    eq(R.pathOr('Unknown', ['j', 1], obj), 'Unknown');
     eq(R.pathOr('Unknown', ['a', 'b', 'c'], null), 'Unknown');
   });
 

--- a/test/pathSatisfies.js
+++ b/test/pathSatisfies.js
@@ -7,7 +7,7 @@ describe('pathSatisfies', function() {
   var isPositive = function(n) { return n > 0; };
 
   it('returns true if the specified object path satisfies the given predicate', function() {
-    eq(R.pathSatisfies(isPositive, ['x', 'y'], {x: {y: 1}}), true);
+    eq(R.pathSatisfies(isPositive, ['x', 1, 'y'], {x: [{y: -1}, {y: 1}]}), true);
   });
 
   it('returns false if the specified path does not exist', function() {


### PR DESCRIPTION
This is an alternative proposal to #1924 for supporting integer path segments in `assocPath` (and `lensPath` by its current implementation).