### PR TITLE
Add eslint semicolon rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -117,6 +117,7 @@
     "no-dupe-keys": 2,
     "no-duplicate-case": 2,
     "no-extra-semi": 2,
-    "no-unreachable": 2
+    "no-unreachable": 2,
+    "semi": 2
   }
 }

--- a/src/applySpec.js
+++ b/src/applySpec.js
@@ -34,7 +34,7 @@ var values = require('./values');
  * @symb R.applySpec({ x: f, y: { z: g } })(a, b) = { x: f(a, b), y: { z: g(a, b) } }
  */
 module.exports = _curry1(function applySpec(spec) {
-  spec = map(function(v) { return typeof v == 'function' ? v : applySpec(v) },
+  spec = map(function(v) { return typeof v == 'function' ? v : applySpec(v); },
              spec);
   return curryN(reduce(max, 0, pluck('length', values(spec))),
                 function() {

--- a/src/dissoc.js
+++ b/src/dissoc.js
@@ -22,6 +22,6 @@ module.exports = _curry2(function dissoc(prop, obj) {
   for (var p in obj) {
     result[p] = obj[p];
   }
-  delete result[prop]
+  delete result[prop];
   return result;
 });

--- a/test/complement.js
+++ b/test/complement.js
@@ -1,4 +1,4 @@
-var S = require('sanctuary')
+var S = require('sanctuary');
 
 var R = require('..');
 var eq = require('./shared/eq');

--- a/test/indexBy.js
+++ b/test/indexBy.js
@@ -30,7 +30,7 @@ describe('indexBy', function() {
         R.adjust(R.toUpper, 0),
         R.adjust(R.omit('id'), 1)
       )));
-    var result = R.into({}, transducer, list)
+    var result = R.into({}, transducer, list);
     eq(result, {ABC: {title: 'B'}, XYZ: {title: 'A'}});
   });
 


### PR DESCRIPTION
I'm not sure why this isn't in the eslint config already. It is the standard for this project - so it makes sense to enforce it with the linter. 

After adding the rule - I found 4 examples of missing semicolons which are also fixed in this PR.