### PR TITLE
remove unwanted dispatching

### DIFF
--- a/src/all.js
+++ b/src/all.js
@@ -27,7 +27,7 @@ var _xall = require('./internal/_xall');
  *      R.all(equals3)([3, 3, 3, 3]); //=> true
  *      R.all(equals3)([3, 3, 1, 3]); //=> false
  */
-module.exports = _curry2(_dispatchable('all', _xall, function all(fn, list) {
+module.exports = _curry2(_dispatchable(['all'], _xall, function all(fn, list) {
   var idx = 0;
   while (idx < list.length) {
     if (!fn(list[idx])) {

--- a/src/any.js
+++ b/src/any.js
@@ -28,7 +28,7 @@ var _xany = require('./internal/_xany');
  *      R.any(lessThan0)([1, 2]); //=> false
  *      R.any(lessThan2)([1, 2]); //=> true
  */
-module.exports = _curry2(_dispatchable('any', _xany, function any(fn, list) {
+module.exports = _curry2(_dispatchable(['any'], _xany, function any(fn, list) {
   var idx = 0;
   while (idx < list.length) {
     if (fn(list[idx])) {

--- a/src/aperture.js
+++ b/src/aperture.js
@@ -8,8 +8,6 @@ var _xaperture = require('./internal/_xaperture');
  * Returns a new list, composed of n-tuples of consecutive elements If `n` is
  * greater than the length of the list, an empty list is returned.
  *
- * Dispatches to the `aperture` method of the second argument, if present.
- *
  * Acts as a transducer if a transformer is given in list position.
  *
  * @func
@@ -27,4 +25,4 @@ var _xaperture = require('./internal/_xaperture');
  *      R.aperture(3, [1, 2, 3, 4, 5]); //=> [[1, 2, 3], [2, 3, 4], [3, 4, 5]]
  *      R.aperture(7, [1, 2, 3, 4, 5]); //=> []
  */
-module.exports = _curry2(_dispatchable('aperture', _xaperture, _aperture));
+module.exports = _curry2(_dispatchable([], _xaperture, _aperture));

--- a/src/chain.js
+++ b/src/chain.js
@@ -27,7 +27,7 @@ var map = require('./map');
  *
  *      R.chain(R.append, R.head)([1, 2, 3]); //=> [1, 2, 3, 1]
  */
-module.exports = _curry2(_dispatchable('chain', _xchain, function chain(fn, monad) {
+module.exports = _curry2(_dispatchable(['chain'], _xchain, function chain(fn, monad) {
   if (typeof monad === 'function') {
     return function(x) { return fn(monad(x))(x); };
   }

--- a/src/drop.js
+++ b/src/drop.js
@@ -28,6 +28,6 @@ var slice = require('./slice');
  *      R.drop(4, ['foo', 'bar', 'baz']); //=> []
  *      R.drop(3, 'ramda');               //=> 'da'
  */
-module.exports = _curry2(_dispatchable('drop', _xdrop, function drop(n, xs) {
+module.exports = _curry2(_dispatchable(['drop'], _xdrop, function drop(n, xs) {
   return slice(Math.max(0, n), Infinity, xs);
 }));

--- a/src/dropLast.js
+++ b/src/dropLast.js
@@ -25,4 +25,4 @@ var _xdropLast = require('./internal/_xdropLast');
  *      R.dropLast(4, ['foo', 'bar', 'baz']); //=> []
  *      R.dropLast(3, 'ramda');               //=> 'ra'
  */
-module.exports = _curry2(_dispatchable('dropLast', _xdropLast, _dropLast));
+module.exports = _curry2(_dispatchable([], _xdropLast, _dropLast));

--- a/src/dropLastWhile.js
+++ b/src/dropLastWhile.js
@@ -26,4 +26,4 @@ var _xdropLastWhile = require('./internal/_xdropLastWhile');
  *
  *      R.dropLastWhile(lteThree, [1, 2, 3, 4, 3, 2, 1]); //=> [1, 2, 3, 4]
  */
-module.exports = _curry2(_dispatchable('dropLastWhile', _xdropLastWhile, _dropLastWhile));
+module.exports = _curry2(_dispatchable([], _xdropLastWhile, _dropLastWhile));

--- a/src/dropRepeats.js
+++ b/src/dropRepeats.js
@@ -9,8 +9,6 @@ var equals = require('./equals');
  * Returns a new list without any consecutively repeating elements. `R.equals`
  * is used to determine equality.
  *
- * Dispatches to the `dropRepeats` method of the first argument, if present.
- *
  * Acts as a transducer if a transformer is given in list position.
  *
  * @func
@@ -25,4 +23,4 @@ var equals = require('./equals');
  *
  *     R.dropRepeats([1, 1, 1, 2, 3, 4, 4, 2, 2]); //=> [1, 2, 3, 4, 2]
  */
-module.exports = _curry1(_dispatchable('dropRepeats', _xdropRepeatsWith(equals), dropRepeatsWith(equals)));
+module.exports = _curry1(_dispatchable([], _xdropRepeatsWith(equals), dropRepeatsWith(equals)));

--- a/src/dropRepeatsWith.js
+++ b/src/dropRepeatsWith.js
@@ -9,8 +9,6 @@ var last = require('./last');
  * determined by applying the supplied predicate two consecutive elements. The
  * first element in a series of equal element is the one being preserved.
  *
- * Dispatches to the `dropRepeatsWith` method of the second argument, if present.
- *
  * Acts as a transducer if a transformer is given in list position.
  *
  * @func
@@ -27,7 +25,7 @@ var last = require('./last');
  *      var l = [1, -1, 1, 3, 4, -4, -4, -5, 5, 3, 3];
  *      R.dropRepeatsWith(R.eqBy(Math.abs), l); //=> [1, 3, 4, -5, 3]
  */
-module.exports = _curry2(_dispatchable('dropRepeatsWith', _xdropRepeatsWith, function dropRepeatsWith(pred, list) {
+module.exports = _curry2(_dispatchable([], _xdropRepeatsWith, function dropRepeatsWith(pred, list) {
   var result = [];
   var idx = 1;
   var len = list.length;

--- a/src/dropWhile.js
+++ b/src/dropWhile.js
@@ -28,7 +28,7 @@ var _xdropWhile = require('./internal/_xdropWhile');
  *
  *      R.dropWhile(lteTwo, [1, 2, 3, 4, 3, 2, 1]); //=> [3, 4, 3, 2, 1]
  */
-module.exports = _curry2(_dispatchable('dropWhile', _xdropWhile, function dropWhile(pred, list) {
+module.exports = _curry2(_dispatchable(['dropWhile'], _xdropWhile, function dropWhile(pred, list) {
   var idx = 0;
   var len = list.length;
   while (idx < len && pred(list[idx])) {

--- a/src/filter.js
+++ b/src/filter.js
@@ -33,7 +33,7 @@ var keys = require('./keys');
  *
  *      R.filter(isEven, {a: 1, b: 2, c: 3, d: 4}); //=> {b: 2, d: 4}
  */
-module.exports = _curry2(_dispatchable('filter', _xfilter, function(pred, filterable) {
+module.exports = _curry2(_dispatchable(['filter'], _xfilter, function(pred, filterable) {
   return (
     _isObject(filterable) ?
       _reduce(function(acc, key) {

--- a/src/find.js
+++ b/src/find.js
@@ -27,7 +27,7 @@ var _xfind = require('./internal/_xfind');
  *      R.find(R.propEq('a', 2))(xs); //=> {a: 2}
  *      R.find(R.propEq('a', 4))(xs); //=> undefined
  */
-module.exports = _curry2(_dispatchable('find', _xfind, function find(fn, list) {
+module.exports = _curry2(_dispatchable(['find'], _xfind, function find(fn, list) {
   var idx = 0;
   var len = list.length;
   while (idx < len) {

--- a/src/findIndex.js
+++ b/src/findIndex.js
@@ -7,8 +7,6 @@ var _xfindIndex = require('./internal/_xfindIndex');
  * Returns the index of the first element of the list which matches the
  * predicate, or `-1` if no element matches.
  *
- * Dispatches to the `findIndex` method of the second argument, if present.
- *
  * Acts as a transducer if a transformer is given in list position.
  *
  * @func
@@ -27,7 +25,7 @@ var _xfindIndex = require('./internal/_xfindIndex');
  *      R.findIndex(R.propEq('a', 2))(xs); //=> 1
  *      R.findIndex(R.propEq('a', 4))(xs); //=> -1
  */
-module.exports = _curry2(_dispatchable('findIndex', _xfindIndex, function findIndex(fn, list) {
+module.exports = _curry2(_dispatchable([], _xfindIndex, function findIndex(fn, list) {
   var idx = 0;
   var len = list.length;
   while (idx < len) {

--- a/src/findLast.js
+++ b/src/findLast.js
@@ -7,8 +7,6 @@ var _xfindLast = require('./internal/_xfindLast');
  * Returns the last element of the list which matches the predicate, or
  * `undefined` if no element matches.
  *
- * Dispatches to the `findLast` method of the second argument, if present.
- *
  * Acts as a transducer if a transformer is given in list position.
  *
  * @func
@@ -27,7 +25,7 @@ var _xfindLast = require('./internal/_xfindLast');
  *      R.findLast(R.propEq('a', 1))(xs); //=> {a: 1, b: 1}
  *      R.findLast(R.propEq('a', 4))(xs); //=> undefined
  */
-module.exports = _curry2(_dispatchable('findLast', _xfindLast, function findLast(fn, list) {
+module.exports = _curry2(_dispatchable([], _xfindLast, function findLast(fn, list) {
   var idx = list.length - 1;
   while (idx >= 0) {
     if (fn(list[idx])) {

--- a/src/findLastIndex.js
+++ b/src/findLastIndex.js
@@ -7,8 +7,6 @@ var _xfindLastIndex = require('./internal/_xfindLastIndex');
  * Returns the index of the last element of the list which matches the
  * predicate, or `-1` if no element matches.
  *
- * Dispatches to the `findLastIndex` method of the second argument, if present.
- *
  * Acts as a transducer if a transformer is given in list position.
  *
  * @func
@@ -27,7 +25,7 @@ var _xfindLastIndex = require('./internal/_xfindLastIndex');
  *      R.findLastIndex(R.propEq('a', 1))(xs); //=> 1
  *      R.findLastIndex(R.propEq('a', 4))(xs); //=> -1
  */
-module.exports = _curry2(_dispatchable('findLastIndex', _xfindLastIndex, function findLastIndex(fn, list) {
+module.exports = _curry2(_dispatchable([], _xfindLastIndex, function findLastIndex(fn, list) {
   var idx = list.length - 1;
   while (idx >= 0) {
     if (fn(list[idx])) {

--- a/src/internal/_dispatchable.js
+++ b/src/internal/_dispatchable.js
@@ -5,28 +5,31 @@ var _isTransformer = require('./_isTransformer');
 /**
  * Returns a function that dispatches with different strategies based on the
  * object in list position (last argument). If it is an array, executes [fn].
- * Otherwise, if it has a function with [methodname], it will execute that
- * function (functor case). Otherwise, if it is a transformer, uses transducer
- * [xf] to return a new transformer (transducer case). Otherwise, it will
- * default to executing [fn].
+ * Otherwise, if it has a function with one of the given method names, it will
+ * execute that function (functor case). Otherwise, if it is a transformer,
+ * uses transducer [xf] to return a new transformer (transducer case).
+ * Otherwise, it will default to executing [fn].
  *
  * @private
- * @param {String} methodname property to check for a custom implementation
+ * @param {Array} methodNames properties to check for a custom implementation
  * @param {Function} xf transducer to initialize if object is transformer
  * @param {Function} fn default ramda implementation
  * @return {Function} A function that dispatches on object in list position
  */
-module.exports = function _dispatchable(methodname, xf, fn) {
+module.exports = function _dispatchable(methodNames, xf, fn) {
   return function() {
-    var length = arguments.length;
-    if (length === 0) {
+    if (arguments.length === 0) {
       return fn();
     }
-    var obj = arguments[length - 1];
+    var args = Array.prototype.slice.call(arguments, 0);
+    var obj = args.pop();
     if (!_isArray(obj)) {
-      var args = Array.prototype.slice.call(arguments, 0, length - 1);
-      if (typeof obj[methodname] === 'function') {
-        return obj[methodname].apply(obj, args);
+      var idx = 0;
+      while (idx < methodNames.length) {
+        if (typeof obj[methodNames[idx]] === 'function') {
+          return obj[methodNames[idx]].apply(obj, args);
+        }
+        idx += 1;
       }
       if (_isTransformer(obj)) {
         var transducer = xf.apply(null, args);

--- a/src/map.js
+++ b/src/map.js
@@ -42,7 +42,7 @@ var keys = require('./keys');
  * @symb R.map(f, { x: a, y: b }) = { x: f(a), y: f(b) }
  * @symb R.map(f, functor_o) = functor_o.map(f)
  */
-module.exports = _curry2(_dispatchable('map', _xmap, function map(fn, functor) {
+module.exports = _curry2(_dispatchable(['map'], _xmap, function map(fn, functor) {
   switch (Object.prototype.toString.call(functor)) {
     case '[object Function]':
       return curryN(functor.length, function() {

--- a/src/none.js
+++ b/src/none.js
@@ -27,4 +27,4 @@ var any = require('./any');
  *      R.none(isEven, [1, 3, 5, 7, 9, 11]); //=> true
  *      R.none(isEven, [1, 3, 5, 7, 8, 11]); //=> false
  */
-module.exports = _curry2(_complement(_dispatchable('any', _xany, any)));
+module.exports = _curry2(_complement(_dispatchable(['any'], _xany, any)));

--- a/src/reduceBy.js
+++ b/src/reduceBy.js
@@ -49,7 +49,7 @@ var _xreduceBy = require('./internal/_xreduceBy');
  *      //   'F': ['Bart']
  *      // }
  */
-module.exports = _curryN(4, [], _dispatchable('reduceBy', _xreduceBy,
+module.exports = _curryN(4, [], _dispatchable([], _xreduceBy,
   function reduceBy(valueFn, valueAcc, keyFn, list) {
     return _reduce(function(acc, elt) {
       var key = keyFn(elt);

--- a/src/take.js
+++ b/src/take.js
@@ -47,6 +47,6 @@ var slice = require('./slice');
  * @symb R.take(1, [a, b]) = [a]
  * @symb R.take(2, [a, b]) = [a, b]
  */
-module.exports = _curry2(_dispatchable('take', _xtake, function take(n, xs) {
+module.exports = _curry2(_dispatchable(['take'], _xtake, function take(n, xs) {
   return slice(0, n < 0 ? Infinity : n, xs);
 }));

--- a/src/takeWhile.js
+++ b/src/takeWhile.js
@@ -29,7 +29,7 @@ var _xtakeWhile = require('./internal/_xtakeWhile');
  *
  *      R.takeWhile(isNotFour, [1, 2, 3, 4, 3, 2, 1]); //=> [1, 2, 3]
  */
-module.exports = _curry2(_dispatchable('takeWhile', _xtakeWhile, function takeWhile(fn, list) {
+module.exports = _curry2(_dispatchable(['takeWhile'], _xtakeWhile, function takeWhile(fn, list) {
   var idx = 0;
   var len = list.length;
   while (idx < len && fn(list[idx])) {


### PR DESCRIPTION
To quote https://github.com/ramda/ramda/pull/1938#issuecomment-254425093:

> It's now apparent to me that there's a significant problem with our current approach to dispatching: it complects transducer support and method dispatching. As a result, we can't have functions which support transducers but do *not* dispatch, leading to silliness such as `R.dropRepeatsWith` dispatching to `dropRepeatsWith`. It's thus unclear whether we actually *intend* a certain function to dispatch.

The solution to this problem is to take an array of method names rather than a string. This will give us the freedom to have a function work with transducers without also dispatching. It will also give us the option of dispatching to one of *several* possible methods (e.g. `fantasy-land/map` or `map`).

At this stage the pull request does not actually remove dispatching. What I will do is comment on each of the functions in question and request that you vote :thumbsup: if you believe the function should continue to dispatch; :thumbsdown: otherwise. As we decide which functions should no longer dispatch I will update the pull request.
