### PR TITLE
Remove dispatching

### DIFF
--- a/.directory
+++ b/.directory
@@ -1,6 +1,0 @@
-[Dolphin]
-Timestamp=2016,10,22,11,5,58
-Version=3
-
-[Settings]
-HiddenFilesShown=true

--- a/.directory
+++ b/.directory
@@ -1,0 +1,6 @@
+[Dolphin]
+Timestamp=2016,10,22,11,5,58
+Version=3
+
+[Settings]
+HiddenFilesShown=true

--- a/.kateproject
+++ b/.kateproject
@@ -1,0 +1,4 @@
+{
+  "name": "CrossEye/ramda",
+  "files": [ { "git": 1 } ]
+}

--- a/.kateproject
+++ b/.kateproject
@@ -1,4 +1,0 @@
-{
-  "name": "CrossEye/ramda",
-  "files": [ { "git": 1 } ]
-}

--- a/src/ap.js
+++ b/src/ap.js
@@ -27,8 +27,6 @@ var map = require('./map');
  */
 module.exports = _curry2(function ap(applicative, fn) {
   return (
-    typeof applicative.ap === 'function' ?
-      applicative.ap(fn) :
     typeof applicative === 'function' ?
       function(x) { return applicative(x)(fn(x)); } :
     // else

--- a/src/composeK.js
+++ b/src/composeK.js
@@ -1,4 +1,3 @@
-var chain = require('./chain');
 var compose = require('./compose');
 var identity = require('./identity');
 var map = require('./map');
@@ -9,7 +8,7 @@ var prepend = require('./prepend');
  * Returns the right-to-left Kleisli composition of the provided functions,
  * each of which must return a value of a type supported by [`chain`](#chain).
  *
- * `R.composeK(h, g, f)` is equivalent to `R.compose(R.chain(h), R.chain(g), R.chain(f))`.
+ * `R.composeK(h, g, f)` is equivalent to `R.compose(x => x.chain(h), x => x.chain(g), x => x.chain(f))`.
  *
  * @func
  * @memberOf R
@@ -36,5 +35,5 @@ var prepend = require('./prepend');
  * @symb R.composeK(f, g, h)(a, b) = R.chain(f, R.chain(g, h(a, b)))
  */
 module.exports = function composeK() {
-  return compose.apply(this, prepend(identity, map(chain, arguments)));
+  return compose.apply(this, prepend(identity, map(function(arg) {return function(x) {return x.chain(arg);};}, arguments)));
 };

--- a/src/concat.js
+++ b/src/concat.js
@@ -1,6 +1,6 @@
 var _curry2 = require('./internal/_curry2');
 var _isArray = require('./internal/_isArray');
-var _isFunction = require('./internal/_isFunction');
+var _isString = require('./internal/_isString');
 var toString = require('./toString');
 
 
@@ -30,11 +30,11 @@ var toString = require('./toString');
  *      R.concat('ABC', 'DEF'); // 'ABCDEF'
  */
 module.exports = _curry2(function concat(a, b) {
-  if (a == null || !_isFunction(a.concat)) {
-    throw new TypeError(toString(a) + ' does not have a method named "concat"');
+  if (!_isArray(a) && !_isString(a)) {
+    throw new TypeError(toString(a) + ' is not a string or array');
   }
-  if (_isArray(a) && !_isArray(b)) {
-    throw new TypeError(toString(b) + ' is not an array');
+  if (!_isArray(b) && !_isString(b)) {
+    throw new TypeError(toString(b) + ' is not a string or array');
   }
   return a.concat(b);
 });

--- a/src/internal/_dispatchable.js
+++ b/src/internal/_dispatchable.js
@@ -26,9 +26,6 @@ module.exports = function _dispatchable(methodname, xf, fn) {
     var obj = arguments[length - 1];
     if (!_isArray(obj)) {
       var args = _slice(arguments, 0, length - 1);
-      if (typeof obj[methodname] === 'function') {
-        return obj[methodname].apply(obj, args);
-      }
       if (_isTransformer(obj)) {
         var transducer = xf.apply(null, args);
         return transducer(obj);

--- a/src/internal/_reduce.js
+++ b/src/internal/_reduce.js
@@ -1,5 +1,4 @@
 var _xwrap = require('./_xwrap');
-var bind = require('../bind');
 var isArrayLike = require('../isArrayLike');
 
 
@@ -31,10 +30,6 @@ module.exports = (function() {
     return xf['@@transducer/result'](acc);
   }
 
-  function _methodReduce(xf, acc, obj) {
-    return xf['@@transducer/result'](obj.reduce(bind(xf['@@transducer/step'], xf), acc));
-  }
-
   var symIterator = (typeof Symbol !== 'undefined') ? Symbol.iterator : '@@iterator';
   return function _reduce(fn, acc, list) {
     if (typeof fn === 'function') {
@@ -42,9 +37,6 @@ module.exports = (function() {
     }
     if (isArrayLike(list)) {
       return _arrayReduce(fn, acc, list);
-    }
-    if (typeof list.reduce === 'function') {
-      return _methodReduce(fn, acc, list);
     }
     if (list[symIterator] != null) {
       return _iterableReduce(fn, acc, list[symIterator]());

--- a/src/lens.js
+++ b/src/lens.js
@@ -1,5 +1,4 @@
 var _curry2 = require('./internal/_curry2');
-var map = require('./map');
 
 
 /**
@@ -28,12 +27,9 @@ var map = require('./map');
 module.exports = _curry2(function lens(getter, setter) {
   return function(toFunctorFn) {
     return function(target) {
-      return map(
-        function(focus) {
-          return setter(focus, target);
-        },
-        toFunctorFn(getter(target))
-      );
+      return toFunctorFn(getter(target)).map(function(focus) {
+        return setter(focus, target);
+      });
     };
   };
 });

--- a/src/sequence.js
+++ b/src/sequence.js
@@ -33,6 +33,7 @@ module.exports = _curry2(function sequence(of, traversable) {
   return typeof traversable.sequence === 'function' ?
     traversable.sequence(of) :
     reduceRight(function(acc, x) { return ap(map(prepend, x), acc); },
+//    reduceRight(function(acc, x) { return ap(map(function(anX) {return function(y) {return prepend(y, anX);};}, x), acc); },
                 of([]),
                 traversable);
 });

--- a/test/ap.js
+++ b/test/ap.js
@@ -25,11 +25,6 @@ describe('ap', function() {
     eq(R.ap(R.add)(g)(10), 10 + (10 * 2));
   });
 
-  it('dispatches to the passed object\'s ap method when values is a non-Array object', function() {
-    var obj = {ap: function(n) { return 'called ap with ' + n; }};
-    eq(R.ap(obj, 10), obj.ap(10));
-  });
-
   it('is curried', function() {
     var val = R.ap([mult2, plus3]);
     eq(typeof val, 'function');

--- a/test/both.js
+++ b/test/both.js
@@ -1,5 +1,3 @@
-var S = require('sanctuary');
-
 var R = require('..');
 var eq = require('./shared/eq');
 
@@ -38,16 +36,6 @@ describe('both', function() {
     eq(typeof evenAnd(gt10), 'function');
     eq(evenAnd(gt10)(11), false);
     eq(evenAnd(gt10)(12), true);
-  });
-
-  it('accepts fantasy-land applicative functors', function() {
-    var Just = S.Just;
-    var Nothing = S.Nothing;
-    eq(R.both(Just(true), Just(true)), Just(true));
-    eq(R.both(Just(true), Just(false)), Just(false));
-    eq(R.both(Just(true), Nothing()), Nothing());
-    eq(R.both(Nothing(), Just(false)), Nothing());
-    eq(R.both(Nothing(), Nothing()), Nothing());
   });
 
 });

--- a/test/chain.js
+++ b/test/chain.js
@@ -41,11 +41,6 @@ describe('chain', function() {
     eq(R.chain(R.append, R.head)([1, 2, 3]), [1, 2, 3, 1]);
   });
 
-  it('dispatches to objects that implement `chain`', function() {
-    var obj = {x: 100, chain: function(f) { return f(this.x); }};
-    eq(R.chain(add1, obj), [101]);
-  });
-
   it('dispatches to transformer objects', function() {
     eq(_isTransformer(R.chain(add1, listXf)), true);
   });

--- a/test/complement.js
+++ b/test/complement.js
@@ -1,5 +1,3 @@
-var S = require('sanctuary');
-
 var R = require('..');
 var eq = require('./shared/eq');
 
@@ -17,14 +15,6 @@ describe('complement', function() {
     var f = R.complement(between);
     eq(f(4, 5, 11), false);
     eq(f(12, 2, 6), true);
-  });
-
-  it('accepts fantasy-land functors', function() {
-    var Just = S.Just;
-    var Nothing = S.Nothing;
-    eq(R.complement(Just(true)), Just(false));
-    eq(R.complement(Just(false)), Just(true));
-    eq(R.complement(Nothing()), Nothing());
   });
 
 });

--- a/test/composeK.js
+++ b/test/composeK.js
@@ -27,7 +27,7 @@ describe('composeK', function() {
     var id = new Identity(8);
 
     eq(fn(id).value, 50);
-    eq(fn(id).value, R.compose(R.chain(h), R.chain(g), R.chain(f))(id).value);
+    eq(fn(id).value, R.compose(x => x.chain(h), x => x.chain(g), x => x.chain(f))(id).value);
   });
 
   it('returns the identity function given no arguments', function() {

--- a/test/concat.js
+++ b/test/concat.js
@@ -10,14 +10,6 @@ describe('concat', function() {
     eq(R.concat([], ['c', 'd']), ['c', 'd']);
   });
 
-  var z1 = {
-    x: 'z1',
-    concat: function(that) { return this.x + ' ' + that.x; }
-  };
-  var z2 = {
-    x: 'z2'
-  };
-
   it('adds combines the elements of the two lists', function() {
     eq(R.concat(['a', 'b'], ['c', 'd']), ['a', 'b', 'c', 'd']);
     eq(R.concat([], ['c', 'd']), ['c', 'd']);
@@ -28,10 +20,6 @@ describe('concat', function() {
     eq(R.concat('x', ''), 'x');
     eq(R.concat('', 'x'), 'x');
     eq(R.concat('', ''), '');
-  });
-
-  it('delegates to non-String object with a concat method, as second param', function() {
-    eq(R.concat(z1, z2), 'z1 z2');
   });
 
   it('is curried', function() {

--- a/test/either.js
+++ b/test/either.js
@@ -1,5 +1,3 @@
-var S = require('sanctuary');
-
 var R = require('..');
 var eq = require('./shared/eq');
 
@@ -38,17 +36,6 @@ describe('either', function() {
     eq(typeof evenOr(gt10), 'function');
     eq(evenOr(gt10)(11), true);
     eq(evenOr(gt10)(9), false);
-  });
-
-  it('accepts fantasy-land applicative functors', function() {
-    var Just = S.Just;
-    var Nothing = S.Nothing;
-    eq(R.either(Just(true), Just(true)), Just(true));
-    eq(R.either(Just(true), Just(false)), Just(true));
-    eq(R.either(Just(false), Just(false)), Just(false));
-    eq(R.either(Just(true), Nothing()), Nothing());
-    eq(R.either(Nothing(), Just(false)), Nothing());
-    eq(R.either(Nothing(), Nothing()), Nothing());
   });
 
 });

--- a/test/filter.js
+++ b/test/filter.js
@@ -26,11 +26,6 @@ describe('filter', function() {
     eq(R.filter(positive, {x: 1, y: 2, z: 3}), {x: 1, y: 2, z: 3});
   });
 
-  it('dispatches to passed-in non-Array object with a `filter` method', function() {
-    var f = {filter: function(f) { return f('called f.filter'); }};
-    eq(R.filter(function(s) { return s; }, f), 'called f.filter');
-  });
-
   it('is curried', function() {
     var onlyEven = R.filter(even);
     eq(onlyEven([1, 2, 3, 4, 5, 6, 7]), [2, 4, 6]);

--- a/test/into.js
+++ b/test/into.js
@@ -28,12 +28,6 @@ describe('into', function() {
     eq(R.into({}, R.identity, [{a: 1}, {b: 2, c: 3}]), {a: 1, b: 2, c: 3});
   });
 
-  it('dispatches to objects that implement `reduce`', function() {
-    var obj = {x: [1, 2, 3], reduce: function() { return 'override'; }};
-    eq(R.into([], R.map(add(1)), obj), 'override');
-    eq(R.into([], R.filter(isOdd), obj), 'override');
-  });
-
   it('is curried', function() {
     var intoArray = R.into([]);
     var add2 = R.map(add(2));

--- a/test/lift.js
+++ b/test/lift.js
@@ -2,7 +2,6 @@
 
 var R = require('..');
 var eq = require('./shared/eq');
-var Maybe = require('./shared/Maybe');
 
 
 var add3 = R.curry(function add3(a, b, c) {
@@ -35,11 +34,6 @@ describe('lift', function() {
     eq(madd3([1, 10], [2], [3]), [6, 15]);
     eq(madd4([1, 10], [2], [3], [40]), [46, 55]);
     eq(madd5([1, 10], [2], [3], [40], [500, 1000]), [546, 1046, 555, 1055]);
-  });
-
-  it('works with other functors such as "Maybe"', function() {
-    var addM = R.lift(R.add);
-    eq(addM(Maybe.of(3), Maybe.of(5)), Maybe.of(8));
   });
 
 });

--- a/test/liftN.js
+++ b/test/liftN.js
@@ -2,7 +2,6 @@
 
 var R = require('..');
 var eq = require('./shared/eq');
-var Maybe = require('./shared/Maybe');
 
 
 var addN = function() {
@@ -37,11 +36,6 @@ describe('liftN', function() {
     var f4 = R.liftN(4);
     eq(typeof f4, 'function');
     eq(f4(addN)([1], [2], [3], [4, 5]), [10, 11]);
-  });
-
-  it('works with other functors such as "Maybe"', function() {
-    var addM = R.liftN(2, R.add);
-    eq(addM(Maybe(3), Maybe(5)), Maybe(8));
   });
 
   it('interprets [a] as a functor', function() {

--- a/test/map.js
+++ b/test/map.js
@@ -30,11 +30,6 @@ describe('map', function() {
     eq(h(10), (10 * 2) - 1);
   });
 
-  it('dispatches to objects that implement `map`', function() {
-    var obj = {x: 100, map: function(f) { return f(this.x); }};
-    eq(R.map(add1, obj), 101);
-  });
-
   it('dispatches to transformer objects', function() {
     eq(R.map(add1, listXf), {
       f: add1,

--- a/test/partition.js
+++ b/test/partition.js
@@ -1,5 +1,3 @@
-var S = require('sanctuary');
-
 var R = require('..');
 var eq = require('./shared/eq');
 
@@ -22,13 +20,6 @@ describe('partition', function() {
        [{ a: 1, b: 3, c: 5, d: 7 }, {}]);
     eq(R.partition(pred, { a: 0, b: 1, c: 2, d: 3 }),
        [{ b: 1, d: 3 }, { a: 0, c: 2 }]);
-  });
-
-  it('works with other filterables', function() {
-    eq(R.partition(R.isEmpty, S.Just(3)),
-       [S.Nothing(), S.Just(3)]);
-    eq(R.partition(R.complement(R.isEmpty), S.Just(3)),
-       [S.Just(3), S.Nothing()]);
   });
 
   it('is curried', function() {

--- a/test/pipeK.js
+++ b/test/pipeK.js
@@ -27,7 +27,7 @@ describe('pipeK', function() {
     var id = new Identity(8);
 
     eq(fn(id).value, 50);
-    eq(fn(id).value, R.pipe(R.chain(f), R.chain(g), R.chain(h))(id).value);
+    eq(fn(id).value, R.pipe(x => x.chain(f), x => x.chain(g), x => x.chain(h))(id).value);
   });
 
   it('returns the identity function given no arguments', function() {

--- a/test/reduce.js
+++ b/test/reduce.js
@@ -10,12 +10,6 @@ describe('reduce', function() {
     eq(R.reduce(mult, 1, [1, 2, 3, 4]), 24);
   });
 
-  it('dispatches to objects that implement `reduce`', function() {
-    var obj = {x: [1, 2, 3], reduce: function() { return 'override'; }};
-    eq(R.reduce(add, 0, obj), 'override');
-    eq(R.reduce(add, 10, obj), 'override');
-  });
-
   it('returns the accumulator for an empty array', function() {
     eq(R.reduce(add, 0, []), 0);
     eq(R.reduce(mult, 1, []), 1);

--- a/test/sequence.js
+++ b/test/sequence.js
@@ -1,7 +1,4 @@
-var S = require('sanctuary');
-
 var R = require('..');
-var Id = require('./shared/Id');
 var eq = require('./shared/eq');
 
 
@@ -14,23 +11,6 @@ describe('sequence', function() {
     eq(R.sequence(R.of, [[1, 2], [3, 4]]), [[1, 3], [1, 4], [2, 3], [2, 4]]);
     eq(R.sequence(R.of, [[1, 2, 3], [4]]), [[1, 4], [2, 4], [3, 4]]);
     eq(R.sequence(R.of, [[1, 2, 3, 4], []]), []);
-  });
-
-  it('operates on a list of applicatives', function() {
-    eq(R.sequence(S.Maybe.of, [S.Just(3), S.Just(4), S.Just(5)]), S.Just([3, 4, 5]));
-    eq(R.sequence(S.Maybe.of, [S.Just(3), S.Nothing(), S.Just(5)]), S.Nothing());
-  });
-
-  it('traverses left to right', function() {
-    eq(R.sequence(S.Either.of, [S.Right(1), S.Right(2)]), S.Right([1, 2]));
-    eq(R.sequence(S.Either.of, [S.Right(1), S.Left('XXX')]), S.Left('XXX'));
-    eq(R.sequence(S.Either.of, [S.Left('XXX'), S.Right(1)]), S.Left('XXX'));
-    eq(R.sequence(S.Either.of, [S.Left('XXX'), S.Left('YYY')]), S.Left('XXX'));
-  });
-
-  it('dispatches to `sequence` method', function() {
-    eq(R.sequence(Id, [Id(1), Id(2), Id(3)]), Id([1, 2, 3]));
-    eq(R.sequence(R.of, Id([1, 2, 3])), [Id(1), Id(2), Id(3)]);
   });
 
 });

--- a/test/transduce.js
+++ b/test/transduce.js
@@ -59,12 +59,6 @@ describe('transduce', function() {
     eq(R.transduce(toxf(mult), mult, 1, [1, 2, 3, 4]), 24);
   });
 
-  it('dispatches to objects that implement `reduce`', function() {
-    var obj = {x: [1, 2, 3], reduce: function() { return 'override'; }};
-    eq(R.transduce(R.map(add(1)), add, 0, obj), 'override');
-    eq(R.transduce(R.map(add(1)), add, 10, obj), 'override');
-  });
-
   it('returns the accumulator for an empty collection', function() {
     eq(R.transduce(toxf(add), addxf, 0, []), 0);
     eq(R.transduce(toxf(mult), multxf, 1, []), 1);

--- a/test/traverse.js
+++ b/test/traverse.js
@@ -1,7 +1,4 @@
-var S = require('sanctuary');
-
 var R = require('..');
-var Id = require('./shared/Id');
 var eq = require('./shared/eq');
 
 
@@ -14,23 +11,6 @@ describe('traverse', function() {
     eq(R.traverse(R.of, R.map(R.add(10)), [[1, 2], [3, 4]]), [[11, 13], [11, 14], [12, 13], [12, 14]]);
     eq(R.traverse(R.of, R.map(R.add(10)), [[1, 2, 3], [4]]), [[11, 14], [12, 14], [13, 14]]);
     eq(R.traverse(R.of, R.map(R.add(10)), [[1, 2, 3, 4], []]), []);
-  });
-
-  it('operates on a list of applicatives', function() {
-    eq(R.traverse(S.Maybe.of, R.map(R.add(10)), [S.Just(3), S.Just(4), S.Just(5)]), S.Just([13, 14, 15]));
-    eq(R.traverse(S.Maybe.of, R.map(R.add(10)), [S.Just(3), S.Nothing(), S.Just(5)]), S.Nothing());
-  });
-
-  it('traverses left to right', function() {
-    eq(R.traverse(S.Either.of, R.identity, [S.Right(1), S.Right(2)]), S.Right([1, 2]));
-    eq(R.traverse(S.Either.of, R.identity, [S.Right(1), S.Left('XXX')]), S.Left('XXX'));
-    eq(R.traverse(S.Either.of, R.identity, [S.Left('XXX'), S.Right(1)]), S.Left('XXX'));
-    eq(R.traverse(S.Either.of, R.identity, [S.Left('XXX'), S.Left('YYY')]), S.Left('XXX'));
-  });
-
-  it('dispatches to `sequence` method', function() {
-    eq(R.traverse(Id, R.map(R.negate), [Id(1), Id(2), Id(3)]), Id([-1, -2, -3]));
-    eq(R.traverse(R.of, R.map(R.negate), Id([1, 2, 3])), [Id(-1), Id(-2), Id(-3)]);
   });
 
 });

--- a/test/unnest.js
+++ b/test/unnest.js
@@ -2,8 +2,6 @@ var assert = require('assert');
 
 var R = require('..');
 var eq = require('./shared/eq');
-var Maybe = require('./shared/Maybe');
-
 
 describe('unnest', function() {
 
@@ -28,17 +26,6 @@ describe('unnest', function() {
   it('flattens an array of empty arrays', function() {
     eq(R.unnest([[], [], []]), []);
     eq(R.unnest([]), []);
-  });
-
-  it('is equivalent to R.chain(R.identity)', function() {
-    var Nothing = Maybe.Nothing;
-    var Just = Maybe.Just;
-
-    eq(R.unnest(Nothing()), Nothing());
-    eq(R.unnest(Just(Nothing())), Nothing());
-    eq(R.unnest(Just(Just(Nothing()))), Just(Nothing()));
-    eq(R.unnest(Just(Just(42))), Just(42));
-    eq(R.unnest(Just(Just(Just(42)))), Just(Just(42)));
   });
 
 });


### PR DESCRIPTION
This is an alternative to #1900 and #1949.

(**Edit**: I don't know why I originally used the words "delegation" and "dispatching" indiscriminately.  Fixed.) 

It seems to me that if we are going to get out of the business of dispatching, then we should do it wholeheartedly.  That means we should stop doing any dispatching whatsoever.
## What is the proposal?

Remove all dispatching.  The only types Ramda functions should operate upon are the ones it handles internally: lists, functions, objects, strings.  This means removing silly dispatching like `dropRepeatsWhile` that was only dispatching because of implementation details of our transducers, removing more useful dispatching like `filter`, which could easily work with user types such as trees as well as the built-in types, and removing quite common dispatching such as `map` that is part of the [FantasyLand Functor](https://github.com/fantasyland/fantasy-land#functor) specification.
## Does this make Ramda less powerful?

No, Ramda will still operate directly on the same types it always has, especially lists, often functions or plain objects, sometimes strings.  And a user [can still use Ramda](https://goo.gl/9ZglGJ) to call her custom type:

``` js
const fmap = R.invoker(1, 'map');
fmap(square, Just(5)); //=> Just(25)
fmap(square, Nothing()); //=> Nothing()
```
## Does this make Ramda less ergonomic?

It does, to an extent that depends on how much the user likes points-free style.  Perhaps a simple example is the change in the test for `composeK`:

**before**

``` js
R.compose(chain(h), chain(g), chain(f))
```

**after**

``` js
R.compose(x => x.chain(h), x => x.chain(g), x => x.chain(f))
```

While this is not horrible, it does make using Ramda less pleasant.
## Are you serious?

Partly.  It seems to me that we're headed very much in the wrong direction by removing dispatching.  (This is not exactly a reaction to #1949; some of the things we dispatch make little sense.)  I believe dispatching is one of the very good parts of Ramda.  But if we're going to remove it, I don't see any good reason to make an exception for the FantasyLand types.

My preference is still to stick with our dispatching.  But I'm not interested in a half-measure of removing the dispatching of everything but those functions currently supported by some other team.  I don't want our API to be subject to the whims of another project.

I'm sure this PR is incomplete.  I pulled it together in an hour, so it may be fairly low quality.  And since I last was online, other code has been merged that means that I'd have to rebase before we could even try to merge it.  That's ok.  I want to see where the conversation goes anyway.
