### PR TITLE
`R.curry` unneeded by `R.lift`

### DIFF
--- a/src/lift.js
+++ b/src/lift.js
@@ -16,11 +16,11 @@ var liftN = require('./liftN');
  * @see R.liftN
  * @example
  *
- *      var madd3 = R.lift(R.curry((a, b, c) => a + b + c));
+ *      var madd3 = R.lift((a, b, c) => a + b + c);
  *
  *      madd3([1,2,3], [1,2,3], [1]); //=> [3, 4, 5, 4, 5, 6, 5, 6, 7]
  *
- *      var madd5 = R.lift(R.curry((a, b, c, d, e) => a + b + c + d + e));
+ *      var madd5 = R.lift((a, b, c, d, e) => a + b + c + d + e);
  *
  *      madd5([1,2], [3], [4, 5], [6], [7, 8]); //=> [21, 22, 22, 23, 22, 23, 23, 24]
  */


### PR DESCRIPTION
Remove unnecessary use of `R.curry` from `R.lift` examples; the function passed to `lift` doesn't need to be curried, so the example is clearer without it.