### PR TITLE
removed curry from the example for liftN

### DIFF
--- a/src/liftN.js
+++ b/src/liftN.js
@@ -19,7 +19,7 @@ var map = require('./map');
  * @see R.lift, R.ap
  * @example
  *
- *      var madd3 = R.liftN(3, R.curryN(3, (...args) => R.sum(args)));
+ *      var madd3 = R.liftN(3,(...args) => R.sum(args));
  *      madd3([1,2,3], [1,2,3], [1]); //=> [3, 4, 5, 4, 5, 6, 5, 6, 7]
  */
 module.exports = _curry2(function liftN(arity, fn) {

--- a/src/liftN.js
+++ b/src/liftN.js
@@ -19,7 +19,7 @@ var map = require('./map');
  * @see R.lift, R.ap
  * @example
  *
- *      var madd3 = R.liftN(3,(...args) => R.sum(args));
+ *      var madd3 = R.liftN(3, (...args) => R.sum(args));
  *      madd3([1,2,3], [1,2,3], [1]); //=> [3, 4, 5, 4, 5, 6, 5, 6, 7]
  */
 module.exports = _curry2(function liftN(arity, fn) {


### PR DESCRIPTION
you don't need to curry functions that you pass to `liftN`, it works just the same, so the example is clearer without the currying