### PR TITLE
Removed node v0.10 support and Q devDependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: node_js
 node_js:
-- '0.10'
 - '0.12'
 - 4
 - 6

--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
     "js-yaml": "^3.2.5",
     "jsverify": "^0.7.3",
     "mocha": "2.x.x",
-    "q": "^1.1.1",
     "ramda": "0.17.x",
     "rimraf": "~2.3.2",
     "sanctuary": "0.7.x",

--- a/test/composeP.js
+++ b/test/composeP.js
@@ -1,7 +1,5 @@
 var assert = require('assert');
 
-var Q = require('q');
-
 var R = require('..');
 var eq = require('./shared/eq');
 
@@ -14,8 +12,8 @@ describe('composeP', function() {
   });
 
   it('performs right-to-left composition of Promise-returning functions', function(done) {
-    var f = function(a) { return Q.Promise(function(res) { res([a]); }); };
-    var g = function(a, b) { return Q.Promise(function(res) { res([a, b]); }); };
+    var f = function(a) { return new Promise(function(res) { res([a]); }); };
+    var g = function(a, b) { return new Promise(function(res) { res([a, b]); }); };
 
     eq(R.composeP(f).length, 1);
     eq(R.composeP(g).length, 2);

--- a/test/pipeP.js
+++ b/test/pipeP.js
@@ -1,7 +1,5 @@
 var assert = require('assert');
 
-var Q = require('q');
-
 var R = require('..');
 var eq = require('./shared/eq');
 
@@ -14,8 +12,8 @@ describe('pipeP', function() {
   });
 
   it('performs left-to-right composition of Promise-returning functions', function(done) {
-    var f = function(a) { return Q.Promise(function(res) { res([a]); }); };
-    var g = function(a, b) { return Q.Promise(function(res) { res([a, b]); }); };
+    var f = function(a) { return new Promise(function(res) { res([a]); }); };
+    var g = function(a, b) { return new Promise(function(res) { res([a, b]); }); };
 
     eq(R.pipeP(f).length, 1);
     eq(R.pipeP(g).length, 2);


### PR DESCRIPTION
Node version 0.10 is EOL at the end of the month per the [LTS Schedule](https://github.com/nodejs/LTS#lts-schedule).

Doing this means no longer having to use an external dependency for testing promise handling functions.
