### PR TITLE
Add pre and post publish npm scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,9 @@
     "posttest": "git checkout -- dist",
     "prebrowser_test": "npm run pretest",
     "browser_test": "testem ci",
-    "postbrowser_test": "npm run posttest"
+    "postbrowser_test": "npm run posttest",
+    "prepublish": "cp -r src/* .",
+    "postpublish": "rm -rf internal && git clean -f && git checkout ."
   },
   "dependencies": {},
   "devDependencies": {


### PR DESCRIPTION
Motivation: fix #1505 .

The proposal is to simply copy the `src` folder into root when publishing to npm. The assumptions are:
1. Individual functions will not need UMD––the target is only CommonJS,
2. …so there is no need for building,
3. …and since the individual modules will be CommonJS, it makes sense to do this only for npm.

The scripts are set up so that any files created locally when building will be removed by the postpublish hook, but of course if you build in CI this is unnecessary.

Does it make sense?
