### PR TITLE
replace R.lift and R.liftN with fixed-arity versions

### DIFF
--- a/index.js
+++ b/index.js
@@ -107,6 +107,8 @@ module.exports = {
   lensPath: require('./src/lensPath'),
   lensProp: require('./src/lensProp'),
   lift: require('./src/lift'),
+  lift2: require('./src/lift2'),
+  lift3: require('./src/lift3'),
   liftN: require('./src/liftN'),
   lt: require('./src/lt'),
   lte: require('./src/lte'),

--- a/src/both.js
+++ b/src/both.js
@@ -1,7 +1,7 @@
 var _curry2 = require('./internal/_curry2');
 var _isFunction = require('./internal/_isFunction');
 var and = require('./and');
-var lift = require('./lift');
+var lift2 = require('./lift2');
 
 
 /**
@@ -37,5 +37,5 @@ module.exports = _curry2(function both(f, g) {
     function _both() {
       return f.apply(this, arguments) && g.apply(this, arguments);
     } :
-    lift(and)(f, g);
+    lift2(and, f, g);
 });

--- a/src/either.js
+++ b/src/either.js
@@ -1,6 +1,6 @@
 var _curry2 = require('./internal/_curry2');
 var _isFunction = require('./internal/_isFunction');
-var lift = require('./lift');
+var lift2 = require('./lift2');
 var or = require('./or');
 
 
@@ -36,5 +36,5 @@ module.exports = _curry2(function either(f, g) {
     function _either() {
       return f.apply(this, arguments) || g.apply(this, arguments);
     } :
-    lift(or)(f, g);
+    lift2(or, f, g);
 });

--- a/src/lift.js
+++ b/src/lift.js
@@ -1,29 +1,21 @@
-var _curry1 = require('./internal/_curry1');
-var liftN = require('./liftN');
+var map = require('./map');
 
 
 /**
- * "lifts" a function of arity > 1 so that it may "map over" a list, Function or other
- * object that satisfies the [FantasyLand Apply spec](https://github.com/fantasyland/fantasy-land#apply).
+ * Alias of [`map`](#map).
  *
  * @func
  * @memberOf R
  * @since v0.7.0
  * @category Function
- * @sig (*... -> *) -> ([*]... -> [*])
- * @param {Function} fn The function to lift into higher context
- * @return {Function} The lifted function.
- * @see R.liftN
+ * @sig Functor f => (a -> b) -> f a -> f b
+ * @param {Function}
+ * @param {*}
+ * @return {*}
+ * @see R.lift2, R.lift3
  * @example
  *
- *      var madd3 = R.lift((a, b, c) => a + b + c);
- *
- *      madd3([1,2,3], [1,2,3], [1]); //=> [3, 4, 5, 4, 5, 6, 5, 6, 7]
- *
- *      var madd5 = R.lift((a, b, c, d, e) => a + b + c + d + e);
- *
- *      madd5([1,2], [3], [4, 5], [6], [7, 8]); //=> [21, 22, 22, 23, 22, 23, 23, 24]
+ *      R.lift(R.inc, Just(2)); //=> Just(3)
+ *      R.lift(R.inc, Nothing); //=> Nothing
  */
-module.exports = _curry1(function lift(fn) {
-  return liftN(fn.length, fn);
-});
+module.exports = map;

--- a/src/lift2.js
+++ b/src/lift2.js
@@ -1,0 +1,28 @@
+var _curry3 = require('./internal/_curry3');
+var ap = require('./ap');
+var map = require('./map');
+
+
+/**
+ * Promotes a curried binary function to a function which operates on two
+ * [Apply](https://github.com/fantasyland/fantasy-land#apply)s.
+ *
+ * This function is derived from `map` and `ap`.
+ *
+ * @func
+ * @memberOf R
+ * @category Function
+ * @sig Apply f => (a -> b -> c) -> f a -> f b -> f c
+ * @param {Function}
+ * @param {*}
+ * @param {*}
+ * @return {*}
+ * @see R.lift, R.lift3
+ * @example
+ *
+ *      R.lift2(x => y => Math.pow(x, y), [10], [1, 2, 3]); //=> [10, 100, 1000]
+ *      R.lift2(x => y => Math.pow(x, y), Just(10), Just(3)); //=> Just(1000)
+ */
+module.exports = _curry3(function lift2(f, x, y) {
+  return ap(map(f, x), y);
+});

--- a/src/lift3.js
+++ b/src/lift3.js
@@ -1,0 +1,29 @@
+var ap = require('./ap');
+var curryN = require('./curryN');
+var map = require('./map');
+
+
+/**
+ * Promotes a curried ternary function to a function which operates on three
+ * [Apply](https://github.com/fantasyland/fantasy-land#apply)s.
+ *
+ * This function is derived from `map` and `ap`.
+ *
+ * @func
+ * @memberOf R
+ * @category Function
+ * @sig Apply f => (a -> b -> c -> d) -> f a -> f b -> f c -> f d
+ * @param {Function}
+ * @param {*}
+ * @param {*}
+ * @param {*}
+ * @return {*}
+ * @see R.lift, R.lift2
+ * @example
+ *
+ *      R.lift3(x => y => z => x + z + y, ['<'], ['>'], ['foo', 'bar', 'baz']); //=> ['<foo>', '<bar>', '<baz>']
+ *      R.lift3(x => y => z => x + z + y, Just('<'), Just('>'), Just('baz')); //=> Just('<baz>')
+ */
+module.exports = curryN(4, function lift3(f, x, y, z) {
+  return ap(ap(map(f, x), y), z);
+});

--- a/src/liftN.js
+++ b/src/liftN.js
@@ -17,6 +17,7 @@ var map = require('./map');
  * @param {Function} fn The function to lift into higher context
  * @return {Function} The lifted function.
  * @see R.lift, R.ap
+ * @deprecated since v0.23.0
  * @example
  *
  *      var madd3 = R.liftN(3, (...args) => R.sum(args));

--- a/test/lift.js
+++ b/test/lift.js
@@ -1,45 +1,12 @@
-/* jshint -W053 */
-
 var R = require('..');
+
 var eq = require('./shared/eq');
-var Maybe = require('./shared/Maybe');
-
-
-var add3 = R.curry(function add3(a, b, c) {
-  return a + b + c;
-});
-var add4 = R.curry(function add4(a, b, c, d) {
-  return a + b + c + d;
-});
-var add5 = R.curry(function add5(a, b, c, d, e) {
-  return a + b + c + d + e;
-});
-var madd3 = R.lift(add3);
-var madd4 = R.lift(add4);
-var madd5 = R.lift(add5);
 
 
 describe('lift', function() {
 
-  it('returns a function if called with just a function', function() {
-    eq(typeof R.lift(R.add), 'function');
-  });
-
-  it('produces a cross-product of array values', function() {
-    eq(madd3([1, 2, 3], [1, 2], [1, 2, 3]), [3, 4, 5, 4, 5, 6, 4, 5, 6, 5, 6, 7, 5, 6, 7, 6, 7, 8]);
-    eq(madd3([1], [2], [3]), [6]);
-    eq(madd3([1, 2], [3, 4], [5, 6]), [9, 10, 10, 11, 10, 11, 11, 12]);
-  });
-
-  it('can lift functions of any arity', function() {
-    eq(madd3([1, 10], [2], [3]), [6, 15]);
-    eq(madd4([1, 10], [2], [3], [40]), [46, 55]);
-    eq(madd5([1, 10], [2], [3], [40], [500, 1000]), [546, 1046, 555, 1055]);
-  });
-
-  it('works with other functors such as "Maybe"', function() {
-    var addM = R.lift(R.add);
-    eq(addM(Maybe.of(3), Maybe.of(5)), Maybe.of(8));
+  it('lifts a unary function', function() {
+    eq(R.lift(R.inc, [1, 2, 3]), [2, 3, 4]);
   });
 
 });

--- a/test/lift2.js
+++ b/test/lift2.js
@@ -1,0 +1,12 @@
+var R = require('..');
+
+var eq = require('./shared/eq');
+
+
+describe('lift2', function() {
+
+  it('lifts a binary function', function() {
+    eq(R.lift2(R.concat, ['A', 'B', 'C'], ['a', 'b', 'c']), ['Aa', 'Ab', 'Ac', 'Ba', 'Bb', 'Bc', 'Ca', 'Cb', 'Cc']);
+  });
+
+});

--- a/test/lift3.js
+++ b/test/lift3.js
@@ -1,0 +1,23 @@
+var R = require('..');
+
+var eq = require('./shared/eq');
+
+
+//  wrap :: Semigroup a => a -> a -> a -> a
+var wrap = function(a) {
+  return function(z) {
+    return function(s) {
+      return R.concat(R.concat(a, s), z);
+    };
+  };
+};
+
+
+describe('lift3', function() {
+
+  it('lifts a ternary function', function() {
+    eq(R.lift3(wrap, ['<'], ['>'], ['A', 'B', 'C']), ['<A>', '<B>', '<C>']);
+    eq(R.lift3(wrap, ['', '<'], ['', '>'], ['A', 'B', 'C']), ['A', 'B', 'C', 'A>', 'B>', 'C>', '<A', '<B', '<C', '<A>', '<B>', '<C>']);
+  });
+
+});


### PR DESCRIPTION
Before:

```purescript
lift :: (*... -> *) -> ([*]... -> [*])
liftN :: Number -> (*... -> *) -> ([*]... -> [*])
```

After:

```javascript
lift :: Functor f => (a -> b) -> f a -> f b
lift2 :: Apply f => (a -> b -> c) -> f a -> f b -> f c
lift3 :: Apply f => (a -> b -> c -> d) -> f a -> f b -> f c -> f d
```

The fixed-arity functions handle at least 99.99% of use cases and have meaningful type signatures! If someone happens to need `lift4` she can trivially define it in terms of `map` and `ap`.

@buzzdecafe expressed enthusiasm for this change in https://github.com/ramda/ramda/pull/1938#issuecomment-257418698.
