### PR TITLE
Update logical function documentation.

### DIFF
--- a/src/and.js
+++ b/src/and.js
@@ -8,10 +8,10 @@ var _curry2 = require('./internal/_curry2');
  * @memberOf R
  * @since v0.1.0
  * @category Logic
- * @sig * -> * -> *
- * @param {Boolean} a A boolean value
- * @param {Boolean} b A boolean value
- * @return {Boolean} `true` if both arguments are `true`, `false` otherwise
+ * @sig a -> b -> a | b
+ * @param {Any} a
+ * @param {Any} b
+ * @return {Any} the first argument if it is falsy, otherwise the second argument.
  * @see R.both
  * @example
  *

--- a/src/or.js
+++ b/src/or.js
@@ -9,10 +9,10 @@ var _curry2 = require('./internal/_curry2');
  * @memberOf R
  * @since v0.1.0
  * @category Logic
- * @sig * -> * -> *
- * @param {Boolean} a A boolean value
- * @param {Boolean} b A boolean value
- * @return {Boolean} `true` if one or both arguments are `true`, `false` otherwise
+ * @sig a -> b -> a | b
+ * @param {Any} a
+ * @param {Any} b
+ * @return {Any} the first argument if truthy, otherwise the second argument.
  * @see R.either
  * @example
  *


### PR DESCRIPTION
The existing documentation is confusing, as it seems to imply that params and return values are of Boolean type.

This is not the case, as both functions work in the same way that their operator counterparts do.