### PR TITLE
pipeK/composeK generated fns now expect unlifted values

### DIFF
--- a/src/composeK.js
+++ b/src/composeK.js
@@ -1,8 +1,6 @@
 var chain = require('./chain');
 var compose = require('./compose');
-var identity = require('./identity');
 var map = require('./map');
-var prepend = require('./prepend');
 
 
 /**
@@ -15,7 +13,7 @@ var prepend = require('./prepend');
  * @memberOf R
  * @since v0.16.0
  * @category Function
- * @sig Chain m => ((y -> m z), (x -> m y), ..., (a -> m b)) -> (m a -> m z)
+ * @sig Chain m => ((y -> m z), (x -> m y), ..., (a -> m b)) -> (a -> m z)
  * @param {...Function} ...functions The functions to compose
  * @return {Function}
  * @see R.pipeK
@@ -31,10 +29,15 @@ var prepend = require('./prepend');
  *         get('address'),
  *         get('user'),
  *       );
- *       getStateCode(Maybe.of({"user":{"address":{"state":"ny"}}})); //=> Maybe.Just("NY")
- *       getStateCode(Maybe.of({})); //=> Maybe.Nothing()
- * @symb R.composeK(f, g, h)(a, b) = R.chain(f, R.chain(g, h(a, b)))
+ *       getStateCode({"user":{"address":{"state":"ny"}}}); //=> Maybe.Just("NY")
+ *       getStateCode({}); //=> Maybe.Nothing()
+ * @symb R.composeK(f, g, h)(a) = R.chain(f, R.chain(g, h(a)))
  */
 module.exports = function composeK() {
-  return compose.apply(this, prepend(identity, map(chain, arguments)));
+  if (arguments.length === 0) {
+    throw new Error('composeK requires at least one argument');
+  }
+  var init = Array.prototype.slice.call(arguments);
+  var last = init.pop();
+  return compose(compose.apply(this, map(chain, init)), last);
 };

--- a/src/pipeK.js
+++ b/src/pipeK.js
@@ -11,7 +11,7 @@ var reverse = require('./reverse');
  * @memberOf R
  * @since v0.16.0
  * @category Function
- * @sig Chain m => ((a -> m b), (b -> m c), ..., (y -> m z)) -> (m a -> m z)
+ * @sig Chain m => ((a -> m b), (b -> m c), ..., (y -> m z)) -> (a -> m z)
  * @param {...Function}
  * @return {Function}
  * @see R.composeK
@@ -29,12 +29,15 @@ var reverse = require('./reverse');
  *        R.compose(Maybe.of, R.toUpper)
  *      );
  *
- *      getStateCode(Maybe.of('{"user":{"address":{"state":"ny"}}}'));
+ *      getStateCode('{"user":{"address":{"state":"ny"}}}');
  *      //=> Just('NY')
- *      getStateCode(Maybe.of('[Invalid JSON]'));
+ *      getStateCode('[Invalid JSON]');
  *      //=> Nothing()
- * @symb R.pipeK(f, g, h)(a, b) = R.chain(h, R.chain(g, f(a, b)))
+ * @symb R.pipeK(f, g, h)(a) = R.chain(h, R.chain(g, f(a)))
  */
 module.exports = function pipeK() {
+  if (arguments.length === 0) {
+    throw new Error('pipeK requires at least one argument');
+  }
   return composeK.apply(this, reverse(arguments));
 };


### PR DESCRIPTION
This changes the functions generated by `pipeK` and `composeK` to now expect an unlifted value rather than a lifted value as its argument, as per composition of arrows in the Kleisli category.

e.g.
```diff
- pipeK :: Monad m => ((a -> m b), (b -> m c), ..., (y -> m z)) -> (m a -> m z)
+ pipeK :: Monad m => ((a -> m b), (b -> m c), ..., (y -> m z)) ->   (a -> m z)
```

This follows the Haskell definition of [`>=>`](https://hackage.haskell.org/package/base/docs/Control-Monad.html#v:-62--61--62-):
```hs
(>=>) :: Monad m => (a -> m b) -> (b -> m c) -> a -> m c
```

(related: #1781)