### PR TITLE
Update path.js

### DIFF
--- a/src/path.js
+++ b/src/path.js
@@ -19,15 +19,9 @@ var _curry2 = require('./internal/_curry2');
  *      R.path(['a', 'b'], {a: {b: 2}}); //=> 2
  *      R.path(['a', 'b'], {c: {b: 2}}); //=> undefined
  */
-module.exports = _curry2(function path(paths, obj) {
-  var val = obj;
-  var idx = 0;
-  while (idx < paths.length) {
-    if (val == null) {
-      return;
+module.exports = _curry2(function path(paths, obj, i) {
+    if (paths[i]) {
+        return path(paths, obj[paths[i]], i + 1);
     }
-    val = val[paths[idx]];
-    idx += 1;
-  }
-  return val;
+    return obj;
 });

--- a/src/path.js
+++ b/src/path.js
@@ -20,11 +20,11 @@ var _curry2 = require('./internal/_curry2');
  *      R.path(['a', 'b'], {c: {b: 2}}); //=> undefined
  */
 
-function recursiveFunc(paths, obj, i){
-    if (paths[i]) {
-        return func(paths, obj[paths[i]], i + 1);
-    }
-    return obj;
+function recursiveFunc(paths, obj, i) {
+  if (paths[i]) {
+    return recursiveFunc(paths, obj[paths[i]], i + 1);
+  }
+  return obj;
 }
 
 module.exports = _curry2(function path(paths, obj) {

--- a/src/path.js
+++ b/src/path.js
@@ -19,9 +19,14 @@ var _curry2 = require('./internal/_curry2');
  *      R.path(['a', 'b'], {a: {b: 2}}); //=> 2
  *      R.path(['a', 'b'], {c: {b: 2}}); //=> undefined
  */
-module.exports = _curry2(function path(paths, obj, i) {
+
+function recursiveFunc(paths, obj, i){
     if (paths[i]) {
-        return path(paths, obj[paths[i]], i + 1);
+        return func(paths, obj[paths[i]], i + 1);
     }
     return obj;
+}
+
+module.exports = _curry2(function path(paths, obj) {
+  return recursiveFunc(paths, obj, 0);
 });


### PR DESCRIPTION
Hi, I've tried to do this function recursively and found out that the performances were better (unless for deep cases, like 5 or 6-deep keys in a object) using benchmark.js (https://github.com/bestiejs/benchmark.js/), is there any reason you guys did it iteratively instead?
Also I know it adds a new 'i' parameter which makes it less practical but I was just wondering... 
Thanks!