### PR TITLE
Updating ap's description

### DIFF
--- a/source/ap.js
+++ b/source/ap.js
@@ -7,7 +7,7 @@ import map from './map.js';
 /**
  * ap applies a list of functions to a list of values.
  *
- * Dispatches to the `ap` method of the second argument, if present. Also
+ * Dispatches to the `ap` method of the first argument, if present. Also
  * treats curried functions as applicatives.
  *
  * @func

--- a/test/ap.js
+++ b/test/ap.js
@@ -25,7 +25,7 @@ describe('ap', function() {
     eq(R.ap(R.add)(g)(10), 10 + (10 * 2));
   });
 
-  it('dispatches to the passed object\'s ap method when values is a non-Array object', function() {
+  it('dispatches to the first passed object\'s ap method when values is a non-Array object', function() {
     var obj = {ap: function(n) { return 'called ap with ' + n; }};
     eq(R.ap(obj, 10), obj.ap(10));
   });


### PR DESCRIPTION
[Fix for issue #2002](https://github.com/ramda/ramda/issues/2002) - ap function dispatches to wrong argument.

From @ davidchambers:
> Ramda currently targets v0.3.0 of the Fantasy Land specification, which explains why the argument order does not match that of the current version of the specification. #1900 will update Ramda to a more recent version of the specification, if merged.