### PR TITLE
curry helper for functions that return functions

### DIFF
--- a/src/allPass.js
+++ b/src/allPass.js
@@ -1,5 +1,5 @@
-var _curry1 = require('./internal/_curry1');
 var curryN = require('./curryN');
+var curryX = require('./curryX');
 var max = require('./max');
 var pluck = require('./pluck');
 var reduce = require('./reduce');
@@ -30,7 +30,8 @@ var reduce = require('./reduce');
  *      isQueenOfSpades({rank: 'Q', suit: '♣︎'}); //=> false
  *      isQueenOfSpades({rank: 'Q', suit: '♠︎'}); //=> true
  */
-module.exports = _curry1(function allPass(preds) {
+
+module.exports = curryX(function allPass(preds) {
   return curryN(reduce(max, 0, pluck('length', preds)), function() {
     var idx = 0;
     var len = preds.length;

--- a/src/curryX.js
+++ b/src/curryX.js
@@ -1,0 +1,33 @@
+var curryN = require('./curryN');
+
+
+/**
+ * todo
+ *
+ * @func
+ * @memberOf R
+ * @category Function
+ * @sig :'(
+ * @param {Function} A function that returns a function
+ * @return {Function} A curried function
+ * @see R.curry, R.curryN
+ * @example
+ *
+ *      todo
+ */
+module.exports = function curryX(f) {
+  return curryN(f.length, function() {
+    if (arguments.length > f.length) {
+      var fArgs = Array.prototype.slice.call(arguments, 0, f.length);
+      var gArgs = Array.prototype.slice.call(arguments, f.length);
+      var g = f.apply(null, fArgs);
+      if (gArgs.length >= g.length) {
+        return g.apply(null, gArgs);
+      } else {
+        return curryN(g.length, g).apply(null, gArgs);
+      }
+    } else {
+      return f.apply(null, arguments);
+    }
+  });
+}

--- a/src/either.js
+++ b/src/either.js
@@ -1,5 +1,7 @@
 var _curry2 = require('./internal/_curry2');
 var _isFunction = require('./internal/_isFunction');
+var curryN = require('./curryN');
+var curryX = require('./curryX');
 var lift = require('./lift');
 var or = require('./or');
 
@@ -31,10 +33,10 @@ var or = require('./or');
  *      f(101); //=> true
  *      f(8); //=> true
  */
-module.exports = _curry2(function either(f, g) {
+module.exports = curryX(function either(f, g) {
   return _isFunction(f) ?
-    function _either() {
+    curryN(f.length, function _either() {
       return f.apply(this, arguments) || g.apply(this, arguments);
-    } :
+    }) :
     lift(or)(f, g);
 });

--- a/test/allPass.js
+++ b/test/allPass.js
@@ -17,6 +17,26 @@ describe('allPass', function() {
     eq(ok(21), false);
   });
 
+  it('consumes arguments as expected', function() {
+    var ok0 = R.allPass([odd, plusEq]);
+    var ok1 = R.allPass([odd, plusEq], 5);
+    var ok2 = R.allPass([odd, plusEq], 5, 7);
+    var ok3 = R.allPass([odd, plusEq], 5, 7, 5);
+    var ok4 = R.allPass([odd, plusEq], 5, 7, 5, 7);
+    eq(ok0(5, 7, 5, 7), true);
+    eq(ok1(7, 5, 7), true);
+    eq(ok2(5, 7), true);
+    eq(ok3(7), true);
+    eq(ok4, true);
+
+    var ok11a = ok1(7);
+    var ok11b = ok1(7);
+    var ok11a1 = ok11a(5);
+    eq(ok11a(5, 7), true);
+    eq(ok11b(5, 7), true);
+    eq(ok11a1(7), true);
+  });
+
   it('returns true on empty predicate list', function() {
     eq(R.allPass([])(3), true);
   });

--- a/test/either.js
+++ b/test/either.js
@@ -14,6 +14,11 @@ describe('either', function() {
     eq(f(7), false);
   });
 
+  it('consumes arguments as expected', function() {
+    eq(R.either(R.identity, R.identity)(1), 1);
+    eq(R.either(R.identity, R.identity, 1), 1);
+  });
+
   it('accepts functions that take multiple parameters', function() {
     var between = function(a, b, c) {return a < b && b < c;};
     var total20 = function(a, b, c) {return a + b + c === 20;};


### PR DESCRIPTION
Quick PoC. Addresses #2006. The idea is to be totally backwards compatible, functions that this is a fit for can be called as they always could, but can now also be invoked all in one go.

Before:

```js
allPass([gt(5), odd]); => Int -> Bool
allPass([gt(5), odd], 4); => Int -> Bool
allPass([gt(5), odd])(4); => false
```
After
```js
allPass([gt(5), odd]); => Int -> Bool
allPass([gt(5), odd], 4); => false
allPass([gt(5), odd])(4); => false
```

Some candidates: allPass anyPass bind cond constructN invoker liftN memoize nthArg once tryCatch

"curryX" could also be an internal function, I'm not sure it needs exporting?