### PR TITLE
fixbug: #2008

### DIFF
--- a/test/chain.js
+++ b/test/chain.js
@@ -33,7 +33,7 @@ describe('chain', function() {
         return r + a;
       };
     };
-    var bound = R.chain(f, h);
+    var bound = R.chain(h, f);
     // (>>=) :: (r -> a) -> (a -> r -> b) -> (r -> b)
     // h >>= f = \w -> f (h w) w
     eq(bound(10), (10 * 2) + 10);


### PR DESCRIPTION
chain test - 'interprets ((->) r) as a monad' is failing

changing from  

`var bound = R.chain(f, h);`

to 

`var bound = R.chain(h, f);`