### PR TITLE
TypeError: Cannot read property 'length' of undefined

### DIFF
--- a/src/groupWith.js
+++ b/src/groupWith.js
@@ -29,7 +29,7 @@ var _curry2 = require('./internal/_curry2');
 module.exports = _curry2(function(fn, list) {
   var res = [];
   var idx = 0;
-  var len = list.length;
+  var len = Array.isArray(list) || typeof list === 'string' ? list.length : 0;
   while (idx < len) {
     var nextidx = idx + 1;
     while (nextidx < len && fn(list[idx], list[nextidx])) {

--- a/test/groupWith.js
+++ b/test/groupWith.js
@@ -25,4 +25,7 @@ describe('groupWith', function() {
     eq(R.groupWith(R.equals)('Mississippi'), ['M','i','ss','i','ss','i','pp','i']);
   });
 
+  it('returns an empty array for non-supported values', function() {
+    eq(R.groupWith(R.equals, undefined), []);
+  });
 });


### PR DESCRIPTION
I am trying to split a string into groups and I found the ``groupWith`` function helpful. However, my string is not always available. I am getting a TypeError in such case.

```
TypeError: Cannot read property 'length' of undefined
    at /path/ramda.js:1910:23
    at /path/ramda.js:466:28
    at f1 (/ramda.js:446:27)
```

Here is a simple test case to reproduce that. The function ``readStr`` first reads a string and sends it to ``groupWith``. If the string is not available, it returns ``undefined``. If ``undefined`` is passed to ``groupWith``, I am getting the above error.

```js
var str = readStr(params); // return undefined if the string is not available
console.log(R.groupWith(R.equals)(str));
```

I think if there is a default value of zero for ``len`` on [line 1910](https://github.com/ramda/ramda/blob/master/dist/ramda.js#L1910) then I can still get the empty array from ``res`` on [line 1908](https://github.com/ramda/ramda/blob/master/dist/ramda.js#L1908) without crashing.
