### PR TITLE
Fix JSDoc annotation in R.drop

### DIFF
--- a/src/drop.js
+++ b/src/drop.js
@@ -17,8 +17,8 @@ var slice = require('./slice');
  * @sig Number -> [a] -> [a]
  * @sig Number -> String -> String
  * @param {Number} n
- * @param {[a]} list
- * @return {[a]} A copy of list without the first `n` elements
+ * @param {Array} list
+ * @return {Array} A copy of list without the first `n` elements
  * @see R.take, R.transduce, R.dropLast, R.dropWhile
  * @example
  *


### PR DESCRIPTION
The [a] format was causing the jsdoc binary to choke when building the website docs