### PR TITLE
Adds integer path support to dissocPath

### DIFF
--- a/src/dissocPath.js
+++ b/src/dissocPath.js
@@ -1,6 +1,9 @@
 var _curry2 = require('./internal/_curry2');
+var _isInteger = require('./internal/_isInteger');
 var assoc = require('./assoc');
 var dissoc = require('./dissoc');
+var remove = require('./remove');
+var update = require('./update');
 
 
 /**
@@ -12,7 +15,8 @@ var dissoc = require('./dissoc');
  * @memberOf R
  * @since v0.11.0
  * @category Object
- * @sig [String] -> {k: v} -> {k: v}
+ * @typedefn Idx = String | Int
+ * @sig [Idx] -> {k: v} -> {k: v}
  * @param {Array} path The path to the value to omit
  * @param {Object} obj The object to clone
  * @return {Object} A new object without the property at path
@@ -26,10 +30,16 @@ module.exports = _curry2(function dissocPath(path, obj) {
     case 0:
       return obj;
     case 1:
-      return dissoc(path[0], obj);
+      return _isInteger(path[0]) ? remove(path[0], 1, obj) : dissoc(path[0], obj);
     default:
       var head = path[0];
       var tail = Array.prototype.slice.call(path, 1);
-      return obj[head] == null ? obj : assoc(head, dissocPath(tail, obj[head]), obj);
+      if (obj[head] == null) {
+        return obj;
+      } else if (_isInteger(path[0])) {
+        return update(head, dissocPath(tail, obj[head]), obj);
+      } else {
+        return assoc(head, dissocPath(tail, obj[head]), obj);
+      }
   }
 });

--- a/test/dissocPath.js
+++ b/test/dissocPath.js
@@ -6,21 +6,22 @@ var eq = require('./shared/eq');
 
 describe('dissocPath', function() {
   it('makes a shallow clone of an object, omitting only what is necessary for the path', function() {
-    var obj1 = {a: {b: 1, c: 2, d: {e: 3}}, f: {g: {h: 4, i: 5, j: {k: 6, l: 7}}}, m: 8};
-    var obj2 = R.dissocPath(['f', 'g', 'i'], obj1);
+    var obj1 = {a: {b: 1, c: 2, d: {e: 3}}, f: [{ g: 4}, {h: 5, i: 6, j: {k: 7, l: 8}}], m: 9};
+    var obj2 = R.dissocPath(['f', 1, 'i'], obj1);
     eq(obj2,
-      {a: {b: 1, c: 2, d: {e: 3}}, f: {g: {h: 4, j: {k: 6, l: 7}}}, m: 8}
+      {a: {b: 1, c: 2, d: {e: 3}}, f: [{g: 4}, {h: 5, j: {k: 7, l: 8}}], m: 9}
     );
     // Note: reference equality below!
     assert.strictEqual(obj2.a, obj1.a);
     assert.strictEqual(obj2.m, obj1.m);
-    assert.strictEqual(obj2.f.g.h, obj1.f.g.h);
-    assert.strictEqual(obj2.f.g.j, obj1.f.g.j);
+    assert.strictEqual(obj2.f[0], obj1.f[0]);
+    assert.strictEqual(obj2.f[1].h, obj1.f[1].h);
+    assert.strictEqual(obj2.f[1].j, obj1.f[1].j);
   });
 
   it('does not try to omit inner properties that do not exist', function() {
     var obj1 = {a: 1, b: {c: 2, d: 3}, e: 4, f: 5};
-    var obj2 = R.dissocPath(['x', 'y', 'z'], obj1);
+    var obj2 = R.dissocPath(['x', 0, 'z'], obj1);
     eq(obj2, {a: 1, b: {c: 2, d: 3}, e: 4, f: 5});
     // Note: reference equality below!
     assert.strictEqual(obj2.a, obj1.a);
@@ -33,6 +34,14 @@ describe('dissocPath', function() {
     var obj2 = R.dissocPath(['b', 'c'], obj1);
     eq(obj2,
       {a: 1, b: {}, d: 3}
+    );
+  });
+
+  it('leaves an empty array when all indexes are omitted', function() {
+    var obj1 = {a: 1, b: [2], d: 3};
+    var obj2 = R.dissocPath(['b', 0], obj1);
+    eq(obj2,
+      {a: 1, b: [], d: 3}
     );
   });
 


### PR DESCRIPTION
This change addresses that `R.dissocPath` was missed when support for integer path segments was added to the other path functions.