### PR TITLE
Replaces function arg with clone to avoid mutation

### DIFF
--- a/src/reduceRight.js
+++ b/src/reduceRight.js
@@ -44,10 +44,11 @@ var _curry3 = require('./internal/_curry3');
  * @symb R.reduceRight(f, a, [b, c, d]) = f(b, f(c, f(d, a)))
  */
 module.exports = _curry3(function reduceRight(fn, acc, list) {
+	var accClone = acc;
   var idx = list.length - 1;
   while (idx >= 0) {
-    acc = fn(list[idx], acc);
+    accClone = fn(list[idx], accClone);
     idx -= 1;
   }
-  return acc;
+  return accClone;
 });


### PR DESCRIPTION
The argument `acc` passed to the function `reduceRight` was mutated by the function.
This change avoids mutation and makes the function pure.