### PR TITLE
Added more helpful error when _reduce is passed null or undefined

### DIFF
--- a/src/internal/_reduce.js
+++ b/src/internal/_reduce.js
@@ -37,6 +37,9 @@ module.exports = (function() {
 
   var symIterator = (typeof Symbol !== 'undefined') ? Symbol.iterator : '@@iterator';
   return function _reduce(fn, acc, list) {
+    if (list === null || typeof list === 'undefined') {
+      throw new TypeError('reduce: list cannot be null or undefined');
+    }
     if (typeof fn === 'function') {
       fn = _xwrap(fn);
     }

--- a/test/internal/_reduce.js
+++ b/test/internal/_reduce.js
@@ -1,0 +1,17 @@
+var assert = require('assert');
+var _reduce = require('../../src/internal/_reduce');
+
+var id = function(acc, next) { return acc; };
+
+describe('_reduce', function() {
+  it('displays a more helpful error when passed null', function() {
+    assert.throws(function() {
+      _reduce(id, 0, null);
+    }, /reduce: list cannot be null or undefined/);
+  });
+  it('displays a more helpful error when passed undefined', function() {
+    assert.throws(function() {
+      _reduce(id, 0, undefined);
+    }, /reduce: list cannot be null or undefined/);
+  });
+});

--- a/test/reduce.js
+++ b/test/reduce.js
@@ -1,4 +1,5 @@
 var R = require('..');
+var assert = require('assert');
 var eq = require('./shared/eq');
 
 describe('reduce', function() {
@@ -35,4 +36,15 @@ describe('reduce', function() {
     eq(sum.length, 1);
   });
 
+  it('fails when list is null', function() {
+    assert.throws(function() {
+      R.reduce(add, 0, null);
+    }, /reduce: list cannot be null or undefined/);
+  });
+
+  it('fails when list is undefined', function() {
+    assert.throws(function() {
+      R.reduce(add, 0, undefined);
+    }, /reduce: list cannot be null or undefined/);
+  });
 });


### PR DESCRIPTION
`R.reduce(R.subtract, 0, null)` throws `Cannot read property 'reduce' of null` which is misleading. This commit checks for null or undefined and throws a more helpful message.