### PR TITLE
Harmonise undefined in path and prop

### DIFF
--- a/src/prop.js
+++ b/src/prop.js
@@ -19,4 +19,6 @@ var _curry2 = require('./internal/_curry2');
  *      R.prop('x', {x: 100}); //=> 100
  *      R.prop('x', {}); //=> undefined
  */
-module.exports = _curry2(function prop(p, obj) { return obj[p]; });
+module.exports = _curry2(function prop(p, obj) {
+  return obj == null ? undefined : obj[p];
+});

--- a/test/path.js
+++ b/test/path.js
@@ -36,6 +36,7 @@ describe('path', function() {
     eq(R.path(['a', 'b', 'foo'], deepObject), undefined);
     eq(R.path(['bar'], deepObject), undefined);
     eq(R.path(['a', 'b'], {a: null}), undefined);
+    eq(R.path(['a', 'b'], undefined), undefined);
   });
 
   it('works with falsy items', function() {

--- a/test/prop.js
+++ b/test/prop.js
@@ -11,4 +11,7 @@ describe('prop', function() {
     eq(nm(fred), 'Fred');
   });
 
+  it('handles undefined as object gracefully', function() {
+    eq(R.prop('name', undefined), undefined);
+  });
 });


### PR DESCRIPTION
This closes #1941. As described there the handling of `undefined` as the object currently differs between `path` and `prop`: The former returns `undefined`, the latter used to throw an exception.

This pull request harmonises this by returning `undefined` for both. 