### PR TITLE
Fixed `xtake` where n < 0

### DIFF
--- a/src/internal/_xtake.js
+++ b/src/internal/_xtake.js
@@ -13,7 +13,7 @@ module.exports = (function() {
   XTake.prototype['@@transducer/step'] = function(result, input) {
     this.i += 1;
     var ret = this.n === 0 ? result : this.xf['@@transducer/step'](result, input);
-    return this.i >= this.n ? _reduced(ret) : ret;
+    return this.n >= 0 && this.i >= this.n ? _reduced(ret) : ret;
   };
 
   return _curry2(function _xtake(n, xf) { return new XTake(n, xf); });

--- a/test/take.js
+++ b/test/take.js
@@ -46,4 +46,10 @@ describe('take', function() {
     sinon.assert.calledTwice(spy);
   });
 
+  it('transducer called for every member of list if `n` is < 0', function() {
+    var spy = sinon.spy();
+    R.into([], R.compose(R.map(spy), R.take(-1)), [1, 2, 3]);
+    sinon.assert.calledThrice(spy);
+  });
+
 });


### PR DESCRIPTION
I noticed that the behaviour of `take` was inconsistent when used normally vs as a transducer. Specifically, `take(-1)` would return a transducer that would only process 1 element. I was expecting it to process every element, effectively doing nothing.

I'm happy for this to be closed if this is the intended behaviour :)