### PR TITLE
Add memoizeWith

### DIFF
--- a/index.js
+++ b/index.js
@@ -124,6 +124,7 @@ module.exports = {
   mean: require('./src/mean'),
   median: require('./src/median'),
   memoize: require('./src/memoize'),
+  memoizeWith: require('./src/memoizeWith'),
   merge: require('./src/merge'),
   mergeAll: require('./src/mergeAll'),
   mergeWith: require('./src/mergeWith'),

--- a/src/memoize.js
+++ b/src/memoize.js
@@ -1,6 +1,4 @@
-var _arity = require('./internal/_arity');
-var _curry1 = require('./internal/_curry1');
-var _has = require('./internal/_has');
+var memoizeWith = require('./memoizeWith');
 var toString = require('./toString');
 
 
@@ -20,8 +18,8 @@ var toString = require('./toString');
  * @return {Function} Memoized version of `fn`.
  * @example
  *
- *      var count = 0;
- *      var factorial = R.memoize(n => {
+ *      let count = 0;
+ *      const factorial = R.memoize(n => {
  *        count += 1;
  *        return R.product(R.range(1, n + 1));
  *      });
@@ -30,13 +28,4 @@ var toString = require('./toString');
  *      factorial(5); //=> 120
  *      count; //=> 1
  */
-module.exports = _curry1(function memoize(fn) {
-  var cache = {};
-  return _arity(fn.length, function() {
-    var key = toString(arguments);
-    if (!_has(key, cache)) {
-      cache[key] = fn.apply(this, arguments);
-    }
-    return cache[key];
-  });
-});
+module.exports = memoizeWith(toString);

--- a/src/memoizeWith.js
+++ b/src/memoizeWith.js
@@ -1,0 +1,43 @@
+var _arity = require('./internal/_arity');
+var _curry2 = require('./internal/_curry2');
+var _has = require('./internal/_has');
+
+
+/**
+ * A customisable version of R.memoize. memoizeWith takes an additional
+ * function that will be applied to a given argument set and used to create
+ * the cache key under which the results of the function to be memoized will
+ * be stored. Care must be taken when implementing key generation to avoid
+ * clashes that may overwrite previous entries erroneously.
+ *
+ *
+ * @func
+ * @memberOf R
+ * @category Function
+ * @sig (*... -> String) -> (*... -> a) -> (*... -> a)
+ * @param {Function} fn The function to generate the cache key.
+ * @param {Function} fn The function to memoize.
+ * @return {Function} Memoized version of `fn`.
+ * @see R.memoize
+ * @example
+ *
+ *      let count = 0;
+ *      const factorial = R.memoizeWith(R.identity, n => {
+ *        count += 1;
+ *        return R.product(R.range(1, n + 1));
+ *      });
+ *      factorial(5); //=> 120
+ *      factorial(5); //=> 120
+ *      factorial(5); //=> 120
+ *      count; //=> 1
+ */
+module.exports = _curry2(function memoizeWith(mFn, fn) {
+  var cache = {};
+  return _arity(fn.length, function() {
+    var key = mFn.apply(this, arguments);
+    if (!_has(key, cache)) {
+      cache[key] = fn.apply(this, arguments);
+    }
+    return cache[key];
+  });
+});

--- a/test/memoize.js
+++ b/test/memoize.js
@@ -3,28 +3,6 @@ var eq = require('./shared/eq');
 
 
 describe('memoize', function() {
-  it('calculates the value for a given input only once', function() {
-    var ctr = 0;
-    var fib = R.memoize(function(n) {ctr += 1; return n < 2 ? n : fib(n - 2) + fib(n - 1);});
-    var result = fib(10);
-    eq(result, 55);
-    eq(ctr, 11); // fib(0), fib(1), ... fib(10), no memoization would take 177 iterations.
-  });
-
-  it('handles multiple parameters', function() {
-    var f = R.memoize(function(a, b, c) {return a + ', ' + b + c;});
-    eq(f('Hello', 'World' , '!'), 'Hello, World!');
-    eq(f('Goodbye', 'Cruel World' , '!!!'), 'Goodbye, Cruel World!!!');
-    eq(f('Hello', 'how are you' , '?'), 'Hello, how are you?');
-    eq(f('Hello', 'World' , '!'), 'Hello, World!');
-  });
-
-  it('does not rely on reported arity', function() {
-    var identity = R.memoize(function() { return arguments[0]; });
-    eq(identity('x'), 'x');
-    eq(identity('y'), 'y');
-  });
-
   it('memoizes "false" return values', function() {
     var count = 0;
     var inc = R.memoize(function(n) {
@@ -34,34 +12,6 @@ describe('memoize', function() {
     eq(inc(-1), 0);
     eq(inc(-1), 0);
     eq(inc(-1), 0);
-    eq(count, 1);
-  });
-
-  it('can be applied to nullary function', function() {
-    var count = 0;
-    var f = R.memoize(function() {
-      count += 1;
-      return 42;
-    });
-    eq(f(), 42);
-    eq(f(), 42);
-    eq(f(), 42);
-    eq(count, 1);
-  });
-
-  it('can be applied to function with optional arguments', function() {
-    var count = 0;
-    var f = R.memoize(function concat(a, b) {
-      count += 1;
-      switch (arguments.length) {
-        case 0: a = 'foo';
-        case 1: b = 'bar';
-      }
-      return a + b;
-    });
-    eq(f(), 'foobar');
-    eq(f(), 'foobar');
-    eq(f(), 'foobar');
     eq(count, 1);
   });
 
@@ -83,11 +33,6 @@ describe('memoize', function() {
     eq(f({x: 1, y: 2}), '{"x": 1, "y": 2}');
     eq(f({y: 2, x: 1}), '{"x": 1, "y": 2}');
     eq(count, 1);
-  });
-
-  it('retains arity', function() {
-    var f = R.memoize(function(a, b) { return a + b; });
-    eq(f.length, 2);
   });
 
 });

--- a/test/memoizeWith.js
+++ b/test/memoizeWith.js
@@ -1,0 +1,66 @@
+var R = require('..');
+var eq = require('./shared/eq');
+
+
+describe('memoizeWith', function() {
+  it('calculates the value for a given input only once', function() {
+    var ctr = 0;
+    var fib = R.memoizeWith(R.identity, function(n) {
+      ctr += 1;
+      return n < 2 ? n : fib(n - 2) + fib(n - 1);
+    });
+    var result = fib(10);
+    eq(result, 55);
+    eq(ctr, 11); // fib(0), fib(1), ... fib(10), no memoization would take 177 iterations.
+  });
+
+  it('handles multiple parameters', function() {
+    var f = R.memoizeWith(function(a, b, c) {
+      return a + b + c;
+    }, function(a, b, c) {return a + ', ' + b + c;});
+    eq(f('Hello', 'World' , '!'), 'Hello, World!');
+    eq(f('Goodbye', 'Cruel World' , '!!!'), 'Goodbye, Cruel World!!!');
+    eq(f('Hello', 'how are you' , '?'), 'Hello, how are you?');
+    eq(f('Hello', 'World' , '!'), 'Hello, World!');
+  });
+
+  it('does not rely on reported arity', function() {
+    var identity = R.memoizeWith(R.identity, function() { return arguments[0]; });
+    eq(identity('x'), 'x');
+    eq(identity('y'), 'y');
+  });
+
+  it('can be applied to nullary function', function() {
+    var count = 0;
+    var f = R.memoizeWith(R.identity, function() {
+      count += 1;
+      return 42;
+    });
+    eq(f(), 42);
+    eq(f(), 42);
+    eq(f(), 42);
+    eq(count, 1);
+  });
+
+  it('can be applied to function with optional arguments', function() {
+    var count = 0;
+    var f = R.memoizeWith(R.concat, function concat(a, b) {
+      count += 1;
+      switch (arguments.length) {
+        case 0: a = 'foo';
+        case 1: b = 'bar';
+      }
+      return a + b;
+    });
+    eq(f(), 'foobar');
+    eq(f(), 'foobar');
+    eq(f(), 'foobar');
+    eq(count, 1);
+  });
+
+  it('retains arity', function() {
+    var f = R.memoizeWith(R.concat, function(a, b) { return a + b; });
+    eq(f.length, 2);
+  });
+
+});


### PR DESCRIPTION
Closes #2125. This isn't as straightforward as being able to do `R.memoizeWith(R.prop('a'))` because we have to support multiple arity functions. This means that the customising function is applied to `arguments` so the correct way to use the function is `R.memoizeWith(R.compose(R.prop('a'), R.head))`. I think the examples in the documentation  I've provided aren't good enough and I was hoping people had some better suggestions.