### PR TITLE
Rephrase docs for 'all'

### DIFF
--- a/dist/ramda.js
+++ b/dist/ramda.js
@@ -990,8 +990,7 @@
     });
 
     /**
-     * Returns `true` if all elements of the list match the predicate, `false` if
-     * there are any that don't.
+     * Returns `false` if any element does not satisfy the predicate, `true` otherwise.
      *
      * Dispatches to the `all` method of the second argument, if present.
      *
@@ -1004,8 +1003,7 @@
      * @sig (a -> Boolean) -> [a] -> Boolean
      * @param {Function} fn The predicate function.
      * @param {Array} list The array to consider.
-     * @return {Boolean} `true` if the predicate is satisfied by every element, `false`
-     *         otherwise.
+     * @return {Boolean} `false` if any element does not satisfy the predicate, `true` otherwise.
      * @see R.any, R.none, R.transduce
      * @example
      *


### PR DESCRIPTION
Rephrased description for 'all' to make it clearer that it should return 'true' for an empty list