### PR TITLE
Fix example for transpose documentation

### DIFF
--- a/src/transpose.js
+++ b/src/transpose.js
@@ -19,8 +19,7 @@ var _curry1 = require('./internal/_curry1');
  *      R.transpose([[1, 'a'], [2, 'b'], [3, 'c']]) //=> [[1, 2, 3], ['a', 'b', 'c']]
  *      R.transpose([[1, 2, 3], ['a', 'b', 'c']]) //=> [[1, 'a'], [2, 'b'], [3, 'c']]
  *
- * If some of the rows are shorter than the following rows, their elements are skipped:
- *
+ *      // If some of the rows are shorter than the following rows, their elements are skipped:
  *      R.transpose([[10, 11], [20], [], [30, 31, 32]]) //=> [[10, 20, 30], [11, 31], [32]]
  * @symb R.transpose([[a], [b], [c]]) = [a, b, c]
  * @symb R.transpose([[a, b], [c, d]]) = [[a, c], [b, d]]


### PR DESCRIPTION
This fixes example for `transpose` failing in REPL because of invalid comment.
http://ramdajs.com/docs/#transpose