### PR TITLE
Added `repeatWith` function

### DIFF
--- a/index.js
+++ b/index.js
@@ -183,6 +183,7 @@ module.exports = {
   reject: require('./src/reject'),
   remove: require('./src/remove'),
   repeat: require('./src/repeat'),
+  repeatWith: require('./src/repeatWith'),
   replace: require('./src/replace'),
   reverse: require('./src/reverse'),
   scan: require('./src/scan'),

--- a/src/repeatWith.js
+++ b/src/repeatWith.js
@@ -1,0 +1,27 @@
+var _curry2 = require('./internal/_curry2');
+var map = require('./map');
+var repeat = require('./repeat');
+
+
+/**
+ * Returns a list of length `n` where each element is the result of evaluating `f()`.
+ * If the function `f` has any side effects they will occur in order from left to right.
+ * If `n` is `0` then `f` will not be executed and will have no side effects.
+ *
+ * @func
+ * @memberOf R
+ * @category List
+ * @sig (* -> n) -> n -> [a]
+ * @param {*} The function to be executed.
+ * @param {Number} n The desired size of the output list.
+ * @return {Array} A new array containing the values of `f()` from `n consecutive calls`.
+ * @see R.repeat
+ * @example
+ *      var i = 0;
+ *      R.repeatWith(() => i = i + 1, 5) //=> [1,2,3,4,5]
+ *      //Note that the side effects occur in a left to right order.
+ *
+ */
+module.exports = _curry2(function repeatWith(f, n) {
+  return map(function(_e) {return f();}, repeat(null, n));
+});

--- a/test/repeatWith.js
+++ b/test/repeatWith.js
@@ -1,0 +1,25 @@
+var R = require('..');
+var eq = require('./shared/eq');
+
+
+describe('repeatWith', function() {
+  it('repeating 0 times has no side effects', function() {
+    var i = 0;
+    R.repeatWith(function() {i = i + 1; return i;}, 0);
+    eq(i, 0);
+  });
+
+  it('the order of the side effects occure from left to right', function() {
+    var i = 0;
+    eq(R.repeatWith(function() {i = i + 1; return i;}, 5), [1,2,3,4,5]);
+
+  });
+
+  it('is curried', function() {
+    var i = 0;
+    var makeFoos = R.repeatWith(function() {i = i + 1; return i;});
+    eq(makeFoos(0), []);
+    eq(makeFoos(3), [1,2,3]);
+  });
+
+});


### PR DESCRIPTION
Added a `repeatWith` function that behaves like `replicateM` in Haskell.

The function takes a nullary function `f` and creates a list of `n` containing the return values of `f` for `n` consecutive calls.

Example:
```
R.repeatWith(Math.random, 3) 
//=> [ 0.44077919192880755, 0.09582463920980899, 0.13967090898447432 ]
```

The side effects produced by `f` will occur in the order from "left to right":
```
var i = 0;
R.repeatWith(() => i = i+1, 5) //=> [1,2,3,4,5]
```

Closes #2145 