### PR TITLE
add Chinese translation link to README.md (home page)

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,10 @@ If you have _PhantomJS_ installed, you can run `testem -l phantomjs` to run the
 tests completely headlessly.
 
 
+Translations
+-----------------
+
+[Chinese(中文)](http://ramda.cn/)
 
 
 Acknowledgements


### PR DESCRIPTION
We've just finished Chinese translation of ramda, and build a website: http://ramda.cn/.

The work is done by five of us(4 other colleagues). we then checked the translation twice carefully to assure quality.

We currently replace the English comment with Chinese in-place on the api file, in the forked [repo](https://github.com/ramdacn/ramda). I'm writing some scripts to move the translation to a single directory, which will make the future translation more easily: 

1. update the forked ramda repo with original repo;
2. show the change parts;
3. only translate the change apis;
4. update the forked ramda.github.io with new translation;
5. update Chinese website.

Should the translations separate from original ramda(only add a link), or be part of it?