### PR TITLE
Updated type for pluck

### DIFF
--- a/src/pluck.js
+++ b/src/pluck.js
@@ -7,19 +7,24 @@ var prop = require('./prop');
  * Returns a new list by plucking the same named property off all objects in
  * the list supplied.
  *
+ * `pluck` will work on
+ * any [functor](https://github.com/fantasyland/fantasy-land#functor) in
+ * addition to arrays, as it is equivalent to `R.map(R.prop(k), f)`.
+ *
  * @func
  * @memberOf R
  * @since v0.1.0
  * @category List
- * @sig k -> [{k: v}] -> [v]
+ * @sig Functor f => k -> f {k: v} -> f v
  * @param {Number|String} key The key name to pluck off of each object.
- * @param {Array} list The array to consider.
+ * @param {Array} f The array or functor to consider.
  * @return {Array} The list of values for the given key.
  * @see R.props
  * @example
  *
  *      R.pluck('a')([{a: 1}, {a: 2}]); //=> [1, 2]
  *      R.pluck(0)([[1, 2], [3, 4]]);   //=> [1, 3]
+ *      R.pluck('val', {a: {val: 3}, b: {val: 5}}); //=> {a: 3, b: 5}
  * @symb R.pluck('x', [{x: 1, y: 2}, {x: 3, y: 4}, {x: 5, y: 6}]) = [1, 3, 5]
  * @symb R.pluck(0, [[1, 2], [3, 4], [5, 6]]) = [1, 3, 5]
  */


### PR DESCRIPTION
Pluck is probably one of our more well used Ramda functions. If we see `map(prop(...))` during code review we'll typically change it to a `pluck`. I recently wrote some code that was using `map(prop())` to pull some values off a nested object, and of course it was pointed out that `pluck` could be used there as well.

While obvious in retrospect, it isn't obvious from the documentation that `pluck` can be used on things that aren't arrays. To me, this behavior seems useful, and isn't ad-hoc due to the `Functor` instance for objects. 

I understand the desire for the docs to be easily understandable, and I know that `Functor` is less well known in the JS community than `Array` is. I don't want to remove the idea that this function operates on lists, simply add in the idea that it will work with other Functors as well.

I wasn't really sure what to do with the jsdoc annotations.  Looking at `map` it still has Array as the type for the second parameter and return value, so I left that here as well.