### PR TITLE
Fix reduced value handling when dispatching to objects implementing the iterable/iterator protocols

### DIFF
--- a/src/internal/_reduce.js
+++ b/src/internal/_reduce.js
@@ -46,15 +46,16 @@ module.exports = (function() {
     if (typeof list['fantasy-land/reduce'] === 'function') {
       return _methodReduce(fn, acc, list, 'fantasy-land/reduce');
     }
-    if (typeof list.reduce === 'function') {
-      return _methodReduce(fn, acc, list, 'reduce');
-    }
     if (list[symIterator] != null) {
       return _iterableReduce(fn, acc, list[symIterator]());
     }
     if (typeof list.next === 'function') {
       return _iterableReduce(fn, acc, list);
     }
+    if (typeof list.reduce === 'function') {
+      return _methodReduce(fn, acc, list, 'reduce');
+    }
+
     throw new TypeError('reduce: list must be array or iterable');
   };
 }());

--- a/src/reduce.js
+++ b/src/reduce.js
@@ -17,7 +17,9 @@ var _reduce = require('./internal/_reduce');
  * on this behavior, see:
  * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/reduce#Description
  *
- * Dispatches to the `reduce` method of the third argument, if present.
+ * Dispatches to the `reduce` method of the third argument, if present. When
+ * doing so, it is up to the user to handle the `R.reduced` shortcuting, as
+ * this is not implemented by `reduce`.
  *
  * @func
  * @memberOf R

--- a/test/reduce.js
+++ b/test/reduce.js
@@ -35,4 +35,51 @@ describe('reduce', function() {
     eq(sum.length, 1);
   });
 
+  it('Prefers the use of the iterator of an object over reduce (and handles short-circuits)', function() {
+    var symIterator = (typeof Symbol !== 'undefined') ? Symbol.iterator : '@@iterator';
+
+    function Reducible(arr) {
+      this.arr = arr;
+    }
+
+    Reducible.prototype.reduce = function(f, init) {
+      var acc = init;
+      for (var i = 0; i < this.arr.length; i += 1) {
+        acc = f(acc, this.arr[i]);
+      }
+      return acc;
+    };
+
+    Reducible.prototype[symIterator] = function() {
+      var a = this.arr;
+      return {
+        _pos: 0,
+
+        next: function() {
+          if (this._pos < a.length) {
+            var v = a[this._pos];
+            this._pos += 1;
+            return {
+              value: v,
+              done: false
+            };
+          } else {
+            return {
+              done: true
+            };
+          }
+        }
+      };
+    };
+
+    var xf = R.take(2);
+    var apendingT = { };
+    apendingT['@@transducer/result'] = R.identity;
+    apendingT['@@transducer/step'] = R.flip(R.append);
+
+    var rfn = xf(apendingT);
+    var list = new Reducible([1, 2, 3, 4, 5, 6]);
+
+    eq(R.reduce(rfn, [], list), [1, 2]);
+  });
 });


### PR DESCRIPTION
According the documentation of `reduce`:

    The iterator function receives two values: *(acc, value)*. It may use 
   `R.reduced` to shortcut the iteration.

and

    Dispatches to the `reduce` method of the third argument, if present.

This pull request fixes the situation where an object with a `reduce` method is passed in list position and a transducer which uses `reduced` (such as `take`) is used as the reducing fn.