### PR TITLE
docs: add missing intra links between Ramda's functions

### DIFF
--- a/src/addIndex.js
+++ b/src/addIndex.js
@@ -7,7 +7,7 @@ var curryN = require('./curryN');
  * Creates a new list iteration function from an existing one by adding two new
  * parameters to its callback function: the current index, and the entire list.
  *
- * This would turn, for instance, Ramda's simple `map` function into one that
+ * This would turn, for instance, [`R.map`](#map) function into one that
  * more closely resembles `Array.prototype.map`. Note that this will only work
  * for functions in which the iteration callback function is the first
  * parameter, and where the list is the last parameter. (This latter might be

--- a/src/call.js
+++ b/src/call.js
@@ -4,8 +4,9 @@ var curry = require('./curry');
 /**
  * Returns the result of calling its first argument with the remaining
  * arguments. This is occasionally useful as a converging function for
- * `R.converge`: the first branch can produce a function while the remaining
- * branches produce values to be passed to that function as its arguments.
+ * [`R.converge`](#converge): the first branch can produce a function while the
+ * remaining branches produce values to be passed to that function as its
+ * arguments.
  *
  * @func
  * @memberOf R

--- a/src/contains.js
+++ b/src/contains.js
@@ -3,8 +3,8 @@ var _curry2 = require('./internal/_curry2');
 
 
 /**
- * Returns `true` if the specified value is equal, in `R.equals` terms, to at
- * least one element of the given list; `false` otherwise.
+ * Returns `true` if the specified value is equal, in [`R.equals`](#equals)
+ * terms, to at least one element of the given list; `false` otherwise.
  *
  * @func
  * @memberOf R

--- a/src/curry.js
+++ b/src/curry.js
@@ -13,10 +13,10 @@ var curryN = require('./curryN');
  *   - `g(1, 2)(3)`
  *   - `g(1, 2, 3)`
  *
- * Secondly, the special placeholder value `R.__` may be used to specify
+ * Secondly, the special placeholder value [`R.__`](#__) may be used to specify
  * "gaps", allowing partial application of any combination of arguments,
- * regardless of their positions. If `g` is as above and `_` is `R.__`, the
- * following are equivalent:
+ * regardless of their positions. If `g` is as above and `_` is [`R.__`](#__),
+ * the following are equivalent:
  *
  *   - `g(1, 2, 3)`
  *   - `g(_, 2, 3)(1)`

--- a/src/curryN.js
+++ b/src/curryN.js
@@ -15,10 +15,10 @@ var _curryN = require('./internal/_curryN');
  *   - `g(1, 2)(3)`
  *   - `g(1, 2, 3)`
  *
- * Secondly, the special placeholder value `R.__` may be used to specify
+ * Secondly, the special placeholder value [`R.__`](#__) may be used to specify
  * "gaps", allowing partial application of any combination of arguments,
- * regardless of their positions. If `g` is as above and `_` is `R.__`, the
- * following are equivalent:
+ * regardless of their positions. If `g` is as above and `_` is [`R.__`](#__),
+ * the following are equivalent:
  *
  *   - `g(1, 2, 3)`
  *   - `g(_, 2, 3)(1)`

--- a/src/dropRepeats.js
+++ b/src/dropRepeats.js
@@ -6,8 +6,8 @@ var equals = require('./equals');
 
 
 /**
- * Returns a new list without any consecutively repeating elements. `R.equals`
- * is used to determine equality.
+ * Returns a new list without any consecutively repeating elements.
+ * [`R.equals`](#equals) is used to determine equality.
  *
  * Acts as a transducer if a transformer is given in list position.
  *

--- a/src/eqProps.js
+++ b/src/eqProps.js
@@ -3,8 +3,8 @@ var equals = require('./equals');
 
 
 /**
- * Reports whether two objects have the same value, in `R.equals` terms, for
- * the specified property. Useful as a curried predicate.
+ * Reports whether two objects have the same value, in [`R.equals`](#equals)
+ * terms, for the specified property. Useful as a curried predicate.
  *
  * @func
  * @memberOf R

--- a/src/indexOf.js
+++ b/src/indexOf.js
@@ -5,8 +5,8 @@ var _isArray = require('./internal/_isArray');
 
 /**
  * Returns the position of the first occurrence of an item in an array, or -1
- * if the item is not included in the array. `R.equals` is used to determine
- * equality.
+ * if the item is not included in the array. [`R.equals`](#equals) is used to
+ * determine equality.
  *
  * @func
  * @memberOf R

--- a/src/into.js
+++ b/src/into.js
@@ -21,7 +21,8 @@ var _stepCat = require('./internal/_stepCat');
  * final accumulator into the return type and in most cases is R.identity. The
  * init function is used to provide the initial accumulator.
  *
- * The iteration is performed with R.reduce after initializing the transducer.
+ * The iteration is performed with [`R.reduce`](#reduce) after initializing the
+ * transducer.
  *
  * @func
  * @memberOf R

--- a/src/invert.js
+++ b/src/invert.js
@@ -4,8 +4,8 @@ var keys = require('./keys');
 
 
 /**
- * Same as R.invertObj, however this accounts for objects with duplicate values
- * by putting the values into an array.
+ * Same as [`R.invertObj`](#invertObj), however this accounts for objects with
+ * duplicate values by putting the values into an array.
  *
  * @func
  * @memberOf R
@@ -13,8 +13,8 @@ var keys = require('./keys');
  * @category Object
  * @sig {s: x} -> {x: [ s, ... ]}
  * @param {Object} obj The object or array to invert
- * @return {Object} out A new object with keys
- * in an array.
+ * @return {Object} out A new object with keys in an array.
+ * @see R.invertObj
  * @example
  *
  *      var raceResultsByFirstName = {

--- a/src/invertObj.js
+++ b/src/invertObj.js
@@ -14,6 +14,7 @@ var keys = require('./keys');
  * @sig {s: x} -> {x: s}
  * @param {Object} obj The object or array to invert
  * @return {Object} out A new object
+ * @see R.invert
  * @example
  *
  *      var raceResults = {

--- a/src/keys.js
+++ b/src/keys.js
@@ -16,6 +16,7 @@ var _isArguments = require('./internal/_isArguments');
  * @sig {k: v} -> [k]
  * @param {Object} obj The object to extract properties from
  * @return {Array} An array of the object's own properties.
+ * @see R.keysIn, R.values
  * @example
  *
  *      R.keys({a: 1, b: 2, c: 3}); //=> ['a', 'b', 'c']

--- a/src/keysIn.js
+++ b/src/keysIn.js
@@ -14,6 +14,7 @@ var _curry1 = require('./internal/_curry1');
  * @sig {k: v} -> [k]
  * @param {Object} obj The object to extract properties from
  * @return {Array} An array of the object's own and prototype properties.
+ * @see R.keys, R.valuesIn
  * @example
  *
  *      var F = function() { this.x = 'X'; };

--- a/src/lastIndexOf.js
+++ b/src/lastIndexOf.js
@@ -5,8 +5,8 @@ var equals = require('./equals');
 
 /**
  * Returns the position of the last occurrence of an item in an array, or -1 if
- * the item is not included in the array. `R.equals` is used to determine
- * equality.
+ * the item is not included in the array. [`R.equals`](#equals) is used to
+ * determine equality.
  *
  * @func
  * @memberOf R

--- a/src/mapAccum.js
+++ b/src/mapAccum.js
@@ -2,7 +2,7 @@ var _curry3 = require('./internal/_curry3');
 
 
 /**
- * The mapAccum function behaves like a combination of map and reduce; it
+ * The `mapAccum` function behaves like a combination of map and reduce; it
  * applies a function to each element of a list, passing an accumulating
  * parameter from left to right, and returning a final value of this
  * accumulator together with the new list.

--- a/src/mapAccumRight.js
+++ b/src/mapAccumRight.js
@@ -2,13 +2,13 @@ var _curry3 = require('./internal/_curry3');
 
 
 /**
- * The mapAccumRight function behaves like a combination of map and reduce; it
+ * The `mapAccumRight` function behaves like a combination of map and reduce; it
  * applies a function to each element of a list, passing an accumulating
  * parameter from right to left, and returning a final value of this
  * accumulator together with the new list.
  *
- * Similar to `mapAccum`, except moves through the input list from the right to
- * the left.
+ * Similar to [`mapAccum`](#mapAccum), except moves through the input list from
+ * the right to the left.
  *
  * The iterator function receives two arguments, *value* and *acc*, and should
  * return a tuple *[value, acc]*.

--- a/src/mapObjIndexed.js
+++ b/src/mapObjIndexed.js
@@ -4,9 +4,9 @@ var keys = require('./keys');
 
 
 /**
- * An Object-specific version of `map`. The function is applied to three
+ * An Object-specific version of [`map`](#map). The function is applied to three
  * arguments: *(value, key, obj)*. If only the value is significant, use
- * `map` instead.
+ * [`map`](#map) instead.
  *
  * @func
  * @memberOf R

--- a/src/mathMod.js
+++ b/src/mathMod.js
@@ -3,10 +3,10 @@ var _isInteger = require('./internal/_isInteger');
 
 
 /**
- * mathMod behaves like the modulo operator should mathematically, unlike the
- * `%` operator (and by extension, R.modulo). So while "-17 % 5" is -2,
- * mathMod(-17, 5) is 3. mathMod requires Integer arguments, and returns NaN
- * when the modulus is zero or negative.
+ * `mathMod` behaves like the modulo operator should mathematically, unlike the
+ * `%` operator (and by extension, [`R.modulo`](#modulo)). So while
+ * `-17 % 5` is `-2`, `mathMod(-17, 5)` is `3`. `mathMod` requires Integer
+ * arguments, and returns NaN when the modulus is zero or negative.
  *
  * @func
  * @memberOf R
@@ -16,6 +16,7 @@ var _isInteger = require('./internal/_isInteger');
  * @param {Number} m The dividend.
  * @param {Number} p the modulus.
  * @return {Number} The result of `b mod a`.
+ * @see R.modulo
  * @example
  *
  *      R.mathMod(-17, 5);  //=> 3

--- a/src/mean.js
+++ b/src/mean.js
@@ -12,6 +12,7 @@ var sum = require('./sum');
  * @sig [Number] -> Number
  * @param {Array} list
  * @return {Number}
+ * @see R.median
  * @example
  *
  *      R.mean([2, 7, 9]); //=> 6

--- a/src/median.js
+++ b/src/median.js
@@ -12,6 +12,7 @@ var mean = require('./mean');
  * @sig [Number] -> Number
  * @param {Array} list
  * @return {Number}
+ * @see R.mean
  * @example
  *
  *      R.median([2, 9, 7]); //=> 7

--- a/src/memoize.js
+++ b/src/memoize.js
@@ -16,6 +16,7 @@ var toString = require('./toString');
  * @sig (*... -> a) -> (*... -> a)
  * @param {Function} fn The function to memoize.
  * @return {Function} Memoized version of `fn`.
+ * @see R.memoizeWith
  * @example
  *
  *      let count = 0;

--- a/src/memoizeWith.js
+++ b/src/memoizeWith.js
@@ -4,10 +4,10 @@ var _has = require('./internal/_has');
 
 
 /**
- * A customisable version of R.memoize. memoizeWith takes an additional
- * function that will be applied to a given argument set and used to create
- * the cache key under which the results of the function to be memoized will
- * be stored. Care must be taken when implementing key generation to avoid
+ * A customisable version of [`R.memoize`](#memoize). `memoizeWith` takes an
+ * additional function that will be applied to a given argument set and used to
+ * create the cache key under which the results of the function to be memoized
+ * will be stored. Care must be taken when implementing key generation to avoid
  * clashes that may overwrite previous entries erroneously.
  *
  *

--- a/src/modulo.js
+++ b/src/modulo.js
@@ -4,7 +4,7 @@ var _curry2 = require('./internal/_curry2');
 /**
  * Divides the first parameter by the second and returns the remainder. Note
  * that this function preserves the JavaScript-style behavior for modulo. For
- * mathematical modulo see `mathMod`.
+ * mathematical modulo see [`mathMod`](#mathMod).
  *
  * @func
  * @memberOf R

--- a/src/o.js
+++ b/src/o.js
@@ -3,8 +3,9 @@ var _curry3 = require('./internal/_curry3');
 
 /**
  * `o` is a curried composition function that returns a unary function.
- * Like `compose`, `o` performs right-to-left function composition. Unlike `compose`,
- * the rightmost function passed to `o` will be invoked with only one argument.
+ * Like [`compose`](#compose), `o` performs right-to-left function composition.
+ * Unlike [`compose`](#compose), the rightmost function passed to `o` will be
+ * invoked with only one argument.
  *
  * @func
  * @memberOf R

--- a/src/pathEq.js
+++ b/src/pathEq.js
@@ -5,7 +5,7 @@ var path = require('./path');
 
 /**
  * Determines whether a nested path on an object has a specific value, in
- * `R.equals` terms. Most likely used to filter a list.
+ * [`R.equals`](#equals) terms. Most likely used to filter a list.
  *
  * @func
  * @memberOf R

--- a/src/propEq.js
+++ b/src/propEq.js
@@ -3,8 +3,8 @@ var equals = require('./equals');
 
 
 /**
- * Returns `true` if the specified object property is equal, in `R.equals`
- * terms, to the given value; `false` otherwise.
+ * Returns `true` if the specified object property is equal, in
+ * [`R.equals`](#equals) terms, to the given value; `false` otherwise.
  *
  * @func
  * @memberOf R

--- a/src/reduce.js
+++ b/src/reduce.js
@@ -8,9 +8,10 @@ var _reduce = require('./internal/_reduce');
  * value from the array, and then passing the result to the next call.
  *
  * The iterator function receives two values: *(acc, value)*. It may use
- * `R.reduced` to shortcut the iteration.
+ * [`R.reduced`](#reduced) to shortcut the iteration.
  *
- * The arguments' order of `reduceRight`'s iterator function is *(value, acc)*.
+ * The arguments' order of [`reduceRight`](#reduceRight)'s iterator function
+ * is *(value, acc)*.
  *
  * Note: `R.reduce` does not skip deleted or unassigned indices (sparse
  * arrays), unlike the native `Array.prototype.reduce` method. For more details
@@ -18,8 +19,8 @@ var _reduce = require('./internal/_reduce');
  * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/reduce#Description
  *
  * Dispatches to the `reduce` method of the third argument, if present. When
- * doing so, it is up to the user to handle the `R.reduced` shortcuting, as
- * this is not implemented by `reduce`.
+ * doing so, it is up to the user to handle the [`R.reduced`](#reduced)
+ * shortcuting, as this is not implemented by `reduce`.
  *
  * @func
  * @memberOf R

--- a/src/reduceBy.js
+++ b/src/reduceBy.js
@@ -10,7 +10,7 @@ var _xreduceBy = require('./internal/_xreduceBy');
  * the String-returning function `keyFn` on each element and reduces the elements
  * of each group to a single value via the reducer function `valueFn`.
  *
- * This function is basically a more general `groupBy` function.
+ * This function is basically a more general [`groupBy`](#groupBy) function.
  *
  * Acts as a transducer if a transformer is given in list position.
  *

--- a/src/reduceRight.js
+++ b/src/reduceRight.js
@@ -6,8 +6,8 @@ var _curry3 = require('./internal/_curry3');
  * the iterator function and passing it an accumulator value and the current
  * value from the array, and then passing the result to the next call.
  *
- * Similar to `reduce`, except moves through the input list from the right to
- * the left.
+ * Similar to [`reduce`](#reduce), except moves through the input list from the
+ * right to the left.
  *
  * The iterator function receives two values: *(value, acc)*, while the arguments'
  * order of `reduce`'s iterator function is *(acc, value)*.

--- a/src/reduceWhile.js
+++ b/src/reduceWhile.js
@@ -4,11 +4,11 @@ var _reduced = require('./internal/_reduced');
 
 
 /**
- * Like `reduce`, `reduceWhile` returns a single item by iterating through
- * the list, successively calling the iterator function. `reduceWhile` also
- * takes a predicate that is evaluated before each step. If the predicate returns
- * `false`, it "short-circuits" the iteration and returns the current value
- * of the accumulator.
+ * Like [`reduce`](#reduce), `reduceWhile` returns a single item by iterating
+ * through the list, successively calling the iterator function. `reduceWhile`
+ * also takes a predicate that is evaluated before each step. If the predicate
+ * returns `false`, it "short-circuits" the iteration and returns the current
+ * value of the accumulator.
  *
  * @func
  * @memberOf R

--- a/src/reduced.js
+++ b/src/reduced.js
@@ -7,7 +7,8 @@ var _reduced = require('./internal/_reduced');
  * box: the internal structure is not guaranteed to be stable.
  *
  * Note: this optimization is unavailable to functions not explicitly listed
- * above. For instance, it is not currently supported by reduceRight.
+ * above. For instance, it is not currently supported by
+ * [`reduceRight`](#reduceRight).
  *
  * @func
  * @memberOf R

--- a/src/reject.js
+++ b/src/reject.js
@@ -4,10 +4,11 @@ var filter = require('./filter');
 
 
 /**
- * The complement of `filter`.
+ * The complement of [`filter`](#filter).
  *
- * Acts as a transducer if a transformer is given in list position. Filterable objects include plain objects or any object
- * that has a filter method such as `Array`.
+ * Acts as a transducer if a transformer is given in list position. Filterable
+ * objects include plain objects or any object that has a filter method such
+ * as `Array`.
  *
  * @func
  * @memberOf R

--- a/src/scan.js
+++ b/src/scan.js
@@ -2,8 +2,8 @@ var _curry3 = require('./internal/_curry3');
 
 
 /**
- * Scan is similar to reduce, but returns a list of successively reduced values
- * from the left
+ * Scan is similar to [`reduce`](#reduce), but returns a list of successively
+ * reduced values from the left
  *
  * @func
  * @memberOf R
@@ -15,6 +15,7 @@ var _curry3 = require('./internal/_curry3');
  * @param {*} acc The accumulator value.
  * @param {Array} list The list to iterate over.
  * @return {Array} A list of all intermediately reduced values.
+ * @see R.reduce
  * @example
  *
  *      var numbers = [1, 2, 3, 4];

--- a/src/transduce.js
+++ b/src/transduce.js
@@ -12,7 +12,7 @@ var curryN = require('./curryN');
  * The iterator function receives two values: *(acc, value)*. It will be
  * wrapped as a transformer to initialize the transducer. A transformer can be
  * passed directly in place of an iterator function. In both cases, iteration
- * may be stopped early with the `R.reduced` function.
+ * may be stopped early with the [`R.reduced`](#reduced) function.
  *
  * A transducer is a function that accepts a transformer and returns a
  * transformer and can be composed directly.
@@ -21,11 +21,11 @@ var curryN = require('./curryN');
  * function, step, 0-arity initial value function, init, and 1-arity result
  * extraction function, result. The step function is used as the iterator
  * function in reduce. The result function is used to convert the final
- * accumulator into the return type and in most cases is R.identity. The init
- * function can be used to provide an initial accumulator, but is ignored by
- * transduce.
+ * accumulator into the return type and in most cases is
+ * [`R.identity`](#identity). The init function can be used to provide an
+ * initial accumulator, but is ignored by transduce.
  *
- * The iteration is performed with R.reduce after initializing the transducer.
+ * The iteration is performed with [`R.reduce`](#reduce) after initializing the transducer.
  *
  * @func
  * @memberOf R

--- a/src/unapply.js
+++ b/src/unapply.js
@@ -9,8 +9,8 @@ var _curry1 = require('./internal/_curry1');
  *   - passes these arguments to `fn` as an array; and
  *   - returns the result.
  *
- * In other words, R.unapply derives a variadic function from a function which
- * takes an array. R.unapply is the inverse of R.apply.
+ * In other words, `R.unapply` derives a variadic function from a function which
+ * takes an array. `R.unapply` is the inverse of [`R.apply`](#apply).
  *
  * @func
  * @memberOf R

--- a/src/uniq.js
+++ b/src/uniq.js
@@ -4,7 +4,7 @@ var uniqBy = require('./uniqBy');
 
 /**
  * Returns a new list containing only one copy of each element in the original
- * list. `R.equals` is used to determine equality.
+ * list. [`R.equals`](#equals) is used to determine equality.
  *
  * @func
  * @memberOf R

--- a/src/uniqBy.js
+++ b/src/uniqBy.js
@@ -6,7 +6,7 @@ var _curry2 = require('./internal/_curry2');
  * Returns a new list containing only one copy of each element in the original
  * list, based upon the value returned by applying the supplied function to
  * each list element. Prefers the first item if the supplied function produces
- * the same value on two items. `R.equals` is used for comparison.
+ * the same value on two items. [`R.equals`](#equals) is used for comparison.
  *
  * @func
  * @memberOf R

--- a/src/values.js
+++ b/src/values.js
@@ -14,6 +14,7 @@ var keys = require('./keys');
  * @sig {k: v} -> [v]
  * @param {Object} obj The object to extract values from
  * @return {Array} An array of the values of the object's own properties.
+ * @see R.valuesIn, R.keys
  * @example
  *
  *      R.values({a: 1, b: 2, c: 3}); //=> [1, 2, 3]

--- a/src/valuesIn.js
+++ b/src/valuesIn.js
@@ -14,6 +14,7 @@ var _curry1 = require('./internal/_curry1');
  * @sig {k: v} -> [v]
  * @param {Object} obj The object to extract values from
  * @return {Array} An array of the values of the object's own and prototype properties.
+ * @see R.values, R.keysIn
  * @example
  *
  *      var F = function() { this.x = 'X'; };

--- a/src/where.js
+++ b/src/where.js
@@ -10,7 +10,7 @@ var _has = require('./internal/_has');
  * otherwise.
  *
  * `where` is well suited to declaratively expressing constraints for other
- * functions such as `filter` and `find`.
+ * functions such as [`filter`](#filter) and [`find`](#find).
  *
  * @func
  * @memberOf R

--- a/src/whereEq.js
+++ b/src/whereEq.js
@@ -8,7 +8,8 @@ var where = require('./where');
  * Takes a spec object and a test object; returns true if the test satisfies
  * the spec, false otherwise. An object satisfies the spec if, for each of the
  * spec's own properties, accessing that property of the object gives the same
- * value (in `R.equals` terms) as accessing that property of the spec.
+ * value (in [`R.equals`](#equals) terms) as accessing that property of the
+ * spec.
  *
  * `whereEq` is a specialization of [`where`](#where).
  *

--- a/src/without.js
+++ b/src/without.js
@@ -6,7 +6,7 @@ var reject = require('./reject');
 
 /**
  * Returns a new list without values in the first argument.
- * `R.equals` is used to determine equality.
+ * [`R.equals`](#equals) is used to determine equality.
  *
  * Acts as a transducer if a transformer is given in list position.
  *


### PR DESCRIPTION
Hello.

Quite often while reading the online docs I feel frustrated because in function descriptions, sometimes function names are clickable, and sometimes they are not.
To ease the navigation and discoverability of related functions, I added the missing links between functions, following what had already been done for a few of them.

So, in this PR:
- no wordings was changed, just added links
- I built the docs on my local machine to try to click on each of them and trap eventual typos.

Potential fixes for a future PR: light inconsistency between Ramda's function starting with a `R.`prefix  and sometimes not.