### PR TITLE
Fix confusing usage of R.__ in the docs of .where

### DIFF
--- a/src/where.js
+++ b/src/where.js
@@ -26,8 +26,8 @@ var _has = require('./internal/_has');
  *      var pred = R.where({
  *        a: R.equals('foo'),
  *        b: R.complement(R.equals('bar')),
- *        x: R.gt(__, 10),
- *        y: R.lt(__, 20)
+ *        x: R.gt(R.__, 10),
+ *        y: R.lt(R.__, 20)
  *      });
  *
  *      pred({a: 'foo', b: 'xxx', x: 11, y: 19}); //=> true


### PR DESCRIPTION
Fixes the issue at https://github.com/ramda/ramda.github.io/issues/177.

Make `__` => `R.__`.