### PR TITLE
Add lazy evaluation example for R.transduce

### DIFF
--- a/src/transduce.js
+++ b/src/transduce.js
@@ -44,8 +44,11 @@ var curryN = require('./curryN');
  *
  *      var numbers = [1, 2, 3, 4];
  *      var transducer = R.compose(R.map(R.add(1)), R.take(2));
- *
  *      R.transduce(transducer, R.flip(R.append), [], numbers); //=> [2, 3]
+ *
+ *      var isOdd = (x) => x % 2 === 1;
+ *      var firstOddTransducer = R.compose(R.filter(isOdd), R.take(1));
+ *      R.transduce(firstOddTransducer, R.flip(R.append), [], R.range(0, 100)); //=> [1]
  */
 module.exports = curryN(4, function transduce(xf, fn, acc, list) {
   return _reduce(xf(typeof fn === 'function' ? _xwrap(fn) : fn), acc, list);

--- a/test/transduce.js
+++ b/test/transduce.js
@@ -38,6 +38,7 @@ describe('transduce', function() {
     eq(R.transduce(R.map(add(1)), R.flip(R.append), [], [1, 2, 3, 4]), [2, 3, 4, 5]);
     eq(R.transduce(R.filter(isOdd), R.flip(R.append), [],  [1, 2, 3, 4]), [1, 3]);
     eq(R.transduce(R.compose(R.map(add(1)), R.take(2)), R.flip(R.append), [],  [1, 2, 3, 4]), [2, 3]);
+    eq(R.transduce(R.compose(R.filter(isOdd), R.take(1)), R.flip(R.append), [],  [1, 2, 3, 4]), [1]);
   });
 
   it('transduces into strings', function() {


### PR DESCRIPTION
transducer is made for lazy evaluation. This is a power feature. I'd like to highlight it in the document. 

In order to do lazy evaluation with `R.transcue`, we could compose with functions that return `R.reduced` in the transducer for termination, such as `R.take`. But what's important is that the execution order of the composed functions is from left to right, which is the opposite order when calling the transducer directly. 

For instance
```
var numbers = [1, 2, 3, 4];
var transducer = R.compose(R.map(R.add(1)), R.take(2));
```
If I call the `transducer` directly like this `transducer(numbers)`, then `R.take(2)` will be executed first, then `R.map(R.add(1))` , which is "right to left" order
If I call the `transducer` with `R.transduce` like this:
```
R.transduce(transducer, R.flip(R.append), [], numbers); //=> [2, 3]
```
then `R.map(R.add(1))` will be executed first, `R.take(2)` next, which is "left to right" order.

However since `map f . take x == take x . map f`, regardless "left to right" or "right to left" order, they both yield to the same result. 

The current document uses this as the example, I think it's not clear enough for reader to notice the execution order of the composed transducers, as well as the lazy evaluation feature.

In this PR, I'm trying to make it more clear by adding one more example so that the reader will see transducers are exeucted from left to right. That is, `R.filter(isOdd)` will be executed first, then `R.take(1)` will terminate before traversing to the end of the array. The other way round won't make sense.

Please review. Thanks!