### PR TITLE
Test ap with fantasy-land and use consistent ordering of combination

### DIFF
--- a/src/ap.js
+++ b/src/ap.js
@@ -27,8 +27,10 @@ var map = require('./map');
  */
 module.exports = _curry2(function ap(applyF, applyX) {
   return (
-    typeof applyX['fantasy-land/ap'] === 'function' ?
-      applyX['fantasy-land/ap'](applyF) :
+    typeof applyF['fantasy-land/ap'] === 'function' ?
+      applyF['fantasy-land/ap'](map(
+        function (x) { return function (f) { return f(x); }; }, applyX)
+      ) :
     typeof applyF.ap === 'function' ?
       applyF.ap(applyX) :
     typeof applyF === 'function' ?


### PR DESCRIPTION
This PR is assuming that fantasy-land's `ap` is supposed to be like Haskell's `(<**>) :: Applicative f => f a -> f (a -> b) -> f b`, and not like `flip (<*>) :: Applicative f => f a -> f (a -> b) -> f b` (which is how Ramda currently treats it).

My test case attempts to show the difference by using `Either`.  The important case is the first one:

```javascript
eq(R.ap(leftFn, leftVal).simple(), leftFn.simple());

// i.e: forall e x. R.ap(Left(e), x) = Left(e)
```