### PR TITLE
Transducer doc was fixed

### DIFF
--- a/src/transduce.js
+++ b/src/transduce.js
@@ -31,7 +31,7 @@ var curryN = require('./curryN');
  * @memberOf R
  * @since v0.12.0
  * @category List
- * @sig (c -> c) -> (a,b -> a) -> a -> [b] -> a
+ * @sig (c -> c) -> ((a, b) -> a) -> a -> [b] -> a
  * @param {Function} xf The transducer function. Receives a transformer and returns a transformer.
  * @param {Function} fn The iterator function. Receives two values, the accumulator and the
  *        current element from the array. Wrapped as transformer, if necessary, and used to


### PR DESCRIPTION
Hello! Thanks for great library.

When I read the documentation I have found one mistake which confused me. It relative with a transducer signature. Documentation says that signature of the [transducer](http://ramdajs.com/docs/#transduce) looks like `(c → c) → (a,b → a) → a → [b] → a` but below the doc says
> The iteration is performed with R.reduce after initializing the transducer.

I think that signature of the transducer should be looks like `(c → c) → ((a, b) → a) → a → [b] → a`.