### PR TITLE
Improve performance of omit

### DIFF
--- a/src/omit.js
+++ b/src/omit.js
@@ -1,4 +1,6 @@
-var _contains = require('./internal/_contains');
+var indexBy = require('./indexBy');
+var _identity = require('./internal/_identity');
+var _has = require('./internal/_has');
 var _curry2 = require('./internal/_curry2');
 
 
@@ -20,8 +22,10 @@ var _curry2 = require('./internal/_curry2');
  */
 module.exports = _curry2(function omit(names, obj) {
   var result = {};
+  var index = indexBy(_identity, names);
+
   for (var prop in obj) {
-    if (!_contains(prop, names)) {
+    if (!_has(prop, index)) {
       result[prop] = obj[prop];
     }
   }

--- a/test/indexBy.js
+++ b/test/indexBy.js
@@ -28,7 +28,7 @@ describe('indexBy', function() {
       R.indexBy(R.prop('id')),
       R.map(R.pipe(
         R.adjust(R.toUpper, 0),
-        R.adjust(R.omit('id'), 1)
+        R.adjust(R.omit(['id']), 1)
       )));
     var result = R.into({}, transducer, list);
     eq(result, {ABC: {title: 'B'}, XYZ: {title: 'A'}});


### PR DESCRIPTION
Rather than iterating the names to omit for every single property name,
which is potentially O(n*m) complexity, create a map prior to iterating
the source object, which we can then look up in O(1) time for each
property name.

This makes the omit function O(n+m) rather than O(n*m).

---

Maybe consider documenting the time complexity of functions like this, because anything over a couple of items in the names list, and it can get really slow.

The previous implementation is generally OK if you have hardcoded a bunch of things to omit (e.g. `omit(['id'], obj)`) but if you use this for something like excluding items from a set by id (e.g. `omit(dynamicListOfIds, fetchedData)` it can get really, really slow. Like blocking execution for seconds at a time slow.

---

Oh, and I also fixed the usage of omit in the `indexyBy` tests. It was passing the thing to omit as a string not an array, which according to the docs is not supported. It was working in the tests for whatever reason, so this might be considered a breaking change, even though it wasn't supposed to work that way in the past.