### PR TITLE
Improve performance of omit

### DIFF
--- a/src/omit.js
+++ b/src/omit.js
@@ -1,6 +1,4 @@
-var _contains = require('./internal/_contains');
 var _curry2 = require('./internal/_curry2');
-
 
 /**
  * Returns a partial copy of an object omitting the keys specified.
@@ -20,8 +18,17 @@ var _curry2 = require('./internal/_curry2');
  */
 module.exports = _curry2(function omit(names, obj) {
   var result = {};
+  var index = {};
+  var idx = 0;
+  var len = names.length;
+
+  while (idx < len) {
+    index[names[idx]] = 1;
+    idx += 1;
+  }
+
   for (var prop in obj) {
-    if (!_contains(prop, names)) {
+    if (!index.hasOwnProperty(prop)) {
       result[prop] = obj[prop];
     }
   }

--- a/test/indexBy.js
+++ b/test/indexBy.js
@@ -28,7 +28,7 @@ describe('indexBy', function() {
       R.indexBy(R.prop('id')),
       R.map(R.pipe(
         R.adjust(R.toUpper, 0),
-        R.adjust(R.omit('id'), 1)
+        R.adjust(R.omit(['id']), 1)
       )));
     var result = R.into({}, transducer, list);
     eq(result, {ABC: {title: 'B'}, XYZ: {title: 'A'}});


### PR DESCRIPTION
Rather than iterating the names to omit for every single property name,
which is potentially O(n*m) complexity, create a map prior to iterating
the source object, which we can then look up in O(1) time for each
property name.

This makes the omit function O(n+m) rather than O(n*m).

---

Resubmitted from #2192