### PR TITLE
chore(fix): translations markup in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,8 +182,8 @@ tests completely headlessly.
 Translations
 -----------------
 
-[Chinese(中文)](http://ramda.cn/)
-[Ukrainian(Українська)](https://github.com/ivanzusko/ramda)
+- [Chinese(中文)](http://ramda.cn/)
+- [Ukrainian(Українська)](https://github.com/ivanzusko/ramda)
 
 
 Acknowledgements


### PR DESCRIPTION
I'm really sorry about didn't think about markup from very beginnig...

Now markup is like this:
![image](https://user-images.githubusercontent.com/8372070/27158818-ab110178-5171-11e7-9904-26077db65b1e.png)

But I should to deal it like this:
![image](https://user-images.githubusercontent.com/8372070/27158830-b762e428-5171-11e7-89bd-f46bdd2006ad.png)

I think the last variant is slightly better...
Sorry for disturbing :disappointed: 