### PR TITLE
Fix to constructN docs example

### DIFF
--- a/src/constructN.js
+++ b/src/constructN.js
@@ -24,7 +24,7 @@ var nAry = require('./nAry');
  *      };
  *      Salad.prototype.recipe = function() {
  *        var instructions = R.map((ingredient) => (
- *          'Add a whollop of ' + ingredient, this.ingredients)
+ *          'Add a whollop of ' + ingredient), this.ingredients
  *        )
  *        return R.join('\n', instructions)
  *      }

--- a/src/constructN.js
+++ b/src/constructN.js
@@ -24,7 +24,7 @@ var nAry = require('./nAry');
  *      }
  *
  *      Salad.prototype.recipe = function() {
- *        var instructions = R.map((ingredient) => 'Add a dollop of ' + ingredient, this.ingredients);
+ *        var instructions = R.map(ingredient => 'Add a dollop of ' + ingredient, this.ingredients);
  *        return R.join('\n', instructions);
  *      };
  *

--- a/src/constructN.js
+++ b/src/constructN.js
@@ -21,16 +21,18 @@ var nAry = require('./nAry');
  *      // Variadic Constructor function
  *      function Salad() {
  *        this.ingredients = arguments;
- *      };
- *      Salad.prototype.recipe = function() {
- *        var instructions = R.map((ingredient) => 'Add a dollop of ' + ingredient, this.ingredients)
- *        return R.join('\n', instructions)
  *      }
  *
- *      var ThreeLayerSalad = R.constructN(3, Salad)
+ *      Salad.prototype.recipe = function() {
+ *        var instructions = R.map((ingredient) => 'Add a dollop of ' + ingredient, this.ingredients);
+ *        return R.join('\n', instructions);
+ *      };
+ *
+ *      var ThreeLayerSalad = R.constructN(3, Salad);
  *
  *      // Notice we no longer need the 'new' keyword, and the constructor is curried for 3 arguments.
- *      var salad = ThreeLayerSalad('Mayonnaise')('Potato Chips')('Ketchup')
+ *      var salad = ThreeLayerSalad('Mayonnaise')('Potato Chips')('Ketchup');
+ *
  *      console.log(salad.recipe());
  *      // Add a dollop of Mayonnaise
  *      // Add a dollop of Potato Chips

--- a/src/constructN.js
+++ b/src/constructN.js
@@ -23,9 +23,7 @@ var nAry = require('./nAry');
  *        this.ingredients = arguments;
  *      };
  *      Salad.prototype.recipe = function() {
- *        var instructions = R.map((ingredient) => (
- *          'Add a whollop of ' + ingredient), this.ingredients
- *        )
+ *        var instructions = R.map((ingredient) => 'Add a dollop of ' + ingredient, this.ingredients)
  *        return R.join('\n', instructions)
  *      }
  *
@@ -34,9 +32,9 @@ var nAry = require('./nAry');
  *      // Notice we no longer need the 'new' keyword, and the constructor is curried for 3 arguments.
  *      var salad = ThreeLayerSalad('Mayonnaise')('Potato Chips')('Ketchup')
  *      console.log(salad.recipe());
- *      // Add a whollop of Mayonnaise
- *      // Add a whollop of Potato Chips
- *      // Add a whollop of Potato Ketchup
+ *      // Add a dollop of Mayonnaise
+ *      // Add a dollop of Potato Chips
+ *      // Add a dollop of Potato Ketchup
  */
 module.exports = _curry2(function constructN(n, Fn) {
   if (n > 10) {

--- a/src/constructN.js
+++ b/src/constructN.js
@@ -36,7 +36,7 @@ var nAry = require('./nAry');
  *      console.log(salad.recipe());
  *      // Add a dollop of Mayonnaise
  *      // Add a dollop of Potato Chips
- *      // Add a dollop of Potato Ketchup
+ *      // Add a dollop of Ketchup
  */
 module.exports = _curry2(function constructN(n, Fn) {
   if (n > 10) {


### PR DESCRIPTION
For the moment docs example for the constructN function 
```
// Variadic Constructor function
function Salad() {
  this.ingredients = arguments;
};
Salad.prototype.recipe = function() {
  var instructions = R.map((ingredient) => (
    'Add a whollop of ' + ingredient, this.ingredients)
  )
  return R.join('\n', instructions)
}

var ThreeLayerSalad = R.constructN(3, Salad)

// Notice we no longer need the 'new' keyword, and the constructor is curried for 3 arguments.
var salad = ThreeLayerSalad('Mayonnaise')('Potato Chips')('Ketchup')
console.log(salad.recipe());
// Add a whollop of Mayonnaise
// Add a whollop of Potato Chips
// Add a whollop of Potato Ketchup
```
produces following result in [REPL](http://ramdajs.com/repl/?v=0.24.1#;%2F%2F%20Variadic%20Constructor%20function%0Afunction%20Salad%28%29%20%7B%0A%20%20this.ingredients%20%3D%20arguments%3B%0A%7D%3B%0ASalad.prototype.recipe%20%3D%20function%28%29%20%7B%0A%20%20var%20instructions%20%3D%20R.map%28%28ingredient%29%20%3D%3E%20%28%0A%20%20%20%20%27Add%20a%20whollop%20of%20%27%20%2B%20ingredient%2C%20this.ingredients%29%0A%20%20%29%0A%20%20return%20R.join%28%27%5Cn%27%2C%20instructions%29%0A%7D%0A%0Avar%20ThreeLayerSalad%20%3D%20R.constructN%283%2C%20Salad%29%0A%0A%2F%2F%20Notice%20we%20no%20longer%20need%20the%20%27new%27%20keyword%2C%20and%20the%20constructor%20is%20curried%20for%203%20arguments.%0Avar%20salad%20%3D%20ThreeLayerSalad%28%27Mayonnaise%27%29%28%27Potato%20Chips%27%29%28%27Ketchup%27%29%0Aconsole.log%28salad.recipe%28%29%29%3B%0A%2F%2F%20Add%20a%20whollop%20of%20Mayonnaise%0A%2F%2F%20Add%20a%20whollop%20of%20Potato%20Chips%0A%2F%2F%20Add%20a%20whollop%20of%20Potato%20Ketchup)
> function n(r){return NaN|b(r)?n:t.apply(this,arguments)} does not have a method named "join"

This PR fixes wrong parenthesis placement for R.map call