### PR TITLE
updated type sigs for function parameters

### DIFF
--- a/src/comparator.js
+++ b/src/comparator.js
@@ -9,7 +9,7 @@ var _curry1 = require('./internal/_curry1');
  * @memberOf R
  * @since v0.1.0
  * @category Function
- * @sig (a, b -> Boolean) -> (a, b -> Number)
+ * @sig ((a, b) -> Boolean) -> ((a, b) -> Number)
  * @param {Function} pred A predicate function of arity two which will return `true` if the first argument
  * is less than the second, `false` otherwise
  * @return {Function} A Function :: a -> b -> Int that returns `-1` if a < b, `1` if b < a, otherwise `0`

--- a/src/converge.js
+++ b/src/converge.js
@@ -17,7 +17,7 @@ var reduce = require('./reduce');
  * @memberOf R
  * @since v0.4.2
  * @category Function
- * @sig (x1 -> x2 -> ... -> z) -> [(a -> b -> ... -> x1), (a -> b -> ... -> x2), ...] -> (a -> b -> ... -> z)
+ * @sig ((x1, x2, ...) -> z) -> [((a, b, ...) -> x1), ((a, b, ...) -> x2), ...] -> (a -> b -> ... -> z)
  * @param {Function} after A function. `after` will be invoked with the return values of
  *        `fn1` and `fn2` as its arguments.
  * @param {Array} functions A list of functions.

--- a/src/dropRepeatsWith.js
+++ b/src/dropRepeatsWith.js
@@ -15,7 +15,7 @@ var last = require('./last');
  * @memberOf R
  * @since v0.14.0
  * @category List
- * @sig (a, a -> Boolean) -> [a] -> [a]
+ * @sig ((a, a) -> Boolean) -> [a] -> [a]
  * @param {Function} pred A predicate used to test whether two items are equal.
  * @param {Array} list The array to consider.
  * @return {Array} `list` without repeating elements.
@@ -40,4 +40,3 @@ module.exports = _curry2(_dispatchable([], _xdropRepeatsWith, function dropRepea
   }
   return result;
 }));
-

--- a/src/flip.js
+++ b/src/flip.js
@@ -10,7 +10,7 @@ var curry = require('./curry');
  * @memberOf R
  * @since v0.1.0
  * @category Function
- * @sig (a -> b -> c -> ... -> z) -> (b -> a -> c -> ... -> z)
+ * @sig ((a, b, c, ...) -> z) -> (b -> a -> c -> ... -> z)
  * @param {Function} fn The function to invoke with its first two parameters reversed.
  * @return {*} The result of invoking `fn` with its first two parameters' order reversed.
  * @example

--- a/src/innerJoin.js
+++ b/src/innerJoin.js
@@ -19,7 +19,7 @@ var _filter = require('./internal/_filter');
  * @memberOf R
  * @since v0.24.0
  * @category Relation
- * @sig (a -> b -> Boolean) -> [a] -> [b] -> [a]
+ * @sig ((a, b) -> Boolean) -> [a] -> [b] -> [a]
  * @param {Function} pred
  * @param {Array} xs
  * @param {Array} ys

--- a/src/mapAccum.js
+++ b/src/mapAccum.js
@@ -14,7 +14,7 @@ var _curry3 = require('./internal/_curry3');
  * @memberOf R
  * @since v0.10.0
  * @category List
- * @sig (acc -> x -> (acc, y)) -> acc -> [x] -> (acc, [y])
+ * @sig ((acc, x) -> (acc, y)) -> acc -> [x] -> (acc, [y])
  * @param {Function} fn The function to be called on every element of the input `list`.
  * @param {*} acc The accumulator value.
  * @param {Array} list The list to iterate over.

--- a/src/mapAccumRight.js
+++ b/src/mapAccumRight.js
@@ -17,7 +17,7 @@ var _curry3 = require('./internal/_curry3');
  * @memberOf R
  * @since v0.10.0
  * @category List
- * @sig (x-> acc -> (y, acc)) -> acc -> [x] -> ([y], acc)
+ * @sig ((x, acc) -> (y, acc)) -> acc -> [x] -> ([y], acc)
  * @param {Function} fn The function to be called on every element of the input `list`.
  * @param {*} acc The accumulator value.
  * @param {Array} list The list to iterate over.

--- a/src/mergeDeepWith.js
+++ b/src/mergeDeepWith.js
@@ -16,7 +16,7 @@ var mergeDeepWithKey = require('./mergeDeepWithKey');
  * @memberOf R
  * @since v0.24.0
  * @category Object
- * @sig (a -> a -> a) -> {a} -> {a} -> {a}
+ * @sig ((a, a) -> a) -> {a} -> {a} -> {a}
  * @param {Function} fn
  * @param {Object} lObj
  * @param {Object} rObj

--- a/src/mergeDeepWithKey.js
+++ b/src/mergeDeepWithKey.js
@@ -17,7 +17,7 @@ var mergeWithKey = require('./mergeWithKey');
  * @memberOf R
  * @since v0.24.0
  * @category Object
- * @sig (String -> a -> a -> a) -> {a} -> {a} -> {a}
+ * @sig ((String, a, a) -> a) -> {a} -> {a} -> {a}
  * @param {Function} fn
  * @param {Object} lObj
  * @param {Object} rObj

--- a/src/mergeWith.js
+++ b/src/mergeWith.js
@@ -12,7 +12,7 @@ var mergeWithKey = require('./mergeWithKey');
  * @memberOf R
  * @since v0.19.0
  * @category Object
- * @sig (a -> a -> a) -> {a} -> {a} -> {a}
+ * @sig ((a, a) -> a) -> {a} -> {a} -> {a}
  * @param {Function} fn
  * @param {Object} l
  * @param {Object} r

--- a/src/mergeWithKey.js
+++ b/src/mergeWithKey.js
@@ -12,7 +12,7 @@ var _has = require('./internal/_has');
  * @memberOf R
  * @since v0.19.0
  * @category Object
- * @sig (String -> a -> a -> a) -> {a} -> {a} -> {a}
+ * @sig ((String, a, a) -> a) -> {a} -> {a} -> {a}
  * @param {Function} fn
  * @param {Object} l
  * @param {Object} r

--- a/src/pickBy.js
+++ b/src/pickBy.js
@@ -9,7 +9,7 @@ var _curry2 = require('./internal/_curry2');
  * @memberOf R
  * @since v0.8.0
  * @category Object
- * @sig (v, k -> Boolean) -> {k: v} -> {k: v}
+ * @sig ((v, k) -> Boolean) -> {k: v} -> {k: v}
  * @param {Function} pred A predicate to determine whether or not a key
  *        should be included on the output object.
  * @param {Object} obj The object to copy from

--- a/src/reduceRight.js
+++ b/src/reduceRight.js
@@ -21,7 +21,7 @@ var _curry3 = require('./internal/_curry3');
  * @memberOf R
  * @since v0.1.0
  * @category List
- * @sig (a, b -> b) -> b -> [a] -> b
+ * @sig ((a, b) -> b) -> b -> [a] -> b
  * @param {Function} fn The iterator function. Receives two values, the current element from the array
  *        and the accumulator.
  * @param {*} acc The accumulator value.

--- a/src/sort.js
+++ b/src/sort.js
@@ -12,7 +12,7 @@ var _curry2 = require('./internal/_curry2');
  * @memberOf R
  * @since v0.1.0
  * @category List
- * @sig (a,a -> Number) -> [a] -> [a]
+ * @sig ((a, a) -> Number) -> [a] -> [a]
  * @param {Function} comparator A sorting function :: a -> b -> Int
  * @param {Array} list The list to sort
  * @return {Array} a new array with its elements sorted by the comparator function.

--- a/src/sortWith.js
+++ b/src/sortWith.js
@@ -8,7 +8,7 @@ var _curry2 = require('./internal/_curry2');
  * @memberOf R
  * @since v0.23.0
  * @category Relation
- * @sig [a -> a -> Number] -> [a] -> [a]
+ * @sig [(a, a) -> Number] -> [a] -> [a]
  * @param {Array} functions A list of comparator functions.
  * @param {Array} list The list to sort.
  * @return {Array} A new list sorted according to the comarator functions.

--- a/src/unionWith.js
+++ b/src/unionWith.js
@@ -12,7 +12,7 @@ var uniqWith = require('./uniqWith');
  * @memberOf R
  * @since v0.1.0
  * @category Relation
- * @sig (a -> a -> Boolean) -> [*] -> [*] -> [*]
+ * @sig ((a, a) -> Boolean) -> [*] -> [*] -> [*]
  * @param {Function} pred A predicate used to test whether two items are equal.
  * @param {Array} list1 The first list.
  * @param {Array} list2 The second list.

--- a/src/uniqWith.js
+++ b/src/uniqWith.js
@@ -12,7 +12,7 @@ var _curry2 = require('./internal/_curry2');
  * @memberOf R
  * @since v0.2.0
  * @category List
- * @sig (a, a -> Boolean) -> [a] -> [a]
+ * @sig ((a, a) -> Boolean) -> [a] -> [a]
  * @param {Function} pred A predicate used to test whether two items are equal.
  * @param {Array} list The array to consider.
  * @return {Array} The list of unique items.

--- a/src/useWith.js
+++ b/src/useWith.js
@@ -18,7 +18,7 @@ var curryN = require('./curryN');
  * @memberOf R
  * @since v0.1.0
  * @category Function
- * @sig (x1 -> x2 -> ... -> z) -> [(a -> x1), (b -> x2), ...] -> (a -> b -> ... -> z)
+ * @sig ((x1, x2, ...) -> z) -> [(a -> x1), (b -> x2), ...] -> (a -> b -> ... -> z)
  * @param {Function} fn The function to wrap.
  * @param {Array} transformers A list of transformer functions
  * @return {Function} The wrapped function.

--- a/src/zipWith.js
+++ b/src/zipWith.js
@@ -10,7 +10,7 @@ var _curry3 = require('./internal/_curry3');
  * @memberOf R
  * @since v0.1.0
  * @category List
- * @sig (a,b -> c) -> [a] -> [b] -> [c]
+ * @sig ((a, b) -> c) -> [a] -> [b] -> [c]
  * @param {Function} fn The function used to combine the two elements into one value.
  * @param {Array} list1 The first array to consider.
  * @param {Array} list2 The second array to consider.


### PR DESCRIPTION
I've updated the type signatures so as not to imply that certain functions take curried functions when they don't. I've also tried to normalize the spacing and paren placement on functions with 2+ arity functions parameters.