### PR TITLE
Fix composeK, pipeK descriptions.

### DIFF
--- a/src/composeK.js
+++ b/src/composeK.js
@@ -7,7 +7,7 @@ var map = require('./map');
  * Returns the right-to-left Kleisli composition of the provided functions,
  * each of which must return a value of a type supported by [`chain`](#chain).
  *
- * `R.composeK(h, g, f)` is equivalent to `R.compose(R.chain(h), R.chain(g), R.chain(f))`.
+ * `R.composeK(h, g, f)` is equivalent to `R.compose(R.chain(h), R.chain(g), f)`.
  *
  * @func
  * @memberOf R

--- a/src/pipeK.js
+++ b/src/pipeK.js
@@ -5,7 +5,7 @@ var reverse = require('./reverse');
  * Returns the left-to-right Kleisli composition of the provided functions,
  * each of which must return a value of a type supported by [`chain`](#chain).
  *
- * `R.pipeK(f, g, h)` is equivalent to `R.pipe(R.chain(f), R.chain(g), R.chain(h))`.
+ * `R.pipeK(f, g, h)` is equivalent to `R.pipe(f, R.chain(g), R.chain(h))`.
  *
  * @func
  * @memberOf R


### PR DESCRIPTION
From the docs:

> R.pipeK(f, g, h) is equivalent to R.pipe(R.chain(f), R.chain(g), R.chain(h))

> R.composeK(h, g, f) is equivalent to R.compose(R.chain(h), R.chain(g), R.chain(f))

That's not actually true, as the first function to be applied (`f`) is not `chain`'ed (see [composeK.js:42](https://github.com/ramda/ramda/blob/v0.24.1/src/composeK.js#L42)). The docs should rather state:

> R.pipeK(f, g, h) is equivalent to R.pipe(f, R.chain(g), R.chain(h))

> R.composeK(h, g, f) is equivalent to R.compose(R.chain(h), R.chain(g), f)