### PR TITLE
Make "Maybe" Traversable and fix sequence

### DIFF
--- a/src/sequence.js
+++ b/src/sequence.js
@@ -1,5 +1,6 @@
 var _curry2 = require('./internal/_curry2');
 var ap = require('./ap');
+var identity = require('./identity');
 var map = require('./map');
 var prepend = require('./prepend');
 var reduceRight = require('./reduceRight');
@@ -30,8 +31,12 @@ var reduceRight = require('./reduceRight');
  *      R.sequence(R.of, Nothing());       //=> [Nothing()]
  */
 module.exports = _curry2(function sequence(of, traversable) {
-  return typeof traversable.sequence === 'function' ?
-    traversable.sequence(of) :
+  if (typeof traversable.sequence === 'function') {
+    return traversable.sequence(of);
+  }
+
+  return typeof traversable['fantasy-land/traverse'] === 'function' ?
+    traversable['fantasy-land/traverse'](of, identity) :
     reduceRight(function(x, acc) { return ap(map(prepend, x), acc); },
                 of([]),
                 traversable);

--- a/test/sequence.js
+++ b/test/sequence.js
@@ -2,6 +2,8 @@ var S = require('sanctuary');
 
 var R = require('..');
 var Id = require('./shared/Id');
+var Just = require('./shared/Maybe').Just;
+var Nothing = require('./shared/Maybe').Nothing;
 var eq = require('./shared/eq');
 
 
@@ -33,4 +35,9 @@ describe('sequence', function() {
     eq(R.sequence(R.of, Id([1, 2, 3])), [Id(1), Id(2), Id(3)]);
   });
 
+  it('should use `traverse` if it exists', function() {
+    eq(R.sequence(Just, [Just(1), Just(2), Just(3)]), Just([1, 2, 3]));
+    eq(R.sequence(R.of, Just([1, 2, 3])), [Just(1), Just(2), Just(3)]);
+    eq(R.sequence(R.of, Nothing), [Nothing]);
+  });
 });

--- a/test/shared/Maybe.js
+++ b/test/shared/Maybe.js
@@ -49,12 +49,12 @@ Maybe.prototype['fantasy-land/chain'] = function(f) {
   return this.isJust ? f(this.value) : Nothing;
 };
 
-// Maybe#reduce :: Maybe f => f a ~> ((b, a) -> b, b) -> b
+// Maybe#reduce :: Foldable f => f a ~> ((b, a) -> b, b) -> b
 Maybe.prototype['fantasy-land/reduce'] = function(f, acc) {
   return this.isJust ? f(acc, this.value) : acc;
 };
 
-// Maybe#traverse :: Applicative f, Maybe m => m (f a) ~> (f, a -> f b) -> f (m b)
+// Maybe#traverse :: Applicative f, Traversable t => t (f a) ~> (f, a -> f b) -> f (t b)
 Maybe.prototype['fantasy-land/traverse']  = function(of, f) {
   return this.isJust ? map(Maybe.Just, f(this.value)) : of(Nothing);
 };

--- a/test/shared/Maybe.js
+++ b/test/shared/Maybe.js
@@ -51,7 +51,7 @@ Maybe.prototype['fantasy-land/chain'] = function(f) {
 
 // Maybe#reduce :: Maybe f => f a ~> ((b, a) -> b, b) -> b
 Maybe.prototype['fantasy-land/reduce'] = function(f, acc) {
-  return this.isJust ? f(acc, this.value) : Nothing;
+  return this.isJust ? f(acc, this.value) : acc;
 };
 
 // Maybe#traverse :: Applicative f, Maybe m => m (f a) ~> (f, a -> f b) -> f (m b)

--- a/test/shared/Maybe.js
+++ b/test/shared/Maybe.js
@@ -1,6 +1,6 @@
 var equals = require('../../src/equals');
 var toString = require('../../src/toString');
-
+var map = require('../../src/map');
 
 var sentinel = {};
 
@@ -47,6 +47,16 @@ Maybe.prototype['fantasy-land/ap'] = function(maybe) {
 //  Maybe#chain :: Maybe a ~> (a -> Maybe b) -> Maybe b
 Maybe.prototype['fantasy-land/chain'] = function(f) {
   return this.isJust ? f(this.value) : Nothing;
+};
+
+// Maybe#reduce :: Maybe f => f a ~> ((b, a) -> b, b) -> b
+Maybe.prototype['fantasy-land/reduce'] = function(f, acc) {
+  return this.isJust ? f(acc, this.value) : Nothing;
+};
+
+// Maybe#traverse :: Applicative f, Maybe m => m (f a) ~> (f, a -> f b) -> f (m b)
+Maybe.prototype['fantasy-land/traverse']  = function(of, f) {
+  return this.isJust ? map(Maybe.Just, f(this.value)) : of(Nothing);
 };
 
 //  Maybe#filter :: Maybe a ~> (a -> Boolean) -> Maybe a


### PR DESCRIPTION
This PR fixes the broken type constraint of `R.sequence`.

**Currently Broken**
R.sequence lists the type constraint `(Applicative f, Traversable t)` in it's type signature, but this breaks for custom data types.

*Example*
Assuming that `Id` implements `Traversable`, the following *is not true*
`R.sequence(R.of, Id([1, 2, 3])) === [Id(1), Id(2), Id(3)]`

This is because `R.sequence` only checks for `sequence` before deferring to `reduceRight` as shown [here](https://github.com/ramda/ramda/blob/master/src/sequence.js#L35).

**The Fix**
Perform an additional check for `fantasy-land/traverse` *after* checking for `sequence`. If the type *does implement fantasy-land/traverse*, sequence will defer to it.


To write the tests for this, I had to implement `Traversable` on something. I chose `Maybe` since it is what is used in the original issue that inspired me to create this PR, and `Id` already has `sequence`, so I wouldn't have been able to write *failing tests first*. To implement Traversable, I also added Foldable, but only for "correctness" since `reduce` isn't used in any tests.

This would fix the bug in #2243 