### PR TITLE
add an alias for R.identity: R.I

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 module.exports = {
   F: require('./src/F'),
   T: require('./src/T'),
+  I: require('./src/I'),
   __: require('./src/__'),
   add: require('./src/add'),
   addIndex: require('./src/addIndex'),

--- a/src/I.js
+++ b/src/I.js
@@ -1,0 +1,24 @@
+var identity = require('./identity');
+
+
+/**
+ * An alias for R.identity (a function that does nothing but
+ * return the parameter supplied to it). Good as a default or
+ * placeholder function.
+ *
+ * @func
+ * @memberOf R
+ * @since v0.1.0
+ * @category Function
+ * @sig a -> a
+ * @param {*} x The value to return.
+ * @return {*} The input value, `x`.
+ * @example
+ *
+ *      R.I(1); //=> 1
+ *
+ *      var obj = {};
+ *      R.I(obj) === obj; //=> true
+ * @symb R.I(a) = a
+ */
+module.exports = identity;

--- a/test/I.js
+++ b/test/I.js
@@ -1,0 +1,16 @@
+var R = require('..');
+var eq = require('./shared/eq');
+
+
+describe('I', function() {
+  it('returns its first argument', function() {
+    eq(R.I(undefined), undefined);
+    eq(R.I('foo'), 'foo');
+    eq(R.I('foo', 'bar'), 'foo');
+  });
+
+  it('has length 1', function() {
+    eq(R.I.length, 1);
+  });
+
+});


### PR DESCRIPTION
`R.identity` is a great placeholder or default function. I use it a lot when a function may not exist.

But because of the nature of how `R.identity` is used, increased brevity would be great.

```
// this is annoying
if (someFunction) {
  someFunction();
}

// this is better
(someFunction || R.identity)();

// this would be even better
(someFunction || R.I)();
```

I think `R.I` would be a perfect alias. `I` is not just the first letter of "identity", it is also commonly used to denote the identity matrix in mathematics.

I don't know how the maintainers feel about aliases, but I think this would be cool.