### PR TITLE
Remove precoverage script

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "bookmarklet": "scripts/bookmarklet",
     "build": "make && make dist/ramda.min.js",
     "clean": "rimraf dist/* coverage/*",
-    "precoverage": "npm run pretest",
     "coverage": "istanbul cover node_modules/.bin/_mocha -- --reporter spec",
     "postcoverage": "npm run posttest",
     "lint": "eslint scripts/bookmarklet scripts/build src/*.js src/internal/*.js test/*.js test/**/*.js lib/sauce/*.js lib/bench/*.js",


### PR DESCRIPTION
The `precoverage` script just called `pretest`, however `pretest` was removed in PR #1928.

So, because of `precoverage` failing, we've been unable to run `coverage` since.