### PR TITLE
Reimplement prop via path

### DIFF
--- a/src/prop.js
+++ b/src/prop.js
@@ -1,4 +1,5 @@
 var _curry2 = require('./internal/_curry2');
+var path = require('./path');
 
 
 /**
@@ -19,4 +20,4 @@ var _curry2 = require('./internal/_curry2');
  *      R.prop('x', {x: 100}); //=> 100
  *      R.prop('x', {}); //=> undefined
  */
-module.exports = _curry2(function prop(p, obj) { return obj[p]; });
+module.exports = _curry2(function prop(p, obj) { return path([p], obj); });

--- a/test/prop.js
+++ b/test/prop.js
@@ -11,4 +11,21 @@ describe('prop', function() {
     eq(nm(fred), 'Fred');
   });
 
+  it('shows the same behaviour as path for an undefined object', function() {
+    var propResult, propException, pathResult, pathException;
+    try {
+      propResult = R.prop('name', undefined);
+    } catch (e) {
+      propException = e;
+    }
+
+    try {
+      pathResult = R.path(['name'], undefined);
+    } catch (e) {
+      pathException = e;
+    }
+
+    eq(propResult, pathResult);
+    eq(propException, pathException);
+  });
 });


### PR DESCRIPTION
As discussed in #2059 we are unsatisfied that `prop` and `path` have
different behaviour when passing `undefined` as the object.

We could not yet agree which behaviour we want to have but at least
we want to have the same behaviour. To achieve that, we now
reimplement `prop` with `path`.

So if we ever define the behaviour of `path` then `prop`
automatically also has the same behaviour.

This also closes #1941.