### PR TITLE
Fix trim and keys which cause isses when generating document

### DIFF
--- a/source/keys.js
+++ b/source/keys.js
@@ -41,11 +41,11 @@ var contains = function contains(list, item) {
  *
  *      R.keys({a: 1, b: 2, c: 3}); //=> ['a', 'b', 'c']
  */
-var _keys = typeof Object.keys === 'function' && !hasArgsEnumBug ?
-  function keys(obj) {
+var keys = typeof Object.keys === 'function' && !hasArgsEnumBug ?
+  _curry1(function keys(obj) {
     return Object(obj) !== obj ? [] : Object.keys(obj);
-  } :
-  function keys(obj) {
+  }) :
+  _curry1(function keys(obj) {
     if (Object(obj) !== obj) {
       return [];
     }
@@ -68,6 +68,5 @@ var _keys = typeof Object.keys === 'function' && !hasArgsEnumBug ?
       }
     }
     return ks;
-  };
-var keys = _curry1(_keys);
+  });
 export default keys;

--- a/source/trim.js
+++ b/source/trim.js
@@ -21,14 +21,13 @@ var hasProtoTrim = (typeof String.prototype.trim === 'function');
  *      R.trim('   xyz  '); //=> 'xyz'
  *      R.map(R.trim, R.split(',', 'x, y, z')); //=> ['x', 'y', 'z']
  */
-var _trim = !hasProtoTrim || (ws.trim() || !zeroWidth.trim()) ?
-    function trim(str) {
-      var beginRx = new RegExp('^[' + ws + '][' + ws + ']*');
-      var endRx = new RegExp('[' + ws + '][' + ws + ']*$');
-      return str.replace(beginRx, '').replace(endRx, '');
-    } :
-    function trim(str) {
-      return str.trim();
-    };
-var trim = _curry1(_trim);
+var trim = !hasProtoTrim || (ws.trim() || !zeroWidth.trim()) ?
+  _curry1(function trim(str) {
+    var beginRx = new RegExp('^[' + ws + '][' + ws + ']*');
+    var endRx = new RegExp('[' + ws + '][' + ws + ']*$');
+    return str.replace(beginRx, '').replace(endRx, '');
+  }) :
+  _curry1(function trim(str) {
+    return str.trim();
+  });
 export default trim;


### PR DESCRIPTION
In current 0.25.0 document, there are extra _ applied to [trim](http://ramdajs.com/docs/#_trim) and [keys](http://ramdajs.com/docs/#_keys).

This is caused by the variable name which jsdocs used to generate.

![keysandtrim](https://user-images.githubusercontent.com/4587603/31439834-699fd276-aed9-11e7-9b6d-7b1a173074d0.png)
