### PR TITLE
Fix contains and toString when generate docs

### DIFF
--- a/source/internal/_isArguments.js
+++ b/source/internal/_isArguments.js
@@ -1,10 +1,10 @@
 import _has from './_has';
 
 
-var toString = Object.prototype.toString;
+var toStringFunc = Object.prototype.toString;
 var _isArguments = function() {
-  return toString.call(arguments) === '[object Arguments]' ?
-    function _isArguments(x) { return toString.call(x) === '[object Arguments]'; } :
+  return toStringFunc.call(arguments) === '[object Arguments]' ?
+    function _isArguments(x) { return toStringFunc.call(x) === '[object Arguments]'; } :
     function _isArguments(x) { return _has('callee', x); };
 };
 

--- a/source/keys.js
+++ b/source/keys.js
@@ -12,7 +12,7 @@ var hasArgsEnumBug = (function() {
   return arguments.propertyIsEnumerable('length');
 }());
 
-var contains = function contains(list, item) {
+var containsFunc = function containsFunc(list, item) {
   var idx = 0;
   while (idx < list.length) {
     if (list[idx] === item) {
@@ -61,7 +61,7 @@ var keys = typeof Object.keys === 'function' && !hasArgsEnumBug ?
       nIdx = nonEnumerableProps.length - 1;
       while (nIdx >= 0) {
         prop = nonEnumerableProps[nIdx];
-        if (_has(prop, obj) && !contains(ks, prop)) {
+        if (_has(prop, obj) && !containsFunc(ks, prop)) {
           ks[ks.length] = prop;
         }
         nIdx -= 1;


### PR DESCRIPTION
This is related to https://github.com/ramda/ramda/issues/2328.

Reason behind this is that, some internal functions used the contains and toString namespaces, so that rollup can only add $1 to the real functions' names.

Below is the doc which I used this fix to generate:

![contains](https://user-images.githubusercontent.com/4587603/31501046-e90ef7fe-afb4-11e7-8bdc-6f67ee19d29e.png)
![tostring](https://user-images.githubusercontent.com/4587603/31501056-eff07ab6-afb4-11e7-93fe-da51cf7cd667.png)

