### PR TITLE
Use Object.is as the implementation of R.identical if available

### DIFF
--- a/source/identical.js
+++ b/source/identical.js
@@ -1,3 +1,4 @@
+import _objectIs from './internal/_objectIs';
 import _curry2 from './internal/_curry2';
 
 
@@ -5,6 +6,8 @@ import _curry2 from './internal/_curry2';
  * Returns true if its arguments are identical, false otherwise. Values are
  * identical if they reference the same memory. `NaN` is identical to `NaN`;
  * `0` and `-0` are not identical.
+ *
+ * Note this is merely a curried version of ES6 `Object.is`.
  *
  * @func
  * @memberOf R
@@ -24,14 +27,5 @@ import _curry2 from './internal/_curry2';
  *      R.identical(0, -0); //=> false
  *      R.identical(NaN, NaN); //=> true
  */
-var identical = _curry2(function identical(a, b) {
-  // SameValue algorithm
-  if (a === b) { // Steps 1-5, 7-10
-    // Steps 6.b-6.e: +0 != -0
-    return a !== 0 || 1 / a === 1 / b;
-  } else {
-    // Step 6.a: NaN == NaN
-    return a !== a && b !== b;
-  }
-});
+var identical = _curry2(_objectIs);
 export default identical;

--- a/source/internal/_assign.js
+++ b/source/internal/_assign.js
@@ -1,4 +1,0 @@
-import _objectAssign from './_objectAssign';
-
-export default
-  typeof Object.assign === 'function' ? Object.assign : _objectAssign;

--- a/source/internal/_equals.js
+++ b/source/internal/_equals.js
@@ -2,7 +2,7 @@ import _arrayFromIterator from './_arrayFromIterator';
 import _containsWith from './_containsWith';
 import _functionName from './_functionName';
 import _has from './_has';
-import identical from '../identical';
+import _objectIs from './_objectIs';
 import keys from '../keys';
 import type from '../type';
 
@@ -32,7 +32,7 @@ function _uniqContentEquals(aIterator, bIterator, stackA, stackB) {
 }
 
 export default function _equals(a, b, stackA, stackB) {
-  if (identical(a, b)) {
+  if (_objectIs(a, b)) {
     return true;
   }
 
@@ -68,12 +68,12 @@ export default function _equals(a, b, stackA, stackB) {
     case 'Boolean':
     case 'Number':
     case 'String':
-      if (!(typeof a === typeof b && identical(a.valueOf(), b.valueOf()))) {
+      if (!(typeof a === typeof b && _objectIs(a.valueOf(), b.valueOf()))) {
         return false;
       }
       break;
     case 'Date':
-      if (!identical(a.valueOf(), b.valueOf())) {
+      if (!_objectIs(a.valueOf(), b.valueOf())) {
         return false;
       }
       break;

--- a/source/internal/_objectAssign.js
+++ b/source/internal/_objectAssign.js
@@ -1,7 +1,7 @@
 import _has from './_has';
 
 // Based on https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
-export default function _objectAssign(target) {
+function _objectAssign(target) {
   if (target == null) {
     throw new TypeError('Cannot convert undefined or null to object');
   }
@@ -22,3 +22,5 @@ export default function _objectAssign(target) {
   }
   return output;
 }
+
+export default typeof Object.assign === 'function' ? Object.assign : _objectAssign;

--- a/source/internal/_objectIs.js
+++ b/source/internal/_objectIs.js
@@ -1,0 +1,13 @@
+// Based on https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is
+function _objectIs(a, b) {
+  // SameValue algorithm
+  if (a === b) { // Steps 1-5, 7-10
+    // Steps 6.b-6.e: +0 != -0
+    return a !== 0 || 1 / a === 1 / b;
+  } else {
+    // Step 6.a: NaN == NaN
+    return a !== a && b !== b;
+  }
+}
+
+export default typeof Object.is === 'function' ? Object.is : _objectIs;

--- a/source/internal/_stepCat.js
+++ b/source/internal/_stepCat.js
@@ -1,4 +1,4 @@
-import _assign from './_assign';
+import _objectAssign from './_objectAssign';
 import _identity from './_identity';
 import _isArrayLike from './_isArrayLike';
 import _isTransformer from './_isTransformer';
@@ -21,7 +21,7 @@ var _stepCatString = {
 var _stepCatObject = {
   '@@transducer/init': Object,
   '@@transducer/step': function(result, input) {
-    return _assign(
+    return _objectAssign(
       result,
       _isArrayLike(input) ? objOf(input[0], input[1]) : input
     );

--- a/source/merge.js
+++ b/source/merge.js
@@ -1,4 +1,4 @@
-import _assign from './internal/_assign';
+import _objectAssign from './internal/_objectAssign';
 import _curry2 from './internal/_curry2';
 
 
@@ -26,6 +26,6 @@ import _curry2 from './internal/_curry2';
  * @symb R.merge({ x: 1, y: 2 }, { y: 5, z: 3 }) = { x: 1, y: 5, z: 3 }
  */
 var merge = _curry2(function merge(l, r) {
-  return _assign({}, l, r);
+  return _objectAssign({}, l, r);
 });
 export default merge;

--- a/source/mergeAll.js
+++ b/source/mergeAll.js
@@ -1,4 +1,4 @@
-import _assign from './internal/_assign';
+import _objectAssign from './internal/_objectAssign';
 import _curry1 from './internal/_curry1';
 
 
@@ -20,6 +20,6 @@ import _curry1 from './internal/_curry1';
  * @symb R.mergeAll([{ x: 1 }, { y: 2 }, { z: 3 }]) = { x: 1, y: 2, z: 3 }
  */
 var mergeAll = _curry1(function mergeAll(list) {
-  return _assign.apply(null, [{}].concat(list));
+  return _objectAssign.apply(null, [{}].concat(list));
 });
 export default mergeAll;


### PR DESCRIPTION
Object.is is identical to R.identical. Similar to what we did with
Object.assign few versions ago, this PR sets R.identical to
~~curry(Object.is) when possible, and polyfills it otherwise.

Also in this PR:
1. Simply “polyfilling” conventions (which I am to blame for, btw)
2) In R.equals use _objectIs rather than identical, which is what we
should do at least until curry performance issues are addressed. This
code path is simply evaluated too much for any abstraction to survive.