### PR TITLE
Guard null and undefined before accessing prop in _IsTransformer

### DIFF
--- a/source/internal/_isTransformer.js
+++ b/source/internal/_isTransformer.js
@@ -1,3 +1,3 @@
 export default function _isTransformer(obj) {
-  return typeof obj['@@transducer/step'] === 'function';
+  return obj != null && typeof obj['@@transducer/step'] === 'function';
 }

--- a/test/map.js
+++ b/test/map.js
@@ -1,6 +1,7 @@
 var listXf = require('./helpers/listXf');
 
 var R = require('..');
+var assert = require('assert');
 var eq = require('./shared/eq');
 var Id = require('./shared/Id');
 
@@ -40,6 +41,11 @@ describe('map', function() {
       f: add1,
       xf: listXf
     });
+  });
+
+  it('throws a TypeError on null and undefined', function() {
+    assert.throws(function() { return R.map(times2, null); }, TypeError);
+    assert.throws(function() { return R.map(times2, undefined); }, TypeError);
   });
 
   it('composes', function() {

--- a/test/tap.js
+++ b/test/tap.js
@@ -11,6 +11,8 @@ describe('tap', function() {
     var f = R.tap(R.identity);
     eq(typeof f, 'function');
     eq(f(100), 100);
+    eq(f(undefined), undefined);
+    eq(f(null), null);
   });
 
   it("may take a function as the first argument that executes with tap's argument", function() {


### PR DESCRIPTION
_IsTransformer was naively checking for an object property on an
argument without first ensuring that the argument was neither null nor
undefined.

Example:
```js
tap( console.log, null ) //-> Cannot read property '@@transducer/step' of null
tap( console.log, undefined ) //-> Cannot read property '@@transducer/step' of undefined
```

[REPL](https://goo.gl/JT7LE2)