### PR TITLE
Change argument order of adjust

### DIFF
--- a/source/adjust.js
+++ b/source/adjust.js
@@ -11,9 +11,9 @@ import _curry3 from './internal/_curry3';
  * @memberOf R
  * @since v0.14.0
  * @category List
- * @sig (a -> a) -> Number -> [a] -> [a]
- * @param {Function} fn The function to apply.
+ * @sig Number -> (a -> a) -> [a] -> [a]
  * @param {Number} idx The index.
+ * @param {Function} fn The function to apply.
  * @param {Array|Arguments} list An array-like object whose value
  *        at the supplied index will be replaced.
  * @return {Array} A copy of the supplied array-like object with
@@ -22,12 +22,12 @@ import _curry3 from './internal/_curry3';
  * @see R.update
  * @example
  *
- *      R.adjust(R.toUpper, 1, ['a', 'b', 'c', 'd']);      //=> ['a', 'B', 'c', 'd']
- *      R.adjust(R.toUpper, -1, ['a', 'b', 'c', 'd']);     //=> ['a', 'b', 'c', 'D']
- * @symb R.adjust(f, -1, [a, b]) = [a, f(b)]
- * @symb R.adjust(f, 0, [a, b]) = [f(a), b]
+ *      R.adjust(1, R.toUpper, ['a', 'b', 'c', 'd']);      //=> ['a', 'B', 'c', 'd']
+ *      R.adjust(-1, R.toUpper, ['a', 'b', 'c', 'd']);     //=> ['a', 'b', 'c', 'D']
+ * @symb R.adjust(-1, f, [a, b]) = [a, f(b)]
+ * @symb R.adjust(0, f, [a, b]) = [f(a), b]
  */
-var adjust = _curry3(function adjust(fn, idx, list) {
+var adjust = _curry3(function adjust(idx, fn, list) {
   if (idx >= list.length || idx < -list.length) {
     return list;
   }

--- a/source/update.js
+++ b/source/update.js
@@ -26,6 +26,6 @@ import always from './always';
  * @symb R.update(1, a, [b, c]) = [b, a]
  */
 var update = _curry3(function update(idx, x, list) {
-  return adjust(always(x), idx, list);
+  return adjust(idx, always(x), list);
 });
 export default update;

--- a/test/adjust.js
+++ b/test/adjust.js
@@ -3,34 +3,30 @@ var eq = require('./shared/eq');
 
 describe('adjust', function() {
   it('applies the given function to the value at the given index of the supplied array', function() {
-    eq(R.adjust(R.add(1), 2, [0, 1, 2, 3]), [0, 1, 3, 3]);
+    eq(R.adjust(2, R.add(1), [0, 1, 2, 3]), [0, 1, 3, 3]);
   });
 
   it('offsets negative indexes from the end of the array', function() {
-    eq(R.adjust(R.add(1), -3, [0, 1, 2, 3]), [0, 2, 2, 3]);
+    eq(R.adjust(-3, R.add(1), [0, 1, 2, 3]), [0, 2, 2, 3]);
   });
 
   it('returns the original array if the supplied index is out of bounds', function() {
     var list = [0, 1, 2, 3];
-    eq(R.adjust(R.add(1), 4, list), list);
-    eq(R.adjust(R.add(1), -5, list), list);
+    eq(R.adjust(4, R.add(1), list), list);
+    eq(R.adjust(-5, R.add(1), list), list);
   });
 
   it('does not mutate the original array', function() {
     var list = [0, 1, 2, 3];
-    eq(R.adjust(R.add(1), 2, list), [0, 1, 3, 3]);
+    eq(R.adjust(2, R.add(1), list), [0, 1, 3, 3]);
     eq(list, [0, 1, 2, 3]);
-  });
-
-  it('curries the arguments', function() {
-    eq(R.adjust(R.add(1))(2)([0, 1, 2, 3]), [0, 1, 3, 3]);
   });
 
   it('accepts an array-like object', function() {
     function args() {
       return arguments;
     }
-    eq(R.adjust(R.add(1), 2, args(0, 1, 2, 3)), [0, 1, 3, 3]);
+    eq(R.adjust(2, R.add(1), args(0, 1, 2, 3)), [0, 1, 3, 3]);
   });
 
 });

--- a/test/countBy.js
+++ b/test/countBy.js
@@ -52,7 +52,7 @@ describe('countBy', function() {
   it('can act as a transducer', function() {
     var transducer = R.compose(
       R.countBy(R.prop('genre')),
-      R.map(R.adjust(R.toString, 1)));
+      R.map(R.adjust(1, R.toString)));
     eq(R.into({}, transducer, albums), {
       Baroque: '2', Rock: '2', Jazz: '2', Romantic: '1', Metal: '1', Modern: '1', Broadway: '1', Folk: '1', Classical: '1'
     });

--- a/test/indexBy.js
+++ b/test/indexBy.js
@@ -20,8 +20,8 @@ describe('indexBy', function() {
     var transducer = R.compose(
       R.indexBy(R.prop('id')),
       R.map(R.pipe(
-        R.adjust(R.toUpper, 0),
-        R.adjust(R.omit(['id']), 1)
+        R.adjust(0, R.toUpper),
+        R.adjust(1, R.omit(['id']))
       )));
     var result = R.into({}, transducer, list);
     eq(result, {ABC: {title: 'B'}, XYZ: {title: 'A'}});

--- a/test/reduceBy.js
+++ b/test/reduceBy.js
@@ -50,7 +50,7 @@ describe('reduceBy', function() {
     var sumByType = reduceToSumsBy(byType);
     eq(R.into(
          {},
-         R.compose(sumByType, R.map(R.adjust(R.multiply(10), 1))),
+         R.compose(sumByType, R.map(R.adjust(1, R.multiply(10)))),
          sumInput),
        {A: 800, B: 800, C: 500});
   });


### PR DESCRIPTION
This PR changes the argument order of `adjust` as discussed in #1716. As to why that is beneficial, I think @iofjuupasli expressed it very well in the original PR:

> `update` and `adjust` is very similar method. I frequently change between them in code. But it seems inconsistent that `adjust` have index as second argument, but `update` have index as first argument. This often leads to errors.

I recently stumbled across this myself when I was implementing `adjust` and `update` for [list](https://github.com/funkia/list).

This is a breaking change. But everybody in the original discussion seemed to be in favor of changing it. Letting `adjust` take the index first not only makes it consistent with `update`, it also makes it more consistent with `assoc`, `dissoc`, `objOf`, `set`, and possibly other functions that all take a "path" before its associated value.

While at it I also removed a curry test from `adjust` in the spirit of @davidchamber's 5e234c9.

This PR closes #1716.