### PR TITLE
add mergeLeft and mergeRight

### DIFF
--- a/source/index.js
+++ b/source/index.js
@@ -130,6 +130,8 @@ export { default as mergeDeepLeft } from './mergeDeepLeft';
 export { default as mergeDeepRight } from './mergeDeepRight';
 export { default as mergeDeepWith } from './mergeDeepWith';
 export { default as mergeDeepWithKey } from './mergeDeepWithKey';
+export { default as mergeLeft } from './mergeLeft';
+export { default as mergeRight } from './mergeRight';
 export { default as mergeWith } from './mergeWith';
 export { default as mergeWithKey } from './mergeWithKey';
 export { default as min } from './min';

--- a/source/mergeLeft.js
+++ b/source/mergeLeft.js
@@ -5,28 +5,26 @@ import _curry2 from './internal/_curry2';
 /**
  * Create a new object with the own properties of the first object merged with
  * the own properties of the second object. If a key exists in both objects,
- * the value from the second object will be used.
+ * the value from the first object will be used.
  *
  * @func
  * @memberOf R
- * @since v0.1.0
  * @category Object
  * @sig {k: v} -> {k: v} -> {k: v}
  * @param {Object} l
  * @param {Object} r
  * @return {Object}
- * @see R.mergeRight, R.mergeDeepRight, R.mergeWith, R.mergeWithKey
- * @deprecated
+ * @see R.mergeRight, R.mergeDeepLeft, R.mergeWith, R.mergeWithKey
  * @example
  *
- *      R.merge({ 'name': 'fred', 'age': 10 }, { 'age': 40 });
+ *      R.mergeLeft({ 'age': 40 }, { 'name': 'fred', 'age': 10 });
  *      //=> { 'name': 'fred', 'age': 40 }
  *
- *      var withDefaults = R.merge({x: 0, y: 0});
- *      withDefaults({y: 2}); //=> {x: 0, y: 2}
- * @symb R.merge(a, b) = {...a, ...b}
+ *      var resetToDefault = R.mergeLeft({x: 0});
+ *      resetToDefault({x: 5, y: 2}); //=> {x: 0, y: 2}
+ * @symb R.mergeLeft(a, b) = {...b, ...a}
  */
-var merge = _curry2(function merge(l, r) {
-  return _objectAssign({}, l, r);
+var mergeLeft = _curry2(function mergeLeft(l, r) {
+  return _objectAssign({}, r, l);
 });
-export default merge;
+export default mergeLeft;

--- a/source/mergeRight.js
+++ b/source/mergeRight.js
@@ -9,24 +9,22 @@ import _curry2 from './internal/_curry2';
  *
  * @func
  * @memberOf R
- * @since v0.1.0
  * @category Object
  * @sig {k: v} -> {k: v} -> {k: v}
  * @param {Object} l
  * @param {Object} r
  * @return {Object}
- * @see R.mergeRight, R.mergeDeepRight, R.mergeWith, R.mergeWithKey
- * @deprecated
+ * @see R.mergeLeft, R.mergeDeepRight, R.mergeWith, R.mergeWithKey
  * @example
  *
- *      R.merge({ 'name': 'fred', 'age': 10 }, { 'age': 40 });
+ *      R.mergeRight({ 'name': 'fred', 'age': 10 }, { 'age': 40 });
  *      //=> { 'name': 'fred', 'age': 40 }
  *
- *      var withDefaults = R.merge({x: 0, y: 0});
+ *      var withDefaults = R.mergeRight({x: 0, y: 0});
  *      withDefaults({y: 2}); //=> {x: 0, y: 2}
- * @symb R.merge(a, b) = {...a, ...b}
+ * @symb R.mergeRight(a, b) = {...a, ...b}
  */
-var merge = _curry2(function merge(l, r) {
+var mergeRight = _curry2(function mergeRight(l, r) {
   return _objectAssign({}, l, r);
 });
-export default merge;
+export default mergeRight;

--- a/test/mergeLeft.js
+++ b/test/mergeLeft.js
@@ -1,0 +1,43 @@
+var assert = require('assert');
+
+var R = require('..');
+var eq = require('./shared/eq');
+
+
+describe('mergeLeft', function() {
+  it('takes two objects, merges their own properties and returns a new object', function() {
+    var a = {w: 1, x: 2};
+    var b = {y: 3, z: 4};
+    eq(R.mergeLeft(a, b), {w: 1, x: 2, y: 3, z: 4});
+  });
+
+  it('overrides properties in the second object with properties in the first object', function() {
+    var a = {w: 1, x: 2};
+    var b = {w: 100, y: 3, z: 4};
+    eq(R.mergeLeft(a, b), {w: 1, x: 2, y: 3, z: 4});
+  });
+
+  it('is not destructive', function() {
+    var a = {w: 1, x: 2};
+    var res = R.mergeLeft(a, {x: 3, y: 4});
+    assert.notStrictEqual(a, res);
+    eq(res, {w: 1, x: 2, y: 4});
+  });
+
+  it('reports only own properties', function() {
+    var a = {w: 1, x: 2};
+    function Cla() {}
+    Cla.prototype.x = 5;
+    eq(R.mergeLeft(new Cla(), a), {w: 1, x: 2});
+    eq(R.mergeLeft(a, new Cla()), {w: 1, x: 2});
+  });
+
+  it('is shallow', function() {
+    var a = { x: { u: 1, v: 2 }, y: 0 };
+    var b = { x: { u: 3, w: 4 }, z: 0 };
+    var res = R.mergeLeft(a, b);
+    assert.strictEqual(a.x, res.x);
+    eq(res, { x: { u: 1, v: 2 }, y: 0, z: 0 });
+  });
+
+});

--- a/test/mergeRight.js
+++ b/test/mergeRight.js
@@ -1,0 +1,43 @@
+var assert = require('assert');
+
+var R = require('..');
+var eq = require('./shared/eq');
+
+
+describe('mergeRight', function() {
+  it('takes two objects, merges their own properties and returns a new object', function() {
+    var a = {w: 1, x: 2};
+    var b = {y: 3, z: 4};
+    eq(R.mergeRight(a, b), {w: 1, x: 2, y: 3, z: 4});
+  });
+
+  it('overrides properties in the first object with properties in the second object', function() {
+    var a = {w: 1, x: 2};
+    var b = {w: 100, y: 3, z: 4};
+    eq(R.mergeRight(a, b), {w: 100, x: 2, y: 3, z: 4});
+  });
+
+  it('is not destructive', function() {
+    var a = {w: 1, x: 2};
+    var res = R.mergeRight(a, {x: 5});
+    assert.notStrictEqual(a, res);
+    eq(res, {w: 1, x: 5});
+  });
+
+  it('reports only own properties', function() {
+    var a = {w: 1, x: 2};
+    function Cla() {}
+    Cla.prototype.x = 5;
+    eq(R.mergeRight(new Cla(), a), {w: 1, x: 2});
+    eq(R.mergeRight(a, new Cla()), {w: 1, x: 2});
+  });
+
+  it('is shallow', function() {
+    var a = { x: { u: 1, v: 2 }, y: 0 };
+    var b = { x: { u: 3, w: 4 }, z: 0 };
+    var res = R.mergeRight(a, b);
+    assert.strictEqual(b.x, res.x);
+    eq(res, { x: { u: 3, w: 4 }, y: 0, z: 0 });
+  });
+
+});


### PR DESCRIPTION
This adds `mergeLeft` and `mergeRight` methods, consistent with the existing `mergeDeepLeft` and `mergeDeepRight` methods. Closes #2225.

If `merge` is going to remain as an alias of `mergeRight` then we should probably also introduce a `mergeDeep` alias of `mergeDeepRight` to be consistent. Alternatively we should deprecate `merge`.