### PR TITLE
Rename side-effects entry in package.json to sideEffects

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   ],
   "name": "ramda",
   "description": "A practical functional library for JavaScript programmers.",
-  "side-effects": false,
+  "sideEffects": false,
   "version": "0.25.0",
   "homepage": "http://ramdajs.com/",
   "license": "MIT",


### PR DESCRIPTION
beta of webpack@4 renamed this key, and its available only there for now, so it is not a breaking change 