### PR TITLE
Update tryCatch example to show correct behaviour

### DIFF
--- a/source/tryCatch.js
+++ b/source/tryCatch.js
@@ -22,7 +22,7 @@ import _curry2 from './internal/_curry2';
  * @example
  *
  *      R.tryCatch(R.prop('x'), R.F)({x: true}); //=> true
- *      R.tryCatch(R.prop('x'), R.F)(null);      //=> false
+ *      R.tryCatch(JSON.parse, R.F)({});      //=> false
  */
 var tryCatch = _curry2(function _tryCatch(tryer, catcher) {
   return _arity(tryer.length, function() {


### PR DESCRIPTION
Before the docs showed

```js
R.tryCatch(R.prop('x'), R.F)(null);      //=> false
```

which actually evaluates as
```js
R.tryCatch(R.prop('x'), R.F)(null);      //=> undefined
```

Updated to use JSON.parse as it actually throws exceptions
```js
R.tryCatch(JSON.parse, R.F)({});      //=> false
```
