### PR TITLE
Preserve property descriptors in assoc and dissoc

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "postcoverage": "npm run posttest",
     "lint": "eslint scripts/bookmarklet scripts/*.js source/*.js source/internal/*.js test/*.js test/**/*.js lib/sauce/*.js lib/bench/*.js",
     "pretest": "npm run build:cjs",
-    "test": "mocha --reporter spec",
+    "test": "mocha --reporter spec -- test test/internal",
     "posttest": "git checkout -- dist",
     "prebrowser_test": "npm run pretest",
     "browser_test": "testem ci",

--- a/source/assoc.js
+++ b/source/assoc.js
@@ -1,4 +1,5 @@
 import _curry3 from './internal/_curry3';
+import _cloneWithDescriptors from './internal/_cloneWithDescriptors';
 
 
 /**
@@ -22,10 +23,7 @@ import _curry3 from './internal/_curry3';
  *      R.assoc('c', 3, {a: 1, b: 2}); //=> {a: 1, b: 2, c: 3}
  */
 var assoc = _curry3(function assoc(prop, val, obj) {
-  var result = {};
-  for (var p in obj) {
-    result[p] = obj[p];
-  }
+  var result = _cloneWithDescriptors(obj);
   result[prop] = val;
   return result;
 });

--- a/source/dissoc.js
+++ b/source/dissoc.js
@@ -1,4 +1,5 @@
 import _curry2 from './internal/_curry2';
+import _cloneWithDescriptors from './internal/_cloneWithDescriptors';
 
 
 /**
@@ -18,10 +19,7 @@ import _curry2 from './internal/_curry2';
  *      R.dissoc('b', {a: 1, b: 2, c: 3}); //=> {a: 1, c: 3}
  */
 var dissoc = _curry2(function dissoc(prop, obj) {
-  var result = {};
-  for (var p in obj) {
-    result[p] = obj[p];
-  }
+  var result = _cloneWithDescriptors(obj);
   delete result[prop];
   return result;
 });

--- a/source/internal/_cloneWithDescriptors.js
+++ b/source/internal/_cloneWithDescriptors.js
@@ -1,0 +1,22 @@
+
+
+/**
+ * Performs a shallow clone of an object while preserving property descriptors.
+ *
+ * @private
+ * @param {Object} obj The object to clone
+ * @return {Object} The cloned object
+ */
+export default function _cloneWithDescriptors(obj) {
+  var result = {};
+  var desc;
+  for (var p in obj) {
+    desc = Object.getOwnPropertyDescriptor(obj, p);
+    if (desc === undefined) {
+      result[p] = obj[p];
+    } else {
+      Object.defineProperty(result, p, desc);
+    }
+  }
+  return result;
+}

--- a/test/assoc.js
+++ b/test/assoc.js
@@ -25,4 +25,10 @@ describe('assoc', function() {
     assert.strictEqual(obj2.f, obj1.f);
   });
 
+  it('preserves computed properties', function() {
+    var obj1 = {a: 1, get b() { return this.a * 2; }};
+    var obj2 = R.assoc('a', 2, obj1);
+    eq(obj2, {a: 2, b: 4});
+  });
+
 });

--- a/test/dissoc.js
+++ b/test/dissoc.js
@@ -29,4 +29,11 @@ describe('dissoc', function() {
     eq(R.dissoc(undefined, {a: 1, b: 2, undefined: 3}), {a: 1, b: 2});
   });
 
+  it('preserves computed properties', function() {
+    var obj1 = {a: 1, get b() { return this.a == null; }};
+    var obj2 = R.dissoc('a', obj1);
+    eq(obj1, {a: 1, b: false});
+    eq(obj2, {b: true});
+  });
+
 });

--- a/test/internal/_cloneWithDescriptors.js
+++ b/test/internal/_cloneWithDescriptors.js
@@ -1,0 +1,26 @@
+var assert = require('assert');
+
+var eq = require('../shared/eq');
+var _cloneWithDescriptors = require('../../src/internal/_cloneWithDescriptors');
+
+
+describe('_cloneWithDescriptors', function() {
+  it('makes a shallow clone of an object', function() {
+    var obj1 = {a: 1, b: {c: 2, d: 3}, e: 4, f: 5};
+    var obj2 = _cloneWithDescriptors(obj1);
+    eq(obj1, obj2);
+    // Note: reference equality below!
+    assert.strictEqual(obj2.a, obj1.a);
+    assert.strictEqual(obj2.b, obj1.b);
+    assert.strictEqual(obj2.f, obj1.f);
+  });
+
+  it('preserves computed properties', function() {
+    var obj = { x: 2 };
+    var obj1 = {a: 1, get b() { return obj.x; }};
+    var obj2 = _cloneWithDescriptors(obj1);
+    obj.x = 3;
+    eq(obj2, {a: 1, b: 3});
+  });
+
+});

--- a/test/internal/_isArrayLike.js
+++ b/test/internal/_isArrayLike.js
@@ -2,7 +2,7 @@ var eq = require('../shared/eq');
 var _isArrayLike = require('../../src/internal/_isArrayLike');
 
 
-describe('isArrayLike', function() {
+describe('_isArrayLike', function() {
   it('is true for Arrays', function() {
     eq(_isArrayLike([]), true);
     eq(_isArrayLike([1, 2, 3, 4]), true);


### PR DESCRIPTION
Fixes #2383 

This change adds an internal function `_cloneWithDescriptors` which creates a shallow object clone, preserving any existing property descriptors. It is used in `assoc` and `dissoc` so that property getters and setters are copied to the returned object.

Something that @CrossEye mentioned is that there may be a performance concern. I tested this in a JSPerf [here](https://jsperf.com/ramda-assoc-perf), and found that this performs ~10x worse than before (~1M ops/sec as opposed to ~10M), which could be a reason to reject this change.

Also... I changed the test script to run tests in `test/internal` 😄 