### PR TITLE
reimplementing propOr atop pathOr, fixes #2391

### DIFF
--- a/source/propOr.js
+++ b/source/propOr.js
@@ -1,5 +1,5 @@
 import _curry3 from './internal/_curry3';
-import _has from './internal/_has';
+import pathOr from './pathOr';
 
 
 /**
@@ -29,6 +29,6 @@ import _has from './internal/_has';
  *      favoriteWithDefault(alice);  //=> 'Ramda'
  */
 var propOr = _curry3(function propOr(val, p, obj) {
-  return (obj != null && _has(p, obj)) ? obj[p] : val;
+  return pathOr(val, [p], obj);
 });
 export default propOr;

--- a/test/propOr.js
+++ b/test/propOr.js
@@ -22,12 +22,9 @@ describe('propOr', function() {
     eq(nm(void 0), 'Unknown');
   });
 
-  it('does not return properties from the prototype chain', function() {
-    var Person = function() {};
-    Person.prototype.age = function() {};
-
-    var bob = new Person();
-    eq(R.propOr(100, 'age', bob), 100);
+  it('uses the default when supplied an object with a nil value', function() {
+    eq(R.propOr('foo', 'x', {x: null}), 'foo');
+    eq(R.propOr('foo', 'x', {x: undefined}), 'foo');
   });
 
 });


### PR DESCRIPTION
We've done this elsewhere recently, implementing the `prop` version in terms of the `path` one for consistency.

This meant removing a test; but I don't think that test was really testing the API we *meant* to expose, only our implementation.  If you disagree, let me know, and we can solve this inconsistency in another manner.