### PR TITLE
Add a new pairwise function

### DIFF
--- a/source/index.js
+++ b/source/index.js
@@ -152,6 +152,7 @@ export { default as once } from './once';
 export { default as or } from './or';
 export { default as over } from './over';
 export { default as pair } from './pair';
+export { default as pairwise } from './pairwise';
 export { default as partial } from './partial';
 export { default as partialRight } from './partialRight';
 export { default as partition } from './partition';

--- a/source/pairwise.js
+++ b/source/pairwise.js
@@ -1,0 +1,28 @@
+import _curry1 from './internal/_curry1';
+import pair from './pair';
+
+/**
+ * Takes a list and returns a sequence of each element in the input sequence and
+ * its predecessor, with the exception of the first element which is only
+ * returned as the predecessor of the second element.
+ *
+ * @func
+ * @memberOf R
+ * @category List
+ * @sig [a,b,c] -> [[a,b],[b,c]]
+ * @param {Array} list
+ * @return {Array}
+ * @example
+ *
+ *      R.pairwise([1, 2, 3]); //=> [[1,2], [2,3]]
+ */
+var pairwise = _curry1(function(list) {
+  var pairs = [];
+  var l = list.length - 1;
+  for (var i = 0; i < l; i = i + 1) {
+    pairs.push(pair(list[i], list[i + 1]));
+  }
+  return pairs;
+});
+
+export default pairwise;

--- a/test/pairwise.js
+++ b/test/pairwise.js
@@ -1,0 +1,12 @@
+var R = require('..');
+var eq = require('./shared/eq');
+
+
+describe('pairwise', function() {
+
+  it('creates a pairwise array', function() {
+    const input = [1, 4, 9, 16];
+    eq(R.pairwise(input), [[1, 4], [4, 9], [9, 16]]);
+  });
+
+});


### PR DESCRIPTION
Add a new `pairwise` function to Ramda, based on F#'s [Seq.pairwise](https://msdn.microsoft.com/en-us/visualfsharpdocs/conceptual/seq.pairwise%5B't%5D-function-%5Bfsharp%5D) function.

Example usage:

    R.pairwise([1, 2, 3, 4]);
    > [[1,2], [2,3], [3,4]]