### PR TITLE
Allow value-returning functions in pipeP (and composeP)

### DIFF
--- a/source/pipeP.js
+++ b/source/pipeP.js
@@ -23,9 +23,10 @@ import tail from './tail';
  *      var followersForUser = R.pipeP(db.getUserById, db.getFollowers);
  */
 export default function pipeP() {
-  if (arguments.length === 0) {
+  var args = arguments;
+  if (args.length === 0) {
     throw new Error('pipeP requires at least one argument');
   }
-  return _arity(arguments[0].length,
-                reduce(_pipeP, arguments[0], tail(arguments)));
+  return _arity(args[0].length,
+                reduce(_pipeP, function() { return Promise.resolve(args[0].apply(this, arguments)); }, tail(args)));
 }

--- a/test/pipeP.js
+++ b/test/pipeP.js
@@ -3,6 +3,34 @@ var assert = require('assert');
 var R = require('..');
 var eq = require('./shared/eq');
 
+// arity of f = 1
+// arity of g = 2
+function testComposition(f, g, done) {
+  eq(R.pipeP(f).length, 1);
+  eq(R.pipeP(g).length, 2);
+  eq(R.pipeP(f, f).length, 1);
+  eq(R.pipeP(f, g).length, 1);
+  eq(R.pipeP(g, f).length, 2);
+  eq(R.pipeP(g, g).length, 2);
+
+  R.pipeP(f, g)(1).then(function(result) {
+    eq(result, [[1], undefined]);
+
+    R.pipeP(g, f)(1).then(function(result) {
+      eq(result, [[1, undefined]]);
+
+      R.pipeP(f, g)(1, 2).then(function(result) {
+        eq(result, [[1], undefined]);
+
+        R.pipeP(g, f)(1, 2).then(function(result) {
+          eq(result, [[1, 2]]);
+
+          done();
+        })['catch'](done);
+      })['catch'](done);
+    })['catch'](done);
+  })['catch'](done);
+}
 
 describe('pipeP', function() {
 
@@ -14,31 +42,13 @@ describe('pipeP', function() {
   it('performs left-to-right composition of Promise-returning functions', function(done) {
     var f = function(a) { return new Promise(function(res) { res([a]); }); };
     var g = function(a, b) { return new Promise(function(res) { res([a, b]); }); };
+    testComposition(f, g, done);
+  });
 
-    eq(R.pipeP(f).length, 1);
-    eq(R.pipeP(g).length, 2);
-    eq(R.pipeP(f, f).length, 1);
-    eq(R.pipeP(f, g).length, 1);
-    eq(R.pipeP(g, f).length, 2);
-    eq(R.pipeP(g, g).length, 2);
-
-    R.pipeP(f, g)(1).then(function(result) {
-      eq(result, [[1], undefined]);
-
-      R.pipeP(g, f)(1).then(function(result) {
-        eq(result, [[1, undefined]]);
-
-        R.pipeP(f, g)(1, 2).then(function(result) {
-          eq(result, [[1], undefined]);
-
-          R.pipeP(g, f)(1, 2).then(function(result) {
-            eq(result, [[1, 2]]);
-
-            done();
-          })['catch'](done);
-        })['catch'](done);
-      })['catch'](done);
-    })['catch'](done);
+  it('performs left-to-right composition of both Promise-returning and value-returning functions', function(done) {
+    var f = function(a) { return [a]; };
+    var g = function(a, b) { return new Promise(function(res) { res([a, b]); }); };
+    testComposition(f, g, done);
   });
 
   it('throws if given no arguments', function() {


### PR DESCRIPTION
The content of this PR makes the behaviour of `R.pipeP` and `R.composeP` more consistent by allowing value-returning functions, even for the first function. It works by wraping in a promise the return value of the first fonction in `R.pipeP`. 

Right now, this kind of composition does not work :
```js
R.pipeP(R.inc, R.inc)(1); // Uncaught TypeError: f.apply(...).then is not a function
```
however, since the implementation uses `.then`, it works if the first function returns a Promise : 
```js
R.pipeP(Promise.resolve.bind(Promise), R.inc, R.inc)(1); // Promise {<resolved>: 3}
```

With this change the first example would work, and swapping functions around in the second example wouldn't break it.

shortcomings : 
- it requires the global `Promise` object since it uses `Promise.resolve`, so in its current form it is probably not mergeable
- it doesn't stick to the documentation

Is it something that can be considered? Maybe in a new function?