### PR TITLE
If only one function is passed to composeK, composeK will return that…

### DIFF
--- a/source/composeK.js
+++ b/source/composeK.js
@@ -39,5 +39,7 @@ export default function composeK() {
   }
   var init = Array.prototype.slice.call(arguments);
   var last = init.pop();
-  return compose(compose.apply(this, map(chain, init)), last);
+  return init.length === 0
+    ? last
+    : compose(compose.apply(this, map(chain, init)), last);
 }


### PR DESCRIPTION
Related to issue [#2380 ](https://github.com/ramda/ramda/issues/2380)
where if only one function is passed to `composeK`, `composeK` will try to pass an empty array to `compose` which will throw as it requires at least one argument.