### PR TITLE
Removed references to deprecated function in docs

### DIFF
--- a/source/mergeDeepWith.js
+++ b/source/mergeDeepWith.js
@@ -21,7 +21,7 @@ import mergeDeepWithKey from './mergeDeepWithKey';
  * @param {Object} lObj
  * @param {Object} rObj
  * @return {Object}
- * @see R.mergeWith, R.mergeDeep, R.mergeDeepWithKey
+ * @see R.mergeWith, R.mergeDeepWithKey
  * @example
  *
  *      R.mergeDeepWith(R.concat,

--- a/source/mergeDeepWithKey.js
+++ b/source/mergeDeepWithKey.js
@@ -22,7 +22,7 @@ import mergeWithKey from './mergeWithKey';
  * @param {Object} lObj
  * @param {Object} rObj
  * @return {Object}
- * @see R.mergeWithKey, R.mergeDeep, R.mergeDeepWith
+ * @see R.mergeWithKey, R.mergeDeepWith
  * @example
  *
  *      let concatValues = (k, l, r) => k == 'values' ? R.concat(l, r) : r


### PR DESCRIPTION
I'm assuming R.mergeDeep was deprecated leaving some dead links in the docs.