### PR TITLE
Arity length explicitly defined

### DIFF
--- a/source/internal/_arity.js
+++ b/source/internal/_arity.js
@@ -1,17 +1,15 @@
+import _isInteger from './_isInteger';
+
 export default function _arity(n, fn) {
-  /* eslint-disable no-unused-vars */
-  switch (n) {
-    case 0: return function() { return fn.apply(this, arguments); };
-    case 1: return function(a0) { return fn.apply(this, arguments); };
-    case 2: return function(a0, a1) { return fn.apply(this, arguments); };
-    case 3: return function(a0, a1, a2) { return fn.apply(this, arguments); };
-    case 4: return function(a0, a1, a2, a3) { return fn.apply(this, arguments); };
-    case 5: return function(a0, a1, a2, a3, a4) { return fn.apply(this, arguments); };
-    case 6: return function(a0, a1, a2, a3, a4, a5) { return fn.apply(this, arguments); };
-    case 7: return function(a0, a1, a2, a3, a4, a5, a6) { return fn.apply(this, arguments); };
-    case 8: return function(a0, a1, a2, a3, a4, a5, a6, a7) { return fn.apply(this, arguments); };
-    case 9: return function(a0, a1, a2, a3, a4, a5, a6, a7, a8) { return fn.apply(this, arguments); };
-    case 10: return function(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9) { return fn.apply(this, arguments); };
-    default: throw new Error('First argument to _arity must be a non-negative integer no greater than ten');
+  if (!_isInteger(n) || n > 10 || n < 0) {
+    throw new Error('First argument to _arity must be a non-negative integer no greater than ten');
   }
+  var arityFn = function() {
+    return fn.apply(this, arguments);
+  };
+  Object.defineProperty(arityFn, 'length', {
+    value: n,
+    configurable: true
+  });
+  return arityFn;
 }


### PR DESCRIPTION
PR for the issue #2459 
I tried to revert `07ecdac`, but it was also removed by dead-code elimination.
So the best solution I found is to use `Object.defineProperty` as @CrossEye suggested. And It works fine. (I kept property attributes same as the specs.)

I discovered that the mocha will not run tests in subdirectories, so the internal tests were not loaded. I've added `--recursive` flag to the runner. Then there was an old test `test.examplesRunner.js` with outdated functions, so I just skip it.

closes #2459 