### PR TITLE
Readme: Import changed in v0.25

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ Usage
 For `v0.25` and up, import the whole library or pick ES modules directly from the library:
 
 ```js
-import R, { identity } from 'ramda'
+import * as R, { identity } from 'ramda'
 
 R.map(identity, [1, 2, 3])
 ```

--- a/README.md
+++ b/README.md
@@ -200,8 +200,9 @@ Usage
 For `v0.25` and up, import the whole library or pick ES modules directly from the library:
 
 ```js
-import * as R, { identity } from 'ramda'
+import * as R from 'ramda'
 
+const {identity} = R
 R.map(identity, [1, 2, 3])
 ```
 


### PR DESCRIPTION
The readme explains that a default import is not existing anymore. The usage example was not adapted and shouldn't be working. I changed it.