### PR TITLE
Travis using node in version 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,6 @@ node_js:
 - '0.12'
 - 4
 - 6
+- 8
 before_script:
 - npm run lint


### PR DESCRIPTION
I'd suggest since node 8 is becoming the new default lts version, it should be added to the travis build.