### PR TITLE
Return false from where and whereEq when testObj is null or undefined

### DIFF
--- a/source/where.js
+++ b/source/where.js
@@ -1,6 +1,7 @@
 import _curry2 from './internal/_curry2';
 import _has from './internal/_has';
 
+var nullObj = Object.create(null);
 
 /**
  * Takes a spec object and a test object; returns true if the test satisfies
@@ -38,8 +39,9 @@ import _has from './internal/_has';
  *      pred({a: 'foo', b: 'xxx', x: 11, y: 20}); //=> false
  */
 var where = _curry2(function where(spec, testObj) {
+  var _testObj = (testObj == null ? nullObj : testObj);
   for (var prop in spec) {
-    if (_has(prop, spec) && !spec[prop](testObj[prop])) {
+    if (_has(prop, spec) && !spec[prop](_testObj[prop])) {
       return false;
     }
   }

--- a/test/where.js
+++ b/test/where.js
@@ -41,6 +41,12 @@ describe('where', function() {
     eq(R.where({}, {a: 1}), true);
   });
 
+  it('returns false if testObj is null or undefined', function() {
+    var spec = { x: R.equals(1), y: R.equals(2) };
+    eq(R.where(spec, null), false);
+    eq(R.where(spec, undefined), false);
+  });
+
   it('matches inherited properties', function() {
     var spec = {
       toString: R.equals(Object.prototype.toString),

--- a/test/whereEq.js
+++ b/test/whereEq.js
@@ -41,6 +41,12 @@ describe('whereEq', function() {
     eq(R.whereEq({}, {a: 1}), true);
   });
 
+  it('returns false if testObj is null or undefined', function() {
+    var spec = { x: 1, y: 2 };
+    eq(R.whereEq(spec, null), false);
+    eq(R.whereEq(spec, undefined), false);
+  });
+
   it('reports true when the object equals the spec', function() {
     eq(R.whereEq(R, R), true);
   });


### PR DESCRIPTION
Why?

1. `null` and `undefined` are the only things that throw on property access and cause the functions to throw.

2.  Better composition with `pathSatisifes` (example from [my real code](https://github.com/GingerPlusPlus/Rextester-bot-v3/blob/ca3d993b26e6e1429643b53db929da35604ecca7/utils/telegram.js#L5-L8)): 

    ```js
    const isCommand = R.pathSatisfies(
        R.whereEq({ offset: 0, type: 'bot_command' }),
        [ 'entities', 0 ]
    );

    isCommand({ entities: [] })
    // Before: throws TypeError: Cannot read property 'offset' of undefined
    // After: returns false
    ```

3. `where` within `where`: https://github.com/ramda/ramda/pull/2288#issuecomment-329931297