### PR TITLE
Update docs and tests for `and` and `or`

### DIFF
--- a/source/and.js
+++ b/source/and.js
@@ -2,7 +2,7 @@ import _curry2 from './internal/_curry2';
 
 
 /**
- * Returns `true` if both arguments are `true`; `false` otherwise.
+ * Returns the first argument if it is falsy, otherwise the second argument.
  *
  * @func
  * @memberOf R
@@ -19,6 +19,10 @@ import _curry2 from './internal/_curry2';
  *      R.and(true, false); //=> false
  *      R.and(false, true); //=> false
  *      R.and(false, false); //=> false
+ *      R.and('a', 'a') //=> 'a'
+ *      R.and('a', '') //=> ''
+ *      R.and('', 'a') //=> ''
+ *      R.and('', '') //=> ''
  */
 var and = _curry2(function and(a, b) {
   return a && b;

--- a/source/or.js
+++ b/source/or.js
@@ -2,8 +2,7 @@ import _curry2 from './internal/_curry2';
 
 
 /**
- * Returns `true` if one or both of its arguments are `true`. Returns `false`
- * if both arguments are `false`.
+ * Returns the first argument if truthy, otherwise the second argument.
  *
  * @func
  * @memberOf R
@@ -20,6 +19,10 @@ import _curry2 from './internal/_curry2';
  *      R.or(true, false); //=> true
  *      R.or(false, true); //=> true
  *      R.or(false, false); //=> false
+ *      R.or('a', 'a') //=> 'a'
+ *      R.or('a', '') //=> 'a'
+ *      R.or('', 'a') //=> 'a'
+ *      R.or('', '') //=> ''
  */
 var or = _curry2(function or(a, b) {
   return a || b;

--- a/test/and.js
+++ b/test/and.js
@@ -8,6 +8,10 @@ describe('and', function() {
     eq(R.and(true, false), false);
     eq(R.and(false, true), false);
     eq(R.and(false, false), false);
+    eq(R.and('a', 'a'), 'a');
+    eq(R.and('a', ''), '');
+    eq(R.and('', 'a'), '');
+    eq(R.and('', ''), '');
   });
 
 });

--- a/test/or.js
+++ b/test/or.js
@@ -8,6 +8,10 @@ describe('or', function() {
     eq(R.or(true, false), true);
     eq(R.or(false, true), true);
     eq(R.or(false, false), false);
+    eq(R.or('a', 'a'), 'a');
+    eq(R.or('a', ''), 'a');
+    eq(R.or('', 'a'), 'a');
+    eq(R.or('', ''), '');
   });
 
 });


### PR DESCRIPTION
This clarifies the doc descriptions for `and` and `or`. Since these use logical operators, they will return one of the operands, not necessarily a boolean. I also added tests so that this behavior is covered.