### PR TITLE
Be able to evolve with an array of transformations

### DIFF
--- a/source/evolve.js
+++ b/source/evolve.js
@@ -29,7 +29,7 @@ import _curry2 from './internal/_curry2';
  *      R.evolve(transformations, tomato); //=> {firstName: 'Tomato', data: {elapsed: 101, remaining: 1399}, id:123}
  */
 var evolve = _curry2(function evolve(transformations, object) {
-  var result = {};
+  var result = object instanceof Array ? [] : {};
   var transformation, key, type;
   for (key in object) {
     transformation = transformations[key];

--- a/test/evolve.js
+++ b/test/evolve.js
@@ -46,4 +46,11 @@ describe('evolve', function() {
     eq(R.evolve(transf, object), expected);
   });
 
+  it('creates a new array by evolving the `array` according to the `transformation` functions', function() {
+    var transf   = [R.add(1), R.add(-1)];
+    var object   = [100, 1400];
+    var expected = [101, 1399];
+    eq(R.evolve(transf, object), expected);
+  });
+
 });


### PR DESCRIPTION
update evolve functions to support evolving with an array of transformations.

An example of use case:

```
var transf   = [R.add(1), R.add(-1)];
var object   = [100, 1400];
var expected = [101, 1399];
eq(R.evolve(transf, object), expected);
```

reference issue
https://github.com/ramda/ramda/issues/2289