### PR TITLE
Enhance `_isFunction` To Handle `AsyncFunction` (+ more)

### DIFF
--- a/source/internal/_isFunction.js
+++ b/source/internal/_isFunction.js
@@ -2,6 +2,5 @@ export default function _isFunction(x) {
   var type = Object.prototype.toString.call(x);
   return type  === '[object Function]' ||
     type === '[object AsyncFunction]' ||
-    type === '[object GeneratorFunction]' ||
-    type === '[object Proxy]';
+    type === '[object GeneratorFunction]';
 }

--- a/source/internal/_isFunction.js
+++ b/source/internal/_isFunction.js
@@ -1,3 +1,7 @@
 export default function _isFunction(x) {
-  return Object.prototype.toString.call(x) === '[object Function]';
+  var type = Object.prototype.toString.call(x);
+  return type  === '[object Function]' ||
+    type === '[object AsyncFunction]' ||
+    type === '[object GeneratorFunction]' ||
+    type === '[object Proxy]';
 }

--- a/source/internal/_isFunction.js
+++ b/source/internal/_isFunction.js
@@ -2,5 +2,6 @@ export default function _isFunction(x) {
   var type = Object.prototype.toString.call(x);
   return type  === '[object Function]' ||
     type === '[object AsyncFunction]' ||
-    type === '[object GeneratorFunction]';
+    type === '[object GeneratorFunction]' ||
+    type === '[object AsyncGeneratorFunction]';
 }

--- a/source/invoker.js
+++ b/source/invoker.js
@@ -27,6 +27,16 @@ import toString from './toString';
  *      sliceFrom(6, 'abcdefghijklm'); //=> 'ghijklm'
  *      const sliceFrom6 = R.invoker(2, 'slice')(6);
  *      sliceFrom6(8, 'abcdefghijklm'); //=> 'gh'
+ *
+ *      const dog = {
+ *        speak: async () => 'Woof!'
+ *      };
+ *      const person = {
+ *        speak: async () => 'Hi!'
+ *      };
+ *      const speak = R.invoker(0, 'speak');
+ *      speak(dog).then(R.identity) //=> 'Woof!'
+ *      speak(person).then(R.identity) //=> 'Hi!'
  * @symb R.invoker(0, 'method')(o) = o['method']()
  * @symb R.invoker(1, 'method')(a, o) = o['method'](a)
  * @symb R.invoker(2, 'method')(a, b, o) = o['method'](a, b)

--- a/source/invoker.js
+++ b/source/invoker.js
@@ -31,12 +31,9 @@ import toString from './toString';
  *      const dog = {
  *        speak: async () => 'Woof!'
  *      };
- *      const person = {
- *        speak: async () => 'Hi!'
- *      };
  *      const speak = R.invoker(0, 'speak');
- *      speak(dog).then(R.identity) //=> 'Woof!'
- *      speak(person).then(R.identity) //=> 'Hi!'
+ *      speak(dog).then(console.log) //~> 'Woof!'
+ *
  * @symb R.invoker(0, 'method')(o) = o['method']()
  * @symb R.invoker(1, 'method')(a, o) = o['method'](a)
  * @symb R.invoker(2, 'method')(a, b, o) = o['method'](a, b)


### PR DESCRIPTION
👋 Hello! First time contributor here so let me know what idiomatic Ramda repo things I'm missing from these changes and I'll be more than happy to make updates ASAP.

I was using `R.invoker` on a `node@8.11.1` project and discovered that it was incorrectly throwing when I would try to invoke an `async` function on an object. Here's a basic example of what I was doing:

```js
const person = {
  speak: async () => 'Hi!'
};
const speak = R.invoker(0, 'speak');
speak(person).then(R.identity) //=> 'Hi!'
```

This [works fine in the Ramda Repl](https://goo.gl/g7WxPS) because `Object.prototype.toString` seems to always give back `'[object Function]'`. In `node@8.11.1` however, `toString` gives back different strings for different types of functions and this was producing false negatives when I tried to use `R.invoker` on my `async` methods.

This PR adds support for `AsyncFunction`, as well as `GeneratorFunction` ~and `Proxy`~ functions. I took a page out of `lodash`'s [`isFunction` implementation](https://github.com/lodash/lodash/blob/4.17.5/lodash.js#L11638).

I didn't add any tests because I didn't see any specific tests for the internal `_isFunction` helper, nor could I easily add tests for `R.invoker` that handles `async` functions because of the `ESLint@2.11.0` dev dependency. I see in the `travis.yml` file that you're targeting `node@8.x.x` so I think the changes are valid given that support.