### PR TITLE
Remove unnecessary currying from pluck example

### DIFF
--- a/source/pluck.js
+++ b/source/pluck.js
@@ -22,8 +22,8 @@ import prop from './prop';
  * @see R.props
  * @example
  *
- *      R.pluck('a')([{a: 1}, {a: 2}]); //=> [1, 2]
- *      R.pluck(0)([[1, 2], [3, 4]]);   //=> [1, 3]
+ *      R.pluck('a', [{a: 1}, {a: 2}]); //=> [1, 2]
+ *      R.pluck(0, [[1, 2], [3, 4]]);   //=> [1, 3]
  *      R.pluck('val', {a: {val: 3}, b: {val: 5}}); //=> {a: 3, b: 5}
  * @symb R.pluck('x', [{x: 1, y: 2}, {x: 3, y: 4}, {x: 5, y: 6}]) = [1, 3, 5]
  * @symb R.pluck(0, [[1, 2], [3, 4], [5, 6]]) = [1, 3, 5]


### PR DESCRIPTION
I've seen several new developers on my project use currying unnecessarily with `R.pluck` due to the documentation. 