### PR TITLE
Add keywords field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,18 @@
   ],
   "name": "ramda",
   "description": "A practical functional library for JavaScript programmers.",
+  "keywords": [
+    "ramda",
+    "functional",
+    "utils",
+    "utilities",
+    "toolkit",
+    "fp",
+    "tacit",
+    "point-free",
+    "curried",
+    "pure"
+  ],
   "sideEffects": false,
   "version": "0.25.0",
   "homepage": "http://ramdajs.com/",


### PR DESCRIPTION
Ramda's `package.json` is missing a `keywords` field. This PR adds this field with a selection of keywords to help discoverability. 

- Please let me know if you would like to add or remove any keywords and I'll amend as needed. 
- Github keywords for this repo should probably be updated to echo the keywords used in the`package.json`.

Closes #2531