### PR TITLE
Change http references to https

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ This requires having Node/io.js installed and ramda's dependencies installed (ju
 Documentation
 -------------
 
-Please review the [API documentation](http://ramdajs.com/docs/).
+Please review the [API documentation](https://ramdajs.com/docs/).
 
 Also available is our [Cookbook](https://github.com/ramda/ramda/wiki/Cookbook) of functions built from Ramda that you may find useful.
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   ],
   "sideEffects": false,
   "version": "0.25.0",
-  "homepage": "http://ramdajs.com/",
+  "homepage": "https://ramdajs.com/",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fix a couple of http references since #2527 has been solved.

The reference on the Ramda GitHub homepage also needs to be changed by a maintainer.