### PR TITLE
fix dissocPath for non-string types in path #2543

### DIFF
--- a/source/dissocPath.js
+++ b/source/dissocPath.js
@@ -1,5 +1,6 @@
 import _curry2 from './internal/_curry2';
 import _isInteger from './internal/_isInteger';
+import _isArray from './internal/_isArray';
 import assoc from './assoc';
 import dissoc from './dissoc';
 import remove from './remove';
@@ -30,13 +31,13 @@ var dissocPath = _curry2(function dissocPath(path, obj) {
     case 0:
       return obj;
     case 1:
-      return _isInteger(path[0]) ? remove(path[0], 1, obj) : dissoc(path[0], obj);
+      return _isInteger(path[0]) && _isArray(obj) ? remove(path[0], 1, obj) : dissoc(path[0], obj);
     default:
       var head = path[0];
       var tail = Array.prototype.slice.call(path, 1);
       if (obj[head] == null) {
         return obj;
-      } else if (_isInteger(path[0])) {
+      } else if (_isInteger(head) && _isArray(obj)) {
         return update(head, dissocPath(tail, obj[head]), obj);
       } else {
         return assoc(head, dissocPath(tail, obj[head]), obj);

--- a/test/dissocPath.js
+++ b/test/dissocPath.js
@@ -60,4 +60,10 @@ describe('dissocPath', function() {
     eq(R.dissocPath([], {a: 1, b: 2}), {a: 1, b: 2});
   });
 
+  it('coerces non-string types', function() {
+    eq(R.dissocPath([42], {a: 1, b: 2, 42: 3}), {a: 1, b: 2});
+    eq(R.dissocPath([null], {a: 1, b: 2, 'null': 3}), {a: 1, b: 2});
+    eq(R.dissocPath([undefined], {a: 1, b: 2, undefined: 3}), {a: 1, b: 2});
+  });
+
 });

--- a/test/dissocPath.js
+++ b/test/dissocPath.js
@@ -60,10 +60,8 @@ describe('dissocPath', function() {
     eq(R.dissocPath([], {a: 1, b: 2}), {a: 1, b: 2});
   });
 
-  it('coerces non-string types', function() {
+  it('allow use integer key for object', function() {
     eq(R.dissocPath([42], {a: 1, b: 2, 42: 3}), {a: 1, b: 2});
-    eq(R.dissocPath([null], {a: 1, b: 2, 'null': 3}), {a: 1, b: 2});
-    eq(R.dissocPath([undefined], {a: 1, b: 2, undefined: 3}), {a: 1, b: 2});
   });
 
 });

--- a/test/dissocPath.js
+++ b/test/dissocPath.js
@@ -60,7 +60,7 @@ describe('dissocPath', function() {
     eq(R.dissocPath([], {a: 1, b: 2}), {a: 1, b: 2});
   });
 
-  it('allow use integer key for object', function() {
+  it('allow integer to be used as key for object', function() {
     eq(R.dissocPath([42], {a: 1, b: 2, 42: 3}), {a: 1, b: 2});
   });
 


### PR DESCRIPTION
This change unifies behavior of `dissocPath` and `dissoc`. I only add tests and behavior by  https://github.com/ramda/ramda/blob/master/test/dissoc.js#L26