### PR TITLE
Add thunkify function

### DIFF
--- a/source/index.js
+++ b/source/index.js
@@ -248,3 +248,4 @@ export { default as xprod } from './xprod';
 export { default as zip } from './zip';
 export { default as zipObj } from './zipObj';
 export { default as zipWith } from './zipWith';
+export { default as thunkify } from './thunkify';

--- a/source/thunkify.js
+++ b/source/thunkify.js
@@ -1,0 +1,30 @@
+import _curry1 from './internal/_curry1';
+import _arity from './internal/_arity';
+
+/**
+ * Creates a thunk out of a function. A thunk delays a calculation until
+ * its result is needed, providing lazy evaluation of arguments.
+ *
+ * @func
+ * @memberOf R
+ * @since v0.25.0
+ * @category Function
+ * @sig (a -> b) -> (a -> b) // FIXME: write appropiate signature
+ * @param {Function} fn A function to wrap in a thunk
+ * @return {Function} Expects arguments for `fn` and returns a new function
+ *  that, when called, applies those arguments to `fn`.
+ * @see R.partial, R.partialRight
+ * @example
+ *
+ *      R.thunkify(R.identity)(42)(); //=> 42
+ */
+var thunkify = _curry1(function thunkify(fn) {
+  return _arity(fn.length, function createThunk() {
+    const fnArgs = arguments;
+    return function invokeThunk() {
+      return fn.apply(this, fnArgs);
+    };
+  });
+});
+
+export default thunkify;

--- a/source/thunkify.js
+++ b/source/thunkify.js
@@ -1,4 +1,4 @@
-import _arity from './internal/_arity';
+import _curryN from './internal/_curryN';
 import _curry1 from './internal/_curry1';
 
 /**
@@ -19,7 +19,7 @@ import _curry1 from './internal/_curry1';
  *      R.thunkify((a, b) => a + b)(25, 17)(); //=> 42
  */
 var thunkify = _curry1(function thunkify(fn) {
-  return _arity(fn.length, function createThunk() {
+  return _curryN(fn.length, [], function createThunk() {
     const fnArgs = arguments;
     return function invokeThunk() {
       return fn.apply(this, fnArgs);

--- a/source/thunkify.js
+++ b/source/thunkify.js
@@ -7,7 +7,6 @@ import _arity from './internal/_arity';
  *
  * @func
  * @memberOf R
- * @since v0.25.0
  * @category Function
  * @sig (a -> b) -> (a -> b) // FIXME: write appropiate signature
  * @param {Function} fn A function to wrap in a thunk

--- a/source/thunkify.js
+++ b/source/thunkify.js
@@ -8,7 +8,7 @@ import _arity from './internal/_arity';
  * @func
  * @memberOf R
  * @category Function
- * @sig (a -> b) -> (a -> b) // FIXME: write appropiate signature
+ * @sig ((a, b, ..., j) -> k) -> (a, b, ..., j) -> (() -> k)
  * @param {Function} fn A function to wrap in a thunk
  * @return {Function} Expects arguments for `fn` and returns a new function
  *  that, when called, applies those arguments to `fn`.

--- a/source/thunkify.js
+++ b/source/thunkify.js
@@ -1,4 +1,4 @@
-import _curryN from './internal/_curryN';
+import curryN from './curryN';
 import _curry1 from './internal/_curry1';
 
 /**
@@ -19,7 +19,7 @@ import _curry1 from './internal/_curry1';
  *      R.thunkify((a, b) => a + b)(25, 17)(); //=> 42
  */
 var thunkify = _curry1(function thunkify(fn) {
-  return _curryN(fn.length, [], function createThunk() {
+  return curryN(fn.length, function createThunk() {
     const fnArgs = arguments;
     return function invokeThunk() {
       return fn.apply(this, fnArgs);

--- a/source/thunkify.js
+++ b/source/thunkify.js
@@ -1,5 +1,5 @@
-import _curry1 from './internal/_curry1';
 import _arity from './internal/_arity';
+import _curry1 from './internal/_curry1';
 
 /**
  * Creates a thunk out of a function. A thunk delays a calculation until
@@ -16,6 +16,7 @@ import _arity from './internal/_arity';
  * @example
  *
  *      R.thunkify(R.identity)(42)(); //=> 42
+ *      R.thunkify((a, b) => a + b)(25, 17)(); //=> 42
  */
 var thunkify = _curry1(function thunkify(fn) {
   return _arity(fn.length, function createThunk() {

--- a/test/thunkify.js
+++ b/test/thunkify.js
@@ -1,0 +1,22 @@
+var R = require('..');
+var eq = require('./shared/eq');
+
+describe('thunkify', function() {
+  it('returns a function with the same arity as the given function', function() {
+    var input = function input(a0, a1) { };
+    var f = R.thunkify(input);
+    eq(typeof f, 'function');
+    eq(f.length, input.length);
+  });
+
+  it('returns a function that expects arguments and returns a new invoker function', function() {
+    var input = function input(a0, a1) { };
+    var f = R.thunkify(input);
+    eq(typeof f(42, 'xyz'), 'function');
+  });
+
+  it('calls the original function with the provided arguments', function() {
+    var f = R.thunkify(R.add(2));
+    eq(f(42)(), 44);
+  });
+});

--- a/test/thunkify.js
+++ b/test/thunkify.js
@@ -19,4 +19,10 @@ describe('thunkify', function() {
     var f = R.thunkify(R.add(2));
     eq(f(42)(), 44);
   });
+
+  it('should support sending partial arguments', function() {
+    var input = function input(a0, a1) { return [a0, a1]; };
+    var f = R.thunkify(input);
+    eq(f(42)(), [42, undefined]);
+  });
 });

--- a/test/thunkify.js
+++ b/test/thunkify.js
@@ -2,6 +2,13 @@ var R = require('..');
 var eq = require('./shared/eq');
 
 describe('thunkify', function() {
+  it('returns a function with the same arity as the given function', function() {
+    var input = function input(a0, a1) { };
+    var thunk = R.thunkify(input);
+    eq(typeof thunk, 'function');
+    eq(thunk.length, input.length);
+  });
+
   it('returns a function that expects arguments and returns a new invoker function', function() {
     var input = function input(a0, a1) { };
     var thunk = R.thunkify(input);

--- a/test/thunkify.js
+++ b/test/thunkify.js
@@ -2,27 +2,14 @@ var R = require('..');
 var eq = require('./shared/eq');
 
 describe('thunkify', function() {
-  it('returns a function with the same arity as the given function', function() {
-    var input = function input(a0, a1) { };
-    var f = R.thunkify(input);
-    eq(typeof f, 'function');
-    eq(f.length, input.length);
-  });
-
   it('returns a function that expects arguments and returns a new invoker function', function() {
     var input = function input(a0, a1) { };
-    var f = R.thunkify(input);
-    eq(typeof f(42, 'xyz'), 'function');
+    var thunk = R.thunkify(input);
+    eq(typeof thunk(42, 'xyz'), 'function');
   });
 
-  it('calls the original function with the provided arguments', function() {
-    var f = R.thunkify(R.add(2));
-    eq(f(42)(), 44);
-  });
-
-  it('should support sending partial arguments', function() {
-    var input = function input(a0, a1) { return [a0, a1]; };
-    var f = R.thunkify(input);
-    eq(f(42)(), [42, undefined]);
+  it('calls the original function with the provided arguments when all were supplied', function() {
+    var thunk = R.thunkify(R.add(2));
+    eq(thunk(40)(), 42);
   });
 });


### PR DESCRIPTION
This PR adds a new, simple `thunkify` function. It takes an `fn` function and returns a new function that asks for arguments before returning a third function that, when called, invokes `fn` with the provided arguments.

```js
const thunkify = fn => (...args) => () => fn(...args);
```

Original PR idea came from @CrossEye at a [Stackoverflow answer](https://stackoverflow.com/questions/50495874/how-to-create-a-function-that-delays-call-to-given-function?noredirect=1#comment88255490_50495874).

### Motivation
- While very simple, wrapping functions to delay their invocations is a really common pattern.
- Ramda itself does not provide any out-of-the-box tool to help with this in a straight forward manner.
- It is specially useful when arguments to the _thunkified_ function are **not known until a later execution stage**.
- It helps with creating composable functions that get arguments from composed chains.
- The `fn` function could be variadic and can be called by the thunk with any number of arguments.

### Example

This has been adapted from a real world application I'm currently working on.

```js
function throwErrorWith(message, data) {
  throw Object.assign(new Error(message), data);
}

const thenThrowErrorWith = R.thunkify(throwErrorWith);

// ...later

const throwIfBadFormat = unless(
  validFormat,
  thenThrowErrorWith(
    'Invalid response format: expected one of <result></result> or <error></error>'
  )
);
```

---

Some considerations:

- Not very keen on the `thunkify` name, to be honest.
- This is my first PR on the project. My knowledge of the internal functions is rather limited, so I'm far from sure if this is the current "Ramda" approach to writing the solution. 
- There might be better ways and/or other internals I should be using. Looking forward to your input!
- I'm not very familiar with Haskell-like signatures so wasn't quite sure how to describe `thunkify`. Help appreciated.



