### PR TITLE
Add toggle function

### DIFF
--- a/source/index.js
+++ b/source/index.js
@@ -217,6 +217,7 @@ export { default as toPairs } from './toPairs';
 export { default as toPairsIn } from './toPairsIn';
 export { default as toString } from './toString';
 export { default as toUpper } from './toUpper';
+export { default as toggle } from './toggle';
 export { default as transduce } from './transduce';
 export { default as transpose } from './transpose';
 export { default as traverse } from './traverse';

--- a/source/toggle.js
+++ b/source/toggle.js
@@ -1,0 +1,22 @@
+import _curry2 from './internal/_curry2';
+
+
+/**
+ * Returns the opposite value comparing against a given set of two values.
+ *
+ * @func
+ * @memberOf R
+ * @category Function
+ * @param {*} val
+ * @param {Array} vals
+ * @return {*}
+ * @example
+ *
+ *      R.toggle("on", ["on", "off"]);       //=>  "off"
+ *      R.toggle("inactive", ["active", "inactive"]);      //=> "active"
+ *      R.toggle(10, [10, 100]); //=> 100
+ */
+var toggle = _curry2(function toggle(val, vals) {
+  return val == vals[0] ? vals[1] : vals[0];
+});
+export default toggle;

--- a/source/toggle.js
+++ b/source/toggle.js
@@ -1,4 +1,5 @@
 import _curry2 from './internal/_curry2';
+import _equals from './internal/_equals';
 
 
 /**
@@ -12,11 +13,25 @@ import _curry2 from './internal/_curry2';
  * @return {*}
  * @example
  *
- *      R.toggle("on", ["on", "off"]);       //=>  "off"
- *      R.toggle("inactive", ["active", "inactive"]);      //=> "active"
- *      R.toggle(10, [10, 100]); //=> 100
+ *      R.toggle(['on', 'off'], 'on');       //=>  'off'
+ *      R.toggle(['active', 'inactive'], 'inactive');      //=> 'active'
+ *      R.toggle([10, 100], 10); //=> 100
+ *      R.toggle(['on', 'off'], 'other'); //=> 'other'
  */
-var toggle = _curry2(function toggle(val, vals) {
-  return val == vals[0] ? vals[1] : vals[0];
+var toggle = _curry2(function toggle(vals, val) {
+
+  if (vals.length < 2) {
+    return val;
+  }
+
+  if (_equals(val, vals[0], [], [])) {
+    return vals[1];
+  }
+
+  if (_equals(val, vals[1], [], [])) {
+    return vals[0];
+  }
+
+  return val;
 });
 export default toggle;

--- a/test/toggle.js
+++ b/test/toggle.js
@@ -1,0 +1,10 @@
+var R = require('..');
+var eq = require('./shared/eq');
+
+describe('toggle', function() {
+  it('toggles a value to the other of two values', function() {
+    eq(R.toggle("on", ["on", "off"]), "off");
+    eq(R.toggle("inactive", ["active", "inactive"]), "active");
+    eq(R.toggle(10, [10, 100]), 100);
+  });
+});

--- a/test/toggle.js
+++ b/test/toggle.js
@@ -3,8 +3,30 @@ var eq = require('./shared/eq');
 
 describe('toggle', function() {
   it('toggles a value to the other of two values', function() {
-    eq(R.toggle("on", ["on", "off"]), "off");
-    eq(R.toggle("inactive", ["active", "inactive"]), "active");
-    eq(R.toggle(10, [10, 100]), 100);
+    eq(R.toggle(['on', 'off'], 'on'), 'off');
+    eq(R.toggle(['active', 'inactive'], 'inactive'), 'active');
+    eq(R.toggle([10, 100], 10), 100);
+  });
+
+  it('returns the given value if it matches neither of the provided two options', function() {
+    eq(R.toggle(['on', 'off'], 'other'), 'other');
+  });
+
+  it('returns the given value if only one option is provided', function() {
+    eq(R.toggle(['something'], 'given'), 'given');
+  });
+
+  it('uses first two options if more than two are provided', function() {
+    eq(R.toggle(['on', 'off', 'neither'], 'on'), 'off');
+    eq(R.toggle(['on', 'off', 'neither'], 'off'), 'on');
+    eq(R.toggle(['on', 'off', 'neither'], 'neither'), 'neither');
+
+    eq(R.toggle(['active', 'inactive', 'neither'], 'inactive'), 'active');
+    eq(R.toggle(['active', 'inactive', 'neither'], 'active'), 'inactive');
+    eq(R.toggle(['active', 'inactive', 'neither'], 'neither'), 'neither');
+
+    eq(R.toggle([10, 100, 50], 10), 100);
+    eq(R.toggle([10, 100, 50], 100), 10);
+    eq(R.toggle([10, 100, 50], 50), 50);
   });
 });


### PR DESCRIPTION
I've run across a case in which it would be convenient to be able to easily "toggle" a value, which is to return the "opposite" of a value when given two possible values. Basically, if your two possible values are `[true, false]`, this toggle function does the equivalent of `value = !value`.

Example:

`R.toggle("on", ["on", "off"]); //=> "off"`

This can be convenient when you would like to toggle a property for an array of objects like so:

`R.map(R.evolve({ status: toggle(["active", "inactive"]) }), users)`