### PR TITLE
Update the 'path' method to it could take a string as the 1st param.

### DIFF
--- a/source/path.js
+++ b/source/path.js
@@ -10,6 +10,7 @@ import _curry2 from './internal/_curry2';
  * @category Object
  * @typedefn Idx = String | Int
  * @sig [Idx] -> {a} -> a | Undefined
+ * @sig String -> {a} -> a | Undefined
  * @param {Array} path The path to use.
  * @param {Object} obj The object to retrieve the nested property from.
  * @return {*} The data at `path`.
@@ -18,8 +19,14 @@ import _curry2 from './internal/_curry2';
  *
  *      R.path(['a', 'b'], {a: {b: 2}}); //=> 2
  *      R.path(['a', 'b'], {c: {b: 2}}); //=> undefined
+ *
+ *      R.path('a.b', {a: {b: 2}}); //=> 2
+ *      R.path('a.b', {c: {b: 2}}); //=> undefined
  */
 var path = _curry2(function path(paths, obj) {
+  if (typeof paths === 'string') {
+    paths = paths.split('.');
+  }
   var val = obj;
   var idx = 0;
   while (idx < paths.length) {

--- a/source/path.js
+++ b/source/path.js
@@ -25,7 +25,9 @@ import _curry2 from './internal/_curry2';
  */
 var path = _curry2(function path(paths, obj) {
   if (typeof paths === 'string') {
-    paths = paths.split('.');
+    paths = paths === ''
+      ? []
+      : paths.split('.');
   }
   var val = obj;
   var idx = 0;

--- a/source/pathEq.js
+++ b/source/pathEq.js
@@ -13,6 +13,7 @@ import path from './path';
  * @category Relation
  * @typedefn Idx = String | Int
  * @sig [Idx] -> a -> {a} -> Boolean
+ * @sig String -> a -> {a} -> Boolean
  * @param {Array} path The path of the nested property to use
  * @param {*} val The value to compare the nested property with
  * @param {Object} obj The object to check the nested property in

--- a/source/pathOr.js
+++ b/source/pathOr.js
@@ -13,6 +13,7 @@ import path from './path';
  * @category Object
  * @typedefn Idx = String | Int
  * @sig a -> [Idx] -> {a} -> a
+ * @sig a -> String -> {a} -> a
  * @param {*} d The default value.
  * @param {Array} p The path to use.
  * @param {Object} obj The object to retrieve the nested property from.
@@ -21,6 +22,9 @@ import path from './path';
  *
  *      R.pathOr('N/A', ['a', 'b'], {a: {b: 2}}); //=> 2
  *      R.pathOr('N/A', ['a', 'b'], {c: {b: 2}}); //=> "N/A"
+ *
+ *      R.pathOr('N/A', 'a.b', {a: {b: 2}}); //=> 2
+ *      R.pathOr('N/A', 'a.b', {c: {b: 2}}); //=> "N/A"
  */
 var pathOr = _curry3(function pathOr(d, p, obj) {
   return defaultTo(d, path(p, obj));

--- a/source/pathSatisfies.js
+++ b/source/pathSatisfies.js
@@ -12,6 +12,7 @@ import path from './path';
  * @category Logic
  * @typedefn Idx = String | Int
  * @sig (a -> Boolean) -> [Idx] -> {a} -> Boolean
+ * @sig (a -> Boolean) -> String -> {a} -> Boolean
  * @param {Function} pred
  * @param {Array} propPath
  * @param {*} obj
@@ -20,6 +21,7 @@ import path from './path';
  * @example
  *
  *      R.pathSatisfies(y => y > 0, ['x', 'y'], {x: {y: 2}}); //=> true
+ *      R.pathSatisfies(y => y > 0, 'x.y', {x: {y: 2}}); //=> true
  */
 var pathSatisfies = _curry3(function pathSatisfies(pred, propPath, obj) {
   return propPath.length > 0 && pred(path(propPath, obj));

--- a/test/path.js
+++ b/test/path.js
@@ -4,23 +4,33 @@ var eq = require('./shared/eq');
 
 describe('path', function() {
   var deepObject = {a: {b: {c: 'c'}}, falseVal: false, nullVal: null, undefinedVal: undefined, arrayVal: ['arr']};
-  it('takes a path and an object and returns the value at the path or undefined', function() {
-    var obj = {
-      a: {
-        b: {
-          c: 100,
-          d: 200
-        },
-        e: {
-          f: [100, 101, 102],
-          g: 'G'
-        },
-        h: 'H'
+
+  var obj =  {
+    a: {
+      b: {
+        c: 100,
+        d: 200
       },
-      i: 'I',
-      j: ['J']
-    };
+      e: {
+        f: [100, 101, 102],
+        g: 'G'
+      },
+      h: 'H'
+    },
+    i: 'I',
+    j: ['J']
+  };
+
+  it('takes a path and an object and returns the value at the path or undefined', function() {
     eq(R.path(['a', 'b', 'c'], obj), 100);
+    eq(R.path([], obj), obj);
+    eq(R.path(['a', 'e', 'f', 1], obj), 101);
+    eq(R.path(['j', 0], obj), 'J');
+    eq(R.path(['j', 1], obj), undefined);
+  });
+
+  it('takes a string which describes path and an object and returns the value at the path or undefined', function() {
+    eq(R.path('a.b.c', obj), 100);
     eq(R.path([], obj), obj);
     eq(R.path(['a', 'e', 'f', 1], obj), 101);
     eq(R.path(['j', 0], obj), 'J');
@@ -30,16 +40,22 @@ describe('path', function() {
   it("gets a deep property's value from objects", function() {
     eq(R.path(['a', 'b', 'c'], deepObject), 'c');
     eq(R.path(['a'], deepObject), deepObject.a);
+    eq(R.path('a.b.c', deepObject), 'c');
+    eq(R.path('a', deepObject), deepObject.a);
   });
 
   it('returns undefined for items not found', function() {
     eq(R.path(['a', 'b', 'foo'], deepObject), undefined);
     eq(R.path(['bar'], deepObject), undefined);
     eq(R.path(['a', 'b'], {a: null}), undefined);
+    eq(R.path('a.b.foo', deepObject), undefined);
+    eq(R.path('bar', deepObject), undefined);
+    eq(R.path('a.b', {a: null}), undefined);
   });
 
   it('works with falsy items', function() {
     eq(R.path(['toString'], false), Boolean.prototype.toString);
+    eq(R.path('toString', false), Boolean.prototype.toString);
   });
 
 });

--- a/test/path.js
+++ b/test/path.js
@@ -31,7 +31,7 @@ describe('path', function() {
 
   it('takes a string which describes path and an object and returns the value at the path or undefined', function() {
     eq(R.path('a.b.c', obj), 100);
-    eq(R.path([], obj), obj);
+    eq(R.path('', obj), obj);
     eq(R.path(['a', 'e', 'f', 1], obj), 101);
     eq(R.path(['j', 0], obj), 'J');
     eq(R.path(['j', 1], obj), undefined);

--- a/test/pathEq.js
+++ b/test/pathEq.js
@@ -16,21 +16,29 @@ describe('pathEq', function() {
   it('returns true if the path matches the value', function() {
     eq(R.pathEq(['a'], 1, obj), true);
     eq(R.pathEq(['b', 1, 'ba'], 3, obj), true);
+    eq(R.pathEq('a', 1, obj), true);
+    eq(R.pathEq('b.1.ba', 3, obj), true);
   });
 
   it('returns false for non matches', function() {
     eq(R.pathEq(['a'], '1', obj), false);
     eq(R.pathEq(['b', 0, 'ba'], 3, obj), false);
+    eq(R.pathEq('a', '1', obj), false);
+    eq(R.pathEq('b.0.ba', 3, obj), false);
   });
 
   it('returns false for non existing values', function() {
     eq(R.pathEq(['c'], 'foo', obj), false);
     eq(R.pathEq(['c', 'd'], 'foo', obj), false);
+    eq(R.pathEq('c', 'foo', obj), false);
+    eq(R.pathEq('c.d', 'foo', obj), false);
   });
 
   it('accepts empty path', function() {
     eq(R.pathEq([], 42, {a: 1, b: 2}), false);
     eq(R.pathEq([], obj, obj), true);
+    eq(R.pathEq('', 42, {a: 1, b: 2}), false);
+    eq(R.pathEq('', obj, obj), true);
   });
 
   it('has R.equals semantics', function() {
@@ -43,6 +51,10 @@ describe('pathEq', function() {
     eq(R.pathEq(['value'], -0, {value: 0}), false);
     eq(R.pathEq(['value'], NaN, {value: NaN}), true);
     eq(R.pathEq(['value'], new Just([42]), {value: new Just([42])}), true);
+    eq(R.pathEq('value', 0, {value: -0}), false);
+    eq(R.pathEq('value', -0, {value: 0}), false);
+    eq(R.pathEq('value', NaN, {value: NaN}), true);
+    eq(R.pathEq('value', new Just([42]), {value: new Just([42])}), true);
   });
 
 });


### PR DESCRIPTION
The idea is to make it easier to use the 'path' method. The method can take not only an array as 1st parameter but and a  string which describes a path. The separator for paths' steps is dot `.` 
E.g.
`'a.b.c'` instead `['a', 'b', 'c']`.   
`R.path('a.b', {a: {b: 2}});` instead `R.path(['a', 'b'], {a: {b: 2}});`