### PR TITLE
casting to Boolean

### DIFF
--- a/source/pathSatisfies.js
+++ b/source/pathSatisfies.js
@@ -22,6 +22,6 @@ import path from './path';
  *      R.pathSatisfies(y => y > 0, ['x', 'y'], {x: {y: 2}}); //=> true
  */
 var pathSatisfies = _curry3(function pathSatisfies(pred, propPath, obj) {
-  return propPath.length > 0 && pred(path(propPath, obj));
+  return propPath.length > 0 && Boolean(pred(path(propPath, obj)));
 });
 export default pathSatisfies;

--- a/source/propSatisfies.js
+++ b/source/propSatisfies.js
@@ -21,6 +21,6 @@ import _curry3 from './internal/_curry3';
  *      R.propSatisfies(x => x > 0, 'x', {x: 1, y: 2}); //=> true
  */
 var propSatisfies = _curry3(function propSatisfies(pred, name, obj) {
-  return pred(obj[name]);
+  return Boolean(pred(obj[name]));
 });
 export default propSatisfies;

--- a/test/pathSatisfies.js
+++ b/test/pathSatisfies.js
@@ -2,7 +2,7 @@ var R = require('..');
 var eq = require('./shared/eq');
 
 
-describe('pathSatisfies', function() {
+describe('pathSatisfies returns Boolean taking predicate', function() {
 
   var isPositive = function(n) { return n > 0; };
 
@@ -20,6 +20,20 @@ describe('pathSatisfies', function() {
 
   it('returns false otherwise', function() {
     eq(R.pathSatisfies(isPositive, ['x', 'y'], {x: {y: 0}}), false);
+  });
+
+});
+
+describe('pathSatisfies returns Boolean taking function that returns falsy or truthy value', function() {
+
+  var identity = function(n) { return n; };
+
+  it('returns true if the specified object property satisfies the given function', function() {
+    eq(R.pathSatisfies(identity, ['x', 1, 'y'], {x: [{y: -1}, {y: 1}]}), true);
+  });
+
+  it('returns false if the specified object path doesn\'t satisfy the given function', function() {
+    eq(R.pathSatisfies(identity, ['x', 'y'], {x: {y: 0}}), false);
   });
 
 });

--- a/test/propSatisfies.js
+++ b/test/propSatisfies.js
@@ -2,7 +2,7 @@ var R = require('..');
 var eq = require('./shared/eq');
 
 
-describe('propSatisfies', function() {
+describe('propSatisfies returns Boolean taking predicate', function() {
 
   var isPositive = function(n) { return n > 0; };
 
@@ -12,6 +12,21 @@ describe('propSatisfies', function() {
 
   it('returns false otherwise', function() {
     eq(R.propSatisfies(isPositive, 'y', {x: 1, y: 0}), false);
+  });
+
+});
+
+
+describe('propSatisfies returns Boolean taking function that returns falsy or truthy value', function() {
+
+  var identity = function(n) { return n; };
+
+  it('returns true if the specified object property satisfies the given function', function() {
+    eq(R.propSatisfies(identity, 'x', {x: 1, y: 0}), true);
+  });
+
+  it('returns false otherwise', function() {
+    eq(R.propSatisfies(identity, 'y', {x: 1, y: 0}), false);
   });
 
 });

--- a/test/propSatisfies.js
+++ b/test/propSatisfies.js
@@ -16,7 +16,6 @@ describe('propSatisfies returns Boolean taking predicate', function() {
 
 });
 
-
 describe('propSatisfies returns Boolean taking function that returns falsy or truthy value', function() {
 
   var identity = function(n) { return n; };


### PR DESCRIPTION
Currently function doesn't return Boolean - it returns result of predicate-function. Ideally, predicate shouldn't return anything except Boolean, but it's easy to introduce a bug like this.
```javascript
R.propSatisfies(
    prop => prop && prop.a && prop.a.b > 3,
    'property'
);
```