### PR TITLE
Adds Traversable instance for Objects

### DIFF
--- a/source/index.js
+++ b/source/index.js
@@ -220,6 +220,7 @@ export { default as toUpper } from './toUpper';
 export { default as transduce } from './transduce';
 export { default as transpose } from './transpose';
 export { default as traverse } from './traverse';
+export { default as traverseWithKey } from './traverseWithKey';
 export { default as trim } from './trim';
 export { default as tryCatch } from './tryCatch';
 export { default as type } from './type';

--- a/source/internal/_flattenCons.js
+++ b/source/internal/_flattenCons.js
@@ -1,0 +1,9 @@
+// flattens [a, [b, [c, []]]] to [a, b, c]
+export default function _flattenCons(xs) {
+  var flattened = [];
+  while (xs.length > 0) {
+    flattened.push(xs[0]);
+    xs = xs[1];
+  }
+  return flattened;
+}

--- a/source/internal/_sequenceArray.js
+++ b/source/internal/_sequenceArray.js
@@ -1,0 +1,12 @@
+import _flattenCons from './_flattenCons';
+import ap from '../ap';
+import map from '../map';
+import pair from '../pair';
+import reduceRight from '../reduceRight';
+
+
+export default function _sequenceArray(of, xs) {
+  return map(_flattenCons, reduceRight(function(x, acc) {
+    return ap(map(pair, x), acc);
+  }, of([]), xs));
+}

--- a/source/traverse.js
+++ b/source/traverse.js
@@ -9,7 +9,8 @@ import sequence from './sequence';
  * then uses [`sequence`](#sequence) to transform the resulting Traversable of Applicative
  * into an Applicative of Traversable.
  *
- * Dispatches to the `traverse` method of the third argument, if present.
+ * Objects and Arrays are both accepted as types of Traversable, otherwise this will
+ * dispatch to the `traverse` method of the third argument, if present.
  *
  * @func
  * @memberOf R
@@ -20,7 +21,7 @@ import sequence from './sequence';
  * @param {Function} f
  * @param {*} traversable
  * @return {*}
- * @see R.sequence
+ * @see R.sequence, R.traverseWithKey
  * @example
  *
  *      // Returns `Maybe.Nothing` if the given divisor is `0`
@@ -28,6 +29,9 @@ import sequence from './sequence';
  *
  *      R.traverse(Maybe.of, safeDiv(10), [2, 4, 5]); //=> Maybe.Just([5, 2.5, 2])
  *      R.traverse(Maybe.of, safeDiv(10), [2, 0, 5]); //=> Maybe.Nothing
+ *
+ *      R.traverse(Maybe.of, safeDiv(10), {a: 2, b: 4, c: 5}); //=> Maybe.Just({a: 5, b: 2.5, c: 2})
+ *      R.traverse(Maybe.of, safeDiv(10), {a: 2, b: 0, c: 5}); //=> Maybe.Nothing
  */
 var traverse = _curry3(function traverse(of, f, traversable) {
   return typeof traversable['fantasy-land/traverse'] === 'function' ?

--- a/source/traverseWithKey.js
+++ b/source/traverseWithKey.js
@@ -1,0 +1,36 @@
+import _curry3 from './internal/_curry3';
+import _sequenceArray from './internal/_sequenceArray';
+import keys from './keys';
+import map from './map';
+import zipObj from './zipObj';
+
+
+/**
+ * Maps an [Applicative](https://github.com/fantasyland/fantasy-land#applicative)-returning
+ * function over the keys and values of an Object, then constructs a new Object within the
+ * Applicative consisting of each returned Applicative value.
+ *
+ * @func
+ * @memberOf R
+ * @since v0.19.0
+ * @category Object
+ * @sig Applicative f => (a -> f a) -> ((a, k) -> f b) -> {a} -> f {b}
+ * @param {Function} of
+ * @param {Function} f
+ * @param {*} obj
+ * @return {*}
+ * @see R.sequence, R.traverse
+ * @example
+ *
+ *      const allValid = (v, k) => k.length >= 3 && v > 0 ? Just(v) : Nothing();
+ *
+ *      R.traverseWithKey(Maybe.of, allValid, { a: 1, b: 2, c: 3 }); //=> Nothing
+ *      R.traverseWithKey(Maybe.of, allValid, { foo: 0, bar: 1, baz: 2 }); //=> Nothing
+ *      R.traverseWithKey(Maybe.of, allValid, { foo: 1, bar: 2, baz: 3 }); //=> Just({ foo: 1, bar: 2, baz: 3 })
+ */
+var traverseWithKey = _curry3(function traverseWithKey(of, f, obj) {
+  var ks = keys(obj).sort();
+  var fxs = _sequenceArray(of, map(function(k) { return f(obj[k], k); }, ks));
+  return map(zipObj(ks), fxs);
+});
+export default traverseWithKey;

--- a/test/sequence.js
+++ b/test/sequence.js
@@ -33,4 +33,17 @@ describe('sequence', function() {
     eq(R.sequence(R.of, Id([1, 2, 3])), [Id(1), Id(2), Id(3)]);
   });
 
+  it('operates on an object of applicatives', function() {
+    eq(R.sequence(S.Maybe.of, { a: S.Just(3), b: S.Just(4), c: S.Just(5)}), S.Just({a: 3, b: 4, c: 5}));
+    eq(R.sequence(S.Maybe.of, { a: S.Just(3), b: S.Nothing(), c: S.Just(5)}), S.Nothing());
+  });
+
+  it('performs the applicative effects in a consistent order on objects', function() {
+    eq(R.sequence(R.of, { a: [1, 2], b: [3, 4] }),
+       R.sequence(R.of, { b: [3, 4], a: [1, 2] }));
+
+    eq(R.sequence(S.Either.of, { a: S.Left(0), b: S.Left(1) }),
+       R.sequence(S.Either.of, { b: S.Left(1), a: S.Left(0) }));
+  });
+
 });

--- a/test/traverse.js
+++ b/test/traverse.js
@@ -21,6 +21,20 @@ describe('traverse', function() {
     eq(R.traverse(S.Maybe.of, R.map(R.add(10)), [S.Just(3), S.Nothing(), S.Just(5)]), S.Nothing());
   });
 
+  it('operates on an object of applicatives', function() {
+    eq(R.traverse(S.Maybe.of, R.map(R.add(10)), { a: S.Just(3), b: S.Just(4), c: S.Just(5) }),
+       S.Just({ a: 13, b: 14, c: 15}));
+    eq(R.traverse(S.Maybe.of, R.map(R.add(10)), { a: S.Just(3), b: S.Nothing(), c: S.Just(5) }), S.Nothing());
+  });
+
+  it('performs the applicative effects in a consistent order on objects', function() {
+    eq(R.traverse(R.of, R.identity, { a: [1, 2], b: [3, 4] }),
+       R.traverse(R.of, R.identity, { b: [3, 4], a: [1, 2] }));
+
+    eq(R.traverse(S.Either.of, R.identity, { a: S.Left(0), b: S.Left(1) }),
+       R.traverse(S.Either.of, R.identity, { b: S.Left(1), a: S.Left(0) }));
+  });
+
   it('traverses left to right', function() {
     eq(R.traverse(S.Either.of, R.identity, [S.Right(1), S.Right(2)]), S.Right([1, 2]));
     eq(R.traverse(S.Either.of, R.identity, [S.Right(1), S.Left('XXX')]), S.Left('XXX'));

--- a/test/traverseWithKey.js
+++ b/test/traverseWithKey.js
@@ -1,0 +1,31 @@
+var S = require('sanctuary');
+
+var R = require('..');
+var eq = require('./shared/eq');
+
+
+describe('traverseWithKey', function() {
+
+  it('passes both the key and value to the applicative producing function', function() {
+    function allValid(v, k) { return k.length >= 3 && v > 0 ? S.Just(v) : S.Nothing(); }
+
+    eq(R.traverseWithKey(S.Maybe.of, allValid, { a: 1, b: 2, c: 3 }), S.Nothing());
+    eq(R.traverseWithKey(S.Maybe.of, allValid, { foo: 0, bar: 1, baz: 2 }), S.Nothing());
+    eq(R.traverseWithKey(S.Maybe.of, allValid, { foo: 1, bar: 2, baz: 3 }), S.Just({ foo: 1, bar: 2, baz: 3 }));
+  });
+
+  it('applies the applicative effects consistently independent of insertion order', function() {
+    function ignoreKey(v, k) { return v; }
+
+    eq(R.traverseWithKey(R.of, ignoreKey, { a: [1, 2], b: [3, 4] }),
+       R.traverseWithKey(R.of, ignoreKey, { b: [3, 4], a: [1, 2] }));
+
+    eq(R.traverseWithKey(S.Either.of, ignoreKey, { a: S.Left(0), b: S.Left(1) }),
+       R.traverseWithKey(S.Either.of, ignoreKey, { b: S.Left(1), a: S.Left(0) }));
+  });
+
+  it('handles an empty object', function() {
+    eq(R.traverseWithKey(S.Either.of, function(k, v) { return v; }, {}), S.Right({}));
+  });
+
+});


### PR DESCRIPTION
This introduces a new function which can then be used to dispatch `Object` types for `R.traverse` and `R.sequence`.
```
R.traverseWithKey :: Applicative f => (a -> f a) -> ((k, a) -> f b) -> {a} -> f {b}
```

This effectively maps over the object's set of keys and values with the provided function, producing `Applicative` values for each. The object is then rebuilt within the context of the `Applicative`.

```js
const allValid = (k, v) => k.length >= 3 && v > 0 ? Just(v) : Nothing();

R.traverseWithKey(Maybe.of, allValid, { a: 1, b: 2, c: 3 }); //=> Nothing
R.traverseWithKey(Maybe.of, allValid, { foo: 0, bar: 1, baz: 2 }); //=> Nothing
R.traverseWithKey(Maybe.of, allValid, { foo: 1, bar: 2, baz: 3 }); //=> Just({ foo: 1, bar: 2, baz: 3 })
```

```js
R.sequence(Maybe.of, { a: Just(1), b: Just(2), c: Just(3) });   //=> Just({a: 1, b: 2, c: 3})
R.sequence(Maybe.of, { a: Just(1), b: Just(2), c: Nothing() }); //=> Nothing()
```

```js
const safeDiv = n => d => d === 0 ? Maybe.Nothing() : Maybe.Just(n / d)

R.traverse(Maybe.of, safeDiv(10), {a: 2, b: 4, c: 5}); //=> Maybe.Just({a: 5, b: 2.5, c: 2})
R.traverse(Maybe.of, safeDiv(10), {a: 2, b: 0, c: 5}); //=> Maybe.Nothing
```