### PR TITLE
Improving the time complexity for the difference function

### DIFF
--- a/source/difference.js
+++ b/source/difference.js
@@ -1,5 +1,5 @@
-import _includes from './internal/_includes';
 import _curry2 from './internal/_curry2';
+import _Set from './internal/_Set';
 
 
 /**
@@ -26,8 +26,15 @@ var difference = _curry2(function difference(first, second) {
   var out = [];
   var idx = 0;
   var firstLen = first.length;
+  var secondLen = second.length;
+  var toFilterOut = new _Set();
+
+  for (var i = 0; i < secondLen; i += 1) {
+    toFilterOut.add(second[i]);
+  }
+
   while (idx < firstLen) {
-    if (!_includes(first[idx], second) && !_includes(first[idx], out)) {
+    if (toFilterOut.add(first[idx])) {
       out[out.length] = first[idx];
     }
     idx += 1;


### PR DESCRIPTION
Before this change, the time complexity for this function was something like O(M x N), being those values the first and the second array lengths.

This can get pretty slow with larger arrays, we learned it the painful way in one of our services :sweat_smile:

This change uses the internal `_Set`, which is O(1)-ish to lookup and insert values. So this function becomes an O(n), which solves our problem.

`differenceWith` remains untouched