### PR TITLE
update lensIndex docs on negative indexes

### DIFF
--- a/source/lensIndex.js
+++ b/source/lensIndex.js
@@ -5,7 +5,7 @@ import update from './update';
 
 
 /**
- * Returns a lens whose focus is the specified index.
+ * Returns a lens whose focus is the specified index, a negative index starts from the end of the array.
  *
  * @func
  * @memberOf R


### PR DESCRIPTION
The docs on lensIndex didn't specify that you can use negative indexes to start from the end of the array.