### PR TITLE
Make R.length operate on Set and Map

### DIFF
--- a/source/length.js
+++ b/source/length.js
@@ -3,21 +3,33 @@ import _isNumber from './internal/_isNumber';
 
 
 /**
- * Returns the number of elements in the array by returning `list.length`.
+ * Returns the number of elements in the array, set or map
+ * by returning `collection.length` or `collection.size`.
  *
  * @func
  * @memberOf R
  * @since v0.3.0
  * @category List
  * @sig [a] -> Number
- * @param {Array} list The array to inspect.
- * @return {Number} The length of the array.
+ * @param {Array|Set|Map} collection The collection to inspect.
+ * @return {Number} The length of the collection.
  * @example
  *
  *      R.length([]); //=> 0
  *      R.length([1, 2, 3]); //=> 3
+ *      R.length(new Set(['x', 'y', 'z'])); //=> 3
+ *      R.length(new Map([['k1', 'v1'], ['k2', 'v2']])); //=> 2
  */
 var length = _curry1(function length(list) {
-  return list != null && _isNumber(list.length) ? list.length : NaN;
+  if (list == null) {
+    return NaN;
+  }
+  if (_isNumber(list.length)) {
+    return list.length;
+  }
+  if (_isNumber(list.size)) {
+    return list.size;
+  }
+  return NaN;
 });
 export default length;

--- a/test/length.js
+++ b/test/length.js
@@ -13,6 +13,18 @@ describe('length', function() {
     eq(R.length('xyz'), 3);
   });
 
+  it('returns the size of a es6 set', function() {
+    if (typeof Set !== 'function') { return; }
+    eq(R.length(new Set()), 0);
+    eq(R.length(new Set(['x', 'y', 'z'])), 3);
+  });
+
+  it('returns the size of a es6 map', function() {
+    if (typeof Map !== 'function') { return; }
+    eq(R.length(new Map()), 0);
+    eq(R.length(new Map([['k1', 'v1'], ['k2', 'v2']])), 2);
+  });
+
   it('returns the length of a function', function() {
     eq(R.length(function() {}), 0);
     eq(R.length(function(x, y, z) { return z; }), 3);


### PR DESCRIPTION
I think making it useful is better than removing it (https://github.com/ramda/ramda/pull/2450#issuecomment-361073664).

I'd like to know why the heck `Set` and `Map` use `.size` instead of `.length` in the first place.

Related to #1055.