### PR TITLE
Make R.propEq and R.propSatisfies safe for null/undefined arguments

### DIFF
--- a/source/propEq.js
+++ b/source/propEq.js
@@ -1,4 +1,5 @@
 import _curry3 from './internal/_curry3';
+import prop from './prop';
 import equals from './equals';
 
 
@@ -28,6 +29,6 @@ import equals from './equals';
  *      R.filter(hasBrownHair, kids); //=> [fred, rusty]
  */
 var propEq = _curry3(function propEq(name, val, obj) {
-  return equals(val, obj[name]);
+  return equals(val, prop(name, obj));
 });
 export default propEq;

--- a/source/propSatisfies.js
+++ b/source/propSatisfies.js
@@ -1,5 +1,5 @@
 import _curry3 from './internal/_curry3';
-
+import prop from './prop';
 
 /**
  * Returns `true` if the specified object property satisfies the given
@@ -21,6 +21,6 @@ import _curry3 from './internal/_curry3';
  *      R.propSatisfies(x => x > 0, 'x', {x: 1, y: 2}); //=> true
  */
 var propSatisfies = _curry3(function propSatisfies(pred, name, obj) {
-  return pred(obj[name]);
+  return pred(prop(name, obj));
 });
 export default propSatisfies;

--- a/test/propEq.js
+++ b/test/propEq.js
@@ -24,4 +24,9 @@ describe('propEq', function() {
     eq(R.propEq('value', new Just([42]), {value: new Just([42])}), true);
   });
 
+  it('returns false if called with a null or undefined object', function () {
+    eq(R.propEq('name', 'Abby', null), false);
+    eq(R.propEq('name', 'Abby', undefined), false);
+  })
+
 });

--- a/test/propEq.js
+++ b/test/propEq.js
@@ -24,9 +24,9 @@ describe('propEq', function() {
     eq(R.propEq('value', new Just([42]), {value: new Just([42])}), true);
   });
 
-  it('returns false if called with a null or undefined object', function () {
+  it('returns false if called with a null or undefined object', function() {
     eq(R.propEq('name', 'Abby', null), false);
     eq(R.propEq('name', 'Abby', undefined), false);
-  })
+  });
 
 });

--- a/test/propSatisfies.js
+++ b/test/propSatisfies.js
@@ -14,4 +14,9 @@ describe('propSatisfies', function() {
     eq(R.propSatisfies(isPositive, 'y', {x: 1, y: 0}), false);
   });
 
+  it('returns false if given a null or undefined object', function() {
+    eq(R.propSatisfies(isPositive, 'y', null), false);
+    eq(R.propSatisfies(isPositive, 'y', undefined), false);
+  });
+
 });


### PR DESCRIPTION
This addresses #2583

It makes sense that `R.prop*` functions would be as safe as `R.prop` so I changed the implementation to build upon them using `prop`.