### PR TITLE
Fix and simplify testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,8 +76,9 @@
     "babel-plugin-annotate-pure-calls": "^0.2.0",
     "babel-register": "^6.26.0",
     "babel-types": "^6.26.0",
+    "babelify": "^8.0.0",
     "benchmark": "~1.0.0",
-    "browserify": "10.x.x",
+    "browserify": "https://api.github.com/repos/browserify/browserify/tarball/9ff7c55cc67a7ddbc64f8e7270bcd75fcc72ce2f",
     "cli-table": "0.3.x",
     "cross-env": "^2.0.1",
     "dox": "latest",
@@ -94,7 +95,7 @@
     "rollup-plugin-terser": "^1.0.1",
     "sanctuary": "0.7.x",
     "sinon": "^1.17.4",
-    "testem": "0.9.x",
+    "testem": "^2.9.0",
     "xyz": "1.0.x"
   }
 }

--- a/package.json
+++ b/package.json
@@ -66,19 +66,15 @@
     "clean": "rimraf es/* src/* dist/* coverage/*",
     "prepare": "npm run clean && npm run build",
     "coverage": "istanbul cover node_modules/.bin/_mocha -- --reporter spec",
-    "postcoverage": "npm run posttest",
     "lint": "eslint scripts/bookmarklet scripts/*.js source/*.js source/internal/*.js test/*.js test/**/*.js lib/sauce/*.js lib/bench/*.js",
-    "pretest": "npm run build:cjs",
-    "test": "mocha --reporter spec",
-    "posttest": "git checkout -- dist",
-    "prebrowser_test": "npm run pretest",
     "browser_test": "testem ci",
-    "postbrowser_test": "npm run posttest"
+    "test": "cross-env BABEL_ENV=cjs mocha --require babel-register --reporter spec"
   },
   "dependencies": {},
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "babel-plugin-annotate-pure-calls": "^0.2.0",
+    "babel-register": "^6.26.0",
     "babel-types": "^6.26.0",
     "benchmark": "~1.0.0",
     "browserify": "10.x.x",

--- a/test/F.js
+++ b/test/F.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/T.js
+++ b/test/T.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/add.js
+++ b/test/add.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 var jsv = require('jsverify');
 

--- a/test/addIndex.js
+++ b/test/addIndex.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/adjust.js
+++ b/test/adjust.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 describe('adjust', function() {

--- a/test/all.js
+++ b/test/all.js
@@ -1,6 +1,6 @@
 var listXf = require('./helpers/listXf');
 
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/allPass.js
+++ b/test/allPass.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/always.js
+++ b/test/always.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 var jsv = require('jsverify');
 

--- a/test/and.js
+++ b/test/and.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/any.js
+++ b/test/any.js
@@ -1,6 +1,6 @@
 var listXf = require('./helpers/listXf');
 
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/anyPass.js
+++ b/test/anyPass.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/ap.js
+++ b/test/ap.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/aperture.js
+++ b/test/aperture.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/append.js
+++ b/test/append.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/apply.js
+++ b/test/apply.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/applySpec.js
+++ b/test/applySpec.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/applyTo.js
+++ b/test/applyTo.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 describe('applyTo', function() {
@@ -11,4 +11,3 @@ describe('applyTo', function() {
   });
 
 });
-

--- a/test/ascend.js
+++ b/test/ascend.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 describe('ascend', function() {

--- a/test/assoc.js
+++ b/test/assoc.js
@@ -1,6 +1,6 @@
 var assert = require('assert');
 
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/assocPath.js
+++ b/test/assocPath.js
@@ -1,6 +1,6 @@
 var assert = require('assert');
 
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/binary.js
+++ b/test/binary.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/bind.js
+++ b/test/bind.js
@@ -1,5 +1,5 @@
 
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/both.js
+++ b/test/both.js
@@ -1,6 +1,6 @@
 var S = require('sanctuary');
 
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/call.js
+++ b/test/call.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/chain.js
+++ b/test/chain.js
@@ -1,8 +1,8 @@
 var listXf = require('./helpers/listXf');
 
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
-var _isTransformer = require('../src/internal/_isTransformer');
+var _isTransformer = require('../source/internal/_isTransformer');
 
 describe('chain', function() {
   var intoArray = R.into([]);

--- a/test/clamp.js
+++ b/test/clamp.js
@@ -1,5 +1,5 @@
 var eq = require('./shared/eq');
-var R = require('..');
+var R = require('../source');
 
 describe('clamp', function() {
   it('clamps to the lower bound', function() {

--- a/test/clone.js
+++ b/test/clone.js
@@ -1,6 +1,6 @@
 var assert = require('assert');
 
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/comparator.js
+++ b/test/comparator.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/complement.js
+++ b/test/complement.js
@@ -1,6 +1,6 @@
 var S = require('sanctuary');
 
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/compose.js
+++ b/test/compose.js
@@ -1,7 +1,7 @@
 var assert = require('assert');
 var jsv = require('jsverify');
 
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/composeK.js
+++ b/test/composeK.js
@@ -1,7 +1,7 @@
 var assert = require('assert');
 var jsv = require('jsverify');
 
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/composeP.js
+++ b/test/composeP.js
@@ -1,6 +1,6 @@
 var assert = require('assert');
 
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/concat.js
+++ b/test/concat.js
@@ -1,6 +1,6 @@
 var assert = require('assert');
 
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/cond.js
+++ b/test/cond.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/construct.js
+++ b/test/construct.js
@@ -1,6 +1,6 @@
 var assert = require('assert');
 
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/constructN.js
+++ b/test/constructN.js
@@ -1,6 +1,6 @@
 var assert = require('assert');
 
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/converge.js
+++ b/test/converge.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/countBy.js
+++ b/test/countBy.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/curry.js
+++ b/test/curry.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 var jsv = require('jsverify');
 var funcN = require('./shared/funcN');

--- a/test/curryN.js
+++ b/test/curryN.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/dec.js
+++ b/test/dec.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/defaultTo.js
+++ b/test/defaultTo.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 describe('defaultTo', function() {

--- a/test/descend.js
+++ b/test/descend.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 describe('descend', function() {

--- a/test/difference.js
+++ b/test/difference.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/differenceWith.js
+++ b/test/differenceWith.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/dissoc.js
+++ b/test/dissoc.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/dissocPath.js
+++ b/test/dissocPath.js
@@ -1,6 +1,6 @@
 var assert = require('assert');
 
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/divide.js
+++ b/test/divide.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/drop.js
+++ b/test/drop.js
@@ -1,6 +1,6 @@
 var assert = require('assert');
 
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/dropLast.js
+++ b/test/dropLast.js
@@ -1,6 +1,6 @@
 var assert = require('assert');
 
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/dropLastWhile.js
+++ b/test/dropLastWhile.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/dropRepeats.js
+++ b/test/dropRepeats.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/dropRepeatsWith.js
+++ b/test/dropRepeatsWith.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/dropWhile.js
+++ b/test/dropWhile.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/either.js
+++ b/test/either.js
@@ -1,6 +1,6 @@
 var S = require('sanctuary');
 
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/empty.js
+++ b/test/empty.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/endsWith.js
+++ b/test/endsWith.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 describe('startsWith', function() {

--- a/test/eqBy.js
+++ b/test/eqBy.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/eqProps.js
+++ b/test/eqProps.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/equals.js
+++ b/test/equals.js
@@ -1,6 +1,6 @@
 /* global Map, Set, WeakMap, WeakSet */
 
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 describe('equals', function() {

--- a/test/evolve.js
+++ b/test/evolve.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/filter.js
+++ b/test/filter.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/find.js
+++ b/test/find.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 var listXf = require('./helpers/listXf');
 

--- a/test/findIndex.js
+++ b/test/findIndex.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 var listXf = require('./helpers/listXf');
 

--- a/test/findLast.js
+++ b/test/findLast.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 var listXf = require('./helpers/listXf');
 

--- a/test/findLastIndex.js
+++ b/test/findLastIndex.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 var listXf = require('./helpers/listXf');
 

--- a/test/flatten.js
+++ b/test/flatten.js
@@ -1,6 +1,6 @@
 var assert = require('assert');
 
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/flip.js
+++ b/test/flip.js
@@ -1,6 +1,6 @@
 var jsv = require('jsverify');
 
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 var funcN = require('./shared/funcN');
 

--- a/test/forEach.js
+++ b/test/forEach.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/forEachObjIndexed.js
+++ b/test/forEachObjIndexed.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/fromPairs.js
+++ b/test/fromPairs.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/groupBy.js
+++ b/test/groupBy.js
@@ -1,6 +1,6 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
-var _isTransformer = require('../src/internal/_isTransformer');
+var _isTransformer = require('../source/internal/_isTransformer');
 
 
 describe('groupBy', function() {

--- a/test/groupWith.js
+++ b/test/groupWith.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 describe('groupWith', function() {

--- a/test/gt.js
+++ b/test/gt.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/gte.js
+++ b/test/gte.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/has.js
+++ b/test/has.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/hasIn.js
+++ b/test/hasIn.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/hasPath.js
+++ b/test/hasPath.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/head.js
+++ b/test/head.js
@@ -1,6 +1,6 @@
 var assert = require('assert');
 
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/helpers/test.examplesRunner.js
+++ b/test/helpers/test.examplesRunner.js
@@ -1,6 +1,6 @@
 var assert = require('assert');
 var fs = require('fs');
-var R = require('..');
+var R = require('../source');
 var dox = require('dox');
 
 // simple object to hold info about our examples

--- a/test/identical.js
+++ b/test/identical.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/identity.js
+++ b/test/identity.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/ifElse.js
+++ b/test/ifElse.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/inc.js
+++ b/test/inc.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/includes.js
+++ b/test/includes.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/index.js
+++ b/test/index.js
@@ -28,6 +28,9 @@ function sourceMethods(dir) {
  * if you would attempt to require non existing file
  */
 describe('API surface', function() {
+  if (require.resolve !== 'function') {
+    return;
+  }
   var exported = Object.keys(R).filter(function(key) {
     return key !== '__esModule';
   });

--- a/test/index.js
+++ b/test/index.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 var fs = require('fs');
 var path = require('path');
@@ -31,7 +31,7 @@ describe('API surface', function() {
   var exported = Object.keys(R).filter(function(key) {
     return key !== '__esModule';
   });
-  var actual = sourceMethods(path.dirname(require.resolve('..')));
+  var actual = sourceMethods(path.dirname(require.resolve('../source')));
 
   it('both APIs are in sync', function() {
     eq(actual.length, exported.length);

--- a/test/indexBy.js
+++ b/test/indexBy.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/indexOf.js
+++ b/test/indexOf.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/init.js
+++ b/test/init.js
@@ -1,6 +1,6 @@
 var assert = require('assert');
 
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/innerJoin.js
+++ b/test/innerJoin.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/insert.js
+++ b/test/insert.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/insertAll.js
+++ b/test/insertAll.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/internal/_curry2.js
+++ b/test/internal/_curry2.js
@@ -1,6 +1,6 @@
 var eq = require('../shared/eq');
-var _ = require('../../src/__');
-var _curry2 = require('../../src/internal/_curry2');
+var _ = require('../../source/__');
+var _curry2 = require('../../source/internal/_curry2');
 
 
 describe('_curry2', function() {

--- a/test/internal/_curry3.js
+++ b/test/internal/_curry3.js
@@ -1,6 +1,6 @@
 var eq = require('../shared/eq');
-var _ = require('../../src/__');
-var _curry3 = require('../../src/internal/_curry3');
+var _ = require('../../source/__');
+var _curry3 = require('../../source/internal/_curry3');
 
 
 describe('_curry3', function() {

--- a/test/internal/_isArrayLike.js
+++ b/test/internal/_isArrayLike.js
@@ -1,5 +1,5 @@
 var eq = require('../shared/eq');
-var _isArrayLike = require('../../src/internal/_isArrayLike');
+var _isArrayLike = require('../../source/internal/_isArrayLike');
 
 
 describe('isArrayLike', function() {

--- a/test/intersection.js
+++ b/test/intersection.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/intersperse.js
+++ b/test/intersperse.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/into.js
+++ b/test/into.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/invariants.js
+++ b/test/invariants.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/invert.js
+++ b/test/invert.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 describe('invert', function() {

--- a/test/invertObj.js
+++ b/test/invertObj.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 describe('invertObj', function() {

--- a/test/invoker.js
+++ b/test/invoker.js
@@ -1,7 +1,7 @@
 var assert = require('assert');
 var vm = require('vm');
 
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/is.js
+++ b/test/is.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/isEmpty.js
+++ b/test/isEmpty.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/isNil.js
+++ b/test/isNil.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 describe('isNil', function() {

--- a/test/join.js
+++ b/test/join.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/juxt.js
+++ b/test/juxt.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/keys.js
+++ b/test/keys.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/keysIn.js
+++ b/test/keysIn.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/last.js
+++ b/test/last.js
@@ -1,6 +1,6 @@
 var assert = require('assert');
 
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/lastIndexOf.js
+++ b/test/lastIndexOf.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/length.js
+++ b/test/length.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/lensIndex.js
+++ b/test/lensIndex.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/lensPath.js
+++ b/test/lensPath.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/lensProp.js
+++ b/test/lensProp.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/lenses.js
+++ b/test/lenses.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 
@@ -67,4 +67,3 @@ describe('view, over, and set', function() {
   });
 
 });
-

--- a/test/lift.js
+++ b/test/lift.js
@@ -1,5 +1,5 @@
 
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 var Maybe = require('./shared/Maybe');
 

--- a/test/liftN.js
+++ b/test/liftN.js
@@ -1,5 +1,5 @@
 
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 var Maybe = require('./shared/Maybe');
 

--- a/test/lt.js
+++ b/test/lt.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/lte.js
+++ b/test/lte.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/map.js
+++ b/test/map.js
@@ -1,6 +1,6 @@
 var listXf = require('./helpers/listXf');
 
-var R = require('..');
+var R = require('../source');
 var assert = require('assert');
 var eq = require('./shared/eq');
 var Id = require('./shared/Id');

--- a/test/mapAccum.js
+++ b/test/mapAccum.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/mapAccumRight.js
+++ b/test/mapAccumRight.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/mapObjIndexed.js
+++ b/test/mapObjIndexed.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/match.js
+++ b/test/match.js
@@ -1,6 +1,6 @@
 var assert = require('assert');
 
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/mathMod.js
+++ b/test/mathMod.js
@@ -1,6 +1,6 @@
 var assert = require('assert');
 
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/max.js
+++ b/test/max.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/maxBy.js
+++ b/test/maxBy.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/mean.js
+++ b/test/mean.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/median.js
+++ b/test/median.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/memoize.js
+++ b/test/memoize.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/memoizeWith.js
+++ b/test/memoizeWith.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/merge.js
+++ b/test/merge.js
@@ -1,6 +1,6 @@
 var assert = require('assert');
 
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/mergeAll.js
+++ b/test/mergeAll.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/mergeDeepLeft.js
+++ b/test/mergeDeepLeft.js
@@ -1,6 +1,6 @@
 var assert = require('assert');
 
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/mergeDeepRight.js
+++ b/test/mergeDeepRight.js
@@ -1,6 +1,6 @@
 var assert = require('assert');
 
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/mergeDeepWith.js
+++ b/test/mergeDeepWith.js
@@ -1,6 +1,6 @@
 var assert = require('assert');
 
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/mergeDeepWithKey.js
+++ b/test/mergeDeepWithKey.js
@@ -1,6 +1,6 @@
 var assert = require('assert');
 
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/mergeLeft.js
+++ b/test/mergeLeft.js
@@ -1,6 +1,6 @@
 var assert = require('assert');
 
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/mergeRight.js
+++ b/test/mergeRight.js
@@ -1,6 +1,6 @@
 var assert = require('assert');
 
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/mergeWith.js
+++ b/test/mergeWith.js
@@ -1,6 +1,6 @@
 var assert = require('assert');
 
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/mergeWithKey.js
+++ b/test/mergeWithKey.js
@@ -1,6 +1,6 @@
 var assert = require('assert');
 
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/min.js
+++ b/test/min.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/minBy.js
+++ b/test/minBy.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/modulo.js
+++ b/test/modulo.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/multiply.js
+++ b/test/multiply.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/nAry.js
+++ b/test/nAry.js
@@ -1,6 +1,6 @@
 var assert = require('assert');
 
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/negate.js
+++ b/test/negate.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/none.js
+++ b/test/none.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/not.js
+++ b/test/not.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/nth.js
+++ b/test/nth.js
@@ -1,6 +1,6 @@
 var assert = require('assert');
 
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/nthArg.js
+++ b/test/nthArg.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/o.js
+++ b/test/o.js
@@ -1,6 +1,6 @@
 var jsv = require('jsverify');
 
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/objOf.js
+++ b/test/objOf.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/of.js
+++ b/test/of.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/omit.js
+++ b/test/omit.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/once.js
+++ b/test/once.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/or.js
+++ b/test/or.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/pair.js
+++ b/test/pair.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/partial.js
+++ b/test/partial.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/partialRight.js
+++ b/test/partialRight.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/partition.js
+++ b/test/partition.js
@@ -1,6 +1,6 @@
 var S = require('sanctuary');
 
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/path.js
+++ b/test/path.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/pathEq.js
+++ b/test/pathEq.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/pathOr.js
+++ b/test/pathOr.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/pathSatisfies.js
+++ b/test/pathSatisfies.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/pick.js
+++ b/test/pick.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/pickAll.js
+++ b/test/pickAll.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/pickBy.js
+++ b/test/pickBy.js
@@ -1,6 +1,6 @@
 var assert = require('assert');
 
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/pipe.js
+++ b/test/pipe.js
@@ -1,6 +1,6 @@
 var assert = require('assert');
 
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/pipeK.js
+++ b/test/pipeK.js
@@ -1,7 +1,7 @@
 var jsv = require('jsverify');
 var assert = require('assert');
 
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/pipeP.js
+++ b/test/pipeP.js
@@ -1,6 +1,6 @@
 var assert = require('assert');
 
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/pluck.js
+++ b/test/pluck.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/prepend.js
+++ b/test/prepend.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/product.js
+++ b/test/product.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/project.js
+++ b/test/project.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/prop.js
+++ b/test/prop.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/propEq.js
+++ b/test/propEq.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/propIs.js
+++ b/test/propIs.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/propOr.js
+++ b/test/propOr.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/propSatisfies.js
+++ b/test/propSatisfies.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/props.js
+++ b/test/props.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/range.js
+++ b/test/range.js
@@ -1,6 +1,6 @@
 var assert = require('assert');
 
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/reduce.js
+++ b/test/reduce.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 describe('reduce', function() {

--- a/test/reduceBy.js
+++ b/test/reduceBy.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 var byType = R.prop('type');

--- a/test/reduceRight.js
+++ b/test/reduceRight.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/reduceWhile.js
+++ b/test/reduceWhile.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 var isOdd = function(_, x) {return x % 2 === 1; };

--- a/test/reduced.js
+++ b/test/reduced.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/reject.js
+++ b/test/reject.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/remove.js
+++ b/test/remove.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/repeat.js
+++ b/test/repeat.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/replace.js
+++ b/test/replace.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/reverse.js
+++ b/test/reverse.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/scan.js
+++ b/test/scan.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/sequence.js
+++ b/test/sequence.js
@@ -1,6 +1,6 @@
 var S = require('sanctuary');
 
-var R = require('..');
+var R = require('../source');
 var Id = require('./shared/Id');
 var eq = require('./shared/eq');
 

--- a/test/shared/Id.js
+++ b/test/shared/Id.js
@@ -1,4 +1,4 @@
-var R = require('../..');
+var R = require('../../source');
 
 
 //  Id :: a -> Id a

--- a/test/shared/Maybe.js
+++ b/test/shared/Maybe.js
@@ -1,4 +1,4 @@
-var R = require('../..');
+var R = require('../../source');
 
 
 var sentinel = {};

--- a/test/shared/eq.js
+++ b/test/shared/eq.js
@@ -1,6 +1,6 @@
 var assert = require('assert');
 
-var R = require('../..');
+var R = require('../../source');
 
 
 module.exports = function(actual, expected) {

--- a/test/slice.js
+++ b/test/slice.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/sort.js
+++ b/test/sort.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/sortBy.js
+++ b/test/sortBy.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/sortWith.js
+++ b/test/sortWith.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/split.js
+++ b/test/split.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/splitAt.js
+++ b/test/splitAt.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/splitEvery.js
+++ b/test/splitEvery.js
@@ -1,6 +1,6 @@
 var assert = require('assert');
 
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/splitWhen.js
+++ b/test/splitWhen.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/startsWith.js
+++ b/test/startsWith.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 describe('startsWith', function() {

--- a/test/subtract.js
+++ b/test/subtract.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/sum.js
+++ b/test/sum.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/symmetricDifference.js
+++ b/test/symmetricDifference.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/symmetricDifferenceWith.js
+++ b/test/symmetricDifferenceWith.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/tail.js
+++ b/test/tail.js
@@ -1,6 +1,6 @@
 var assert = require('assert');
 
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/take.js
+++ b/test/take.js
@@ -1,7 +1,7 @@
 var assert = require('assert');
 var sinon = require('sinon');
 
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/takeLast.js
+++ b/test/takeLast.js
@@ -1,6 +1,6 @@
 var assert = require('assert');
 
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/takeLastWhile.js
+++ b/test/takeLastWhile.js
@@ -1,6 +1,6 @@
 var assert = require('assert');
 
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/takeWhile.js
+++ b/test/takeWhile.js
@@ -1,6 +1,6 @@
 var assert = require('assert');
 
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/tap.js
+++ b/test/tap.js
@@ -1,7 +1,7 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 var listXf = require('./helpers/listXf');
-var _curry2 = require('../src/internal/_curry2');
+var _curry2 = require('../source/internal/_curry2');
 
 
 describe('tap', function() {

--- a/test/test.js
+++ b/test/test.js
@@ -1,6 +1,6 @@
 var assert = require('assert');
 
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/thunkify.js
+++ b/test/thunkify.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 describe('thunkify', function() {

--- a/test/times.js
+++ b/test/times.js
@@ -1,6 +1,6 @@
 var assert = require('assert');
 
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/toLower.js
+++ b/test/toLower.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/toPairs.js
+++ b/test/toPairs.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/toPairsIn.js
+++ b/test/toPairsIn.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/toString.js
+++ b/test/toString.js
@@ -1,6 +1,6 @@
 var assert = require('assert');
 
-var R = require('..');
+var R = require('../source');
 
 
 describe('toString', function() {
@@ -83,7 +83,8 @@ describe('toString', function() {
   });
 
   it('returns the string representation of a function', function() {
-    assert.strictEqual(R.toString(function add(a, b) { return a + b; }), 'function add(a, b) { return a + b; }');
+    var add = function add(a, b) { return a + b; };
+    assert.strictEqual(R.toString(add), add.toString());
   });
 
   it('returns the string representation of an array', function() {

--- a/test/toUpper.js
+++ b/test/toUpper.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/transduce.js
+++ b/test/transduce.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 describe('transduce', function() {

--- a/test/transpose.js
+++ b/test/transpose.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 describe('transpose', function() {

--- a/test/traverse.js
+++ b/test/traverse.js
@@ -1,6 +1,6 @@
 var S = require('sanctuary');
 
-var R = require('..');
+var R = require('../source');
 var Id = require('./shared/Id');
 var eq = require('./shared/eq');
 

--- a/test/trim.js
+++ b/test/trim.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/tryCatch.js
+++ b/test/tryCatch.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/type.js
+++ b/test/type.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/unapply.js
+++ b/test/unapply.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/unary.js
+++ b/test/unary.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/uncurryN.js
+++ b/test/uncurryN.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/unfold.js
+++ b/test/unfold.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/union.js
+++ b/test/union.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/unionWith.js
+++ b/test/unionWith.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/uniq.js
+++ b/test/uniq.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/uniqBy.js
+++ b/test/uniqBy.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/uniqWith.js
+++ b/test/uniqWith.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/unless.js
+++ b/test/unless.js
@@ -1,6 +1,6 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
-var _isArrayLike = require('../src/internal/_isArrayLike');
+var _isArrayLike = require('../source/internal/_isArrayLike');
 
 
 describe('unless', function() {

--- a/test/unnest.js
+++ b/test/unnest.js
@@ -1,6 +1,6 @@
 var assert = require('assert');
 
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 var Maybe = require('./shared/Maybe');
 

--- a/test/until.js
+++ b/test/until.js
@@ -1,6 +1,6 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
-var _isArrayLike = require('../src/internal/_isArrayLike');
+var _isArrayLike = require('../source/internal/_isArrayLike');
 
 
 describe('until', function() {

--- a/test/update.js
+++ b/test/update.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 describe('update', function() {

--- a/test/useWith.js
+++ b/test/useWith.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/values.js
+++ b/test/values.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/valuesIn.js
+++ b/test/valuesIn.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/when.js
+++ b/test/when.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/where.js
+++ b/test/where.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/whereEq.js
+++ b/test/whereEq.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/without.js
+++ b/test/without.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/xprod.js
+++ b/test/xprod.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/zip.js
+++ b/test/zip.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/zipObj.js
+++ b/test/zipObj.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/test/zipWith.js
+++ b/test/zipWith.js
@@ -1,4 +1,4 @@
-var R = require('..');
+var R = require('../source');
 var eq = require('./shared/eq');
 
 

--- a/testem.json
+++ b/testem.json
@@ -8,6 +8,6 @@
   "serve_files": [
       "tmp-test-bundle.js"
   ],
-  "before_tests": "node_modules/.bin/browserify test/*.js --outfile tmp-test-bundle.js",
-  "after_tests": "rm tmp-test-bundle.js"
+  "before_tests": "cross-env BABEL_ENV=cjs browserify test/*.js -t babelify --outfile tmp-test-bundle.js",
+  "after_tests": "rimraf tmp-test-bundle.js"
 }


### PR DESCRIPTION
Uses babel as a plugin to avoid  having to create commonjs build on disk before running tests.

Also, fixes browser tests (https://github.com/ramda/ramda/pull/2589#issuecomment-405263241), so closes #2597.

