### PR TITLE
Use UMD in Node, don't build CommonJS by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,22 +46,20 @@
     "url": "git://github.com/ramda/ramda.git"
   },
   "module": "es/index.js",
-  "main": "src/index.js",
+  "main": "dist/ramda.js",
   "unpkg": "dist/ramda.min.js",
   "jsdelivr": "dist/ramda.min.js",
   "files": [
     "es",
-    "src",
     "dist"
   ],
   "scripts": {
     "bench": "scripts/benchRunner",
     "bookmarklet": "scripts/bookmarklet",
     "build:es": "cross-env BABEL_ENV=es babel source --out-dir es",
-    "build:cjs": "cross-env BABEL_ENV=cjs babel source --out-dir src",
     "build:umd": "cross-env NODE_ENV=development rollup -c -o dist/ramda.js",
     "build:umd:min": "cross-env NODE_ENV=production rollup -c -o dist/ramda.min.js",
-    "build": "npm run build:es && npm run build:cjs && npm run build:umd && npm run build:umd:min",
+    "build": "npm run build:es && npm run build:umd && npm run build:umd:min",
     "partial-build": "node ./scripts/partialBuild",
     "clean": "rimraf es/* src/* dist/* coverage/*",
     "prepare": "npm run clean && npm run build",


### PR DESCRIPTION
UMD contains additional code to work as AMD, CommonJS and in browsers. Therefore, I don't see any value in having Node-only CommonJS build when there is UMD build.

This PR decreases size of the package (one less build to include), simplifies build process, and enables slightly faster loading in Node (because it needs to resolve and read one file instead of 325).

~~Alternative solution: replace UMD build with smaller, browser-optimized IIFE build.~~ CommonJS build doesn't provide AMD compatibility.

Closes #2035.
Incompatible with #1959, closes #1959.

Note to self: after merging, consider using rollup to create es build, and maybe test bundle.
