### PR TITLE
Improve R.without and R.intersection time complexity

### DIFF
--- a/source/intersection.js
+++ b/source/intersection.js
@@ -22,21 +22,12 @@ import uniq from './uniq.js';
  *      R.intersection([1,2,3,4], [7,6,5,4,3]); //=> [4, 3]
  */
 var intersection = _curry2(function intersection(list1, list2) {
-  var lookupList, filteredList;
   var toKeep = new _Set();
 
-  if (list1.length > list2.length) {
-    lookupList = list1;
-    filteredList = list2;
-  } else {
-    lookupList = list2;
-    filteredList = list1;
+  for (var i = 0; i < list1.length; i += 1) {
+    toKeep.add(list1[i]);
   }
 
-  for (var i = 0; i < lookupList.length; i += 1) {
-    toKeep.add(lookupList[i]);
-  }
-
-  return uniq(_filter(toKeep.has.bind(toKeep), filteredList));
+  return uniq(_filter(toKeep.has.bind(toKeep), list2));
 });
 export default intersection;

--- a/source/intersection.js
+++ b/source/intersection.js
@@ -1,7 +1,6 @@
-import _includes from './internal/_includes.js';
 import _curry2 from './internal/_curry2.js';
 import _filter from './internal/_filter.js';
-import flip from './flip.js';
+import _Set from './internal/_Set.js';
 import uniq from './uniq.js';
 
 
@@ -24,6 +23,8 @@ import uniq from './uniq.js';
  */
 var intersection = _curry2(function intersection(list1, list2) {
   var lookupList, filteredList;
+  var toKeep = new _Set();
+
   if (list1.length > list2.length) {
     lookupList = list1;
     filteredList = list2;
@@ -31,6 +32,11 @@ var intersection = _curry2(function intersection(list1, list2) {
     lookupList = list2;
     filteredList = list1;
   }
-  return uniq(_filter(flip(_includes)(lookupList), filteredList));
+
+  for (var i = 0; i < lookupList.length; i += 1) {
+    toKeep.add(lookupList[i]);
+  }
+
+  return uniq(_filter(toKeep.has.bind(toKeep), filteredList));
 });
 export default intersection;

--- a/source/without.js
+++ b/source/without.js
@@ -1,6 +1,5 @@
-import _includes from './internal/_includes.js';
 import _curry2 from './internal/_curry2.js';
-import flip from './flip.js';
+import _Set from './internal/_Set.js';
 import reject from './reject.js';
 
 
@@ -23,7 +22,13 @@ import reject from './reject.js';
  *
  *      R.without([1, 2], [1, 2, 1, 3, 4]); //=> [3, 4]
  */
-var without = _curry2(function(xs, list) {
-  return reject(flip(_includes)(xs), list);
+var without = _curry2(function without(xs, list) {
+  var toRemove = new _Set();
+
+  for (var i = 0; i < xs.length; i += 1) {
+    toRemove.add(xs[i]);
+  }
+
+  return reject(toRemove.has.bind(toRemove), list);
 });
 export default without;

--- a/test/intersection.js
+++ b/test/intersection.js
@@ -15,6 +15,14 @@ describe('intersection', function() {
     eq(R.intersection(M2, N2), [3, 4]);
   });
 
+  it('does not allow duplicates in the output even if the first list is bigger and has duplicates', function() {
+    eq(R.intersection(M2, N), [3, 4]);
+  });
+
+  it('does not allow duplicates in the output even if the second list is bigger and has duplicates', function() {
+    eq(R.intersection(M, N2), [3, 4]);
+  });
+
   it('has R.equals semantics', function() {
     function Just(x) { this.value = x; }
     Just.prototype.equals = function(x) {


### PR DESCRIPTION
I am using the internal `_Set` in both functions to drop the time complexity from O(n²) to O(n).
That's the same way the `R.difference` is improved in #2581.

Before/after (in milliseconds):
```
-- R.without
Before:
  10k [size 10] arrays: 65.593378
  10k [size 100] arrays: 437.021462
  1k [size 1000] arrays: 1186.243514
  100 [size 10000] arrays: 9127.722465
After:
  10k [size 10] arrays: 37.329974
  10k [size 100] arrays: 102.189432
  1k [size 1000] arrays: 93.958924
  100 [size 10000] arrays: 114.788804

-- R.intersection
Before:
  10k [size 10] arrays: 86.015134
  10k [size 100] arrays: 502.037411
  1k [size 1000] arrays: 1212.673359
  100 [size 10000] arrays: 9114.332054
After:
  10k [size 10] arrays: 45.109575
  10k [size 100] arrays: 175.27189
  1k [size 1000] arrays: 165.56708
  100 [size 10000] arrays: 199.455852
```