### PR TITLE
Proposal: keyed transducers

### DIFF
--- a/source/concat.js
+++ b/source/concat.js
@@ -1,7 +1,9 @@
 import _curry2 from './internal/_curry2';
+import _identity from './internal/_identity';
 import _isArray from './internal/_isArray';
 import _isFunction from './internal/_isFunction';
 import _isString from './internal/_isString';
+import into from './into';
 import toString from './toString';
 
 
@@ -52,6 +54,9 @@ var concat = _curry2(function concat(a, b) {
   if (a != null && _isFunction(a.concat)) {
     return a.concat(b);
   }
+  try {
+    return into(a, _identity, b);
+  } catch (error) {}
   throw new TypeError(toString(a) + ' does not have a method named "concat" or "fantasy-land/concat"');
 });
 export default concat;

--- a/source/filter.js
+++ b/source/filter.js
@@ -1,10 +1,6 @@
 import _curry2 from './internal/_curry2';
-import _dispatchable from './internal/_dispatchable';
-import _filter from './internal/_filter';
-import _isObject from './internal/_isObject';
-import _reduce from './internal/_reduce';
+import _dispatchKeyed from './internal/_dispatchKeyed';
 import _xfilter from './internal/_xfilter';
-import keys from './keys';
 
 
 /**
@@ -34,17 +30,5 @@ import keys from './keys';
  *
  *      R.filter(isEven, {a: 1, b: 2, c: 3, d: 4}); //=> {b: 2, d: 4}
  */
-var filter = _curry2(_dispatchable(['filter'], _xfilter, function(pred, filterable) {
-  return (
-    _isObject(filterable) ?
-      _reduce(function(acc, key) {
-        if (pred(filterable[key])) {
-          acc[key] = filterable[key];
-        }
-        return acc;
-      }, {}, keys(filterable)) :
-    // else
-      _filter(pred, filterable)
-  );
-}));
+const filter = _curry2(_dispatchKeyed(['fantasy-land/filter', 'filter'], _xfilter));
 export default filter;

--- a/source/internal/_dispatchKeyed.js
+++ b/source/internal/_dispatchKeyed.js
@@ -1,0 +1,40 @@
+import _isArray from './_isArray';
+import _isTransformer from './_isTransformer';
+import _pcall from './_pcall';
+import _reduce from './_reduce';
+import _stepCat from './_stepCat';
+
+
+/**
+ * @private
+ * @param {Array} methodNames properties to check for a custom implementation
+ * @param {Function} xf transducer
+ * @param {Function} fn catch-all implementation
+ * @return {Function} A function that dispatches on object in list position
+ */
+export default function _dispatchKeyed(methodNames, xf, fn) {
+  return function(...args) {
+    const obj = args.pop();
+    if (!_isArray(obj)) {
+      var idx = 0;
+      while (idx < methodNames.length) {
+        if (typeof obj[methodNames[idx]] === 'function') {
+          return obj[methodNames[idx]].apply(obj, args);
+        }
+        idx += 1;
+      }
+    }
+    const transducer = xf.apply(null, args);
+    if (typeof obj.transduce === 'function') {
+      return obj.transduce(transducer);
+    }
+    if (_isTransformer(obj)) {
+      return transducer(obj);
+    }
+    const sink = _pcall(_stepCat, obj);
+    if (sink.ok) {
+      return _reduce(transducer(sink.value), sink.value['@@transducer/init'](), obj);
+    }
+    return fn.apply(this, arguments);
+  };
+}

--- a/source/internal/_isMap.js
+++ b/source/internal/_isMap.js
@@ -1,0 +1,2 @@
+export default value =>
+  typeof Map === 'function' && value instanceof Map;

--- a/source/internal/_pcall.js
+++ b/source/internal/_pcall.js
@@ -1,0 +1,7 @@
+export default function _pcall(fn, ...args) {
+  try {
+    return { ok: true, value: fn.apply(this, args) };
+  } catch (error) {
+    return { ok: false, error };
+  }
+}

--- a/source/internal/_stepCat.js
+++ b/source/internal/_stepCat.js
@@ -1,8 +1,7 @@
-import _objectAssign from './_objectAssign';
 import _identity from './_identity';
 import _isArrayLike from './_isArrayLike';
+import _isMap from './_isMap';
 import _isTransformer from './_isTransformer';
-import objOf from '../objOf';
 
 
 var _stepCatArray = {
@@ -13,6 +12,16 @@ var _stepCatArray = {
   },
   '@@transducer/result': _identity
 };
+var _stepCatMap = {
+  '@@transducer/init': function() {
+    return new Map();
+  },
+  '@@transducer/step': function(result, value, key) {
+    result.set(key, value);
+    return result;
+  },
+  '@@transducer/result': _identity
+};
 var _stepCatString = {
   '@@transducer/init': String,
   '@@transducer/step': function(a, b) { return a + b; },
@@ -20,11 +29,12 @@ var _stepCatString = {
 };
 var _stepCatObject = {
   '@@transducer/init': Object,
-  '@@transducer/step': function(result, input) {
-    return _objectAssign(
-      result,
-      _isArrayLike(input) ? objOf(input[0], input[1]) : input
-    );
+  '@@transducer/step': function(result, value, key) {
+    if (arguments.length === 2) { // backwards compat
+      [key, value] = value;
+    }
+    result[key] = value;
+    return result;
   },
   '@@transducer/result': _identity
 };
@@ -38,6 +48,9 @@ export default function _stepCat(obj) {
   }
   if (typeof obj === 'string') {
     return _stepCatString;
+  }
+  if (_isMap(obj)) {
+    return _stepCatMap;
   }
   if (typeof obj === 'object') {
     return _stepCatObject;

--- a/source/internal/_xfilter.js
+++ b/source/internal/_xfilter.js
@@ -8,8 +8,10 @@ function XFilter(f, xf) {
 }
 XFilter.prototype['@@transducer/init'] = _xfBase.init;
 XFilter.prototype['@@transducer/result'] = _xfBase.result;
-XFilter.prototype['@@transducer/step'] = function(result, input) {
-  return this.f(input) ? this.xf['@@transducer/step'](result, input) : result;
+XFilter.prototype['@@transducer/step'] = function(result, input, ...args) {
+  return this.f(input)
+    ? this.xf['@@transducer/step'](result, input, ...args)
+    : result;
 };
 
 var _xfilter = _curry2(function _xfilter(f, xf) { return new XFilter(f, xf); });

--- a/source/internal/_xmap.js
+++ b/source/internal/_xmap.js
@@ -8,8 +8,8 @@ function XMap(f, xf) {
 }
 XMap.prototype['@@transducer/init'] = _xfBase.init;
 XMap.prototype['@@transducer/result'] = _xfBase.result;
-XMap.prototype['@@transducer/step'] = function(result, input) {
-  return this.xf['@@transducer/step'](result, this.f(input));
+XMap.prototype['@@transducer/step'] = function(result, input, ...args) {
+  return this.xf['@@transducer/step'](result, this.f(input), ...args);
 };
 
 var _xmap = _curry2(function _xmap(f, xf) { return new XMap(f, xf); });

--- a/source/internal/_xtap.js
+++ b/source/internal/_xtap.js
@@ -8,9 +8,9 @@ function XTap(f, xf) {
 }
 XTap.prototype['@@transducer/init'] = _xfBase.init;
 XTap.prototype['@@transducer/result'] = _xfBase.result;
-XTap.prototype['@@transducer/step'] = function(result, input) {
+XTap.prototype['@@transducer/step'] = function(result, input, ...args) {
   this.f(input);
-  return this.xf['@@transducer/step'](result, input);
+  return this.xf['@@transducer/step'](result, input, ...args);
 };
 
 var _xtap = _curry2(function _xtap(f, xf) { return new XTap(f, xf); });

--- a/source/map.js
+++ b/source/map.js
@@ -1,10 +1,7 @@
 import _curry2 from './internal/_curry2';
-import _dispatchable from './internal/_dispatchable';
-import _map from './internal/_map';
-import _reduce from './internal/_reduce';
+import _dispatchKeyed from './internal/_dispatchKeyed';
 import _xmap from './internal/_xmap';
-import curryN from './curryN';
-import keys from './keys';
+import compose from './compose';
 
 
 /**
@@ -42,19 +39,5 @@ import keys from './keys';
  * @symb R.map(f, { x: a, y: b }) = { x: f(a), y: f(b) }
  * @symb R.map(f, functor_o) = functor_o.map(f)
  */
-var map = _curry2(_dispatchable(['fantasy-land/map', 'map'], _xmap, function map(fn, functor) {
-  switch (Object.prototype.toString.call(functor)) {
-    case '[object Function]':
-      return curryN(functor.length, function() {
-        return fn.call(this, functor.apply(this, arguments));
-      });
-    case '[object Object]':
-      return _reduce(function(acc, key) {
-        acc[key] = fn(functor[key]);
-        return acc;
-      }, {}, keys(functor));
-    default:
-      return _map(fn, functor);
-  }
-}));
+const map = _curry2(_dispatchKeyed(['fantasy-land/map', 'map'], _xmap, compose));
 export default map;

--- a/test/concat.js
+++ b/test/concat.js
@@ -34,12 +34,27 @@ describe('concat', function() {
     eq(R.concat(z1, z2), 'z1 z2');
   });
 
+  it('merges objects', function() {
+    const src = { foo: 1, bar: 2 };
+    const res = R.concat(src, { foo: 3 });
+    eq(res, { foo: 3, bar: 2 });
+    assert.notDeepStrictEqual(src, res, "doesn't mutate src");
+  });
+
+  it('merges Maps', function() {
+    const src = new Map([['foo', 1], ['bar', 2]]);
+    const res = R.concat(src, new Map([['foo', 3]]));
+    assert.deepStrictEqual(res, new Map([['foo', 3], ['bar', 2]]));
+    assert.notDeepStrictEqual(src, res, "doesn't mutate src");
+  });
+
   it('throws if attempting to combine an array with a non-array', function() {
     assert.throws(function() { return R.concat([1], 2); }, TypeError);
   });
 
-  it('throws if not an array, String, or object with a concat method', function() {
-    assert.throws(function() { return R.concat({}, {}); }, TypeError);
+  it('throws if not an array, string, or object', function() {
+    assert.throws(function() { return R.concat(null, null); }, TypeError);
+    assert.throws(function() { return R.concat(0, 0); }, TypeError);
   });
 
 });

--- a/test/filter.js
+++ b/test/filter.js
@@ -1,4 +1,5 @@
 var R = require('../source');
+var assert = require('assert');
 var eq = require('./shared/eq');
 
 
@@ -24,6 +25,18 @@ describe('filter', function() {
     eq(R.filter(positive, {x: 1, y: 0, z: 0}), {x: 1});
     eq(R.filter(positive, {x: 1, y: 2, z: 0}), {x: 1, y: 2});
     eq(R.filter(positive, {x: 1, y: 2, z: 3}), {x: 1, y: 2, z: 3});
+  });
+
+  it('can act as keyed transducer', function() {
+    var positive = function(x) { return x > 0; };
+    eq(R.into({}, R.filter(positive), { x: 1, y: 0, z: 0 }), { x: 1 });
+    eq(R.into([], R.filter(positive), { x: 1, y: 0, z: 0 }), [1]);
+    if (typeof Map !== 'function') {
+      return;
+    }
+    eq(R.into({}, R.filter(positive), new Map([['x', 1], ['y', 0], ['z', 0]])), { x: 1 });
+    assert.deepStrictEqual(R.into(new Map(), R.filter(positive), { x: 1, y: 0, z: 0 }), new Map([['x', 1]]));
+    assert.deepStrictEqual(R.into(new Map(), R.filter(positive), new Map([['x', 1], ['y', 0], ['z', 0]])), new Map([['x', 1]]));
   });
 
   it('dispatches to passed-in non-Array object with a `filter` method', function() {

--- a/test/into.js
+++ b/test/into.js
@@ -25,7 +25,6 @@ describe('into', function() {
 
   it('transduces into objects', function() {
     eq(R.into({}, R.identity, [['a', 1], ['b', 2]]), {a: 1, b: 2});
-    eq(R.into({}, R.identity, [{a: 1}, {b: 2, c: 3}]), {a: 1, b: 2, c: 3});
   });
 
   it('dispatches to objects that implement `reduce`', function() {

--- a/test/map.js
+++ b/test/map.js
@@ -24,6 +24,17 @@ describe('map', function() {
     eq(R.map(dec, {x: 4, y: 5, z: 6}), {x: 3, y: 4, z: 5});
   });
 
+  it('can act as keyed transducer', function() {
+    eq(R.into({}, R.map(dec), { x: 4, y: 5, z: 6 }), { x: 3, y: 4, z: 5 });
+    eq(R.into([], R.map(dec), { x: 4, y: 5, z: 6 }), [3, 4, 5]);
+    if (typeof Map !== 'function') {
+      return;
+    }
+    eq(R.into({}, R.map(dec), new Map([['x', 4], ['y', 5], ['z', 6]])), { x: 3, y: 4, z: 5 });
+    assert.deepStrictEqual(R.into(new Map(), R.map(dec), { x: 4, y: 5, z: 6 }), new Map([['x', 3], ['y', 4], ['z', 5]]));
+    assert.deepStrictEqual(R.into(new Map(), R.map(dec), new Map([['x', 4], ['y', 5], ['z', 6]])), new Map([['x', 3], ['y', 4], ['z', 5]]));
+  });
+
   it('interprets ((->) r) as a functor', function() {
     var f = function(a) { return a - 1; };
     var g = function(b) { return b * 2; };


### PR DESCRIPTION
`filter` has 3 specializations: for arrays, objects and transformers (ie. transducer version).

Specialization for arrays can be easily expressed in terms of transducers.

The same transducers can't be reused for objects, tho &mdash; `R.into({})` expects `'@@transducer/step'` to have signature `(acc, [key, value]) => newAcc`, which is inherently incompatible with `(acc, value) => newAcc`.

## Proposal

I suggest to change signature of `step` function of object-compatible ("keyed") transducers to 
`(acc, value, key?) => newAcc`.

This allows to reuse transducers to transform objects.

Because `key` is optional, keyed transducers remain compatible with non-keyed.

## To do

1. [x] In transformations<sup>1</sup>, when dispatching, use transducers when Map, array or object is passed as input.
2. [x] Get rid of redundant array and object specializations.
3. [ ] Ensure that `reduceBy` (and derived functions) works with keyed transducers.
4. [ ] Get rid of legacy `(result, [key, value]) => result` signature from [`_stepCatObject`'s `step`](https://github.com/ramda/ramda/pull/2622/files#diff-c78dd3dc852a1f37454e6a9c243cf6fcR33).
4. [ ] Update `R.into`'s docs.
5. [ ] After merging #2585, consider moving functionality from `_dispatchKeyed` into `_dispatchable`.

<sup>1</sup>By "transformation", I mean function which takes a collection and returns a collection of the same type.

I'll <ins>try to</ins> wait with working on those until the idea is approved.

## Other issues

Obviously, in order to transduce an object, I needed to add object support to `_reduce`; resolves #2046.

Also, I added `Map` support (#1055).

Note how all the switching on types happens in `_reduce` and `_stepCat` (https://github.com/ramda/ramda/issues/1055#issuecomment-371014572).

## After merging

- Reimplement `object -> object` methods in terms of keyed transducers to add Map support to them without adding type-switching.
- Merge `update` and `assoc` into 1 function, supporting objects, Maps and arrays.
- Add Map and object support to `concat`, deprecate `merge`
(in progress, test fails because `_clone` doesn't support Map).
- Consider reviving #2626.
- Try to write universal, performant `concatAll` (working on strings, arrays, objects, Maps, iteratbles).