### PR TITLE
Ignore lock files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 /lib/docs/public/
 /node_modules/
 /npm-debug.log
+/package-lock.json
+/shrinkwrap.yaml
+/yarn.lock
 /lib/test/bundle.js
 /tmp
 /bower_components/


### PR DESCRIPTION
Just so they don't show up in git, and don't get committed accidentally (https://github.com/ramda/ramda/pull/2186#issuecomment-304993652, https://github.com/ramda/ramda/pull/2506#pullrequestreview-111300673).

Incompatible with #2071, closes #2071.