### PR TITLE
Change flip's arity from 1 to 3

### DIFF
--- a/source/flip.js
+++ b/source/flip.js
@@ -1,33 +1,30 @@
-import _curry1 from './internal/_curry1';
 import curryN from './curryN';
 
 
 /**
- * Returns a new function much like the supplied one, except that the first two
- * arguments' order is reversed.
+ * Calls the passed function with first 2 arguments swapped.
  *
  * @func
  * @memberOf R
  * @since v0.1.0
  * @category Function
- * @sig ((a, b, c, ...) -> z) -> (b -> a -> c -> ... -> z)
+ * @sig ((a, b, c, ...) -> z) -> b -> (a, c, ...) -> z
  * @param {Function} fn The function to invoke with its first two parameters reversed.
+ * @param {*} a First argument
+ * @param {*} b Second argument
  * @return {*} The result of invoking `fn` with its first two parameters' order reversed.
  * @example
  *
- *      const mergeThree = (a, b, c) => [].concat(a, b, c);
+ *      const mergeThree = (a, b, c) => [a, b, c];
+ *
+ *      const isPositive = R.flip(R.gt, 0);
  *
  *      mergeThree(1, 2, 3); //=> [1, 2, 3]
  *
  *      R.flip(mergeThree)(1, 2, 3); //=> [2, 1, 3]
  * @symb R.flip(f)(a, b, c) = f(b, a, c)
  */
-var flip = _curry1(function flip(fn) {
-  return curryN(fn.length, function(a, b) {
-    var args = Array.prototype.slice.call(arguments, 0);
-    args[0] = b;
-    args[1] = a;
-    return fn.apply(this, args);
-  });
+const flip = curryN(3, function flip(fn, a, b, ...args) {
+  return fn(b, a, ...args);
 });
 export default flip;

--- a/test/flip.js
+++ b/test/flip.js
@@ -19,11 +19,10 @@ describe('flip', function() {
     eq(g('b', 'c'), 'b a c');
   });
 
-  it('returns a function with the correct arity', function() {
-    var f2 = function(a, b) {return a + ' ' + b;};
-    var f3 = function(a, b, c) {return a + ' ' + b + ' ' + c;};
-    eq(R.flip(f2).length, 2);
-    eq(R.flip(f3).length, 3);
+  it('can be used as right section', function() {
+    const isPositive = R.flip(R.gt, 0);
+    eq(isPositive(5), true);
+    eq(isPositive(-5), false);
   });
 
 });


### PR DESCRIPTION
### Pros:

+ Simplifies `flip`'s implementation (no implicit currying).
+ Makes `flip` work as right section (#2177).
`applyTo` can be used as left section (and as `infix`, if redefined as `flip(call)`), so resolves #2177.

### Cons:

- Doesn't preserve function's arity.

### Alternative approaches:

* Add `f_` and `_f`, deprecate `flip` and `applyTo`.
* `uncurryN(2)` `flip`?

### What's next?

+ Deprecate placeholder.
+ Remove `mergeLeft` = `flip(merge)`, `mergeRight` = `merge`.
`merge` can stay deprecated, I added support for objects to `concat` at #2622.