### PR TITLE
Add R.xor (Exclusive OR)

### DIFF
--- a/source/and.js
+++ b/source/and.js
@@ -12,7 +12,7 @@ import _curry2 from './internal/_curry2';
  * @param {Any} a
  * @param {Any} b
  * @return {Any} the first argument if it is falsy, otherwise the second argument.
- * @see R.both
+ * @see R.both, R.xor
  * @example
  *
  *      R.and(true, true); //=> true

--- a/source/index.js
+++ b/source/index.js
@@ -246,6 +246,7 @@ export { default as when } from './when';
 export { default as where } from './where';
 export { default as whereEq } from './whereEq';
 export { default as without } from './without';
+export { default as xor } from './xor';
 export { default as xprod } from './xprod';
 export { default as zip } from './zip';
 export { default as zipObj } from './zipObj';

--- a/source/or.js
+++ b/source/or.js
@@ -1,6 +1,5 @@
 import _curry2 from './internal/_curry2';
 
-
 /**
  * Returns `true` if one or both of its arguments are `true`. Returns `false`
  * if both arguments are `false`.
@@ -13,7 +12,7 @@ import _curry2 from './internal/_curry2';
  * @param {Any} a
  * @param {Any} b
  * @return {Any} the first argument if truthy, otherwise the second argument.
- * @see R.either
+ * @see R.either, R.xor
  * @example
  *
  *      R.or(true, true); //=> true

--- a/source/xor.js
+++ b/source/xor.js
@@ -1,6 +1,5 @@
 import _curry2 from './internal/_curry2';
 
-
 /**
  * Exclusive disjunction logical operation.
  * Returns `true` if one of the arguments is `true` and the other is `false`.
@@ -22,6 +21,6 @@ import _curry2 from './internal/_curry2';
  *      R.xor(false, false); //=> false
  */
 var xor = _curry2(function xor(a, b) {
-  return (a || b) && !(a && b);
+  return Boolean(a || b) && !(a && b);
 });
 export default xor;

--- a/source/xor.js
+++ b/source/xor.js
@@ -21,6 +21,6 @@ import _curry2 from './internal/_curry2';
  *      R.xor(false, false); //=> false
  */
 var xor = _curry2(function xor(a, b) {
-  return Boolean(a || b) && !(a && b);
+  return Boolean(!a ^ !b);
 });
 export default xor;

--- a/source/xor.js
+++ b/source/xor.js
@@ -1,0 +1,27 @@
+import _curry2 from './internal/_curry2';
+
+
+/**
+ * Exclusive disjunction logical operation.
+ * Returns `true` if one of the arguments is `true` and the other is `false`.
+ * Otherwise, it returns `false`.
+ *
+ * @func
+ * @memberOf R
+ * @category Logic
+ * @sig a -> b -> Boolean
+ * @param {Any} a
+ * @param {Any} b
+ * @return {Boolean} true if one of the arguments is truthy and the other is falsy
+ * @see R.or, R.and
+ * @example
+ *
+ *      R.xor(true, true); //=> false
+ *      R.xor(true, false); //=> true
+ *      R.xor(false, true); //=> true
+ *      R.xor(false, false); //=> false
+ */
+var xor = _curry2(function xor(a, b) {
+  return (a || b) && !(a && b);
+});
+export default xor;

--- a/source/xor.js
+++ b/source/xor.js
@@ -2,7 +2,7 @@ import _curry2 from './internal/_curry2';
 
 /**
  * Exclusive disjunction logical operation.
- * Returns `true` if one of the arguments is `true` and the other is `false`.
+ * Returns `true` if one of the arguments is truthy and the other is falsy.
  * Otherwise, it returns `false`.
  *
  * @func

--- a/test/xor.js
+++ b/test/xor.js
@@ -1,7 +1,6 @@
 var R = require('../source');
 var eq = require('./shared/eq');
 
-
 describe('xor', function() {
   it('compares two values with exclusive or', function() {
     eq(R.xor(true, true), false);
@@ -10,4 +9,47 @@ describe('xor', function() {
     eq(R.xor(false, false), false);
   });
 
+  it('when both values are truthy, it should return false', function() {
+    eq(R.xor(true, 'foo'), false);
+    eq(R.xor(42, true), false);
+    eq(R.xor('foo', 42), false);
+    eq(R.xor({}, true), false);
+    eq(R.xor(true, []), false);
+    eq(R.xor([], {}), false);
+    eq(R.xor(new Date(), true), false);
+    eq(R.xor(true, Infinity), false);
+    eq(R.xor(Infinity, new Date()), false);
+  });
+
+  it('when both values are falsy, it should return false', function() {
+    eq(R.xor(null, false), false);
+    eq(R.xor(false, undefined), false);
+    eq(R.xor(undefined, null), false);
+    eq(R.xor(0, false), false);
+    eq(R.xor(false, NaN), false);
+    eq(R.xor(NaN, 0), false);
+    eq(R.xor('', false), false);
+  });
+
+  it('when one argument is truthy and the other is falsy, it should return true', function() {
+    eq(R.xor('foo', null), true);
+    eq(R.xor(null, 'foo'), true);
+    eq(R.xor(undefined, 42), true);
+    eq(R.xor(42, undefined), true);
+    eq(R.xor(Infinity, NaN), true);
+    eq(R.xor(NaN, Infinity), true);
+    eq(R.xor({}, ''), true);
+    eq(R.xor('', {}), true);
+    eq(R.xor(new Date(), 0), true);
+    eq(R.xor(0, new Date()), true);
+    eq(R.xor([], null), true);
+    eq(R.xor(undefined, []), true);
+  });
+
+  it('returns a curried function', function() {
+    eq(R.xor()(true)(true), false);
+    eq(R.xor()(true)(false), true);
+    eq(R.xor()(false)(true), true);
+    eq(R.xor()(false)(false), false);
+  });
 });

--- a/test/xor.js
+++ b/test/xor.js
@@ -1,0 +1,13 @@
+var R = require('../source');
+var eq = require('./shared/eq');
+
+
+describe('xor', function() {
+  it('compares two values with exclusive or', function() {
+    eq(R.xor(true, true), false);
+    eq(R.xor(true, false), true);
+    eq(R.xor(false, true), true);
+    eq(R.xor(false, false), false);
+  });
+
+});


### PR DESCRIPTION
_Exclusive OR_, or _exclusive disjunction_ is a logical operation that returns `true` if only one the arguments is `true` and the other is `false`. 

It can be easily implemented with other logical operations like `and`, `or` and `not`, but I guess it would be nice to have it in Ramda to improve the code readability.

Since it's my first pull request here, please let me know if I'm missing something.

Kind regards