### PR TITLE
Enhance `map` To Handle `AsyncFunction` (+ more), add docs for `type`

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,7 @@
 {
   "parserOptions": {
-    "sourceType": "module"
+    "sourceType": "module",
+    "ecmaVersion": 2017
   },
   "env": {
     "node": true,

--- a/source/map.js
+++ b/source/map.js
@@ -45,6 +45,9 @@ import keys from './keys';
 var map = _curry2(_dispatchable(['fantasy-land/map', 'map'], _xmap, function map(fn, functor) {
   switch (Object.prototype.toString.call(functor)) {
     case '[object Function]':
+    case '[object AsyncFunction]':
+    case '[object GeneratorFunction]':
+    case '[object AsyncGeneratorFunction]':
       return curryN(functor.length, function() {
         return fn.call(this, functor.apply(this, arguments));
       });

--- a/source/type.js
+++ b/source/type.js
@@ -24,6 +24,8 @@ import _curry1 from './internal/_curry1';
  *      R.type([]); //=> "Array"
  *      R.type(/[A-z]/); //=> "RegExp"
  *      R.type(() => {}); //=> "Function"
+ *      R.type(async () => {}); //=> "AsyncFunction"
+ *      R.type(function* () {}); //=> "GeneratorFunction"
  *      R.type(undefined); //=> "Undefined"
  */
 var type = _curry1(function type(val) {

--- a/test/map.js
+++ b/test/map.js
@@ -42,10 +42,10 @@ describe('map', function() {
   });
 
   it('interprets generator as a functor', function() {
-    var f = function(gen) { return [gen.next().value - 1, gen.next().value - 2, gen.next().value - 3]; };
-    var g = function* (b) { yield b * 1; yield b * 2; yield b * 3; };
+    var f = function(gen) { return gen.next().value - 1; };
+    var g = function* (b) { yield b * 2; };
     var h = R.map(f, g);
-    eq(h(10), [(10 * 1) - 1, (10 * 2) - 2, (10 * 3) - 3]);
+    eq(h(10), (10 * 2) - 1);
   });
 
   it('dispatches to objects that implement `map`', function() {

--- a/test/map.js
+++ b/test/map.js
@@ -31,6 +31,23 @@ describe('map', function() {
     eq(h(10), (10 * 2) - 1);
   });
 
+  it('interprets (async (->) r) as a functor', function() {
+    var f = function(a) { return a.then(function(a) { return a - 1; }); };
+    var g = async function(b) { return b * 2; };
+    var h = R.map(f, g);
+    return h(10)
+      .then(h => {
+        eq(h, (10 * 2) - 1);
+      });
+  });
+
+  it('interprets generator as a functor', function() {
+    var f = function(gen) { return [gen.next().value - 1, gen.next().value - 2, gen.next().value - 3]; };
+    var g = function* (b) { yield b * 1; yield b * 2; yield b * 3; };
+    var h = R.map(f, g);
+    eq(h(10), [(10 * 1) - 1, (10 * 2) - 2, (10 * 3) - 3]);
+  });
+
   it('dispatches to objects that implement `map`', function() {
     var obj = {x: 100, map: function(f) { return f(this.x); }};
     eq(R.map(add1, obj), 101);

--- a/test/type.js
+++ b/test/type.js
@@ -45,4 +45,15 @@ describe('type', function() {
     eq(R.type(undefined), 'Undefined');
   });
 
+  it('"Function" if given a function', function() {
+    eq(R.type(() => {}), 'Function');
+  });
+
+  it('"AsyncFunction" if given an async function', function() {
+    eq(R.type(async() => {}), 'AsyncFunction');
+  });
+
+  it('"Generator Function" if given a generator function', function() {
+    eq(R.type(function* () {}), 'GeneratorFunction');
+  });
 });

--- a/test/type.js
+++ b/test/type.js
@@ -53,7 +53,7 @@ describe('type', function() {
     eq(R.type(async() => {}), 'AsyncFunction');
   });
 
-  it('"Generator Function" if given a generator function', function() {
+  it('"GeneratorFunction" if given a generator function', function() {
     eq(R.type(function* () {}), 'GeneratorFunction');
   });
 });


### PR DESCRIPTION
This is intended as an addendum to https://github.com/ramda/ramda/pull/2513, but the previous PR is consistent without these changes and can be merged before this one.

The main change I've made is to `map`, which can take a function as a functor.
I've included the same fix @rjhilgefort did here: https://github.com/ramda/ramda/commit/b5a3cb6563d22d29b5798bfeca02938ab94c2761
with some tests to show what it would look like.

The only other changes are superficial - adding documentation and tests to prove the behaviour of `type`: https://github.com/ramda/ramda/commit/92b96c72f179c452d4894b7bc9642c1a17cabb87
which unfortunately requires making a change to eslint to parse async functions:
https://github.com/ramda/ramda/commit/764b105dba86ed3b256e1bb46a4057e187157ddc
I'd appreciate any feedback on whether this is OK or if there are any reasons to hold back on changing eslint settings.

Is `(async (->) r)` the right signature for an async function?

I've kept the `type` docs/tests and eslintrc changes separate so the `map` changes can be easily merged without them.

Please let me know if anything else needs changing!