### PR TITLE
remove mentions of .js extension from imports

### DIFF
--- a/source/pipeWith.js
+++ b/source/pipeWith.js
@@ -1,9 +1,9 @@
-import _arity from './internal/_arity.js';
+import _arity from './internal/_arity';
 import _curry2 from './internal/_curry2';
-import head from './head.js';
-import _reduce from './internal/_reduce.js';
-import tail from './tail.js';
-import identity from './identity.js';
+import head from './head';
+import _reduce from './internal/_reduce';
+import tail from './tail';
+import identity from './identity';
 
 
 /**


### PR DESCRIPTION
In the file `source/pipeWith.js`, somebody forgot to remove the explicit .js extensions from the imports.