### PR TITLE
Fix err with applySpec "map" keys

### DIFF
--- a/source/applySpec.js
+++ b/source/applySpec.js
@@ -1,12 +1,20 @@
 import _curry1 from './internal/_curry1';
 import apply from './apply';
 import curryN from './curryN';
-import map from './map';
 import max from './max';
 import pluck from './pluck';
 import reduce from './reduce';
+import keys from './keys';
 import values from './values';
 
+// Use custom mapValues function to avoid issues with specs that include a "map" key and R.map
+// delegating calls to .map
+function mapValues(fn, obj) {
+  return keys(obj).reduce(function(acc, key) {
+    acc[key] = fn(obj[key]);
+    return acc;
+  }, {});
+}
 
 /**
  * Given a spec object recursively mapping properties to functions, creates a
@@ -34,12 +42,16 @@ import values from './values';
  * @symb R.applySpec({ x: f, y: { z: g } })(a, b) = { x: f(a, b), y: { z: g(a, b) } }
  */
 var applySpec = _curry1(function applySpec(spec) {
-  spec = map(function(v) { return typeof v == 'function' ? v : applySpec(v); },
-             spec);
-  return curryN(reduce(max, 0, pluck('length', values(spec))),
-                function() {
-                  var args = arguments;
-                  return map(function(f) { return apply(f, args); }, spec);
-                });
+  spec = mapValues(
+    function(v) { return typeof v == 'function' ? v : applySpec(v); },
+    spec
+  );
+
+  return curryN(
+    reduce(max, 0, pluck('length', values(spec))),
+    function() {
+      var args = arguments;
+      return mapValues(function(f) { return apply(f, args); }, spec);
+    });
 });
 export default applySpec;

--- a/test/applySpec.js
+++ b/test/applySpec.js
@@ -21,6 +21,10 @@ describe('applySpec', function() {
        { unnested: 0, nested: { sum: 3 } });
   });
 
+  it('works with a spec defining a map key', function() {
+    eq(R.applySpec({map: R.prop('a')})({a: 1}), {map: 1});
+  });
+
   it('retains the highest arity', function() {
     var f = R.applySpec({ f1: R.nAry(2, R.T), f2: R.nAry(5, R.T) });
     eq(f.length, 5);
@@ -29,5 +33,4 @@ describe('applySpec', function() {
   it('returns a curried function', function() {
     eq(R.applySpec({ sum: R.add })(1)(2), { sum: 3 });
   });
-
 });


### PR DESCRIPTION
## Summary
This PR addresses the issue described at https://github.com/ramda/ramda/issues/2681. `applySpec` was using ramda's `map` function, which calls out to a functions `.map` method if it is present. When a spec object with a `map` key was defined, it would think the value was a function it needed to call out to, producing undefined behavior. 

## Test Plan
TDD - Added a failing unit test. Wrote some code. Unit test passes.