### PR TITLE
simplify T and F

### DIFF
--- a/source/F.js
+++ b/source/F.js
@@ -1,4 +1,3 @@
-import always from './always';
 
 
 /**
@@ -11,10 +10,10 @@ import always from './always';
  * @sig * -> Boolean
  * @param {*}
  * @return {Boolean}
- * @see R.always, R.T
+ * @see R.T
  * @example
  *
  *      R.F(); //=> false
  */
-var F = always(false);
+var F = function() {return false;};
 export default F;

--- a/source/T.js
+++ b/source/T.js
@@ -1,4 +1,3 @@
-import always from './always';
 
 
 /**
@@ -11,10 +10,10 @@ import always from './always';
  * @sig * -> Boolean
  * @param {*}
  * @return {Boolean}
- * @see R.always, R.F
+ * @see R.F
  * @example
  *
  *      R.T(); //=> true
  */
-var T = always(true);
+var T = function() {return true;};
 export default T;


### PR DESCRIPTION
Following discussion in https://github.com/ramda/ramda/pull/2685 simplifying the implementation of `R.T` and `R.F` to be self contained function definitions and removing link to always