### PR TITLE
Update docs for memoizeWith

### DIFF
--- a/source/memoizeWith.js
+++ b/source/memoizeWith.js
@@ -4,11 +4,10 @@ import _has from './internal/_has';
 
 
 /**
- * A customisable version of [`R.memoize`](#memoize). `memoizeWith` takes an
- * additional function that will be applied to a given argument set and used to
- * create the cache key under which the results of the function to be memoized
- * will be stored. Care must be taken when implementing key generation to avoid
- * clashes that may overwrite previous entries erroneously.
+ * Takes an additional function that will be applied to a given argument set 
+ * and used to create the cache key under which the results of the function to be 
+ * memoized will be stored. Care must be taken when implementing key generation 
+ * to avoid clashes that may overwrite previous entries erroneously.
  *
  *
  * @func

--- a/source/memoizeWith.js
+++ b/source/memoizeWith.js
@@ -4,9 +4,9 @@ import _has from './internal/_has';
 
 
 /**
- * Takes an additional function that will be applied to a given argument set 
- * and used to create the cache key under which the results of the function to be 
- * memoized will be stored. Care must be taken when implementing key generation 
+ * Takes an additional function that will be applied to a given argument set
+ * and used to create the cache key under which the results of the function to be
+ * memoized will be stored. Care must be taken when implementing key generation
  * to avoid clashes that may overwrite previous entries erroneously.
  *
  *


### PR DESCRIPTION
The documentation for memoizeWith was not updated when memoize was removed.

This PR simply removes the reference to memoize.