### PR TITLE
Fixed passing banner option to rollup

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -14,9 +14,9 @@ var config = {
   output: {
     format: 'umd',
     name: 'R',
-    exports: 'named'
+    exports: 'named',
+    banner: banner
   },
-  banner: banner,
   plugins: []
 };
 


### PR DESCRIPTION
I've missed this when upgrading rollup in https://github.com/ramda/ramda/pull/2724