### PR TITLE
fix(hasPath): forces hasPath to be safe

### DIFF
--- a/source/hasPath.js
+++ b/source/hasPath.js
@@ -1,6 +1,8 @@
 import _curry2 from './internal/_curry2';
 import _has from './internal/_has';
 
+import isNil from './isNil';
+
 
 /**
  * Returns whether or not a path exists in an object. Only the object's
@@ -24,13 +26,13 @@ import _has from './internal/_has';
  *      R.hasPath(['a', 'b'], {});                  // => false
  */
 var hasPath = _curry2(function hasPath(_path, obj) {
-  if (_path.length === 0) {
+  if (_path.length === 0 || isNil(obj)) {
     return false;
   }
   var val = obj;
   var idx = 0;
   while (idx < _path.length) {
-    if (_has(_path[idx], val)) {
+    if (!isNil(val) && _has(_path[idx], val)) {
       val = val[_path[idx]];
       idx += 1;
     } else {

--- a/test/has.js
+++ b/test/has.js
@@ -22,4 +22,15 @@ describe('has', function() {
     eq(R.has('age', bob), false);
   });
 
+  it('tests paths on non-objects', function() {
+    eq(R.has('a', undefined), false);
+    eq(R.has('a', null), false);
+    eq(R.has('a', true), false);
+    eq(R.has('a', ''), false);
+    eq(R.has('a', /a/), false);
+  });
+
+  it('tests currying', function() {
+    eq(R.has('a')({ a: { b: 1 } }), true);
+  });
 });

--- a/test/has.js
+++ b/test/has.js
@@ -22,7 +22,7 @@ describe('has', function() {
     eq(R.has('age', bob), false);
   });
 
-  it('tests paths on non-objects', function() {
+  it('returns false for non-objects', function() {
     eq(R.has('a', undefined), false);
     eq(R.has('a', null), false);
     eq(R.has('a', true), false);

--- a/test/hasPath.js
+++ b/test/hasPath.js
@@ -56,7 +56,7 @@ describe('hasPath', function() {
     eq(R.hasPath(['toString'], bob), false);
   });
 
-  it('returns false for empty path', function() {
+  it('returns false for non-objects', function() {
     eq(R.hasPath([], obj), false);
   });
 

--- a/test/hasPath.js
+++ b/test/hasPath.js
@@ -32,6 +32,15 @@ describe('hasPath', function() {
     eq(R.hasPath(['arrayVal', 1], obj), false);
   });
 
+  it('tests for paths in arrays', function() {
+    eq(R.hasPath([0], [1, 2]), true);
+    eq(R.hasPath([2], [1, 2]), false);
+
+    eq(R.hasPath(['0'], [1, 2]), true);
+    eq(R.hasPath(['2'], [1, 2]), false);
+  });
+
+
   it('returns false for non-existent path', function() {
     eq(R.hasPath(['Unknown'], obj), false);
     eq(R.hasPath(['objVal', 'Unknown'], obj), false);
@@ -49,5 +58,17 @@ describe('hasPath', function() {
 
   it('returns false for empty path', function() {
     eq(R.hasPath([], obj), false);
+  });
+
+  it('tests paths on non-objects', function() {
+    eq(R.hasPath(['a', 'b'], undefined), false);
+    eq(R.hasPath(['a', 'b'], null), false);
+    eq(R.hasPath('a', true), false);
+    eq(R.hasPath('a', ''), false);
+    eq(R.hasPath('a', /a/), false);
+  });
+
+  it('tests currying', function() {
+    eq(R.hasPath(['a', 'b'])({ a: { b: 1 } }), true);
   });
 });


### PR DESCRIPTION
The function now doesn't throw Errors anymore when supplied with non-object.
Also fixes R.has.

Closes #2738

Signed-off-by: Vladimir Gorej <vladimir.gorej@gmail.com>