### PR TITLE
Add `omitArgs`

### DIFF
--- a/source/index.js
+++ b/source/index.js
@@ -151,6 +151,7 @@ export { default as o } from './o';
 export { default as objOf } from './objOf';
 export { default as of } from './of';
 export { default as omit } from './omit';
+export { default as omitArgs } from './omitArgs';
 export { default as once } from './once';
 export { default as or } from './or';
 export { default as otherwise } from './otherwise';

--- a/source/omitArgs.js
+++ b/source/omitArgs.js
@@ -32,17 +32,17 @@ var omitArgs = _curry2(function omitArgs(n, fn) {
   }
   var arity = n + fn.length;
   switch (arity) {
-    case 0: return function() { return fn.apply(this, Array.from(arguments).slice(n)); };
-    case 1: return function(a0) { return fn.apply(this, Array.from(arguments).slice(n)); };
-    case 2: return function(a0, a1) { return fn.apply(this, Array.from(arguments).slice(n)); };
-    case 3: return function(a0, a1, a2) { return fn.apply(this, Array.from(arguments).slice(n)); };
-    case 4: return function(a0, a1, a2, a3) { return fn.apply(this, Array.from(arguments).slice(n)); };
-    case 5: return function(a0, a1, a2, a3, a4) { return fn.apply(this, Array.from(arguments).slice(n)); };
-    case 6: return function(a0, a1, a2, a3, a4, a5) { return fn.apply(this, Array.from(arguments).slice(n)); };
-    case 7: return function(a0, a1, a2, a3, a4, a5, a6) { return fn.apply(this, Array.from(arguments).slice(n)); };
-    case 8: return function(a0, a1, a2, a3, a4, a5, a6, a7) { return fn.apply(this, Array.from(arguments).slice(n)); };
-    case 9: return function(a0, a1, a2, a3, a4, a5, a6, a7, a8) { return fn.apply(this, Array.from(arguments).slice(n)); };
-    case 10: return function(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9) { return fn.apply(this, Array.from(arguments).slice(n)); };
+    case 0: return function() { return fn.apply(this, Array.prototype.slice.call(arguments).slice(n)); };
+    case 1: return function(a0) { return fn.apply(this, Array.prototype.slice.call(arguments).slice(n)); };
+    case 2: return function(a0, a1) { return fn.apply(this, Array.prototype.slice.call(arguments).slice(n)); };
+    case 3: return function(a0, a1, a2) { return fn.apply(this, Array.prototype.slice.call(arguments).slice(n)); };
+    case 4: return function(a0, a1, a2, a3) { return fn.apply(this, Array.prototype.slice.call(arguments).slice(n)); };
+    case 5: return function(a0, a1, a2, a3, a4) { return fn.apply(this, Array.prototype.slice.call(arguments).slice(n)); };
+    case 6: return function(a0, a1, a2, a3, a4, a5) { return fn.apply(this, Array.prototype.slice.call(arguments).slice(n)); };
+    case 7: return function(a0, a1, a2, a3, a4, a5, a6) { return fn.apply(this, Array.prototype.slice.call(arguments).slice(n)); };
+    case 8: return function(a0, a1, a2, a3, a4, a5, a6, a7) { return fn.apply(this, Array.prototype.slice.call(arguments).slice(n)); };
+    case 9: return function(a0, a1, a2, a3, a4, a5, a6, a7, a8) { return fn.apply(this, Array.prototype.slice.call(arguments).slice(n)); };
+    case 10: return function(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9) { return fn.apply(this, Array.prototype.slice.call(arguments).slice(n)); };
     default: throw new Error('The increased arity of the function passed to omitArgs must be no greater than ten');
   }
 });

--- a/source/omitArgs.js
+++ b/source/omitArgs.js
@@ -30,7 +30,21 @@ var omitArgs = _curry2(function omitArgs(n, fn) {
   if (n < 0) {
     throw new Error('First argument to omitArgs must be a non-negative integer');
   }
-  return function () { fn.apply(this, Array.from(arguments).slice(n)) }
+  var arity = n + fn.length;
+  switch (arity) {
+    case 0: return function() { return fn.apply(this, Array.from(arguments).slice(n)); };
+    case 1: return function(a0) { return fn.apply(this, Array.from(arguments).slice(n)); };
+    case 2: return function(a0, a1) { return fn.apply(this, Array.from(arguments).slice(n)); };
+    case 3: return function(a0, a1, a2) { return fn.apply(this, Array.from(arguments).slice(n)); };
+    case 4: return function(a0, a1, a2, a3) { return fn.apply(this, Array.from(arguments).slice(n)); };
+    case 5: return function(a0, a1, a2, a3, a4) { return fn.apply(this, Array.from(arguments).slice(n)); };
+    case 6: return function(a0, a1, a2, a3, a4, a5) { return fn.apply(this, Array.from(arguments).slice(n)); };
+    case 7: return function(a0, a1, a2, a3, a4, a5, a6) { return fn.apply(this, Array.from(arguments).slice(n)); };
+    case 8: return function(a0, a1, a2, a3, a4, a5, a6, a7) { return fn.apply(this, Array.from(arguments).slice(n)); };
+    case 9: return function(a0, a1, a2, a3, a4, a5, a6, a7, a8) { return fn.apply(this, Array.from(arguments).slice(n)); };
+    case 10: return function(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9) { return fn.apply(this, Array.from(arguments).slice(n)); };
+    default: throw new Error('The increased arity of the function passed to omitArgs must be no greater than ten');
+  }
 });
 
 export default omitArgs;

--- a/source/omitArgs.js
+++ b/source/omitArgs.js
@@ -1,0 +1,10 @@
+import _curry2 from './internal/_curry2';
+
+var omitArgs = _curry2(function omitArgs(n, fn) {
+  if (n < 0) {
+    throw new Error('First argument to omitArgs must be a non-negative integer');
+  }
+  return function () { fn.apply(this, Array.from(arguments).slice(n)) }
+});
+
+export default omitArgs;

--- a/source/omitArgs.js
+++ b/source/omitArgs.js
@@ -1,5 +1,31 @@
 import _curry2 from './internal/_curry2';
 
+/**
+ * Wraps a function of any arity (including nullary) in a function additional
+ * parameters that are omitted.
+ *
+ * @func
+ * @memberOf R
+ * @category Function
+ * @sig Number -> (* -> a) -> (* -> a)
+ * @param {Number} n The desired number of ignored parameters.
+ * @param {Function} fn The function to wrap.
+ * @return {Function} A new function wrapping `fn`.
+ * @see R.nAry
+ * @example
+ *
+ *      const takesTwoArgs = (a, b) => a + b;
+ *
+ *      takesTwoArgs(1, 2); //=> 3
+ *
+ *      const ignoresTwoArgs = R.omitArgs(2, takesTwoArgs);
+ *
+ *      // First `n` arguments are completely ignored
+ *      ignoresTwoArgs(1, 2, 3, 4); //=> 7
+ * @symb R.omitArgs(0, f)(a, b) = f(a, b)
+ * @symb R.omitArgs(1, f)(a, b) = f(b)
+ * @symb R.omitArgs(2, f)(a, b) = f()
+ */
 var omitArgs = _curry2(function omitArgs(n, fn) {
   if (n < 0) {
     throw new Error('First argument to omitArgs must be a non-negative integer');

--- a/test/omitArgs.js
+++ b/test/omitArgs.js
@@ -1,0 +1,34 @@
+var assert = require('assert');
+
+var R = require('../source');
+var eq = require('./shared/eq');
+
+
+describe('omitArgs', function() {
+
+  function sumThree(a, b, c) { return a + b + c; }
+
+  it('adds omitted parameters to a function', function() {
+    var fn = R.omitArgs(3, sumThree);
+    eq(fn(1, 2, 3, 4, 5, 6), sumThree(4, 5, 6));
+  });
+
+  it('maintains the correct length property of a function', function() {
+    var fn = R.omitArgs(3, sumThree);
+    eq(fn.length, 3 + sumThree.length);
+  });
+
+  it('throws if resulting arity is greater than ten', function() {
+    var checkError = function(err) {
+      return (err instanceof Error &&
+              err.message === 'The increased arity of the function passed to omitArgs must be no greater than ten');
+    };
+    assert.throws(function() {
+      R.omitArgs(11, function() {});
+    }, checkError);
+    assert.throws(function() {
+      R.omitArgs(2, function(a, b, c, d, e, f, g, h, i) {});
+    }, checkError);
+  });
+
+});


### PR DESCRIPTION
Adds the function `omitArgs` which wraps a function of any arity into a (left) padded function with `n` parameters that are ignored before the original parameters.

The code is not very readable due to backwards compatibility and array length property but the following does the same in more idiomatic JS: 

```javascript
const omitArgs = (num, fn) => (...args) => fn.apply(null, args.slice(num))
```

I've previously found the function useful for example when writing callbacks for asynchronous functions that pass the callback some data it doesn't need. `omitArgs` enables omitting unnecessary parameters from the callback signature.

I'd be happy to hear if there are any suggestions for a more intuitive name for the function.