### PR TITLE
Ignore reduced from functions passed to reduce (3.9x to 7.2x speedup)

### DIFF
--- a/source/reduce.js
+++ b/source/reduce.js
@@ -7,7 +7,9 @@ import _reduce from './internal/_reduce';
  * the iterator function and passing it an accumulator value and the current
  * value from the array, and then passing the result to the next call.
  *
- * The iterator function receives two values: *(acc, value)*. It may use
+ * The iterator function receives two values: *(acc, value)*.
+ *
+ * If transformer is passed instead of function, it may use
  * [`R.reduced`](#reduced) to shortcut the iteration.
  *
  * The arguments' order of [`reduceRight`](#reduceRight)'s iterator function

--- a/source/reduceWhile.js
+++ b/source/reduceWhile.js
@@ -1,6 +1,7 @@
 import _curryN from './internal/_curryN';
 import _reduce from './internal/_reduce';
 import _reduced from './internal/_reduced';
+import _xwrap from './internal/_xwrap';
 
 
 /**
@@ -33,8 +34,8 @@ import _reduced from './internal/_reduced';
  *      R.reduceWhile(isOdd, R.add, 111, ys); //=> 111
  */
 var reduceWhile = _curryN(4, [], function _reduceWhile(pred, fn, a, list) {
-  return _reduce(function(acc, x) {
+  return _reduce(_xwrap(function(acc, x) {
     return pred(acc, x) ? fn(acc, x) : _reduced(acc);
-  }, a, list);
+  }), a, list);
 });
 export default reduceWhile;

--- a/source/reduced.js
+++ b/source/reduced.js
@@ -7,7 +7,7 @@ import _reduced from './internal/_reduced';
  * box: the internal structure is not guaranteed to be stable.
  *
  * Note: this optimization is only available to the below functions:
- * - [`reduce`](#reduce)
+ * - [`reduce`](#reduce) (**when passed a transformer**)
  * - [`reduceWhile`](#reduceWhile)
  * - [`transduce`](#transduce)
  *

--- a/test/reduce.js
+++ b/test/reduce.js
@@ -1,4 +1,5 @@
 var R = require('../source');
+var _xwrap = require('../source/internal/_xwrap');
 var eq = require('./shared/eq');
 
 describe('reduce', function() {
@@ -71,7 +72,7 @@ describe('reduce', function() {
   });
 
   it('short circuits with reduced', function() {
-    var addWithMaxOf10 = function(acc, val) {return acc + val > 10 ? R.reduced(acc) : acc + val;};
+    var addWithMaxOf10 = _xwrap(function(acc, val) {return acc + val > 10 ? R.reduced(acc) : acc + val;});
     eq(R.reduce(addWithMaxOf10, 0, [1, 2, 3, 4]), 10);
     eq(R.reduce(addWithMaxOf10, 0, [2, 4, 6, 8]), 6);
   });

--- a/test/reduced.js
+++ b/test/reduced.js
@@ -1,4 +1,5 @@
 var R = require('../source');
+var _xwrap = require('../source/internal/_xwrap');
 var eq = require('./shared/eq');
 
 
@@ -18,11 +19,11 @@ describe('reduced', function() {
     // black box test.
     eq(
       R.reduce(
-        function(acc, v) {
+        _xwrap(function(acc, v) {
           var result = acc + v;
           if (result >= 10) {result = R.reduced(result);}
           return result;
-        },
+        }),
         0,
         [1, 2, 3, 4, 5]),
       10);


### PR DESCRIPTION
Changed `_reduce` to allow `reduced` to be returned only by transformers, not functions.

This is a breaking change, but it speeds up `reduce` by a factor of 3.9 to 7.2.

<details>
<summary>Benchmark</summary>
Before:
<pre>
┌────────────────────────┬────────────────────────┬────────────────────────┐
│ reduce                 │ Hertz                  │ Margin of Error        │
├────────────────────────┼────────────────────────┼────────────────────────┤
│ reduce(add, 0, nums)   │ 411,807                │ 2.37%                  │
├────────────────────────┼────────────────────────┼────────────────────────┤
│ reduce(add, 0)(nums)   │ 400,479                │ 1.69%                  │
├────────────────────────┼────────────────────────┼────────────────────────┤
│ reduceAdd(nums)        │ 508,636                │ 1.19%                  │
├────────────────────────┼────────────────────────┼────────────────────────┤
│ native reduce          │ 4,752,316              │ 0.26%                  │
└────────────────────────┴────────────────────────┴────────────────────────┘
</pre>
After:
<pre>
┌────────────────────────┬────────────────────────┬────────────────────────┐
│ reduce                 │ Hertz                  │ Margin of Error        │
├────────────────────────┼────────────────────────┼────────────────────────┤
│ reduce(add, 0, nums)   │ 2,911,028              │ 1.25%                  │
├────────────────────────┼────────────────────────┼────────────────────────┤
│ reduce(add, 0)(nums)   │ 1,520,781              │ 0.55%                  │
├────────────────────────┼────────────────────────┼────────────────────────┤
│ reduceAdd(nums)        │ 2,138,148              │ 0.16%                  │
├────────────────────────┼────────────────────────┼────────────────────────┤
│ native reduce          │ 4,843,689              │ 0.28%                  │
└────────────────────────┴────────────────────────┴────────────────────────┘
</pre>
</details>

Analysis of possible `_reduced` optimizations: https://github.com/ramda/ramda/pull/2613#issuecomment-453164165.

<hr />

Also, `_reduce` no longer tries to dispatch transformers to `fantasy-land/reduce`, because `reduced` support is forbidden by [the spec](https://github.com/fantasyland/fantasy-land#reduce-method):

   >  iii. `f` must return a value of the same type as `x`.
   >  iv.  No parts of `f`'s return value should be checked.
