### PR TITLE
remove erroneous quotes in tryCatch documentation

### DIFF
--- a/source/tryCatch.js
+++ b/source/tryCatch.js
@@ -23,7 +23,7 @@ import _curry2 from './internal/_curry2';
  *      R.tryCatch(R.prop('x'), R.F)({x: true}); //=> true
  *      R.tryCatch(() => { throw 'foo'}, R.always('catched'))('bar') // => 'catched'
  *      R.tryCatch(R.times(R.identity), R.always([]))('s') // => []
- `` */
+ */
 var tryCatch = _curry2(function _tryCatch(tryer, catcher) {
   return _arity(tryer.length, function() {
     try {


### PR DESCRIPTION
This was breaking the repl with:
`R.tryCatch(...)(...) is not a function`