### PR TITLE
Don't dispatch transformers to 'fantasy-land/reduce'

### DIFF
--- a/source/internal/_reduce.js
+++ b/source/internal/_reduce.js
@@ -38,13 +38,13 @@ var symIterator = (typeof Symbol !== 'undefined') ? Symbol.iterator : '@@iterato
 
 export default function _reduce(fn, acc, list) {
   if (typeof fn === 'function') {
+    if (typeof list['fantasy-land/reduce'] === 'function') {
+      return list['fantasy-land/reduce'](fn, acc);
+    }
     fn = _xwrap(fn);
   }
   if (_isArrayLike(list)) {
     return _arrayReduce(fn, acc, list);
-  }
-  if (typeof list['fantasy-land/reduce'] === 'function') {
-    return _methodReduce(fn, acc, list, 'fantasy-land/reduce');
   }
   if (list[symIterator] != null) {
     return _iterableReduce(fn, acc, list[symIterator]());

--- a/test/reduce.js
+++ b/test/reduce.js
@@ -16,6 +16,12 @@ describe('reduce', function() {
     eq(R.reduce(add, 10, obj), 'override');
   });
 
+  it('dispatches to objects that implement `fantasy-land/reduce`', function() {
+    var obj = { x: [1, 2, 3], 'fantasy-land/reduce': function() { return 'override'; }};
+    eq(R.reduce(add, 0, obj), 'override');
+    eq(R.reduce(add, 10, obj), 'override');
+  });
+
   it('returns the accumulator for an empty array', function() {
     eq(R.reduce(add, 0, []), 0);
     eq(R.reduce(mult, 1, []), 1);


### PR DESCRIPTION
`_reduce` no longer tries to dispatch transformers to `fantasy-land/reduce`, because `reduced` support is forbidden by [the spec](https://github.com/fantasyland/fantasy-land#reduce-method):

   >  iii. `f` must return a value of the same type as `x`.
   >  iv.  No parts of `f`'s return value should be checked.

<hr />

Extracted from #2762, discussing it over there could be messy.

This solution avoids unnecessary `_xwrap`. An [alternative solution](https://github.com/ramda/ramda/pull/2762/files#diff-5861836cf1fab2e7793d633617b63889R51) avoids nesting.