### PR TITLE
fix: rename then to andThen

### DIFF
--- a/source/andThen.js
+++ b/source/andThen.js
@@ -24,12 +24,12 @@ import _assertPromise from './internal/_assertPromise';
  *      var getMemberName = R.pipe(
  *        makeQuery,
  *        fetchMember,
- *        R.then(R.pick(['firstName', 'lastName']))
+ *        R.andThen(R.pick(['firstName', 'lastName']))
  *      );
  */
-var then = _curry2(function then(f, p) {
-  _assertPromise('then', p);
+var andThen = _curry2(function andThen(f, p) {
+  _assertPromise('andThen', p);
 
   return p.then(f);
 });
-export default then;
+export default andThen;

--- a/source/index.js
+++ b/source/index.js
@@ -214,7 +214,7 @@ export { default as takeLastWhile } from './takeLastWhile';
 export { default as takeWhile } from './takeWhile';
 export { default as tap } from './tap';
 export { default as test } from './test';
-export { default as then } from './then';
+export { default as andThen } from './andThen';
 export { default as times } from './times';
 export { default as toLower } from './toLower';
 export { default as toPairs } from './toPairs';

--- a/test/andThen.js
+++ b/test/andThen.js
@@ -4,9 +4,9 @@ var R = require('../source');
 var eq = require('./shared/eq');
 
 
-describe('then', function() {
+describe('andThen', function() {
   it('invokes then on the promise with the function passed to it', function(done) {
-    R.then(
+    R.andThen(
       function(n) {
         eq(n, 1);
         done();
@@ -17,9 +17,9 @@ describe('then', function() {
 
   it('flattens promise returning functions', function(done) {
     var incAndWrap = R.compose(Promise.resolve.bind(Promise), R.inc);
-    var asyncAddThree = R.pipe(incAndWrap, R.then(incAndWrap), R.then(incAndWrap));
+    var asyncAddThree = R.pipe(incAndWrap, R.andThen(incAndWrap), R.andThen(incAndWrap));
 
-    R.then(function(result) {
+    R.andThen(function(result) {
       eq(result, 4);
       done();
     })(asyncAddThree(1));
@@ -27,10 +27,10 @@ describe('then', function() {
 
   it('throws a typeError if the then method does not exist', function() {
     assert.throws(
-      function() { R.then(R.inc, 1); },
+      function() { R.andThen(R.inc, 1); },
       function(err) {
         return err.constructor === TypeError &&
-          err.message === '`then` expected a Promise, received 1';
+          err.message === '`andThen` expected a Promise, received 1';
       }
     );
   });
@@ -47,6 +47,6 @@ describe('then', function() {
       done();
     };
 
-    R.then(f, thennable);
+    R.andThen(f, thennable);
   });
 });

--- a/test/otherwise.js
+++ b/test/otherwise.js
@@ -16,9 +16,9 @@ describe('otherwise', function() {
   });
 
   it('does nothing to successfully resolved promises', function(done) {
-    var asyncAddTwo = R.pipe(Promise.resolve.bind(Promise), R.then(R.inc), R.otherwise(R.multiply(0)), R.then(R.inc));
+    var asyncAddTwo = R.pipe(Promise.resolve.bind(Promise), R.andThen(R.inc), R.otherwise(R.multiply(0)), R.andThen(R.inc));
 
-    R.then(function(result) {
+    R.andThen(function(result) {
       eq(result, 3);
       done();
     })(asyncAddTwo(1));


### PR DESCRIPTION
BREAKING CHANGE

The addition of R.then in Ramda 0.26 made the R object
a Promise-like object, and meant that Promise.resolve() will attempt
to resolve it by calling the then() method. R is not a Promise, and
to reassure JavaScript of this fact, R.then is renamed to R.andThen.

Fixes #2751 