### PR TITLE
Fixes over/set losing prototype (#2775), adds tests

### DIFF
--- a/source/assoc.js
+++ b/source/assoc.js
@@ -22,7 +22,7 @@ import _curry3 from './internal/_curry3';
  *      R.assoc('c', 3, {a: 1, b: 2}); //=> {a: 1, b: 2, c: 3}
  */
 var assoc = _curry3(function assoc(prop, val, obj) {
-  var result = obj === undefined || obj === null ? {} : Object.create(obj.__proto__);
+  var result = obj === undefined || obj === null ? {} : Object.create(Object.getPrototypeOf(obj));
   for (var p in obj) {
     result[p] = obj[p];
   }

--- a/source/assoc.js
+++ b/source/assoc.js
@@ -22,7 +22,7 @@ import _curry3 from './internal/_curry3';
  *      R.assoc('c', 3, {a: 1, b: 2}); //=> {a: 1, b: 2, c: 3}
  */
 var assoc = _curry3(function assoc(prop, val, obj) {
-  var result = {};
+  var result = obj === undefined || obj === null ? {} : Object.create(obj.__proto__);
   for (var p in obj) {
     result[p] = obj[p];
   }

--- a/test/assoc.js
+++ b/test/assoc.js
@@ -8,9 +8,9 @@ describe('assoc', function() {
   it('keeps `__proto__` property of source object', function() {
     class X {
       constructor({a, b, e, f}) {
-        Object.assign(this, {a, b, e, f})
+        Object.assign(this, {a, b, e, f});
       }
-    };
+    }
 
     var obj1 = new X({a: 1, b: {c: 2, d: 3}, e: 4, f: 5});
     var obj2 = R.assoc('e', {x: 42}, obj1);
@@ -25,9 +25,9 @@ describe('assoc', function() {
   it('keeps `__proto__` property of source object unless overridden', function() {
     class X {
       constructor({a, b, e, f}) {
-        Object.assign(this, {a, b, e, f})
+        Object.assign(this, {a, b, e, f});
       }
-    };
+    }
 
     class Y {}
 

--- a/test/assoc.js
+++ b/test/assoc.js
@@ -19,7 +19,7 @@ describe('assoc', function() {
     assert.strictEqual(obj2.a, obj1.a);
     assert.strictEqual(obj2.b, obj1.b);
     assert.strictEqual(obj2.f, obj1.f);
-    assert.strictEqual(obj2.__proto__, obj1.__proto__);
+    assert.strictEqual(Object.getPrototypeOf(obj2), Object.getPrototypeOf(obj1));
   });
 
   it('keeps `__proto__` property of source object unless overridden', function() {
@@ -39,7 +39,7 @@ describe('assoc', function() {
     assert.strictEqual(obj2.b, obj1.b);
     assert.strictEqual(obj2.e, obj1.e);
     assert.strictEqual(obj2.f, obj1.f);
-    assert.strictEqual(obj2.__proto__, Y.prototype);
+    assert.strictEqual(Object.getPrototypeOf(obj2), Y.prototype);
   });
 
   it('makes a shallow clone of an object, overriding only the specified property', function() {

--- a/test/assoc.js
+++ b/test/assoc.js
@@ -5,6 +5,43 @@ var eq = require('./shared/eq');
 
 
 describe('assoc', function() {
+  it('keeps `__proto__` property of source object', function() {
+    class X {
+      constructor({a, b, e, f}) {
+        Object.assign(this, {a, b, e, f})
+      }
+    };
+
+    var obj1 = new X({a: 1, b: {c: 2, d: 3}, e: 4, f: 5});
+    var obj2 = R.assoc('e', {x: 42}, obj1);
+    eq(obj2, {a: 1, b: {c: 2, d: 3}, e: {x: 42}, f: 5});
+    // Note: reference equality below!
+    assert.strictEqual(obj2.a, obj1.a);
+    assert.strictEqual(obj2.b, obj1.b);
+    assert.strictEqual(obj2.f, obj1.f);
+    assert.strictEqual(obj2.__proto__, obj1.__proto__);
+  });
+
+  it('keeps `__proto__` property of source object unless overridden', function() {
+    class X {
+      constructor({a, b, e, f}) {
+        Object.assign(this, {a, b, e, f})
+      }
+    };
+
+    class Y {}
+
+    var obj1 = new X({a: 1, b: {c: 2, d: 3}, e: 4, f: 5});
+    var obj2 = R.assoc('__proto__', Y.prototype, obj1);
+    eq(obj2, {a: 1, b: {c: 2, d: 3}, e: 4, f: 5});
+    // Note: reference equality below!
+    assert.strictEqual(obj2.a, obj1.a);
+    assert.strictEqual(obj2.b, obj1.b);
+    assert.strictEqual(obj2.e, obj1.e);
+    assert.strictEqual(obj2.f, obj1.f);
+    assert.strictEqual(obj2.__proto__, Y.prototype);
+  });
+
   it('makes a shallow clone of an object, overriding only the specified property', function() {
     var obj1 = {a: 1, b: {c: 2, d: 3}, e: 4, f: 5};
     var obj2 = R.assoc('e', {x: 42}, obj1);

--- a/test/lenses.js
+++ b/test/lenses.js
@@ -1,3 +1,5 @@
+var assert = require('assert');
+
 var R = require('../source');
 var eq = require('./shared/eq');
 
@@ -71,5 +73,21 @@ describe('view, over, and set', function() {
       pets: {dog: 'joker', cat: 'batman'}
     });
   });
+
+  they('keep the prototype of source object', function() {
+    class X {
+      constructor(a) {
+        this.a = a
+      }
+    }
+    let a  = R.lensPath(["a"])
+    let x0 = new X(2)
+    let x1 = R.over(a, y => y + 5, x0)
+    assert.strictEqual(x1.a, 7);
+    assert.strictEqual(x1.__proto__, x0.__proto__);
+    let x2 = R.set(a, 5, x1)
+    assert.strictEqual(x2.a, 5);
+    assert.strictEqual(x2.__proto__, x1.__proto__);
+  })
 
 });

--- a/test/lenses.js
+++ b/test/lenses.js
@@ -84,10 +84,10 @@ describe('view, over, and set', function() {
     let x0 = new X(2);
     let x1 = R.over(a, y => y + 5, x0);
     assert.strictEqual(x1.a, 7);
-    assert.strictEqual(x1.__proto__, x0.__proto__);
+    assert.strictEqual(Object.getPrototypeOf(x1), Object.getPrototypeOf(x0));
     let x2 = R.set(a, 5, x1);
     assert.strictEqual(x2.a, 5);
-    assert.strictEqual(x2.__proto__, x1.__proto__);
+    assert.strictEqual(Object.getPrototypeOf(x2), Object.getPrototypeOf(x1));
   });
 
 });

--- a/test/lenses.js
+++ b/test/lenses.js
@@ -77,17 +77,17 @@ describe('view, over, and set', function() {
   they('keep the prototype of source object', function() {
     class X {
       constructor(a) {
-        this.a = a
+        this.a = a;
       }
     }
-    let a  = R.lensPath(["a"])
-    let x0 = new X(2)
-    let x1 = R.over(a, y => y + 5, x0)
+    let a  = R.lensPath(['a']);
+    let x0 = new X(2);
+    let x1 = R.over(a, y => y + 5, x0);
     assert.strictEqual(x1.a, 7);
     assert.strictEqual(x1.__proto__, x0.__proto__);
-    let x2 = R.set(a, 5, x1)
+    let x2 = R.set(a, 5, x1);
     assert.strictEqual(x2.a, 5);
     assert.strictEqual(x2.__proto__, x1.__proto__);
-  })
+  });
 
 });


### PR DESCRIPTION
I made so `assoc` starts not from `{}` as accumulator, but with `Object.create(obj.__proto__)`, when `obj` isn't `null` or `undefined`.

This makes `R.set`/`R.over` not lose the prototype of object being changed.

Fixes issue #2775 .

I added tests for `assoc` and `set`/`over`.