### PR TITLE
assoc/dissoc support operate array

### DIFF
--- a/source/assoc.js
+++ b/source/assoc.js
@@ -1,5 +1,5 @@
 import _curry3 from './internal/_curry3.js';
-
+import assocPath from './assocPath.js';
 
 /**
  * Makes a shallow clone of an object, setting or overriding the specified
@@ -11,8 +11,9 @@ import _curry3 from './internal/_curry3.js';
  * @memberOf R
  * @since v0.8.0
  * @category Object
- * @sig String -> a -> {k: v} -> {k: v}
- * @param {String} prop The property name to set
+ * @typedefn Idx = String | Int
+ * @sig Idx -> a -> {k: v} -> {k: v}
+ * @param {String|Number} prop The property name to set
  * @param {*} val The new value
  * @param {Object} obj The object to clone
  * @return {Object} A new object equivalent to the original except for the changed property.
@@ -21,12 +22,5 @@ import _curry3 from './internal/_curry3.js';
  *
  *      R.assoc('c', 3, {a: 1, b: 2}); //=> {a: 1, b: 2, c: 3}
  */
-var assoc = _curry3(function assoc(prop, val, obj) {
-  var result = {};
-  for (var p in obj) {
-    result[p] = obj[p];
-  }
-  result[prop] = val;
-  return result;
-});
+var assoc = _curry3(function assoc(prop, val, obj) { return assocPath([prop], val, obj); });
 export default assoc;

--- a/source/assocPath.js
+++ b/source/assocPath.js
@@ -1,10 +1,8 @@
 import _curry3 from './internal/_curry3.js';
 import _has from './internal/_has.js';
-import _isArray from './internal/_isArray.js';
 import _isInteger from './internal/_isInteger.js';
-import assoc from './assoc.js';
+import _assoc from './internal/_assoc.js';
 import isNil from './isNil.js';
-
 
 /**
  * Makes a shallow clone of an object, setting or overriding the nodes required
@@ -39,12 +37,6 @@ var assocPath = _curry3(function assocPath(path, val, obj) {
     var nextObj = (!isNil(obj) && _has(idx, obj)) ? obj[idx] : _isInteger(path[1]) ? [] : {};
     val = assocPath(Array.prototype.slice.call(path, 1), val, nextObj);
   }
-  if (_isInteger(idx) && _isArray(obj)) {
-    var arr = [].concat(obj);
-    arr[idx] = val;
-    return arr;
-  } else {
-    return assoc(idx, val, obj);
-  }
+  return _assoc(idx, val, obj);
 });
 export default assocPath;

--- a/source/dissoc.js
+++ b/source/dissoc.js
@@ -1,5 +1,5 @@
 import _curry2 from './internal/_curry2.js';
-
+import dissocPath from './dissocPath.js';
 
 /**
  * Returns a new object that does not contain a `prop` property.
@@ -17,12 +17,5 @@ import _curry2 from './internal/_curry2.js';
  *
  *      R.dissoc('b', {a: 1, b: 2, c: 3}); //=> {a: 1, c: 3}
  */
-var dissoc = _curry2(function dissoc(prop, obj) {
-  var result = {};
-  for (var p in obj) {
-    result[p] = obj[p];
-  }
-  delete result[prop];
-  return result;
-});
+var dissoc = _curry2(function dissoc(prop, obj) { return dissocPath([prop], obj); });
 export default dissoc;

--- a/source/dissocPath.js
+++ b/source/dissocPath.js
@@ -1,11 +1,30 @@
 import _curry2 from './internal/_curry2.js';
+import _dissoc from './internal/_dissoc.js';
 import _isInteger from './internal/_isInteger.js';
 import _isArray from './internal/_isArray.js';
 import assoc from './assoc.js';
-import dissoc from './dissoc.js';
-import remove from './remove.js';
-import update from './update.js';
 
+/**
+ * Makes a shallow clone of an object. Note that this copies and flattens
+ * prototype properties onto the new object as well. All non-primitive
+ * properties are copied by reference.
+ *
+ * @private
+ * @param {String|Integer} prop The prop operating
+ * @param {Object|Array} obj The object to clone
+ * @return {Object|Array} A new object equivalent to the original.
+ */
+function _shallowCloneObject(prop, obj) {
+  if (_isInteger(prop) && _isArray(obj)) {
+    return [].concat(obj);
+  }
+
+  var result = {};
+  for (var p in obj) {
+    result[p] = obj[p];
+  }
+  return result;
+}
 
 /**
  * Makes a shallow clone of an object, omitting the property at the given path.
@@ -27,18 +46,20 @@ import update from './update.js';
  *      R.dissocPath(['a', 'b', 'c'], {a: {b: {c: 42}}}); //=> {a: {b: {}}}
  */
 var dissocPath = _curry2(function dissocPath(path, obj) {
+  if (obj == null) {
+    return obj;
+  }
+
   switch (path.length) {
     case 0:
       return obj;
     case 1:
-      return _isInteger(path[0]) && _isArray(obj) ? remove(path[0], 1, obj) : dissoc(path[0], obj);
+      return _dissoc(path[0], obj);
     default:
       var head = path[0];
       var tail = Array.prototype.slice.call(path, 1);
       if (obj[head] == null) {
-        return obj;
-      } else if (_isInteger(head) && _isArray(obj)) {
-        return update(head, dissocPath(tail, obj[head]), obj);
+        return _shallowCloneObject(head, obj);
       } else {
         return assoc(head, dissocPath(tail, obj[head]), obj);
       }

--- a/source/internal/_assoc.js
+++ b/source/internal/_assoc.js
@@ -1,0 +1,29 @@
+import _isArray from './_isArray';
+import _isInteger from './_isInteger';
+
+/**
+ * Makes a shallow clone of an object, setting or overriding the specified
+ * property with the given value. Note that this copies and flattens prototype
+ * properties onto the new object as well. All non-primitive properties are
+ * copied by reference.
+ *
+ * @private
+ * @param {String|Number} prop The property name to set
+ * @param {*} val The new value
+ * @param {Object|Array} obj The object to clone
+ * @return {Object|Array} A new object equivalent to the original except for the changed property.
+ */
+export default function _assoc(prop, val, obj) {
+  if (_isInteger(prop) && _isArray(obj)) {
+    var arr = [].concat(obj);
+    arr[prop] = val;
+    return arr;
+  }
+
+  var result = {};
+  for (var p in obj) {
+    result[p] = obj[p];
+  }
+  result[prop] = val;
+  return result;
+}

--- a/source/internal/_dissoc.js
+++ b/source/internal/_dissoc.js
@@ -1,0 +1,28 @@
+import _isInteger from './_isInteger';
+import _isArray from './_isArray';
+import remove from '../remove';
+
+/**
+ * Returns a new object that does not contain a `prop` property.
+ *
+ * @private
+ * @param {String|Number} prop The name of the property to dissociate
+ * @param {Object|Array} obj The object to clone
+ * @return {Object} A new object equivalent to the original but without the specified property
+ */
+export default function _dissoc(prop, obj) {
+  if (obj == null) {
+    return obj;
+  }
+
+  if (_isInteger(prop) && _isArray(obj)) {
+    return remove(prop, 1, obj);
+  }
+
+  var result = {};
+  for (var p in obj) {
+    result[p] = obj[p];
+  }
+  delete result[prop];
+  return result;
+}

--- a/test/assoc.js
+++ b/test/assoc.js
@@ -25,4 +25,28 @@ describe('assoc', function() {
     assert.strictEqual(obj2.f, obj1.f);
   });
 
+  it('makes a shallow clone of an array, overriding only the specified index', function() {
+    var newValue = [4, 2];
+    var ary1 = [1, [2, 3], 4, 5];
+    var ary2 = R.assoc(2, newValue, ary1);
+    eq(ary2, [1, [2, 3], [4, 2], 5]);
+    // Note: reference equality below!
+    assert.strictEqual(ary2[0], ary1[0]);
+    assert.strictEqual(ary2[1], ary1[1]);
+    assert.strictEqual(ary2[2], newValue);
+    assert.strictEqual(ary2[3], ary1[3]);
+  });
+
+  it('is the equivalent of clone and set if the index is not on the original', function() {
+    var newValue = [4, 2];
+    var ary1 = [1, [2, 3], 4];
+    var ary2 = R.assoc(5, newValue, ary1);
+    eq(ary2, [1, [2, 3], 4, undefined, undefined, [4, 2]]);
+    // Note: reference equality below!
+    assert.strictEqual(ary2[0], ary1[0]);
+    assert.strictEqual(ary2[1], ary1[1]);
+    assert.strictEqual(ary2[2], ary1[2]);
+    assert.strictEqual(ary2[5], newValue);
+  });
+
 });

--- a/test/dissoc.js
+++ b/test/dissoc.js
@@ -1,11 +1,41 @@
 var R = require('../source');
 var eq = require('./shared/eq');
+var assert = require('assert');
 
 
 describe('dissoc', function() {
   it('copies an object omitting the specified property', function() {
     eq(R.dissoc('b', {a: 1, b: 2, c: 3}), {a: 1, c: 3});
     eq(R.dissoc('d', {a: 1, b: 2, c: 3}), {a: 1, b: 2, c: 3});
+    eq(R.dissoc('c', {a: 1, b: 2, c: null}), {a: 1, b: 2});
+    eq(R.dissoc('c', {a: 1, b: 2, c: undefined}), {a: 1, b: 2});
+
+    var obj1 = {a: 1, b: 2};
+    var obj2 = R.dissoc('c', obj1);
+
+    eq(obj2, obj1);
+
+    // Note: reference equality below!
+    assert.notStrictEqual(obj2, obj1);
+  });
+
+  it('makes a shallow clone of an array, remove only the specified index', function() {
+    var ary1 = [1, [2, 3], 4, 5];
+    var ary2 = R.dissoc(2, ary1);
+    var ary3 = R.dissoc(4, ary1);
+
+    eq(ary2, [1, [2, 3], 5]);
+    eq(ary3, [1, [2, 3], 4, 5]);
+
+    // Note: reference equality below!
+    assert.strictEqual(ary2[0], ary1[0]);
+    assert.strictEqual(ary2[1], ary1[1]);
+    assert.strictEqual(ary2[2], ary1[3]);
+    assert.notStrictEqual(ary3, ary1);
+    assert.strictEqual(ary3[0], ary1[0]);
+    assert.strictEqual(ary3[1], ary1[1]);
+    assert.strictEqual(ary3[2], ary1[2]);
+    assert.strictEqual(ary3[3], ary1[3]);
   });
 
   it('includes prototype properties', function() {

--- a/test/dissocPath.js
+++ b/test/dissocPath.js
@@ -64,4 +64,17 @@ describe('dissocPath', function() {
     eq(R.dissocPath([42], {a: 1, b: 2, 42: 3}), {a: 1, b: 2});
   });
 
+  it('support remove null/undefined value path', function() {
+    eq(R.dissocPath(['c', 'd'], {a: 1, b: 2, c: null}), {a: 1, b: 2, c: null});
+    eq(R.dissocPath(['c', 'd'], {a: 1, b: 2, c: undefined}), {a: 1, b: 2, c: undefined});
+
+    var obj1 = {a: 1, b: 2};
+    var obj2 = R.dissocPath(['c', 'd'], obj1);
+
+    eq(obj2, obj1);
+
+    // Note: reference equality below!
+    assert.notStrictEqual(obj2, obj1);
+  });
+
 });


### PR DESCRIPTION
Related https://github.com/ramda/ramda/issues/773#issuecomment-462097072

I noticed `dissocPath` has code:

https://github.com/ramda/ramda/blob/efd899ba81cc5290330f5ca0833746a7ecbe165c/source/dissocPath.js#L38-L39

So

```js
;(a => R.dissocPath([3], a) === a)([0, 1])
;(a => R.dissocPath(['b'], a) === a)({a: 1})
// and
;(a => R.dissoc(3, a) !== a)([0, 1])
;(a => R.dissoc('b', a) !== a)({a: 1})
```

Should their behavior be consistent in this scenario?

Another question, the previous version `dissocPath` use `R.update` to update array input:

https://github.com/ramda/ramda/blob/efd899ba81cc5290330f5ca0833746a7ecbe165c/source/dissocPath.js#L38-L44

In my version, I use 'R.assoc` uniformly:

https://github.com/ramda/ramda/blob/528df9777200a31c754117cdfd2e64871985f4d3/source/dissocPath.js#L33-L37

The behavior of `R.update` is different from `R.assoc` in some scenarios:

```js
R.update(2, 'a', []) // => []
R.assoc(2, 'a', []) // => [undefined, undefined, 'a']
```

Should I keep current version or rollback?