### PR TITLE
Update `pathSatisfies` to handles empty `path` arguments

### DIFF
--- a/source/pathSatisfies.js
+++ b/source/pathSatisfies.js
@@ -20,8 +20,9 @@ import path from './path';
  * @example
  *
  *      R.pathSatisfies(y => y > 0, ['x', 'y'], {x: {y: 2}}); //=> true
+ *      R.pathSatisfies(R.is(Object), [], {x: {y: 2}}); //=> true
  */
 var pathSatisfies = _curry3(function pathSatisfies(pred, propPath, obj) {
-  return propPath.length > 0 && pred(path(propPath, obj));
+  return pred(path(propPath, obj));
 });
 export default pathSatisfies;

--- a/test/pathSatisfies.js
+++ b/test/pathSatisfies.js
@@ -14,8 +14,12 @@ describe('pathSatisfies', function() {
     eq(R.pathSatisfies(isPositive, ['x', 'y'], {x: {z: 42}}), false);
   });
 
-  it('handles empty paths by just comparing data', function() {
+  it('handles empty paths by applying pred to data: positive', function() {
     eq(R.pathSatisfies(R.is(Object), [], {x: {z: 42}}), true);
+  });
+
+  it('handles empty paths by applying pred to data: negative', function() {
+    eq(R.pathSatisfies(R.has('y'), [], {x: {z: 42}}), false);
   });
 
   it('returns false otherwise', function() {

--- a/test/pathSatisfies.js
+++ b/test/pathSatisfies.js
@@ -14,8 +14,8 @@ describe('pathSatisfies', function() {
     eq(R.pathSatisfies(isPositive, ['x', 'y'], {x: {z: 42}}), false);
   });
 
-  it('returns false if the path is empty', function() {
-    eq(R.pathSatisfies(isPositive, [], {x: {z: 42}}), false);
+  it('handles empty paths by just comparing data', function() {
+    eq(R.pathSatisfies(R.is(Object), [], {x: {z: 42}}), true);
   });
 
   it('returns false otherwise', function() {


### PR DESCRIPTION
Let `R.path` handle everything about how `pathSatisfies` deals with the `path` argument by removing the check for empty arrays. This implements #2788.