### PR TITLE
docs: Add @since where it is missing

### DIFF
--- a/source/composeWith.js
+++ b/source/composeWith.js
@@ -12,6 +12,7 @@ import reverse from './reverse';
  *
  * @func
  * @memberOf R
+ * @since v0.26.0
  * @category Function
  * @sig ((* -> *), [(y -> z), (x -> y), ..., (o -> p), ((a, b, ..., n) -> o)]) -> ((a, b, ..., n) -> z)
  * @param {...Function} ...functions The functions to compose

--- a/source/mergeLeft.js
+++ b/source/mergeLeft.js
@@ -9,6 +9,7 @@ import _curry2 from './internal/_curry2';
  *
  * @func
  * @memberOf R
+ * @since v0.26.0
  * @category Object
  * @sig {k: v} -> {k: v} -> {k: v}
  * @param {Object} l

--- a/source/mergeRight.js
+++ b/source/mergeRight.js
@@ -9,6 +9,7 @@ import _curry2 from './internal/_curry2';
  *
  * @func
  * @memberOf R
+ * @since v0.26.0
  * @category Object
  * @sig {k: v} -> {k: v} -> {k: v}
  * @param {Object} l

--- a/source/otherwise.js
+++ b/source/otherwise.js
@@ -9,6 +9,7 @@ import _assertPromise from './internal/_assertPromise';
  *
  * @func
  * @memberOf R
+ * @since v0.26.0
  * @category Function
  * @sig (e -> b) -> (Promise e a) -> (Promise e b)
  * @sig (e -> (Promise f b)) -> (Promise e a) -> (Promise f b)

--- a/source/pipeWith.js
+++ b/source/pipeWith.js
@@ -15,6 +15,7 @@ import identity from './identity';
  *
  * @func
  * @memberOf R
+ * @since v0.26.0
  * @category Function
  * @sig ((* -> *), [((a, b, ..., n) -> o), (o -> p), ..., (x -> y), (y -> z)]) -> ((a, b, ..., n) -> z)
  * @param {...Function} functions

--- a/source/thunkify.js
+++ b/source/thunkify.js
@@ -7,6 +7,7 @@ import _curry1 from './internal/_curry1';
  *
  * @func
  * @memberOf R
+ * @since v0.26.0
  * @category Function
  * @sig ((a, b, ..., j) -> k) -> (a, b, ..., j) -> (() -> k)
  * @param {Function} fn A function to wrap in a thunk


### PR DESCRIPTION
Hello,

Really not a big deal but some `@since` are missing for some functions introduced in `v0.26.0`, which makes it hard to know when they were introduced in the docs. This should fix it :)

See the screenshot below:
![image](https://user-images.githubusercontent.com/7644970/53689159-97ccc180-3d4f-11e9-8e2c-a0879e62a3cb.png)
