### PR TITLE
fix(applySpec): reintroduce support for arrays of nested specs and functions

### DIFF
--- a/source/applySpec.js
+++ b/source/applySpec.js
@@ -1,4 +1,5 @@
 import _curry1 from './internal/_curry1';
+import _isArray from './internal/_isArray';
 import apply from './apply';
 import curryN from './curryN';
 import max from './max';
@@ -7,13 +8,16 @@ import reduce from './reduce';
 import keys from './keys';
 import values from './values';
 
+
 // Use custom mapValues function to avoid issues with specs that include a "map" key and R.map
 // delegating calls to .map
 function mapValues(fn, obj) {
-  return keys(obj).reduce(function(acc, key) {
-    acc[key] = fn(obj[key]);
-    return acc;
-  }, {});
+  return _isArray(obj)
+    ? obj.map(fn)
+    : keys(obj).reduce(function(acc, key) {
+      acc[key] = fn(obj[key]);
+      return acc;
+    }, {});
 }
 
 /**

--- a/test/applySpec.js
+++ b/test/applySpec.js
@@ -22,6 +22,25 @@ describe('applySpec', function() {
     );
   });
 
+  it('works with arrays of nested specs', function() {
+    eq(R.applySpec({ unnested: R.always(0), nested:[{ sum: R.add }] })(1, 2),
+      { unnested: 0, nested: [{ sum: 3 }] }
+    );
+  });
+
+  it('works with arrays of spec objects', function() {
+    eq(R.applySpec([{ sum: R.add }])(1, 2),
+      [{ sum: 3 }]
+    );
+  });
+
+  it('works with arrays of functions', function() {
+    eq(R.applySpec([R.map(R.prop('a')), R.map(R.prop('b'))])([
+      {a: 'a1', b: 'b1'}, {a: 'a2', b: 'b2'}
+    ]),
+    [['a1', 'a2'], ['b1', 'b2']]);
+  });
+
   it('works with a spec defining a map key', function() {
     eq(R.applySpec({map: R.prop('a')})({a: 1}), {map: 1});
   });


### PR DESCRIPTION
Addresses #2784

Prior to 0.26.x, this was a valid structure, where an array could be passed at an arbitrary depth and could contain other values/functions to be traversed:
```javascript
// Ex. 1
R.applySpec([ R.sum ])(1,2) // [ 3 ]

// Ex. 2
R.applySpec({ nested: [{ sum: R.sum }])(1,2) // { nested: [{ sum: 3 }]}
```
After the PR to address #2681, the output changed to:
```javascript
// Ex. 1
{ "0": [ 3 ]}

// Ex. 2
{ nested: { "0": { sum: 3 }}}
```

These changes add a condition to `applySpec`'s private function, `mapValues`, to just add a check if the current `obj` is an array before branching to `.map()` or `.keys().reduce()` operations based on the result.