### PR TITLE
Fix traverse type signature in documentation comment

### DIFF
--- a/source/traverse.js
+++ b/source/traverse.js
@@ -15,7 +15,7 @@ import sequence from './sequence';
  * @memberOf R
  * @since v0.19.0
  * @category List
- * @sig (Applicative f, Traversable t) => (a -> f a) -> (a -> f b) -> t a -> f (t b)
+ * @sig (Applicative f, Traversable t) => (b -> f b) -> (a -> f b) -> t a -> f (t b)
  * @param {Function} of
  * @param {Function} f
  * @param {*} traversable


### PR DESCRIPTION
Since `traverse = sequence of (map f traversable)`, and `sequence :: (x -> f x) -> t (f x) -> f (t x)`, `f :: a -> f b` and `traversable :: t a`, the type of `(map f traversable)` is `t (f b)`.

Therefore the type parameter `x` in `sequence` is `b`, and the type of the `of` parameter needs to be `b -> f b`.