### PR TITLE
[feat]: scope omit behavior & new inter fn.

### DIFF
--- a/source/internal/_arrayWrapper.js
+++ b/source/internal/_arrayWrapper.js
@@ -1,4 +1,3 @@
-import _curry1 from './_curry1';
 import _isArray from './_isArray';
 
 /**
@@ -22,5 +21,5 @@ import _isArray from './_isArray';
 //           Object.prototype.toString.call(val) === '[object Array]');
 // };
 export default function _arrayWrapper(val) {
-  return _isArray(val) ? val : [val]
-};
+  return _isArray(val) ? val : [val];
+}

--- a/source/internal/_arrayWrapper.js
+++ b/source/internal/_arrayWrapper.js
@@ -15,11 +15,6 @@ import _isArray from './_isArray';
  *
  */
 
-// export default Array.isArray || function _isArray(val) {
-//   return (val != null &&
-//           val.length >= 0 &&
-//           Object.prototype.toString.call(val) === '[object Array]');
-// };
 export default function _arrayWrapper(val) {
   return _isArray(val) ? val : [val];
 }

--- a/source/internal/_arrayWrapper.js
+++ b/source/internal/_arrayWrapper.js
@@ -1,0 +1,26 @@
+import _curry1 from './_curry1';
+import _isArray from './_isArray';
+
+/**
+ * Wraps an object into array if it not an array.
+ *
+ * @private
+ * @param {*} val The object to wrap.
+ * @return {Array} An array
+ * @example
+ *
+ *      _arrayWrapper([]); //=> []
+ *      _arrayWrapper('key'); //=> ['key']
+ *      _arrayWrapper(100); //=> [100]
+ *      _arrayWrapper({a: 1}); //=> [{a: 1}]
+ *
+ */
+
+// export default Array.isArray || function _isArray(val) {
+//   return (val != null &&
+//           val.length >= 0 &&
+//           Object.prototype.toString.call(val) === '[object Array]');
+// };
+export default function _arrayWrapper(val) {
+  return _isArray(val) ? val : [val]
+};

--- a/source/omit.js
+++ b/source/omit.js
@@ -23,7 +23,7 @@ var omit = _curry2(function omit(names, obj) {
   var index = {};
   var idx = 0;
   var len = names.length;
-  names = _arrayWrapper(names)
+  names = _arrayWrapper(names);
 
   while (idx < len) {
     index[names[idx]] = 1;

--- a/source/omit.js
+++ b/source/omit.js
@@ -1,4 +1,5 @@
 import _curry2 from './internal/_curry2';
+import _arrayWrapper from './internal/_arrayWrapper';
 
 /**
  * Returns a partial copy of an object omitting the keys specified.
@@ -8,19 +9,21 @@ import _curry2 from './internal/_curry2';
  * @since v0.1.0
  * @category Object
  * @sig [String] -> {String: *} -> {String: *}
- * @param {Array} names an array of String property names to omit from the new object
+ * @param {Array | String} names an array of String property names or single String property names to omit from the new object
  * @param {Object} obj The object to copy from
  * @return {Object} A new object with properties from `names` not on it.
  * @see R.pick
  * @example
  *
  *      R.omit(['a', 'd'], {a: 1, b: 2, c: 3, d: 4}); //=> {b: 2, c: 3}
+ *      R.omit('prop', {a: 1, b:2, prop: 3}); //=> {a: 1, b:2}
  */
 var omit = _curry2(function omit(names, obj) {
   var result = {};
   var index = {};
   var idx = 0;
   var len = names.length;
+  names = _arrayWrapper(names)
 
   while (idx < len) {
     index[names[idx]] = 1;

--- a/test/omit.js
+++ b/test/omit.js
@@ -16,11 +16,13 @@ describe('omit', function() {
     obj.v = 10; obj.w = 20;
     eq(R.omit(['w', 'x', 'y'], obj), {v: 10, z: 50});
   });
+
   it('pass single string prop to omit', function() {
     eq(R.omit('a', obj), { b: 2, c: 3, d: 4, e: 5, f: 6});
-  })
+  });
+
   it('pass single string prop but undeclared', function() {
     eq(R.omit('notExist', obj), obj);
-  })
+  });
 
 });

--- a/test/omit.js
+++ b/test/omit.js
@@ -16,5 +16,11 @@ describe('omit', function() {
     obj.v = 10; obj.w = 20;
     eq(R.omit(['w', 'x', 'y'], obj), {v: 10, z: 50});
   });
+  it('pass single string prop to omit', function() {
+    eq(R.omit('a', obj), { b: 2, c: 3, d: 4, e: 5, f: 6});
+  })
+  it('pass single string prop but undeclared', function() {
+    eq(R.omit('notExist', obj), obj);
+  })
 
 });


### PR DESCRIPTION
In my opinion, there is a problem with the existing `omit` method:
1. The `names` parameter is expected to be an array but there is no type checking inside.
2. When only one attribute needs to be omitted, the `names` parameter must be written in the array or an unexpected usage will occur.

So make it more safety, I made some change below:
1. Add a new internal function `_ArrayWrapper` that use to check whether an object is an array and wrapped, it returns an array.
2. First, preprocess the `names` parameter of the `omit` method as: `names =  _ArrayWrapper(names)` to compatible with the original usage, and can pass a single `String` property directly
3. Add some new unit test to make sure the method behavior is supposed to.