### PR TITLE
Add isNotNil

### DIFF
--- a/source/index.js
+++ b/source/index.js
@@ -99,6 +99,7 @@ export { default as invoker } from './invoker.js';
 export { default as is } from './is.js';
 export { default as isEmpty } from './isEmpty.js';
 export { default as isNil } from './isNil.js';
+export { default as isNotNil } from './isNotNil.js';
 export { default as join } from './join.js';
 export { default as juxt } from './juxt.js';
 export { default as keys } from './keys.js';

--- a/source/isNotNil.js
+++ b/source/isNotNil.js
@@ -1,0 +1,22 @@
+import isNil from './isNil';
+import _curry1 from './internal/_curry1';
+
+
+/**
+ * Checks if the input value is not `null` and not `undefined`.
+ *
+ * @func
+ * @memberOf R
+ * @category Type
+ * @sig * -> Boolean
+ * @param {*} x The value to test.
+ * @return {Boolean} `true` if `x` is not `undefined` or not `null`, otherwise `false`.
+ * @example
+ *
+ *      R.isNotNil(null); //=> false
+ *      R.isNotNil(undefined); //=> false
+ *      R.isNotNil(0); //=> true
+ *      R.isNotNil([]); //=> true
+ */
+var isNotNil = _curry1(function isNotNil(x) { return !isNil(x); });
+export default isNotNil;

--- a/source/isNotNil.js
+++ b/source/isNotNil.js
@@ -1,5 +1,5 @@
-import isNil from './isNil';
-import _curry1 from './internal/_curry1';
+import isNil from './isNil.js';
+import _curry1 from './internal/_curry1.js';
 
 
 /**

--- a/test/isNotNil.js
+++ b/test/isNotNil.js
@@ -1,0 +1,15 @@
+var R = require('../source');
+var eq = require('./shared/eq');
+
+describe('isNotNil', function() {
+  it('tests a value for `null` or `undefined`', function() {
+    eq(R.isNotNil(void 0), false);
+    eq(R.isNotNil(undefined), false);
+    eq(R.isNotNil(null), false);
+    eq(R.isNotNil([]), true);
+    eq(R.isNotNil({}), true);
+    eq(R.isNotNil(0), true);
+    eq(R.isNotNil(''), true);
+  });
+
+});


### PR DESCRIPTION
I feel like writing complement(isNil) a lot to do null/undefned checking.

I haven't found an appropriate alternative, so I think it might be a good addition to the library to add
a function named 

isDefined: Object -> Bool 

which does the null/undefined checking.

What do you think of this addition?
