### PR TITLE
hasPath return false for non-object checks

### DIFF
--- a/source/hasPath.js
+++ b/source/hasPath.js
@@ -1,7 +1,6 @@
 import _curry2 from './internal/_curry2';
 import _has from './internal/_has';
 
-import is from './is';
 import isNil from './isNil';
 
 
@@ -33,7 +32,7 @@ var hasPath = _curry2(function hasPath(_path, obj) {
   var val = obj;
   var idx = 0;
   while (idx < _path.length) {
-    if (!isNil(val) && is(Object, val) && _has(_path[idx], val)) {
+    if (!isNil(val) && _has(_path[idx], val)) {
       val = val[_path[idx]];
       idx += 1;
     } else {

--- a/source/hasPath.js
+++ b/source/hasPath.js
@@ -1,6 +1,7 @@
 import _curry2 from './internal/_curry2';
 import _has from './internal/_has';
 
+import is from './is';
 import isNil from './isNil';
 
 
@@ -32,7 +33,7 @@ var hasPath = _curry2(function hasPath(_path, obj) {
   var val = obj;
   var idx = 0;
   while (idx < _path.length) {
-    if (!isNil(val) && _has(_path[idx], val)) {
+    if (!isNil(val) && is(Object, val) && _has(_path[idx], val)) {
       val = val[_path[idx]];
       idx += 1;
     } else {

--- a/test/hasPath.js
+++ b/test/hasPath.js
@@ -23,6 +23,13 @@ describe('hasPath', function() {
     eq(R.hasPath(['nullVal'], obj), true);
     eq(R.hasPath(['undefinedVal'], obj), true);
   });
+ 
+  it('return false for a test for a child to a non-object', function() {
+    eq(R.hasPath(['undefinedVal', 'child'], obj), false);
+    eq(R.hasPath(['falseVal', 'child'], obj), false);
+    eq(R.hasPath(['nullVal', 'child'], obj), false);
+    eq(R.hasPath(['arrayVal', 0, 'child'], obj), false);
+  });
 
   it('returns true for existing path with indexes', function() {
     eq(R.hasPath(['arrayVal', 0], obj), true);

--- a/test/hasPath.js
+++ b/test/hasPath.js
@@ -25,10 +25,10 @@ describe('hasPath', function() {
   });
 
   it('return false for a test for a child to a non-object', function() {
-    eq(R.hasPath(['undefinedVal', 'child'], obj), false);
-    eq(R.hasPath(['falseVal', 'child'], obj), false);
-    eq(R.hasPath(['nullVal', 'child'], obj), false);
-    eq(R.hasPath(['arrayVal', 0, 'child'], obj), false);
+    eq(R.hasPath(['undefinedVal', 'child', 'grandchild'], obj), false);
+    eq(R.hasPath(['falseVal', 'child', 'grandchild'], obj), false);
+    eq(R.hasPath(['nullVal', 'child', 'grandchild'], obj), false);
+    eq(R.hasPath(['arrayVal', 0, 'child', 'grandchild'], obj), false);
   });
 
   it('returns true for existing path with indexes', function() {

--- a/test/hasPath.js
+++ b/test/hasPath.js
@@ -23,7 +23,7 @@ describe('hasPath', function() {
     eq(R.hasPath(['nullVal'], obj), true);
     eq(R.hasPath(['undefinedVal'], obj), true);
   });
- 
+
   it('return false for a test for a child to a non-object', function() {
     eq(R.hasPath(['undefinedVal', 'child'], obj), false);
     eq(R.hasPath(['falseVal', 'child'], obj), false);


### PR DESCRIPTION
Used to throw an Error for non-object children tests
Added test for object checking if val is an object when testing a path
Added tests testing false is returned for non-objects children tests
Related to GitHub issue #2771
Fixed based on the discussion in ticket