### PR TITLE
Remove _isArrayLike.js's redundant code

### DIFF
--- a/source/internal/_isArrayLike.js
+++ b/source/internal/_isArrayLike.js
@@ -19,13 +19,13 @@ import _isString from './_isString';
  *      _isArrayLike({}); //=> false
  *      _isArrayLike({length: 10}); //=> false
  *      _isArrayLike({0: 'zero', 9: 'nine', length: 10}); //=> true
+ *      _isArrayLike({nodeType: 1, length: 1}) // => false
  */
 var _isArrayLike = _curry1(function isArrayLike(x) {
   if (_isArray(x)) { return true; }
   if (!x) { return false; }
   if (typeof x !== 'object') { return false; }
   if (_isString(x)) { return false; }
-  if (x.nodeType === 1) { return !!x.length; }
   if (x.length === 0) { return true; }
   if (x.length > 0) {
     return x.hasOwnProperty(0) && x.hasOwnProperty(x.length - 1);


### PR DESCRIPTION
As we talk about in the issue， I think we shoud remove the redundant code。
[Questions about Internal functions _isArrayLike](https://github.com/ramda/ramda/issues/2836)