### PR TITLE
feat(applySpec): support literal values

### DIFF
--- a/source/applySpec.js
+++ b/source/applySpec.js
@@ -1,5 +1,6 @@
 import _curry1 from './internal/_curry1';
 import _isArray from './internal/_isArray';
+import always from './always';
 import apply from './apply';
 import curryN from './curryN';
 import max from './max';
@@ -39,15 +40,19 @@ function mapValues(fn, obj) {
  * @example
  *
  *      const getMetrics = R.applySpec({
+ *        list: [R.add, 'value']
  *        sum: R.add,
- *        nested: { mul: R.multiply }
+ *        some: 'value',
+ *        nested: { mul: R.multiply, any: 'value' }
  *      });
- *      getMetrics(2, 4); // => { sum: 6, nested: { mul: 8 } }
+ *      getMetrics(2, 4); // =>  {  list: [6, 'value'], sum: 6, some: 'value', nested: { mul: 8, any: 'value' } }
  * @symb R.applySpec({ x: f, y: { z: g } })(a, b) = { x: f(a, b), y: { z: g(a, b) } }
  */
 var applySpec = _curry1(function applySpec(spec) {
   spec = mapValues(
-    function(v) { return typeof v == 'function' ? v : applySpec(v); },
+    function(v) {
+      return typeof v === 'function' ? v : typeof v === 'object' ? applySpec(v) : always(v);
+    },
     spec
   );
 

--- a/test/applySpec.js
+++ b/test/applySpec.js
@@ -41,6 +41,21 @@ describe('applySpec', function() {
     [['a1', 'a2'], ['b1', 'b2']]);
   });
 
+  it('should retain literal values on the spec', () => {
+    eq(R.applySpec({ v: [42, 'foo'], u: 'bar' })(2), {
+      v: [42, 'foo'],
+      u: 'bar'
+    });
+  });
+
+  it('should support mixing literal values and spec functions', () => {
+    eq(R.applySpec({ v: [x => x + 40, 'foo'], u: 'bar', w: x => 2 * x })(2), {
+      v: [42, 'foo'],
+      u: 'bar',
+      w: 4
+    });
+  });
+
   it('works with a spec defining a map key', function() {
     eq(R.applySpec({map: R.prop('a')})({a: 1}), {map: 1});
   });


### PR DESCRIPTION
I saw the [introduction of new changes in `applySpec`](https://github.com/ramda/ramda/commit/f3023ea9fc16b2665be890e73d80746cdf2f4112) and was happy to find out that one of the two things that always bugged me about `applySpec` was fixed: support for spec functions in arrays (thanks @bensbigolbeard!). This PR is for the other one I wish made the cut: support for literal values.

The current behaviour is kinda odd and unexpected:

```js
> applySpec({ foo: 'bar', bar: {}, baz: 42, meh: [42] })(2)
{ foo: {}, bar: {}, baz: {}, meh: { '0': {} } }
```

Yes, I'm aware of the whole "crap-in-crap-out" philosophy - but this is just silly, IMHO. Forcing `always` wrappers everywhere seems unnecessary.

After changes in this PR, the above would become:

```js
> applySpec({ foo: 'bar', bar: {}, baz: 42, meh: [42] })(2)
{ foo: 'bar', bar: {}, baz: 42, meh: [ 42 ] }
```