### PR TITLE
clone: Update description

### DIFF
--- a/source/clone.js
+++ b/source/clone.js
@@ -3,9 +3,9 @@ import _curry1 from './internal/_curry1';
 
 
 /**
- * Creates a deep copy of the value which may contain (nested) `Array`s and
- * `Object`s, `Number`s, `String`s, `Boolean`s and `Date`s. `Function`s are
- * assigned by reference rather than copied
+ * Creates a deep copy of the source that can be used in place of the source object without retaining any references to it.
+ * The source object may contain (nested) `Array`s, `Object`s, `Number`s, `String`s, `Boolean`s and `Date`s.
+ * `Function`s are assigned by reference rather than copied.
  *
  * Dispatches to a `clone` method if present.
  *

--- a/source/clone.js
+++ b/source/clone.js
@@ -3,11 +3,17 @@ import _curry1 from './internal/_curry1';
 
 
 /**
- * Creates a deep copy of the source that can be used in place of the source object without retaining any references to it.
- * The source object may contain (nested) `Array`s, `Object`s, `Number`s, `String`s, `Boolean`s and `Date`s.
+ * Creates a deep copy of the source that can be used in place of the source
+ * object without retaining any references to it.
+ * The source object may contain (nested) `Array`s and `Object`s,
+ * `Number`s, `String`s, `Boolean`s and `Date`s.
  * `Function`s are assigned by reference rather than copied.
  *
  * Dispatches to a `clone` method if present.
+ *
+ * Note that if the source object has multiple nodes that share a reference,
+ * the returned object will have the same structure, but the references will
+ * be pointed to the location within the cloned value.
  *
  * @func
  * @memberOf R


### PR DESCRIPTION
Updates the clone description to match the way the function behaves (preserving structural isomorphism with the source object). (fixes #2850)