### PR TITLE
WIP: Add mapAsync, mapGenerator

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,7 @@
 {
   "parserOptions": {
-    "sourceType": "module"
+    "sourceType": "module",
+    "ecmaVersion": 2017
   },
   "env": {
     "node": true,

--- a/source/index.js
+++ b/source/index.js
@@ -115,6 +115,8 @@ export { default as lte } from './lte';
 export { default as map } from './map';
 export { default as mapAccum } from './mapAccum';
 export { default as mapAccumRight } from './mapAccumRight';
+export { default as mapAsync } from './mapAsync';
+export { default as mapGenerator } from './mapGenerator';
 export { default as mapObjIndexed } from './mapObjIndexed';
 export { default as match } from './match';
 export { default as mathMod } from './mathMod';

--- a/source/mapAsync.js
+++ b/source/mapAsync.js
@@ -1,0 +1,32 @@
+import _curry2 from './internal/_curry2';
+import curryN from './curryN';
+
+/**
+ * Takes a function and
+ * an async function, treated as a [functor](https://github.com/fantasyland/fantasy-land#functor),
+ * applies the function to the promise's resolved value, and returns
+ * a promise-returning function of the same arity as the async function.
+ *
+ * To treat the async function as a function functor, use `R.map` instead.
+ *
+ * @func
+ * @memberOf R
+ * @since v0.26.1
+ * @category List
+ * @sig Functor f => (a -> b) -> f a -> f b
+ * @param {Function} fn The function to be called with the contents of the promise of the input `asyncFunction`.
+ * @param {AsyncFunction} asyncFunction The async function that returns the promise to be mapped over.
+ * @return {Function} The new function.
+ * @see R.map
+ * @example
+ *
+ *      const double = x => x * 2;
+ *
+ *      R.map(double, async () => 4); //=> () => (async () => 8)()
+ */
+var mapAsync = _curry2(function mapAsync(fn, asyncFunction) {
+  return curryN(asyncFunction.length, async function() {
+    return fn.call(this, await asyncFunction.apply(this, arguments));
+  });
+});
+export default mapAsync;

--- a/source/mapGenerator.js
+++ b/source/mapGenerator.js
@@ -1,0 +1,34 @@
+import _curry2 from './internal/_curry2';
+import curryN from './curryN';
+
+/**
+ * Takes a function and
+ * a generator function, treated as a [functor](https://github.com/fantasyland/fantasy-land#functor),
+ * applies the function to the generator's values, and returns
+ * a generator-returning function of the same arity as the generator function.
+ *
+ * To treat the generator function as a function functor, use `R.map` instead.
+ *
+ * @func
+ * @memberOf R
+ * @since v0.26.1
+ * @category List
+ * @sig Functor f => (a -> b) -> f a -> f b
+ * @param {Function} fn The function to be called on every element of the generator of the input `generatorFunction`.
+ * @param {GeneratorFunction} generatorFunction The generator function that returns the generator to be mapped over.
+ * @return {Function} The new function.
+ * @see R.map
+ * @example
+ *
+ *      const double = x => x * 2;
+ *
+ *      R.map(double, function*(){ yield 4 }); //=> () => (function*(){ yield 8 })()
+ */
+var mapGenerator = _curry2(function mapGenerator(fn, generatorFunction) {
+  return curryN(generatorFunction.length, function*() {
+    for (let val of generatorFunction.apply(this, arguments)) {
+      yield fn.call(this, val);
+    }
+  });
+});
+export default mapGenerator;

--- a/test/mapAsync.js
+++ b/test/mapAsync.js
@@ -1,0 +1,26 @@
+var R = require('../source');
+var eq = require('./shared/eq');
+
+describe('mapAsync', function() {
+
+  it('interprets (async (->) r) as a functor', function() {
+    var f = function(a) { return a - 1; };
+    var g = async function(b) { return b * 2; };
+    var h = R.mapAsync(f, g);
+    return h(10)
+      .then(h => {
+        eq(h, (10 * 2) - 1);
+      });
+  });
+
+  it('interprets (async (->) r) as a functor and handles multiple arguments', function() {
+    var f = function(a) { return a - 1; };
+    var g = async function(a, b, c) { return a + b + c; };
+    var h = R.mapAsync(f, g);
+    return h(10, 20, 30)
+      .then(h => {
+        eq(h, (10 + 20 + 30) - 1);
+      });
+  });
+
+});

--- a/test/mapGenerator.js
+++ b/test/mapGenerator.js
@@ -1,0 +1,20 @@
+var R = require('../source');
+var eq = require('./shared/eq');
+
+describe('mapGenerator', function() {
+
+  it('interprets generator function as a functor', function() {
+    var f = function(value) { return value - 1; };
+    var g = function* (b) { yield b * 2; };
+    var h = R.mapGenerator(f, g);
+    eq(h(10).next().value, (10 * 2) - 1);
+  });
+
+  it('interprets generator function as a functor and handles multiple arguments', function() {
+    var f = function(value) { return value - 1; };
+    var g = function* (a, b, c) { yield a + b + c; };
+    var h = R.mapGenerator(f, g);
+    eq(h(10, 20, 30).next().value, (10 + 20 + 30) - 1);
+  });
+
+});


### PR DESCRIPTION
This PR is a follow up to https://github.com/ramda/ramda/pull/2675, on the [suggestion](https://github.com/ramda/ramda/pull/2675#issuecomment-501063184) by @CrossEye, attempting to implement the [concept](https://github.com/ramda/ramda/pull/2675/files#r249646227) described by @scott-christopher.

@GingerPlusPlus may be interested in this too!

I've deliberately left out handling `[object AsyncGeneratorFunction]`s ([MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for-await...of)), as strictly speaking it's still in the draft for [ECMAScript 2020](https://tc39.es/ecma262/#sec-for-in-and-for-of-statements), and Ramda's test framework couldn't parse the syntax anyway and I didn't want to change too much.

I've left in the handling of `[object AsyncGeneratorFunction]` in https://github.com/ramda/ramda/pull/2675 because we can handle it in a future-compatible way (because it's pretty likely to stay as '[object AsyncGeneratorFunction]', as supported in many browsers + node). If this does turn out to be an issue though, I can remove it from that PR.

I'm not 100% happy with the descriptions/tests - the descriptions could probably do with being a bit clearer and I thought it was worth checking the arity/ability to curry is preserved. Would appreciate some comments on this.

---

This PR naturally raises the question of mapping over Promises or Generators directly?
We already have `andThen` for map/flatMapping over Promises, so you can get away with just doing:
`map(andThen(x => x + 1), async x => x * 2)(42) // Promise(85)`

A Generator (object) can only be iterated over once:
```
const foo = function*(){ yield 1; yield 2; yield 3 }
const generatorFoo = foo()
generatorFoo.next()
// {value: 1, done: false}
for (val of generatorFoo){ console.log(val) }
// 2
// 3
for (val of generatorFoo){ console.log(val) }
// (nothing logged!)
generatorFoo.next()
{value: undefined, done: true}
```
Generator objects are naturally stateful so to my knowledge they can't be copied, so presumably a `R.map` that works with Generator objects (as opposed to Generator Functions) should create a new generator that internally invokes the original (potentially already used) generator.
(this is admittedly possible to do yourself with `mapGenerator` manually e.g. `mapGenerator(x => x + 1, function*() { yield* someOtherGeneratorObject })` and it carries all the same ambiguities of a side effect)

Unlike `mapAsync`, which at least implies some relationship to AsyncFunctions, not Promises, Generators are their own object that GeneratorFunctions create. 
If this ability to map over Generator objects was added to `map`, I wonder if `mapGenerator` would be a misleading name for anyone unaware of the dichotomy. On the other hand, `mapGeneratorFunctionAsGeneratorFunctor` is not very good either.

---

I experimented with having `mapAsync` return an async function, and `mapGenerator` return a generator function, but aside from being difficult to get right and likely complicating the currying/arity-related internal functions, it also is inconsistent with the way Ramda handles (auto)currying.

e.g.
```
const foo = mapAsync(x => x + 1, (a, b, c) => a + b + c)(10) // AsyncFunction
const bar = foo(20) // Promise of an AsyncFunction?
```
If `foo` is now an AsyncFunction, then we can't continue to invoke it with
the extra arguments like (20, 30) as we'll get a Promise of a (Async)Function, not a Function.
```
const foo = mapAsync(x => x + 1, (a, b, c) => a + b + c)(10) // Function
const bar = foo(20) // AsyncFunction
const baz = bar() // Promise of an AsyncFunction?
```
If `foo` is now a Function, we CAN continue to apply it into `bar`, which is now an AsyncFunction, then this breaks in the same way as the previous example - `bar` should always return a Promise, but if we apply it with no arguments (or with `(_)`), then Ramda's autocurrying rules require it to return the same function as before, but AsyncFunctions always return Promises.

So as far as I can see it doesn't really work to mapAsync/Generator async/generator functions into other async/generator functions, because Ramda's rules require autocurried functions to be able to always return a value or the function again.

The alternative would be to not use any autocurrying at all, but that would mean `mapAsync` and `mapGenerator` would now have different behaviour to `map` in the kind of function they return. Maybe this is desirable, I'm not sure. It would look something like this:
```
var mapAsync = _curry2(function mapAsync(fn, asyncFunction) {
  return async function() {
    return fn.call(this, await asyncFunction.apply(this, arguments));
  };
});
```

As mentioned in https://github.com/ramda/ramda/pull/2675#discussion_r249797293
> probably only for v1.0+

I don't expect this PR to be merged in the short term as it would mean requiring runtime support for AsyncFunctions and GeneratorFunctions- this PR is hopefully a way to unblock/provide clarity for https://github.com/ramda/ramda/pull/2675 !

What do you think?