### PR TITLE
fix(_clone): refFrom and refTo assignment wrong

### DIFF
--- a/source/internal/_clone.js
+++ b/source/internal/_clone.js
@@ -22,8 +22,8 @@ export default function _clone(value, refFrom, refTo, deep) {
       }
       idx += 1;
     }
-    refFrom[idx + 1] = value;
-    refTo[idx + 1] = copiedValue;
+    refFrom[idx] = value;
+    refTo[idx] = copiedValue;
     for (var key in value) {
       copiedValue[key] = deep ?
         _clone(value[key], refFrom, refTo, true) : value[key];


### PR DESCRIPTION
```js
var len = refFrom.length;
var idx = 0;
while (idx < len) {
  if (value === refFrom[idx]) {
    return refTo[idx];
  }
  idx += 1;
}
refFrom[idx + 1] = value;
refTo[idx + 1] = copiedValue;
```

idx is already equal to refFrom.length.

```js
refFrom[refFrom.length + 1] = value;
refTo[refFrom.length + 1] = copiedValue;
```
Obviously, is wrong
