### PR TITLE
Fix documentation for complement

### DIFF
--- a/source/complement.js
+++ b/source/complement.js
@@ -19,9 +19,9 @@ import not from './not';
  * @example
  *
  *      const isNotNil = R.complement(R.isNil);
- *      isNil(null); //=> true
+ *      R.isNil(null); //=> true
  *      isNotNil(null); //=> false
- *      isNil(7); //=> false
+ *      R.isNil(7); //=> false
  *      isNotNil(7); //=> true
  */
 var complement = lift(not);


### PR DESCRIPTION
The documentation of `complement` leaves `isNil` in the example without a clear definition, and the REPL is picking out `isNil` from the scope of `R` (so it does work...). However, that seems unclear to someone reading the example without running the REPL as this var seems to come out of nowhere.