### PR TITLE
Fix a bug in `R.values` test file

### DIFF
--- a/test/keys.js
+++ b/test/keys.js
@@ -20,10 +20,15 @@ describe('keys', function() {
   });
 
   it('works for primitives', function() {
-    var result = R.map(function(val) {
-      return R.keys(val);
-    }, [null, undefined, 55, '', true, false, NaN, Infinity, , []]);
-    eq(result, R.repeat([], 10));
+    eq(R.keys(null), []);
+    eq(R.keys(undefined), []);
+    eq(R.keys(55), []);
+    eq(R.keys('foo'), []);
+    eq(R.keys(true), []);
+    eq(R.keys(false), []);
+    eq(R.keys(NaN), []);
+    eq(R.keys(Infinity), []);
+    eq(R.keys([]), []);
   });
 
   it("does not include the given object's prototype properties", function() {

--- a/test/values.js
+++ b/test/values.js
@@ -30,10 +30,15 @@ describe('values', function() {
   });
 
   it('returns an empty object for primitives', function() {
-    var result = R.map(function(val) {
-      return R.keys(val);
-    }, [null, undefined, 55, '', true, false, NaN, Infinity, , []]);
-    eq(result, R.repeat([], 10));
+    eq(R.values(null), []);
+    eq(R.values(undefined), []);
+    eq(R.values(55), []);
+    eq(R.values('foo'), []);
+    eq(R.values(true), []);
+    eq(R.values(false), []);
+    eq(R.values(NaN), []);
+    eq(R.values(Infinity), []);
+    eq(R.values([]), []);
   });
 
 });


### PR DESCRIPTION
It makes no sense to test for `R.keys` in `R.values` testfile. `R.keys` accidently passed the test clause, but it needs to fix for sure.