### PR TITLE
Make `R.split` work with arrays.

### DIFF
--- a/source/split.js
+++ b/source/split.js
@@ -1,18 +1,20 @@
+import _curry2 from './internal/_curry2';
 import invoker from './invoker';
+import is from './is';
+import equals from './equals';
 
 
 /**
- * Splits a string into an array of strings based on the given
- * separator.
+ * Splits a list or string based on the given separator.
  *
  * @func
  * @memberOf R
  * @since v0.1.0
- * @category String
- * @sig (String | RegExp) -> String -> [String]
- * @param {String|RegExp} sep The pattern.
- * @param {String} str The string to separate into an array.
- * @return {Array} The array of strings from `str` separated by `sep`.
+ * @category List
+ * @sig a -> [a] -> [a]
+ * @param {String|RegExp|a} sep The pattern.
+ * @param {String|[a]} iter Array or string to separate.
+ * @return {Array} The array of items separated by `sep`.
  * @see R.join
  * @example
  *
@@ -20,6 +22,32 @@ import invoker from './invoker';
  *      R.tail(pathComponents('/usr/local/bin/node')); //=> ['usr', 'local', 'bin', 'node']
  *
  *      R.split('.', 'a.b.c.xyz.d'); //=> ['a', 'b', 'c', 'xyz', 'd']
+ *
+ *      const arr = [0, 1, 0, 2, 0, 3]
+ *
+ *      R.split(0, arr); //=> [[], [1], [2], [3]]
+ *
  */
-var split = invoker(1, 'split');
-export default split;
+var splitString = invoker(1, 'split');
+
+var splitArray = function splitArray(sep, list) {
+  var res = list.reduce(
+    function(acc, item) {
+      if (equals(sep)(item)) {
+        acc[0].push(acc[1]);
+        acc[1] = [];
+      } else {
+        acc[1].push(item);
+      }
+      return acc;
+    },
+    [[], []]
+  );
+  return res[0].concat([res[1]]);
+};
+
+export default _curry2(
+  function split(sep, iter) {
+    return is(String, iter) ? splitString(sep, iter) : splitArray(sep, iter);
+  }
+);

--- a/test/split.js
+++ b/test/split.js
@@ -11,4 +11,13 @@ describe('split', function() {
     eq(R.split('at', 'The Cat in the Hat sat on the mat'), ['The C', ' in the H', ' s', ' on the m', '']);
   });
 
+  it('split an array', function() {
+    eq(
+      R.split(
+        0,
+        [0, 1, 0, 2, 0, 3]
+      ),
+      [[], [1], [2], [3]]
+    );
+  });
 });


### PR DESCRIPTION
Fixes #2619.

I wrote it with a `reduce` to allow other iterables to also work,
but it can be written to use the Iterable protocol.

Let me know if there is something to improve on this PR.
