### PR TITLE
change see of 'either' and 'both' to match type signature

### DIFF
--- a/source/and.js
+++ b/source/and.js
@@ -12,7 +12,7 @@ import _curry2 from './internal/_curry2';
  * @param {Any} a
  * @param {Any} b
  * @return {Any} the first argument if it is falsy, otherwise the second argument.
- * @see R.both, R.xor
+ * @see R.both, R.or
  * @example
  *
  *      R.and(true, true); //=> true

--- a/source/both.js
+++ b/source/both.js
@@ -23,7 +23,7 @@ import lift from './lift';
  * @param {Function} f A predicate
  * @param {Function} g Another predicate
  * @return {Function} a function that applies its arguments to `f` and `g` and `&&`s their outputs together.
- * @see R.either
+ * @see R.either, R.and
  * @example
  *
  *      const gt10 = R.gt(R.__, 10)

--- a/source/both.js
+++ b/source/both.js
@@ -23,7 +23,7 @@ import lift from './lift';
  * @param {Function} f A predicate
  * @param {Function} g Another predicate
  * @return {Function} a function that applies its arguments to `f` and `g` and `&&`s their outputs together.
- * @see R.and
+ * @see R.either
  * @example
  *
  *      const gt10 = R.gt(R.__, 10)

--- a/source/either.js
+++ b/source/either.js
@@ -22,7 +22,7 @@ import or from './or';
  * @param {Function} f a predicate
  * @param {Function} g another predicate
  * @return {Function} a function that applies its arguments to `f` and `g` and `||`s their outputs together.
- * @see R.both
+ * @see R.both, R.or
  * @example
  *
  *      const gt10 = x => x > 10;

--- a/source/either.js
+++ b/source/either.js
@@ -22,7 +22,7 @@ import or from './or';
  * @param {Function} f a predicate
  * @param {Function} g another predicate
  * @return {Function} a function that applies its arguments to `f` and `g` and `||`s their outputs together.
- * @see R.or
+ * @see R.both
  * @example
  *
  *      const gt10 = x => x > 10;

--- a/source/or.js
+++ b/source/or.js
@@ -12,7 +12,7 @@ import _curry2 from './internal/_curry2';
  * @param {Any} a
  * @param {Any} b
  * @return {Any} the first argument if truthy, otherwise the second argument.
- * @see R.either, R.xor
+ * @see R.either, R.and
  * @example
  *
  *      R.or(true, true); //=> true


### PR DESCRIPTION
Currently R.both uses R.and for "see also" but R.and accepts two booleans and both two functions. I propose to **change the @see from R.and to R.either**.

And the same goes for R.either:  **change the @see from R.or to R.both**.