### PR TITLE
change propEq/pathEq parameters order

### DIFF
--- a/source/pathEq.js
+++ b/source/pathEq.js
@@ -12,22 +12,23 @@ import path from './path.js';
  * @since v0.7.0
  * @category Relation
  * @typedefn Idx = String | Int | Symbol
- * @sig [Idx] -> a -> {a} -> Boolean
- * @param {Array} path The path of the nested property to use
+ * @sig a -> [Idx] -> {a} -> Boolean
  * @param {*} val The value to compare the nested property with
+ * @param {Array} path The path of the nested property to use
  * @param {Object} obj The object to check the nested property in
  * @return {Boolean} `true` if the value equals the nested object property,
  *         `false` otherwise.
+ * @see R.whereEq, R.propEq, R.pathSatisfies, R.equals
  * @example
  *
  *      const user1 = { address: { zipCode: 90210 } };
  *      const user2 = { address: { zipCode: 55555 } };
  *      const user3 = { name: 'Bob' };
  *      const users = [ user1, user2, user3 ];
- *      const isFamous = R.pathEq(['address', 'zipCode'], 90210);
+ *      const isFamous = R.pathEq(90210, ['address', 'zipCode']);
  *      R.filter(isFamous, users); //=> [ user1 ]
  */
-var pathEq = _curry3(function pathEq(_path, val, obj) {
+var pathEq = _curry3(function pathEq(val, _path, obj) {
   return equals(path(_path, obj), val);
 });
 export default pathEq;

--- a/source/propEq.js
+++ b/source/propEq.js
@@ -6,18 +6,20 @@ import equals from './equals.js';
 /**
  * Returns `true` if the specified object property is equal, in
  * [`R.equals`](#equals) terms, to the given value; `false` otherwise.
- * You can test multiple properties with [`R.whereEq`](#whereEq).
+ * You can test multiple properties with [`R.whereEq`](#whereEq),
+ * and test nested path property with [`R.pathEq`](#pathEq).
  *
  * @func
  * @memberOf R
  * @since v0.1.0
  * @category Relation
- * @sig String -> a -> Object -> Boolean
- * @param {String} name
- * @param {*} val
- * @param {*} obj
- * @return {Boolean}
- * @see R.whereEq, R.propSatisfies, R.equals
+ * @sig a -> String -> Object -> Boolean
+ * @param {*} val The value to compare the property with
+ * @param {String} name the specified object property's key
+ * @param {*} obj The object to check the property in
+ * @return {Boolean} `true` if the value equals the specified object property,
+ *         `false` otherwise.
+ * @see R.whereEq, R.pathEq, R.propSatisfies, R.equals
  * @example
  *
  *      const abby = {name: 'Abby', age: 7, hair: 'blond'};
@@ -25,10 +27,10 @@ import equals from './equals.js';
  *      const rusty = {name: 'Rusty', age: 10, hair: 'brown'};
  *      const alois = {name: 'Alois', age: 15, disposition: 'surly'};
  *      const kids = [abby, fred, rusty, alois];
- *      const hasBrownHair = R.propEq('hair', 'brown');
+ *      const hasBrownHair = R.propEq('brown', 'hair');
  *      R.filter(hasBrownHair, kids); //=> [fred, rusty]
  */
-var propEq = _curry3(function propEq(name, val, obj) {
+var propEq = _curry3(function propEq(val, name, obj) {
   return equals(val, prop(name, obj));
 });
 export default propEq;

--- a/test/pathEq.js
+++ b/test/pathEq.js
@@ -14,23 +14,23 @@ describe('pathEq', function() {
   };
 
   it('returns true if the path matches the value', function() {
-    eq(R.pathEq(['a'], 1, obj), true);
-    eq(R.pathEq(['b', 1, 'ba'], 3, obj), true);
+    eq(R.pathEq(1, ['a'], obj), true);
+    eq(R.pathEq(3, ['b', 1, 'ba'], obj), true);
   });
 
   it('returns false for non matches', function() {
-    eq(R.pathEq(['a'], '1', obj), false);
-    eq(R.pathEq(['b', 0, 'ba'], 3, obj), false);
+    eq(R.pathEq('1', ['a'], obj), false);
+    eq(R.pathEq(3, ['b', 0, 'ba'], obj), false);
   });
 
   it('returns false for non existing values', function() {
-    eq(R.pathEq(['c'], 'foo', obj), false);
-    eq(R.pathEq(['c', 'd'], 'foo', obj), false);
+    eq(R.pathEq('foo', ['c'], obj), false);
+    eq(R.pathEq('foo', ['c', 'd'], obj), false);
   });
 
   it('accepts empty path', function() {
-    eq(R.pathEq([], 42, {a: 1, b: 2}), false);
-    eq(R.pathEq([], obj, obj), true);
+    eq(R.pathEq(42, [], {a: 1, b: 2}), false);
+    eq(R.pathEq(obj, [], obj), true);
   });
 
   it('has R.equals semantics', function() {
@@ -39,10 +39,10 @@ describe('pathEq', function() {
       return x instanceof Just && R.equals(x.value, this.value);
     };
 
-    eq(R.pathEq(['value'], 0, {value: -0}), false);
-    eq(R.pathEq(['value'], -0, {value: 0}), false);
-    eq(R.pathEq(['value'], NaN, {value: NaN}), true);
-    eq(R.pathEq(['value'], new Just([42]), {value: new Just([42])}), true);
+    eq(R.pathEq(0, ['value'], {value: -0}), false);
+    eq(R.pathEq(-0, ['value'], {value: 0}), false);
+    eq(R.pathEq(NaN, ['value'], {value: NaN}), true);
+    eq(R.pathEq(new Just([42]), ['value'], {value: new Just([42])}), true);
   });
 
 });

--- a/test/propEq.js
+++ b/test/propEq.js
@@ -7,18 +7,18 @@ describe('propEq', function() {
   var obj2 = {name: 'Fred', age: 12, hair: 'brown'};
 
   it('determines whether a particular property matches a given value for a specific object', function() {
-    eq(R.propEq('name', 'Abby', obj1), true);
-    eq(R.propEq('hair', 'brown', obj2), true);
-    eq(R.propEq('hair', 'blond', obj2), false);
+    eq(R.propEq('Abby', 'name', obj1), true);
+    eq(R.propEq('brown', 'hair', obj2), true);
+    eq(R.propEq('blond', 'hair', obj2), false);
   });
 
   it('handles number as property', function() {
     var deities = ['Cthulhu', 'Dagon', 'Yog-Sothoth'];
-    eq(R.propEq(0, 'Cthulhu', deities), true);
-    eq(R.propEq(1, 'Dagon', deities), true);
-    eq(R.propEq(2, 'Yog-Sothoth', deities), true);
-    eq(R.propEq(-1, 'Yog-Sothoth', deities), true);
-    eq(R.propEq(3, undefined, deities), true);
+    eq(R.propEq('Cthulhu', 0, deities), true);
+    eq(R.propEq('Dagon', 1, deities), true);
+    eq(R.propEq('Yog-Sothoth', 2, deities), true);
+    eq(R.propEq('Yog-Sothoth', -1, deities), true);
+    eq(R.propEq(undefined, 3, deities), true);
   });
 
   it('has R.equals semantics', function() {
@@ -27,15 +27,15 @@ describe('propEq', function() {
       return x instanceof Just && R.equals(x.value, this.value);
     };
 
-    eq(R.propEq('value', 0, {value: -0}), false);
-    eq(R.propEq('value', -0, {value: 0}), false);
-    eq(R.propEq('value', NaN, {value: NaN}), true);
-    eq(R.propEq('value', new Just([42]), {value: new Just([42])}), true);
+    eq(R.propEq(0, 'value', {value: -0}), false);
+    eq(R.propEq(-0, 'value', {value: 0}), false);
+    eq(R.propEq(NaN, 'value', {value: NaN}), true);
+    eq(R.propEq(new Just([42]), 'value', {value: new Just([42])}), true);
   });
 
   it('returns false if called with a null or undefined object', function() {
-    eq(R.propEq('name', 'Abby', null), false);
-    eq(R.propEq('name', 'Abby', undefined), false);
+    eq(R.propEq('Abby', 'name', null), false);
+    eq(R.propEq('Abby', 'name', undefined), false);
   });
 
 });


### PR DESCRIPTION
Make `propEq/pathEq` parameters order be consistent to `propSatisfies/pathSatisfies` parameters order.

related to #2937 