### PR TITLE
make unionWith's description more clear: use first element from first list if duplicate

### DIFF
--- a/source/unionWith.js
+++ b/source/unionWith.js
@@ -6,7 +6,8 @@ import uniqWith from './uniqWith';
 /**
  * Combines two lists into a set (i.e. no duplicates) composed of the elements
  * of each list. Duplication is determined according to the value returned by
- * applying the supplied predicate to two list elements.
+ * applying the supplied predicate to two list elements. If an element exists
+ * in both lists, the first element from the first list will be used.
  *
  * @func
  * @memberOf R


### PR DESCRIPTION
make `unionWith`'s description more clear, use first element from first list if duplicate, for example:

```js
const l1 = [{a: 1, b: 1}, {a: 1, b: 2}, {a: 2}];
const l2 = [{a: 1}, {a: 4}];
R.unionWith(R.eqProps('a'), l1, l2); 
//=> [{a: 1, b: 1}, {a: 2}, {a: 4}]
```

