### PR TITLE
make tap's symb description more clearly

### DIFF
--- a/source/tap.js
+++ b/source/tap.js
@@ -21,7 +21,7 @@ import _xtap from './internal/_xtap';
  *      const sayX = x => console.log('x is ' + x);
  *      R.tap(sayX, 100); //=> 100
  *      // logs 'x is 100'
- * @symb R.tap(f, a) = a
+ * @symb R.tap(f, a) = (f(a), a)
  */
 var tap = _curry2(_dispatchable([], _xtap, function tap(fn, x) {
   fn(x);


### PR DESCRIPTION
`tap` run the side-effect with input first, and return the input. 

`@symb R.tap(f, a) = (f(a), a)` describes what `R.tap` do more clearly.