### PR TITLE
Add clarification example to compose not auto-currying

### DIFF
--- a/source/compose.js
+++ b/source/compose.js
@@ -25,6 +25,7 @@ import reverse from './reverse';
  *      R.compose(Math.abs, R.add(1), R.multiply(2))(-4) //=> 7
  *
  * @symb R.compose(f, g, h)(a, b) = f(g(h(a, b)))
+ * @symb R.compose(f, g, h)(a)(b) = f(g(h(a)))(b)
  */
 export default function compose() {
   if (arguments.length === 0) {

--- a/source/pipe.js
+++ b/source/pipe.js
@@ -26,6 +26,7 @@ import tail from './tail';
  *
  *      f(3, 4); // -(3^4) + 1
  * @symb R.pipe(f, g, h)(a, b) = h(g(f(a, b)))
+ * @symb R.pipe(f, g, h)(a)(b) = h(g(f(a)))(b)
  */
 export default function pipe() {
   if (arguments.length === 0) {


### PR DESCRIPTION
This is a rather small change so I understand if it isn't worth adding given that there's already the note, but for someone rather new to functional programming like myself, seeing the consequence of the fact that `compose` and `pipe` do not auto-curry is helpful. 