### PR TITLE
"prop" optimization (10x faster)

### DIFF
--- a/source/prop.js
+++ b/source/prop.js
@@ -1,5 +1,6 @@
 import _curry2 from './internal/_curry2';
-import path from './path';
+import _isInteger from './internal/_isInteger';
+import nth from './nth';
 
 
 /**
@@ -24,5 +25,10 @@ import path from './path';
  *      R.compose(R.inc, R.prop('x'))({ x: 3 }) //=> 4
  */
 
-var prop = _curry2(function prop(p, obj) { return path([p], obj); });
+var prop = _curry2(function prop(p, obj) {
+  if (obj == null) {
+    return;
+  }
+  return _isInteger(p) ? nth(p, obj) : obj[p];
+});
 export default prop;

--- a/source/propOr.js
+++ b/source/propOr.js
@@ -1,5 +1,6 @@
 import _curry3 from './internal/_curry3';
-import pathOr from './pathOr';
+import defaultTo from './defaultTo';
+import prop from './prop';
 
 
 /**
@@ -29,6 +30,6 @@ import pathOr from './pathOr';
  *      favoriteWithDefault(alice);  //=> 'Ramda'
  */
 var propOr = _curry3(function propOr(val, p, obj) {
-  return pathOr(val, [p], obj);
+  return defaultTo(val, prop(p, obj));
 });
 export default propOr;

--- a/test/prop.js
+++ b/test/prop.js
@@ -11,6 +11,36 @@ describe('prop', function() {
     eq(nm(fred), 'Fred');
   });
 
+  it('shows the same behaviour as path for a nonexistent property', function() {
+    var propResult = R.prop('incorrect', fred);
+    var pathResult = R.path(['incorrect'], fred);
+    eq(propResult, pathResult);
+  })
+
+  it('shows the same behaviour as path for an undefined property', function() {
+    var propResult = R.prop(undefined, fred);
+    var pathResult = R.path([undefined], fred);
+    eq(propResult, pathResult);
+  })
+
+  it('shows the same behaviour as path for a null property', function() {
+    var propResult = R.prop(null, fred);
+    var pathResult = R.path([null], fred);
+    eq(propResult, pathResult);
+  })
+
+  it('shows the same behaviour as path for a valid property and object', function() {
+    var propResult = R.prop('age', fred);
+    var pathResult = R.path(['age'], fred);
+    eq(propResult, pathResult);
+  })
+
+  it('shows the same behaviour as path for a null object', function() {
+    var propResult = R.prop('age', null);
+    var pathResult = R.path(['age'], null);
+    eq(propResult, pathResult);
+  })
+
   it('shows the same behaviour as path for an undefined object', function() {
     var propResult, propException, pathResult, pathException;
     try {

--- a/test/prop.js
+++ b/test/prop.js
@@ -15,31 +15,31 @@ describe('prop', function() {
     var propResult = R.prop('incorrect', fred);
     var pathResult = R.path(['incorrect'], fred);
     eq(propResult, pathResult);
-  })
+  });
 
   it('shows the same behaviour as path for an undefined property', function() {
     var propResult = R.prop(undefined, fred);
     var pathResult = R.path([undefined], fred);
     eq(propResult, pathResult);
-  })
+  });
 
   it('shows the same behaviour as path for a null property', function() {
     var propResult = R.prop(null, fred);
     var pathResult = R.path([null], fred);
     eq(propResult, pathResult);
-  })
+  });
 
   it('shows the same behaviour as path for a valid property and object', function() {
     var propResult = R.prop('age', fred);
     var pathResult = R.path(['age'], fred);
     eq(propResult, pathResult);
-  })
+  });
 
   it('shows the same behaviour as path for a null object', function() {
     var propResult = R.prop('age', null);
     var pathResult = R.path(['age'], null);
     eq(propResult, pathResult);
-  })
+  });
 
   it('shows the same behaviour as path for an undefined object', function() {
     var propResult, propException, pathResult, pathException;

--- a/test/propOr.js
+++ b/test/propOr.js
@@ -27,37 +27,37 @@ describe('propOr', function() {
     eq(R.propOr('foo', 'x', {x: undefined}), 'foo');
   });
 
-  it('shows the same behaviour as path for a nonexistent property', function() {
+  it('shows the same behaviour as pathOr for a nonexistent property', function() {
     var propOrResult = R.propOr('Unknown', 'incorrect', fred);
     var pathOrResult = R.pathOr('Unknown', ['incorrect'], fred);
     eq(propOrResult, pathOrResult);
-  })
+  });
 
-  it('shows the same behaviour as path for an undefined property', function() {
+  it('shows the same behaviour as pathOr for an undefined property', function() {
     var propOrResult = R.propOr('Unknown', undefined, fred);
     var pathOrResult = R.pathOr('Unknown', [undefined], fred);
     eq(propOrResult, pathOrResult);
-  })
+  });
 
-  it('shows the same behaviour as path for a null property', function() {
+  it('shows the same behaviour as pathOr for a null property', function() {
     var propOrResult = R.propOr('Unknown', null, fred);
     var pathOrResult = R.pathOr('Unknown', [null], fred);
     eq(propOrResult, pathOrResult);
-  })
+  });
 
-  it('shows the same behaviour as path for a valid property and object', function() {
+  it('shows the same behaviour as pathOr for a valid property and object', function() {
     var propOrResult = R.propOr('Unknown', 'age', fred);
     var pathOrResult = R.pathOr('Unknown', ['age'], fred);
     eq(propOrResult, pathOrResult);
-  })
+  });
 
-  it('shows the same behaviour as path for a null object', function() {
+  it('shows the same behaviour as pathOr for a null object', function() {
     var propOrResult = R.propOr('Unknown', 'age', null);
     var pathOrResult = R.pathOr('Unknown', ['age'], null);
     eq(propOrResult, pathOrResult);
-  })
+  });
 
-  it('shows the same behaviour as path for an undefined object', function() {
+  it('shows the same behaviour as pathOr for an undefined object', function() {
     var propOrResult = R.propOr('Unknown', 'age', undefined);
     var pathOrResult = R.pathOr('Unknown', ['age'], undefined);
     eq(propOrResult, pathOrResult);

--- a/test/propOr.js
+++ b/test/propOr.js
@@ -27,4 +27,39 @@ describe('propOr', function() {
     eq(R.propOr('foo', 'x', {x: undefined}), 'foo');
   });
 
+  it('shows the same behaviour as path for a nonexistent property', function() {
+    var propOrResult = R.propOr('Unknown', 'incorrect', fred);
+    var pathOrResult = R.pathOr('Unknown', ['incorrect'], fred);
+    eq(propOrResult, pathOrResult);
+  })
+
+  it('shows the same behaviour as path for an undefined property', function() {
+    var propOrResult = R.propOr('Unknown', undefined, fred);
+    var pathOrResult = R.pathOr('Unknown', [undefined], fred);
+    eq(propOrResult, pathOrResult);
+  })
+
+  it('shows the same behaviour as path for a null property', function() {
+    var propOrResult = R.propOr('Unknown', null, fred);
+    var pathOrResult = R.pathOr('Unknown', [null], fred);
+    eq(propOrResult, pathOrResult);
+  })
+
+  it('shows the same behaviour as path for a valid property and object', function() {
+    var propOrResult = R.propOr('Unknown', 'age', fred);
+    var pathOrResult = R.pathOr('Unknown', ['age'], fred);
+    eq(propOrResult, pathOrResult);
+  })
+
+  it('shows the same behaviour as path for a null object', function() {
+    var propOrResult = R.propOr('Unknown', 'age', null);
+    var pathOrResult = R.pathOr('Unknown', ['age'], null);
+    eq(propOrResult, pathOrResult);
+  })
+
+  it('shows the same behaviour as path for an undefined object', function() {
+    var propOrResult = R.propOr('Unknown', 'age', undefined);
+    var pathOrResult = R.pathOr('Unknown', ['age'], undefined);
+    eq(propOrResult, pathOrResult);
+  });
 });


### PR DESCRIPTION
In the current version of the code, "prop" uses "paths" underneath. This is only done so as not to duplicate **one** line of logic.
I copied the logic choosing property directly to "prop".
The overhead on "prop" was so great that this function started to work **10x faster**!

Why is this optimization so important? Most programmers use "prop" as a substitute for the null safety "**?.**" syntax. This PR will drastically accelerate all React projects where Ramda is used during every rerender (e.g. in selectors).

https://jsperf.com/ramda-optimized-prop

<img width="964" alt="Zrzut ekranu 2020-01-25 o 16 53 23" src="https://user-images.githubusercontent.com/16975059/73123875-1d271900-3f95-11ea-89e4-d616ec73f73c.png">
