### PR TITLE
improve clone performance

### DIFF
--- a/source/clone.js
+++ b/source/clone.js
@@ -30,8 +30,6 @@ import _curry1 from './internal/_curry1.js';
  *      objects[0] === objectsClone[0]; //=> false
  */
 var clone = _curry1(function clone(value) {
-  return value != null && typeof value.clone === 'function' ?
-    value.clone() :
-    _clone(value, [], [], true);
+  return value != null && typeof value.clone === 'function' ? value.clone() : _clone(value, true);
 });
 export default clone;

--- a/source/internal/_clone.js
+++ b/source/internal/_clone.js
@@ -10,7 +10,10 @@ import type from '../type.js';
  * @param {Boolean} deep Whether or not to perform deep cloning.
  * @return {*} The copied value.
  */
-export default function _clone(value, deep, map = new Map()) {
+export default function _clone(value, deep, map) {
+
+  map || (map = new _ObjectMap());
+
   // this avoids the slower switch with a quick if decision removing some milliseconds in each run.
   if (_isPrimitive(value)) {
     return value;
@@ -23,6 +26,7 @@ export default function _clone(value, deep, map = new Map()) {
     if (cachedCopy) {
       return cachedCopy;
     }
+
     map.set(value, copiedValue);
 
     for (var key in value) {
@@ -58,3 +62,61 @@ function _isPrimitive(param) {
   var type = typeof param;
   return param == null || (type != 'object' && type != 'function');
 }
+
+function _ObjectMap() {
+  this.map = {};
+  this.length = 0;
+}
+
+_ObjectMap.prototype.set = function(key, value) {
+  const hashedKey = this.hash(key);
+
+  let bucket = this.map[hashedKey];
+  if (!bucket) {
+    this.map[hashedKey] = bucket = [];
+  }
+
+  bucket.push([key, value]);
+  this.length += 1;
+};
+
+_ObjectMap.prototype.hash = function(key) {
+  let hashedKey = [];
+  for (var value in key) {
+    hashedKey.push(key[value]);
+  }
+  return hashedKey.join();
+};
+
+_ObjectMap.prototype.get = function(key) {
+
+  /**
+   * depending on the number of objects to be cloned is faster to just iterate over the items in the map just because the hash function is so costly,
+   * on my tests this number is 180, anything above that using the hash function is faster.
+   */
+  if (this.length <= 180) {
+
+    for (const p in this.map) {
+      const bucket = this.map[p];
+
+      for (let i = 0; i < bucket.length; i += 1) {
+        const element = bucket[i];
+        if (element[0] === key) {return element[1];}
+      }
+
+    }
+    return;
+  }
+
+  const hashedKey = this.hash(key);
+  const bucket = this.map[hashedKey];
+
+  if (!bucket) {return;}
+
+  for (let i = 0; i < bucket.length; i += 1) {
+    const element = bucket[i];
+    if (element[0] === key) {return element[1];}
+  }
+
+};
+

--- a/source/internal/_clone.js
+++ b/source/internal/_clone.js
@@ -7,30 +7,32 @@ import type from '../type.js';
  *
  * @private
  * @param {*} value The value to be copied
- * @param {Array} refFrom Array containing the source references
- * @param {Array} refTo Array containing the copied source references
  * @param {Boolean} deep Whether or not to perform deep cloning.
  * @return {*} The copied value.
  */
-export default function _clone(value, refFrom, refTo, deep) {
+export default function _clone(value, deep, map = new Map()) {
+  // this avoids the slower switch with a quick if decision removing some milliseconds in each run.
+  if (_isPrimitive(value)) {
+    return value;
+  }
+
   var copy = function copy(copiedValue) {
-    var len = refFrom.length;
-    var idx = 0;
-    while (idx < len) {
-      if (value === refFrom[idx]) {
-        return refTo[idx];
-      }
-      idx += 1;
+    // Check for circular and same references on the object graph and return its corresponding clone.
+    var cachedCopy = map.get(value);
+
+    if (cachedCopy) {
+      return cachedCopy;
     }
-    refFrom[idx] = value;
-    refTo[idx] = copiedValue;
+    map.set(value, copiedValue);
+
     for (var key in value) {
       if (value.hasOwnProperty(key)) {
-        copiedValue[key] = deep ? _clone(value[key], refFrom, refTo, true) : value[key];
+        copiedValue[key] = deep ? _clone(value[key], true, map) : value[key];
       }
     }
     return copiedValue;
   };
+
   switch (type(value)) {
     case 'Object':  return copy(Object.create(Object.getPrototypeOf(value)));
     case 'Array':   return copy([]);
@@ -50,4 +52,9 @@ export default function _clone(value, refFrom, refTo, deep) {
       return value.slice();
     default:        return value;
   }
+}
+
+function _isPrimitive(param) {
+  var type = typeof param;
+  return param == null || (type != 'object' && type != 'function');
 }

--- a/source/into.js
+++ b/source/into.js
@@ -45,8 +45,8 @@ import _stepCat from './internal/_stepCat.js';
  *      intoArray(transducer, numbers); //=> [2, 3]
  */
 var into = _curry3(function into(acc, xf, list) {
-  return _isTransformer(acc) ?
-    _reduce(xf(acc), acc['@@transducer/init'](), list) :
-    _reduce(xf(_stepCat(acc)), _clone(acc, [], [], false), list);
+  return _isTransformer(acc)
+    ? _reduce(xf(acc), acc['@@transducer/init'](), list)
+    : _reduce(xf(_stepCat(acc)), _clone(acc, false), list);
 });
 export default into;

--- a/source/reduceBy.js
+++ b/source/reduceBy.js
@@ -55,7 +55,7 @@ var reduceBy = _curryN(4, [], _dispatchable([], _xreduceBy,
   function reduceBy(valueFn, valueAcc, keyFn, list) {
     return _reduce(function(acc, elt) {
       var key = keyFn(elt);
-      var value = valueFn(_has(key, acc) ? acc[key] : _clone(valueAcc, [], [], false), elt);
+      var value = valueFn(_has(key, acc) ? acc[key] : _clone(valueAcc, false), elt);
 
       if (value && value['@@transducer/reduced']) {
         return _reduced(acc);


### PR DESCRIPTION
Changed _clone to use a Map to cache and retrieve the cloned objects.
this is NOT a breaking change and in my tests reduce the time to clone this [object](https://paste.ee/p/LNvsR) from 93.2ms to 6.8ms on average after 100 iterations.