### PR TITLE
hasIn: protection against undefined object

### DIFF
--- a/source/hasIn.js
+++ b/source/hasIn.js
@@ -1,4 +1,5 @@
 import _curry2 from './internal/_curry2';
+import isNil from './isNil';
 
 
 /**
@@ -28,6 +29,9 @@ import _curry2 from './internal/_curry2';
  *      R.hasIn('area', square);  //=> true
  */
 var hasIn = _curry2(function hasIn(prop, obj) {
+  if (isNil(obj)) {
+    return false;
+  }
   return prop in obj;
 });
 export default hasIn;

--- a/test/hasIn.js
+++ b/test/hasIn.js
@@ -26,4 +26,8 @@ describe('hasIn', function() {
     eq(R.hasIn('name', anon), false);
   });
 
+  it('returns false when non-existent object', function() {
+    eq(R.hasIn('name', null), false);
+    eq(R.hasIn('name', undefined), false);
+  });
 });


### PR DESCRIPTION
sometimes people write code like this:
```
let obj = null
hasIn('test', obj) && prop('test', obj)
```