### PR TITLE
new function: recall

### DIFF
--- a/source/index.js
+++ b/source/index.js
@@ -177,6 +177,7 @@ export { default as propOr } from './propOr';
 export { default as propSatisfies } from './propSatisfies';
 export { default as props } from './props';
 export { default as range } from './range';
+export { default as recall } from './recall';
 export { default as reduce } from './reduce';
 export { default as reduceBy } from './reduceBy';
 export { default as reduceRight } from './reduceRight';

--- a/source/recall.js
+++ b/source/recall.js
@@ -1,0 +1,34 @@
+import uncurryN from './uncurryN';
+
+/**
+ * Collapses a high-order unary function. The order N of the function
+ * is implicit. A maximum number of N values are singularly fed.
+ *
+ * @func
+ * @category Function
+ * @sig ((a -> b -> * -> c), *...) -> d
+ * @param {Function} fn The N-order function to be collapsed.
+ * @param {...*} args Up to N input values.
+ * @return {*}
+ * @see R.call
+ * @example
+ *
+ *      const xs = [{a: 1}, {a: 2}, {a: 3}];
+ *      const f = R.compose(R.find, R.propEq('a'));
+ *      R.recall(f, 2, xs); //=> {"a": 2}
+ *
+ * @symb R.recall(f, a, b) = f(a)(b)
+ */
+var recall = uncurryN(2, function(fn) {
+  return function() {
+    var numArgs = arguments.length;
+    var value = fn;
+    var i = 0;
+    while(typeof value == 'function' && i < numArgs) {
+      value = value(arguments[ i++ ]);
+    }
+    return value;
+  };
+});
+
+export default recall;

--- a/test/recall.js
+++ b/test/recall.js
@@ -1,0 +1,22 @@
+var R = require('../source');
+var eq = require('./shared/eq');
+
+var fn = function(a) {
+  var x = a + 1;
+  return function(b) {
+    var y = x * b;
+    return function(c) {
+      return y * c;
+    }
+  }
+};
+
+describe('recall', function() {
+  it('collapses a high-order unary function', function() {
+    eq(R.recall(fn, 1, 2, 3), 12);
+  });
+
+  it('accepts no more than N arguments for an N-order function', function() {
+    eq(R.recall(fn, 1, 2, 3), R.recall(fn, 1, 2, 3, 4));
+  });
+});


### PR DESCRIPTION
This is in reference to #2980. It supports a particular class of function: A unary function that if returns a function, is also unary with the same rule. 