### PR TITLE
`pipe` - throw on non-function arguments

### DIFF
--- a/source/pipe.js
+++ b/source/pipe.js
@@ -1,7 +1,10 @@
 import _arity from './internal/_arity';
+import _isFunction from './internal/_isFunction';
 import _pipe from './internal/_pipe';
+import complement from './complement';
 import reduce from './reduce';
 import tail from './tail';
+import toString from './toString';
 
 
 /**
@@ -31,6 +34,12 @@ import tail from './tail';
 export default function pipe() {
   if (arguments.length === 0) {
     throw new Error('pipe requires at least one argument');
+  }
+  const firstNonFunction = [].slice.call(arguments).find(complement(_isFunction));
+  if (firstNonFunction) {
+    throw new TypeError(
+      'pipe: ' + toString(firstNonFunction) + ' is not a function'
+    );
   }
   return _arity(
     arguments[0].length,

--- a/source/pipe.js
+++ b/source/pipe.js
@@ -1,7 +1,6 @@
 import _arity from './internal/_arity';
 import _isFunction from './internal/_isFunction';
 import _pipe from './internal/_pipe';
-import complement from './complement';
 import reduce from './reduce';
 import tail from './tail';
 import toString from './toString';
@@ -35,11 +34,15 @@ export default function pipe() {
   if (arguments.length === 0) {
     throw new Error('pipe requires at least one argument');
   }
-  const firstNonFunction = [].slice.call(arguments).find(complement(_isFunction));
-  if (firstNonFunction) {
-    throw new TypeError(
-      'pipe: ' + toString(firstNonFunction) + ' is not a function'
-    );
+  var args = [].slice.call(arguments);
+  var idx = 0;
+  while (idx < args.length) {
+    if (!_isFunction(args[idx])) {
+      throw new TypeError(
+        'pipe: ' + toString(args[idx]) + ' is not a function'
+      );
+    }
+    idx += 1;
   }
   return _arity(
     arguments[0].length,

--- a/test/pipe.js
+++ b/test/pipe.js
@@ -56,4 +56,13 @@ describe('pipe', function() {
     eq(g(1, 2, 3), [1, 2, 3]);
   });
 
+  it('throws given non-function arguments', function() {
+    assert.throws(
+      function() { R.pipe(x => x, x => x, 'not-a-function'); },
+      function(err) {
+        return err.constructor === TypeError &&
+               err.message === 'pipe: "not-a-function" is not a function';
+      }
+    );
+  });
 });


### PR DESCRIPTION
Hey there, I was recently bitten by this -- I had a function composition that I thought looked like:

```js
pipe(
  curriedTernaryFunction(a, b),
  someOtherFn,
  anotherFn
)('blah')
```

But the function that I thought was ternary was actually binary, so instead of being a function it was the result of calling that function inside the pipe. This results in an error `TypeError: g.call is not a function.` -- as I was several levels above this it took a while to chase this down.

I'd love if this or something similar could land in `ramda` as it is a core library for me, also happy to make any changes.



