### PR TITLE
Fix typo in the tryCatch docs

### DIFF
--- a/source/tryCatch.js
+++ b/source/tryCatch.js
@@ -17,7 +17,7 @@ import _curry2 from './internal/_curry2';
  * @sig (...x -> a) -> ((e, ...x) -> a) -> (...x -> a)
  * @param {Function} tryer The function that may throw.
  * @param {Function} catcher The function that will be evaluated if `tryer` throws.
- * @return {Function} A new function that will catch exceptions and send then to the catcher.
+ * @return {Function} A new function that will catch exceptions and send them to the catcher.
  * @example
  *
  *      R.tryCatch(R.prop('x'), R.F)({x: true}); //=> true


### PR DESCRIPTION
I accidentally noticed a typo in `@returns` message. Here's a quick fix for it.