### PR TITLE
arguments.length will always be the same as n

### DIFF
--- a/source/constructN.js
+++ b/source/constructN.js
@@ -46,7 +46,7 @@ var constructN = _curry2(function constructN(n, Fn) {
     return function() { return new Fn(); };
   }
   return curry(nAry(n, function($0, $1, $2, $3, $4, $5, $6, $7, $8, $9) {
-    switch (arguments.length) {
+    switch (n) {
       case  1: return new Fn($0);
       case  2: return new Fn($0, $1);
       case  3: return new Fn($0, $1, $2);


### PR DESCRIPTION
https://github.com/ramda/ramda/blob/998f798d9ac6297bb9f5b45136e3ff06a56df09a/source/constructN.js#L48-L49

`arguments.length` will always be the same as `n`, so there's no need to dynamically calculate arguments' length. And `switch(n)` may be more clear to source code readers?