### PR TITLE
prop(path)Satisfies should always return boolean

### DIFF
--- a/source/pathSatisfies.js
+++ b/source/pathSatisfies.js
@@ -23,6 +23,6 @@ import path from './path';
  *      R.pathSatisfies(R.is(Object), [], {x: {y: 2}}); //=> true
  */
 var pathSatisfies = _curry3(function pathSatisfies(pred, propPath, obj) {
-  return pred(path(propPath, obj));
+  return Boolean(pred(path(propPath, obj)));
 });
 export default pathSatisfies;

--- a/source/propSatisfies.js
+++ b/source/propSatisfies.js
@@ -21,6 +21,6 @@ import prop from './prop';
  *      R.propSatisfies(x => x > 0, 'x', {x: 1, y: 2}); //=> true
  */
 var propSatisfies = _curry3(function propSatisfies(pred, name, obj) {
-  return pred(prop(name, obj));
+  return Boolean(pred(prop(name, obj)));
 });
 export default propSatisfies;


### PR DESCRIPTION
According to #2966 
I agree with the author of the issue. It is a bit confusing to have a number, for example, as a return value of propSatisfies(). 