### PR TITLE
removing recursion from _clone

### DIFF
--- a/source/clone.js
+++ b/source/clone.js
@@ -32,6 +32,6 @@ import _curry1 from './internal/_curry1';
 var clone = _curry1(function clone(value) {
   return value != null && typeof value.clone === 'function' ?
     value.clone() :
-    _clone(value, [], [], true);
+    _clone(value, true);
 });
 export default clone;

--- a/source/internal/_queue.js
+++ b/source/internal/_queue.js
@@ -1,0 +1,28 @@
+function itself(x) {
+  return x;
+}
+
+function none() {
+  return;
+}
+
+/**
+ * Specific util for removing recursion with queue
+ * @param callback - iteration takes value and push function
+ * @param initialValue - will be passed as value on the first iteration
+ * @param get - getter from push arguments as Array to value, return Array of push arguments by default
+ * @param set - takes push arguments as Array and callback result, none by default
+ * @returns {*}
+ */
+export default  function _queue(callback, initialValue, get = itself, set = none) {
+  const qe = [];
+  const push = (...args) => {
+    qe.push(args);
+  };
+  const result = callback(initialValue, push);
+  while (qe.length) {
+    set(qe[0], callback(get(qe[0]), push));
+    qe.shift();
+  }
+  return result;
+}

--- a/source/into.js
+++ b/source/into.js
@@ -47,6 +47,6 @@ import _stepCat from './internal/_stepCat';
 var into = _curry3(function into(acc, xf, list) {
   return _isTransformer(acc) ?
     _reduce(xf(acc), acc['@@transducer/init'](), list) :
-    _reduce(xf(_stepCat(acc)), _clone(acc, [], [], false), list);
+    _reduce(xf(_stepCat(acc)), _clone(acc,  false), list);
 });
 export default into;

--- a/source/reduceBy.js
+++ b/source/reduceBy.js
@@ -51,7 +51,7 @@ var reduceBy = _curryN(4, [], _dispatchable([], _xreduceBy,
   function reduceBy(valueFn, valueAcc, keyFn, list) {
     return _reduce(function(acc, elt) {
       var key = keyFn(elt);
-      acc[key] = valueFn(_has(key, acc) ? acc[key] : _clone(valueAcc, [], [], false), elt);
+      acc[key] = valueFn(_has(key, acc) ? acc[key] : _clone(valueAcc,  false), elt);
       return acc;
     }, {}, list);
   }));

--- a/test/clone.js
+++ b/test/clone.js
@@ -6,7 +6,7 @@ var eq = require('./shared/eq');
 
 let nestedObject = {};
 let nestedArray = [];
-for (var i = 0; i < Math.pow(10, 6); i += 1) {
+for (var i = 0; i < 1.15 * Math.pow(10, 4); i += 1) {
   nestedObject = {next: nestedObject};
   nestedArray = [nestedArray];
 }
@@ -70,12 +70,9 @@ describe('deep clone objects', function() {
     assert.notDeepEqual(clone.c.b, x.c.b);
   });
 
-  it('clones objects with deep nesting', function(done) {
-    setTimeout(() => {
-      var clone = R.clone(nestedObject);
-      assert.notStrictEqual(clone, nestedObject);
-      done();
-    });
+  it('clones objects with deep nesting', function() {
+    var clone = R.clone(nestedObject);
+    assert.notStrictEqual(clone, nestedObject);
   });
 
   it('clone instances', function() {
@@ -123,12 +120,9 @@ describe('deep clone arrays', function() {
     eq(clone, [1, [1, 2, 3], [[[5]]]]);
   });
 
-  it('clones deep nested arrays', function(done) {
-    setTimeout(() => {
-      var clone = R.clone(nestedArray);
-      assert.notStrictEqual(clone, nestedArray);
-      done();
-    });
+  it('clones deep nested arrays', function() {
+    var clone = R.clone(nestedArray);
+    assert.notStrictEqual(clone, nestedArray);
   });
 
 });

--- a/test/clone.js
+++ b/test/clone.js
@@ -4,6 +4,14 @@ var R = require('../source');
 var eq = require('./shared/eq');
 
 
+let nestedObject = {};
+let nestedArray = [];
+for (var i = 0; i < Math.pow(10, 6); i += 1) {
+  nestedObject = {next: nestedObject};
+  nestedArray = [nestedArray];
+}
+
+
 describe('deep clone integers, strings and booleans', function() {
   it('clones integers', function() {
     eq(R.clone(-4), -4);
@@ -62,6 +70,14 @@ describe('deep clone objects', function() {
     assert.notDeepEqual(clone.c.b, x.c.b);
   });
 
+  it('clones objects with deep nesting', function(done) {
+    setTimeout(() => {
+      var clone = R.clone(nestedObject);
+      assert.notStrictEqual(clone, nestedObject);
+      done();
+    });
+  });
+
   it('clone instances', function() {
     var Obj = function(x) {
       this.x = x;
@@ -105,6 +121,14 @@ describe('deep clone arrays', function() {
     assert.notStrictEqual(list[2][0], clone[2][0]);
 
     eq(clone, [1, [1, 2, 3], [[[5]]]]);
+  });
+
+  it('clones deep nested arrays', function(done) {
+    setTimeout(() => {
+      var clone = R.clone(nestedArray);
+      assert.notStrictEqual(clone, nestedArray);
+      done();
+    });
   });
 
 });


### PR DESCRIPTION
Current _clone implementation is recursive and implements O(nˆ2) solution for reference counting (to deal with objects with circular dependencies). The time complexity for refs counting makes performance on large object graphs poor. In the case of very deep nested objects (new test case for _clone) _clone does not work at all because of maximum call stack size exceeded error. 

This PR fixes these two issues.