### PR TITLE
Fix dispatching to `traverse` method 

### DIFF
--- a/source/traverse.js
+++ b/source/traverse.js
@@ -30,8 +30,12 @@ import sequence from './sequence.js';
  *      R.traverse(Maybe.of, safeDiv(10), [2, 0, 5]); //=> Maybe.Nothing
  */
 var traverse = _curry3(function traverse(of, f, traversable) {
-  return typeof traversable['fantasy-land/traverse'] === 'function' ?
-    traversable['fantasy-land/traverse'](f, of) :
-    sequence(of, map(f, traversable));
+  return (
+    typeof traversable['fantasy-land/traverse'] === 'function'
+      ? traversable['fantasy-land/traverse'](f, of)
+      : typeof traversable.traverse === 'function'
+        ? traversable.traverse(f, of)
+        : sequence(of, map(f, traversable))
+  );
 });
 export default traverse;

--- a/test/traverse.js
+++ b/test/traverse.js
@@ -28,9 +28,33 @@ describe('traverse', function() {
     eq(R.traverse(S.Either.of, R.identity, [S.Left('XXX'), S.Left('YYY')]), S.Left('XXX'));
   });
 
-  it('dispatches to `sequence` method', function() {
-    eq(R.traverse(Id, R.map(R.negate), [Id(1), Id(2), Id(3)]), Id([-1, -2, -3]));
-    eq(R.traverse(R.of, R.map(R.negate), Id([1, 2, 3])), [Id(-1), Id(-2), Id(-3)]);
+  it('dispatches to `traverse` method', function() {
+    const mockTraversable = { traverse(_1, _2) { return 'traverse called'; } };
+
+    eq(R.traverse(Id, R.identity, mockTraversable), 'traverse called');
+  });
+
+  it('dispatches to `fantasy-land/traverse` method', function() {
+    const mockTraversable2 = {
+      ['fantasy-land/traverse'](_1, _2) { return 'fantasy-land/traverse called'; }
+    };
+    eq(R.traverse(Id, R.identity, mockTraversable2), 'fantasy-land/traverse called');
+  });
+
+  it('dispatches to `fantasy-land/traverse` method when it and `traverse` exist', function() {
+    const mockTraversable3 = {
+      traverse(_1, _2) { return 'traverse called'; },
+      ['fantasy-land/traverse'](_1, _2) { return 'fantasy-land/traverse called'; }
+    };
+    eq(R.traverse(Id, R.identity, mockTraversable3), 'fantasy-land/traverse called');
+  });
+
+  it('dispatches to `traverse` when it exists and `fantasy-land/traverse` is not a function', function() {
+    const mockTraversable4 = {
+      traverse(_1, _2) { return 'traverse called'; },
+      'fantasy-land/traverse': new Error()
+    };
+    eq(R.traverse(Id, R.identity, mockTraversable4), 'traverse called');
   });
 
 });


### PR DESCRIPTION
This makes R.traverse dispatch to `traverse` if it's available and `fantasy-land/traverse` is not, as noted in issue #3026.