### PR TITLE
Add promap

### DIFF
--- a/source/index.js
+++ b/source/index.js
@@ -171,6 +171,7 @@ export { default as pluck } from './pluck';
 export { default as prepend } from './prepend';
 export { default as product } from './product';
 export { default as project } from './project';
+export { default as promap } from './promap';
 export { default as prop } from './prop';
 export { default as propEq } from './propEq';
 export { default as propIs } from './propIs';

--- a/source/internal/_promap.js
+++ b/source/internal/_promap.js
@@ -1,0 +1,5 @@
+export default function _promap(f, g, profunctor) {
+  return function(x) {
+    return g(profunctor(f(x)));
+  };
+}

--- a/source/internal/_xpromap.js
+++ b/source/internal/_xpromap.js
@@ -1,0 +1,18 @@
+import _curry3 from './_curry3';
+import _xfBase from './_xfBase';
+import _promap from './_promap';
+
+
+function XPromap(f, g, xf) {
+  this.xf = xf;
+  this.f = f;
+  this.g = g;
+}
+XPromap.prototype['@@transducer/init'] = _xfBase.init;
+XPromap.prototype['@@transducer/result'] = _xfBase.result;
+XPromap.prototype['@@transducer/step'] = function(result, input) {
+  return this.xf['@@transducer/step'](result, _promap(this.f, this.g, input));
+};
+
+var _xpromap = _curry3(function _xpromap(f, g, xf) { return new XPromap(f, g, xf); });
+export default _xpromap;

--- a/source/promap.js
+++ b/source/promap.js
@@ -1,0 +1,37 @@
+import _curry3 from './internal/_curry3';
+import _dispatchable from './internal/_dispatchable';
+import _promap from './internal/_promap';
+import _xpromap from './internal/_xpromap';
+
+
+/**
+ * Takes two functions as pre- and post- processors respectively for a third function,
+ * i.e. `promap(f, g, h)(x) === g(h(f(x)))`.
+ *
+ * Dispatches to the `promap` method of the third argument, if present,
+ * according to the [FantasyLand Profunctor spec](https://github.com/fantasyland/fantasy-land#profunctor).
+ *
+ * Acts as a transducer if a transformer is given in profunctor position.
+ *
+ * @func
+ * @memberOf R
+ * @category Function
+ * @sig (a -> b) -> (c -> d) -> (b -> c) -> (a -> d)
+ * @sig Profunctor p => (a -> b) -> (c -> d) -> p b c -> p a d
+ * @param {Function} f The preprocessor function, a -> b
+ * @param {Function} g The postprocessor function, c -> d
+ * @param {Profunctor} profunctor The profunctor instance to be promapped, e.g. b -> c
+ * @return {Profunctor} The new profunctor instance, e.g. a -> d
+ * @see R.transduce
+ * @example
+ *
+ *      const decodeChar = R.promap(s => s.charCodeAt(), String.fromCharCode, R.add(-8))
+ *      const decodeString = R.promap(R.split(''), R.join(''), R.map(decodeChar))
+ *      decodeString("ziuli") //=> "ramda"
+ *
+ * @symb R.promap(f, g, h) = x => g(h(f(x)))
+ * @symb R.promap(f, g, profunctor) = profunctor.promap(f, g)
+ */
+var promap = _curry3(_dispatchable(['fantasy-land/promap', 'promap'], _xpromap, _promap));
+
+export default promap;

--- a/test/promap.js
+++ b/test/promap.js
@@ -1,0 +1,46 @@
+var assert = require('assert');
+
+var R = require('../source');
+var eq = require('./shared/eq');
+var Pair = require('./shared/Pair');
+
+
+describe('promap', function() {
+  var fromCharCode = String.fromCharCode;
+  function charCodeAt(s) { return s.charCodeAt(); }
+  function Costar(run) {
+    return {
+      promap: function promap(f, g) {
+        return Costar(R.pipe(R.map(f), run, g));
+      },
+      run: run
+    };
+  }
+
+  it(`dispatches to pronfuctor["fantasy-land/promap"]() if present`, function() {
+    var setJson = R.promap(JSON.parse, JSON.stringify);
+    var pair = setJson(
+      Pair(R.assoc("left-promapped", true), R.assoc("right-promapped", true))
+    );
+    function mergeWithJson(json) {
+      return function(left, right) { return right(left(json)); };
+    };
+
+    eq(pair.merge(mergeWithJson("{}")), `{"left-promapped":true,"right-promapped":true}`);
+  });
+
+  it(`dispatches to pronfuctor.promap() if present`, function() {
+    var is1337Change = R.promap(R.multiply(100), R.equals(1337), Costar(R.sum));
+    var data = [10, 3, 0.3, 0.07];
+
+    eq(is1337Change.run(data), true);
+  });
+
+  it('composes two functions, f and g, before and after the final function respectively', function() {
+    var decodeChar = R.promap(charCodeAt, fromCharCode, R.add(-8));
+    var decodeString = R.promap(R.split(''), R.join(''), R.map(decodeChar));
+    var code = "ziuli";
+
+    eq(decodeString(code), "ramda");
+  });
+});

--- a/test/shared/Pair.js
+++ b/test/shared/Pair.js
@@ -1,0 +1,45 @@
+var R = require('../../source');
+
+
+function Pair(left, right) {
+  return {
+    '@@type': 'ramda/Pair',
+    'fantasy-land/equals': function equals(pair) {
+      return pair != null
+        && pair['@@type'] === this['@@type']
+        && R.equals(left, pair.left)
+        && R.equals(right, pair.right);
+    },
+    'fantasy-land/concat': function concat(pair) {
+      return Pair(R.concat(left, pair.left), R.concat(right, pair.right));
+    },
+    'fantasy-land/map': function map(f) { return Pair(left, f(right)); },
+    'fantasy-land/ap': function ap(pair) {
+      return Pair(R.concat(left, pair.left), right(pair.right));
+    },
+    'fantasy-land/reduce': function reduce(f, x) { return f(x, right); },
+    'fantasy-land/traverse': function traverse(of, f) {
+      return R.map(
+        function(x) { return Pair(left, x); },
+        of(f(right))
+      );
+    },
+    'fantasy-land/chain': function chain(f) {
+      var pair = f(right);
+      return Pair(R.concat(left, pair.left), pair.right);
+    },
+    'fantasy-land/bimap': function bimap(f, g) { return Pair(f(left), g(right)); },
+    'fantasy-land/promap': function promap(f, g) {
+      return Pair(R.promap(f, g, left), R.promap(f, g, right));
+    },
+    merge: function merge(f) { return f(left, right); },
+    toString: function toString() {
+      return `Pair(${R.toString(left)}, ${R.toString(right)})`;
+    },
+    toArray: function toArray() { return [left, right]; },
+    left: left,
+    right: right,
+  };
+}
+
+module.exports = Pair;


### PR DESCRIPTION
Adds fantasy-land compliant [`promap()`](https://github.com/fantasyland/fantasy-land#fantasy-landpromap-method). `promap()` provides an interface for wrapping a process with a pre- and post-process, which has famously found application in the development of optics. It also could be useful for building and composing SerDes.

I took some inspiration from Tom Harding's [Fantas, Eel, and Specification 18: Bifunctor and Profunctor](http://www.tomharding.me/2017/06/26/fantas-eel-and-specification-18/) for the `profunctor.promap()` test case.