### PR TITLE
doc: update Idx union type with Symbol and use it to describe key-returning functions

### DIFF
--- a/source/assocPath.js
+++ b/source/assocPath.js
@@ -16,7 +16,7 @@ import isNil from './isNil';
  * @memberOf R
  * @since v0.8.0
  * @category Object
- * @typedefn Idx = String | Int
+ * @typedefn Idx = String | Int | Symbol
  * @sig [Idx] -> a -> {a} -> {a}
  * @param {Array} path the path to set
  * @param {*} val The new value

--- a/source/collectBy.js
+++ b/source/collectBy.js
@@ -2,14 +2,15 @@ import _curry2 from './internal/_curry2';
 import _reduce from './internal/_reduce';
 
 /**
- * Splits a list into sub-lists, based on the result of calling a String-returning function on each element,
+ * Splits a list into sub-lists, based on the result of calling a key-returning function on each element,
  * and grouping the results according to values returned.
  *
  * @func
  * @memberOf R
  * @category List
- * @sig (a -> String) -> [a] -> [[a]]
- * @param {Function} fn Function :: a -> String
+ * @typedefn Idx = String | Int | Symbol
+ * @sig Idx a => (b -> a) -> [b] -> [[b]]
+ * @param {Function} fn Function :: a -> Idx
  * @param {Array} list The array to group
  * @return {Array}
  *    An array of arrays where each sub-array contains items for which

--- a/source/dissocPath.js
+++ b/source/dissocPath.js
@@ -16,7 +16,7 @@ import update from './update';
  * @memberOf R
  * @since v0.11.0
  * @category Object
- * @typedefn Idx = String | Int
+ * @typedefn Idx = String | Int | Symbol
  * @sig [Idx] -> {k: v} -> {k: v}
  * @param {Array} path The path to the value to omit
  * @param {Object} obj The object to clone

--- a/source/groupBy.js
+++ b/source/groupBy.js
@@ -4,7 +4,7 @@ import reduceBy from './reduceBy';
 
 /**
  * Splits a list into sub-lists stored in an object, based on the result of
- * calling a String-returning function on each element, and grouping the
+ * calling a key-returning function on each element, and grouping the
  * results according to values returned.
  *
  * Dispatches to the `groupBy` method of the second argument, if present.
@@ -15,8 +15,9 @@ import reduceBy from './reduceBy';
  * @memberOf R
  * @since v0.1.0
  * @category List
- * @sig (a -> String) -> [a] -> {String: [a]}
- * @param {Function} fn Function :: a -> String
+ * @typedefn Idx = String | Int | Symbol
+ * @sig Idx a => (b -> a) -> [b] -> {a: [b]}
+ * @param {Function} fn Function :: a -> Idx
  * @param {Array} list The array to group
  * @return {Object} An object with the output of `fn` for keys, mapped to arrays of elements
  *         that produced that key when passed to `fn`.

--- a/source/hasPath.js
+++ b/source/hasPath.js
@@ -12,7 +12,7 @@ import isNil from './isNil';
  * @memberOf R
  * @since v0.26.0
  * @category Object
- * @typedefn Idx = String | Int
+ * @typedefn Idx = String | Int | Symbol
  * @sig [Idx] -> {a} -> Boolean
  * @param {Array} path The path to use.
  * @param {Object} obj The object to check the path in.

--- a/source/indexBy.js
+++ b/source/indexBy.js
@@ -13,8 +13,9 @@ import reduceBy from './reduceBy';
  * @memberOf R
  * @since v0.19.0
  * @category List
- * @sig (a -> String) -> [{k: v}] -> {k: {k: v}}
- * @param {Function} fn Function :: a -> String
+ * @typedefn Idx = String | Int | Symbol
+ * @sig Idx a => (b -> a) -> [b] -> {a: b}
+ * @param {Function} fn Function :: a -> Idx
  * @param {Array} array The array of objects to index
  * @return {Object} An object indexing each array element by the given property.
  * @example

--- a/source/lensPath.js
+++ b/source/lensPath.js
@@ -11,7 +11,7 @@ import path from './path';
  * @memberOf R
  * @since v0.19.0
  * @category Object
- * @typedefn Idx = String | Int
+ * @typedefn Idx = String | Int | Symbol
  * @typedefn Lens s a = Functor f => (a -> f a) -> s -> f s
  * @sig [Idx] -> Lens s a
  * @param {Array} path The path to use.

--- a/source/path.js
+++ b/source/path.js
@@ -8,7 +8,7 @@ import paths from './paths';
  * @memberOf R
  * @since v0.2.0
  * @category Object
- * @typedefn Idx = String | Int
+ * @typedefn Idx = String | Int | Symbol
  * @sig [Idx] -> {a} -> a | Undefined
  * @param {Array} path The path to use.
  * @param {Object} obj The object to retrieve the nested property from.

--- a/source/pathEq.js
+++ b/source/pathEq.js
@@ -11,7 +11,7 @@ import path from './path';
  * @memberOf R
  * @since v0.7.0
  * @category Relation
- * @typedefn Idx = String | Int
+ * @typedefn Idx = String | Int | Symbol
  * @sig [Idx] -> a -> {a} -> Boolean
  * @param {Array} path The path of the nested property to use
  * @param {*} val The value to compare the nested property with

--- a/source/pathOr.js
+++ b/source/pathOr.js
@@ -11,7 +11,7 @@ import path from './path';
  * @memberOf R
  * @since v0.18.0
  * @category Object
- * @typedefn Idx = String | Int
+ * @typedefn Idx = String | Int | Symbol
  * @sig a -> [Idx] -> {a} -> a
  * @param {*} d The default value.
  * @param {Array} p The path to use.

--- a/source/pathSatisfies.js
+++ b/source/pathSatisfies.js
@@ -10,7 +10,7 @@ import path from './path';
  * @memberOf R
  * @since v0.19.0
  * @category Logic
- * @typedefn Idx = String | Int
+ * @typedefn Idx = String | Int | Symbol
  * @sig (a -> Boolean) -> [Idx] -> {a} -> Boolean
  * @param {Function} pred
  * @param {Array} propPath

--- a/source/paths.js
+++ b/source/paths.js
@@ -8,7 +8,7 @@ import nth from './nth';
  * @func
  * @memberOf R
  * @category Object
- * @typedefn Idx = [String | Int]
+ * @typedefn Idx = [String | Int | Symbol]
  * @sig [Idx] -> {a} -> [a | Undefined]
  * @param {Array} pathsArray The array of paths to be fetched.
  * @param {Object} obj The object to retrieve the nested properties from.

--- a/source/prop.js
+++ b/source/prop.js
@@ -11,7 +11,7 @@ import nth from './nth';
  * @memberOf R
  * @since v0.1.0
  * @category Object
- * @typedefn Idx = String | Int
+ * @typedefn Idx = String | Int | Symbol
  * @sig Idx -> {s: a} -> a | Undefined
  * @param {String|Number} p The property name or array index
  * @param {Object} obj The object to query


### PR DESCRIPTION
Follow up to #2715 and this [conversation](https://github.com/ramda/ramda/pull/2715#discussion_r436256330).

There was an existing `Idx` type (i.e. `Idx = String | Int`) which I extended to include `Symbol` (i.e. `Idx = String | Int | Symbol`).

@CrossEye I didn't use the name `Index`  as I assumed that `Idx` was already what you meant (and also to make the review easier to the eyes) _and_ I also assumed that all indexes can be either a string, a number or a symbol. (I can't see why not but happy to be corrected here.)

**What's in the PR?**

1. Update existing `Idx` type
2. Reuse `Idx` in function signature (e.g. in `@sig Idx a => (b -> a)`)
3. Instead of "String-returning function" to describe functions that return a key, I used "key-returning function" as this how these functions are referred to in [`indexBy`](https://ramdajs.com/docs/#indexBy) for example.
4. Updated `@sig` examples to distinguish the Idx type from the "other" type. (Even though they could be the same type, it's better to clear here IMHO)
