### PR TITLE
Minor performance improvement for _dispatchable in simplest cases

### DIFF
--- a/source/internal/_dispatchable.js
+++ b/source/internal/_dispatchable.js
@@ -21,18 +21,17 @@ export default function _dispatchable(methodNames, xf, fn) {
     if (arguments.length === 0) {
       return fn();
     }
-    var args = Array.prototype.slice.call(arguments, 0);
-    var obj = args.pop();
+    var obj = arguments[arguments.length - 1];
     if (!_isArray(obj)) {
       var idx = 0;
       while (idx < methodNames.length) {
         if (typeof obj[methodNames[idx]] === 'function') {
-          return obj[methodNames[idx]].apply(obj, args);
+          return obj[methodNames[idx]].apply(obj, Array.prototype.slice.call(arguments, 0, -1));
         }
         idx += 1;
       }
       if (_isTransformer(obj)) {
-        var transducer = xf.apply(null, args);
+        var transducer = xf.apply(null, Array.prototype.slice.call(arguments, 0, -1));
         return transducer(obj);
       }
     }


### PR DESCRIPTION
I think this will be insignificant for the vast majority of use cases, but it seemed nice to do anyway 🤷.

When running the benchmarks I noticed that `map` seemed unreasonably slow for the simplest case. I narrowed it down to the `_dispatchable` function and noticed that in the case of directly calling the function it wraps, we copy the arguments array even though we don't use it. This PR just moves that copying to the return statements where the copied array was used.

Original `map` benchmarks:
```
┌────────────────────────┬────────────────────────┬────────────────────────┐
│ map                    │ Hertz                  │ Margin of Error        │
├────────────────────────┼────────────────────────┼────────────────────────┤
│ map(sq, nums)          │ 7,759,834              │ 3.96%                  │
├────────────────────────┼────────────────────────┼────────────────────────┤
│ map(sq)(nums)          │ 2,444,420              │ 3.41%                  │
├────────────────────────┼────────────────────────┼────────────────────────┤
│ mapSq(nums)            │ 3,025,428              │ 3.54%                  │
├────────────────────────┼────────────────────────┼────────────────────────┤
│ native map             │ 17,078,257             │ 5.00%                  │
└────────────────────────┴────────────────────────┴────────────────────────┘
```

With this change:
```
┌────────────────────────┬────────────────────────┬────────────────────────┐
│ map                    │ Hertz                  │ Margin of Error        │
├────────────────────────┼────────────────────────┼────────────────────────┤
│ map(sq, nums)          │ 15,731,745             │ 2.94%                  │
├────────────────────────┼────────────────────────┼────────────────────────┤
│ map(sq)(nums)          │ 3,321,226              │ 3.10%                  │
├────────────────────────┼────────────────────────┼────────────────────────┤
│ mapSq(nums)            │ 4,358,381              │ 1.92%                  │
├────────────────────────┼────────────────────────┼────────────────────────┤
│ native map             │ 17,926,157             │ 4.43%                  │
└────────────────────────┴────────────────────────┴────────────────────────┘
```

Original `findIndex` benchmarks:
```
┌────────────────────────┬────────────────────────┬────────────────────────┐
│ findIndex              │ Hertz                  │ Margin of Error        │
├────────────────────────┼────────────────────────┼────────────────────────┤
│ findIndex(isZero, num… │ 4,229,101              │ 5.12%                  │
├────────────────────────┼────────────────────────┼────────────────────────┤
│ findIndex(isZero)(num… │ 1,924,030              │ 3.77%                  │
├────────────────────────┼────────────────────────┼────────────────────────┤
│ findIndexZero(nums)    │ 2,156,670              │ 3.81%                  │
├────────────────────────┼────────────────────────┼────────────────────────┤
│ native findIndex       │ 61,190,816             │ 6.02%                  │
└────────────────────────┴────────────────────────┴────────────────────────┘
```

With this change:
```
┌────────────────────────┬────────────────────────┬────────────────────────┐
│ findIndex              │ Hertz                  │ Margin of Error        │
├────────────────────────┼────────────────────────┼────────────────────────┤
│ findIndex(isZero, num… │ 5,926,183              │ 6.50%                  │
├────────────────────────┼────────────────────────┼────────────────────────┤
│ findIndex(isZero)(num… │ 2,488,570              │ 3.75%                  │
├────────────────────────┼────────────────────────┼────────────────────────┤
│ findIndexZero(nums)    │ 2,789,492              │ 4.19%                  │
├────────────────────────┼────────────────────────┼────────────────────────┤
│ native findIndex       │ 55,793,304             │ 7.24%                  │
└────────────────────────┴────────────────────────┴────────────────────────┘
```