### PR TITLE
Add extension to dissoc and assoc

### DIFF
--- a/source/internal/_assoc.js
+++ b/source/internal/_assoc.js
@@ -1,5 +1,5 @@
-import _isArray from './_isArray';
-import _isInteger from './_isInteger';
+import _isArray from './_isArray.js';
+import _isInteger from './_isInteger.js';
 
 /**
  * Makes a shallow clone of an object, setting or overriding the specified

--- a/source/internal/_dissoc.js
+++ b/source/internal/_dissoc.js
@@ -1,6 +1,6 @@
-import _isInteger from './_isInteger';
-import _isArray from './_isArray';
-import remove from '../remove';
+import _isInteger from './_isInteger.js';
+import _isArray from './_isArray.js';
+import remove from '../remove.js';
 
 /**
  * Returns a new object that does not contain a `prop` property.


### PR DESCRIPTION
It is necessary for Ramda to be a valid ESM project to have proper extensions -- Deno and the browsers will throw errors.

Note: There is a lint rule to make sure that the extension is added to the import path.