### PR TITLE
Fix Clone Function Copy Prototype Issue

### DIFF
--- a/source/internal/_clone.js
+++ b/source/internal/_clone.js
@@ -25,9 +25,12 @@ export default function _clone(value, refFrom, refTo, deep) {
     refFrom[idx] = value;
     refTo[idx] = copiedValue;
     for (var key in value) {
-      copiedValue[key] = deep ?
-        _clone(value[key], refFrom, refTo, true) : value[key];
+      if (value.hasOwnProperty(key)) {
+        copiedValue[key] = deep ?
+          _clone(value[key], refFrom, refTo, true) : value[key];
+      }
     }
+    copiedValue.__proto__ = value.__proto__;
     return copiedValue;
   };
   switch (type(value)) {

--- a/source/internal/_clone.js
+++ b/source/internal/_clone.js
@@ -30,11 +30,10 @@ export default function _clone(value, refFrom, refTo, deep) {
           _clone(value[key], refFrom, refTo, true) : value[key];
       }
     }
-    copiedValue.__proto__ = value.__proto__;
     return copiedValue;
   };
   switch (type(value)) {
-    case 'Object':  return copy({});
+    case 'Object':  return copy(Object.create(Object.getPrototypeOf(value)));
     case 'Array':   return copy([]);
     case 'Date':    return new Date(value.valueOf());
     case 'RegExp':  return _cloneRegExp(value);

--- a/source/internal/_clone.js
+++ b/source/internal/_clone.js
@@ -26,8 +26,7 @@ export default function _clone(value, refFrom, refTo, deep) {
     refTo[idx] = copiedValue;
     for (var key in value) {
       if (value.hasOwnProperty(key)) {
-        copiedValue[key] = deep ?
-          _clone(value[key], refFrom, refTo, true) : value[key];
+        copiedValue[key] = deep ? _clone(value[key], refFrom, refTo, true) : value[key];
       }
     }
     return copiedValue;

--- a/test/clone.js
+++ b/test/clone.js
@@ -86,6 +86,32 @@ describe('deep clone objects', function() {
     eq(clone.get(), 10);
   });
 
+  it('only own properties be copied', function() {
+    function Obj() {
+      this.x = 'own property';
+    }
+
+    Obj.prototype = {
+      y: 'not own property'
+    };
+
+    const obj = new Obj();
+    const cloneObj = R.clone(obj);
+    eq(Object.keys(obj), Object.keys(cloneObj));
+  });
+
+  it('the prototype should keep the same', function() {
+    function Obj() {}
+
+    Obj.prototype = {
+      x: 'prototype property'
+    };
+
+    const obj = new Obj();
+    const cloneObj = R.clone(obj);
+    eq(Object.getPrototypeOf(obj), Object.getPrototypeOf(cloneObj));
+  });
+
 });
 
 describe('deep clone arrays', function() {


### PR DESCRIPTION
To fix the issue mention in #3066 .

1. Check the property key with `hasOwnProperty` when copy to avoid copying the prototype from the original value.
2. Make the new value's prototype point to the origin value's prototype.