### PR TITLE
update CONTRIBUTING and package.json to prevent linting errors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,10 +18,11 @@
     commit message, wrapped at 72 characters. Do not commit changes to
     `dist/ramda.js`.
 
-1.  Run `npm test` (or `make test lint`) and address any errors. It will install
-    needed dependencies locally.  Preferably, fix commits in place using `git
-    rebase` or `git commit --amend` to make the changes easier to review and to
-    keep the history tidy.
+1.  Run `npm install` to install needed local dependencies.
+
+1.  Run `npm test` and address any errors.  Preferably, fix commits in place
+    using `git rebase` or `git commit --amend` to make the changes easier to
+    review and to keep the history tidy.
 
 1.  Push to your fork:
 

--- a/package.json
+++ b/package.json
@@ -79,7 +79,8 @@
     "coverage": "BABEL_ENV=cjs nyc --reporter=lcov mocha -- --require @babel/register",
     "lint": "eslint scripts/bookmarklet scripts/*.js source/*.js source/internal/*.js test/*.js test/**/*.js lib/sauce/*.js lib/bench/*.js",
     "browser_test": "testem ci",
-    "test": "cross-env BABEL_ENV=cjs mocha --require @babel/register --reporter spec"
+    "spec": "cross-env BABEL_ENV=cjs mocha --require @babel/register --reporter spec",
+    "test": "npm run spec && npm run lint"
   },
   "dependencies": {},
   "devDependencies": {


### PR DESCRIPTION
I noticed that running `npm test` doesn't do linting, and that our CONTRIBUTING.md file doesn't specify linting as a separate step. As a result a contributor following our process could introduce linting errors. This has happened recently.

I'd like to avoid issues like this in the future.

I updated our CONTRIBUTING.md to be more true to life, and I updated our package.json to run the linting on `npm test`. 

Is there a preferred alternative to these changes? 
Should we update CI so it doesn't run linting twice?