### PR TITLE
added links between groupBy and indexBy

### DIFF
--- a/source/groupBy.js
+++ b/source/groupBy.js
@@ -21,7 +21,7 @@ import reduceBy from './reduceBy.js';
  * @param {Array} list The array to group
  * @return {Object} An object with the output of `fn` for keys, mapped to arrays of elements
  *         that produced that key when passed to `fn`.
- * @see R.reduceBy, R.transduce
+ * @see R.reduceBy, R.transduce, R.indexBy
  * @example
  *
  *      const byGrade = R.groupBy(function(student) {

--- a/source/indexBy.js
+++ b/source/indexBy.js
@@ -18,6 +18,7 @@ import reduceBy from './reduceBy.js';
  * @param {Function} fn Function :: a -> Idx
  * @param {Array} array The array of objects to index
  * @return {Object} An object indexing each array element by the given property.
+ * @see R.groupBy
  * @example
  *
  *      const list = [{id: 'xyz', title: 'A'}, {id: 'abc', title: 'B'}];


### PR DESCRIPTION
I was looking at our docs and noticed we don't have links between these two very similar functions. In fact `indexBy` didn't have any `@see` annotations at all.