### PR TITLE
evolve: ignores transform if the input value is not Array and Object

### DIFF
--- a/source/evolve.js
+++ b/source/evolve.js
@@ -1,4 +1,6 @@
 import _curry2 from './internal/_curry2.js';
+import _isArray from './internal/_isArray.js';
+import _isObject from './internal/_isObject.js';
 
 
 /**
@@ -29,6 +31,9 @@ import _curry2 from './internal/_curry2.js';
  *      R.evolve(transformations, tomato); //=> {firstName: 'Tomato', data: {elapsed: 101, remaining: 1399}, id:123}
  */
 var evolve = _curry2(function evolve(transformations, object) {
+  if (!_isObject(object) && !_isArray(object)) {
+    return object;
+  }
   var result = object instanceof Array ? [] : {};
   var transformation, key, type;
   for (key in object) {

--- a/test/evolve.js
+++ b/test/evolve.js
@@ -53,4 +53,11 @@ describe('evolve', function() {
     eq(R.evolve(transf, object), expected);
   });
 
+  it('ignores transformations if the input value is not Array and Object', function() {
+    var transf   = { a: R.add(1) };
+    eq(R.evolve(transf, 42), 42);
+    eq(R.evolve(transf, undefined), undefined);
+    eq(R.evolve(transf, null), null);
+    eq(R.evolve(transf, ''), '');
+  });
 });


### PR DESCRIPTION
If the input is a primitive value, `evolve` will always return an empty object -- `{}`. 

So if the input is a primitive value, it's better to return itself than return an empty object?