### PR TITLE
Update documentation of propOr to describe defaulting beahviour.

### DIFF
--- a/source/propOr.js
+++ b/source/propOr.js
@@ -4,9 +4,10 @@ import prop from './prop.js';
 
 
 /**
- * If the given, non-null object has an own property with the specified name,
- * returns the value of that property. Otherwise returns the provided default
- * value.
+ * Return the specified property of the given non-null object if the property
+ * is present and it's value is not `null`, `undefined` or `NaN`.
+ *
+ * Otherwise the first argument is returned.
  *
  * @func
  * @memberOf R


### PR DESCRIPTION
fixes: #3084 

The documentation for [propOr](https://ramdajs.com/docs/#propOr) says

> If the given, non-null object **has an own property with the specified name**, returns the value of that property. Otherwise returns the provided default value.

Emphasis mine. However #2394 changed this behavior to align with [pathOr](https://ramdajs.com/docs/#pathOr) and return the default if the value is falsey. 

The documentation is now inconsistent with this behavior because there are now cases where the object has an own property but the default is returned. E.g.

```
R.propOr('Ramda', 'favoriteLibrary')({favoriteLibrary: null})
```

The new behavior is more likely what people are expecting, but contradicts the documentation.


This updates the documentation to align with the documentation of `prop` and
`defaultTo` which is what is used in the implementation so should be an
accurate description of the behavior.