### PR TITLE
chore: rename xf to transducerCreator

### DIFF
--- a/source/internal/_dispatchable.js
+++ b/source/internal/_dispatchable.js
@@ -7,16 +7,17 @@ import _isTransformer from './_isTransformer.js';
  * object in list position (last argument). If it is an array, executes [fn].
  * Otherwise, if it has a function with one of the given method names, it will
  * execute that function (functor case). Otherwise, if it is a transformer,
- * uses transducer [xf] to return a new transformer (transducer case).
+ * uses transducer created by [transducerCreator] to return a new transformer
+ * (transducer case).
  * Otherwise, it will default to executing [fn].
  *
  * @private
  * @param {Array} methodNames properties to check for a custom implementation
- * @param {Function} xf transducer to initialize if object is transformer
+ * @param {Function} transducerCreator transducer constructor if object is transformer
  * @param {Function} fn default ramda implementation
  * @return {Function} A function that dispatches on object in list position
  */
-export default function _dispatchable(methodNames, xf, fn) {
+export default function _dispatchable(methodNames, transducerCreator, fn) {
   return function() {
     if (arguments.length === 0) {
       return fn();
@@ -31,7 +32,7 @@ export default function _dispatchable(methodNames, xf, fn) {
         idx += 1;
       }
       if (_isTransformer(obj)) {
-        var transducer = xf.apply(null, Array.prototype.slice.call(arguments, 0, -1));
+        var transducer = transducerCreator.apply(null, Array.prototype.slice.call(arguments, 0, -1));
         return transducer(obj);
       }
     }

--- a/source/internal/_dispatchable.js
+++ b/source/internal/_dispatchable.js
@@ -13,7 +13,7 @@ import _isTransformer from './_isTransformer.js';
  *
  * @private
  * @param {Array} methodNames properties to check for a custom implementation
- * @param {Function} transducerCreator transducer constructor if object is transformer
+ * @param {Function} transducerCreator transducer factory if object is transformer
  * @param {Function} fn default ramda implementation
  * @return {Function} A function that dispatches on object in list position
  */


### PR DESCRIPTION
When I looked into some source code of ramda related to transducer, and some other articles about transducer, I found out that `xf` in `_dispatchable` is not a transducer, but a transducer constructor.

So in order to make the description more clear, I rename `xf` to `transducerCreator`.