### PR TITLE
fix: partial build

### DIFF
--- a/scripts/partialBuild.js
+++ b/scripts/partialBuild.js
@@ -12,7 +12,8 @@ rollupConfig.plugins.push(partialBuildPlugin);
 rollup.rollup(rollupConfig).then(function(bundle) {
   return bundle.generate(rollupConfig.output);
 }).then(function(result) {
-  process.stdout.write(result.code);
+  var chunk = result.output[0];
+  process.stdout.write(chunk.code);
 });
 
 function partialBuild(options) {

--- a/scripts/partialBuild.js
+++ b/scripts/partialBuild.js
@@ -12,8 +12,7 @@ rollupConfig.plugins.push(partialBuildPlugin);
 rollup.rollup(rollupConfig).then(function(bundle) {
   return bundle.generate(rollupConfig.output);
 }).then(function(result) {
-  var chunk = result.output[0];
-  process.stdout.write(chunk.code);
+  result.output.forEach(x => process.stdout.write(x.code))
 });
 
 function partialBuild(options) {


### PR DESCRIPTION
It seems like partial builds broke with the recent rollup update,  output is now formatted as chunks.
```
events.js:187
      throw er; // Unhandled 'error' event
      ^

TypeError [ERR_INVALID_ARG_TYPE]: The "chunk" argument must be one of type string or Buffer. Received type undefined
    at validChunk (_stream_writable.js:268:10)
    at SyncWriteStream.Writable.write (_stream_writable.js:303:21)
    at ramda/scripts/partialBuild.js:15:18
Emitted 'error' event on SyncWriteStream instance at:
    at emitErrorNT (internal/streams/destroy.js:92:8)
    at emitErrorAndCloseNT (internal/streams/destroy.js:60:3)
    at processTicksAndRejections (internal/process/task_queues.js:80:21) {
  code: 'ERR_INVALID_ARG_TYPE'
}
```