### PR TITLE
chore: rename _iterableReduce to _iteratorReduce

### DIFF
--- a/source/internal/_reduce.js
+++ b/source/internal/_reduce.js
@@ -56,5 +56,5 @@ export default function _reduce(fn, acc, list) {
     return _methodReduce(fn, acc, list, 'reduce');
   }
 
-  throw new TypeError('reduce: list must be array or iterable');
+  throw new TypeError('reduce: list must be array, iterable or iterator');
 }

--- a/source/internal/_reduce.js
+++ b/source/internal/_reduce.js
@@ -17,15 +17,15 @@ function _arrayReduce(xf, acc, list) {
   return xf['@@transducer/result'](acc);
 }
 
-function _iterableReduce(xf, acc, iter) {
-  var step = iter.next();
+function _iteratorReduce(xf, acc, iterator) {
+  var step = iterator.next();
   while (!step.done) {
     acc = xf['@@transducer/step'](acc, step.value);
     if (acc && acc['@@transducer/reduced']) {
       acc = acc['@@transducer/value'];
       break;
     }
-    step = iter.next();
+    step = iterator.next();
   }
   return xf['@@transducer/result'](acc);
 }
@@ -47,10 +47,10 @@ export default function _reduce(fn, acc, list) {
     return _methodReduce(fn, acc, list, 'fantasy-land/reduce');
   }
   if (list[symIterator] != null) {
-    return _iterableReduce(fn, acc, list[symIterator]());
+    return _iteratorReduce(fn, acc, list[symIterator]());
   }
   if (typeof list.next === 'function') {
-    return _iterableReduce(fn, acc, list);
+    return _iteratorReduce(fn, acc, list);
   }
   if (typeof list.reduce === 'function') {
     return _methodReduce(fn, acc, list, 'reduce');


### PR DESCRIPTION
According to [MDN document](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols), `iterable` an `iterator ` are two different thing:

* `iterable` is an object that can create an `iterator` by `@@iterator` method;
* `iterator` is  an object that implements a `next()` method, which can produce a sequence of values;

So in the `_reduce`'s implementation,  `_iterableReduce` processes `iterator` instead of `iterable` actually. I think it's better to be called as `_iteratorReduce`.