### PR TITLE
revert "align lensPath with lensIndex by supporting negative indeces'

### DIFF
--- a/source/lensIndex.js
+++ b/source/lensIndex.js
@@ -15,7 +15,7 @@ import update from './update.js';
  * @sig Number -> Lens s a
  * @param {Number} n
  * @return {Lens}
- * @see R.view, R.set, R.over, R.nth
+ * @see R.view, R.set, R.over
  * @example
  *
  *      const headLens = R.lensIndex(0);

--- a/source/path.js
+++ b/source/path.js
@@ -13,7 +13,7 @@ import paths from './paths.js';
  * @param {Array} path The path to use.
  * @param {Object} obj The object to retrieve the nested property from.
  * @return {*} The data at `path`.
- * @see R.prop, R.nth
+ * @see R.prop
  * @example
  *
  *      R.path(['a', 'b'], {a: {b: 2}}); //=> 2

--- a/source/paths.js
+++ b/source/paths.js
@@ -1,6 +1,4 @@
 import _curry2 from './internal/_curry2.js';
-import _isInteger from './internal/_isInteger.js';
-import nth from './nth.js';
 
 /**
  * Retrieves the values at given paths of an object.
@@ -24,13 +22,11 @@ var paths = _curry2(function paths(pathsArray, obj) {
   return pathsArray.map(function(paths) {
     var val = obj;
     var idx = 0;
-    var p;
     while (idx < paths.length) {
       if (val == null) {
         return;
       }
-      p = paths[idx];
-      val = _isInteger(p) ? nth(p, val) : val[p];
+      val = val[paths[idx]];
       idx += 1;
     }
     return val;

--- a/source/prop.js
+++ b/source/prop.js
@@ -1,7 +1,4 @@
 import _curry2 from './internal/_curry2.js';
-import _isInteger from './internal/_isInteger.js';
-import nth from './nth.js';
-
 
 /**
  * Returns a function that when supplied an object returns the indicated
@@ -16,7 +13,7 @@ import nth from './nth.js';
  * @param {String|Number} p The property name or array index
  * @param {Object} obj The object to query
  * @return {*} The value at `obj.p`.
- * @see R.path, R.props, R.pluck, R.project, R.nth
+ * @see R.path, R.props, R.pluck, R.project
  * @example
  *
  *      R.prop('x', {x: 100}); //=> 100
@@ -29,6 +26,6 @@ var prop = _curry2(function prop(p, obj) {
   if (obj == null) {
     return;
   }
-  return _isInteger(p) ? nth(p, obj) : obj[p];
+  return obj[p];
 });
 export default prop;

--- a/test/path.js
+++ b/test/path.js
@@ -39,8 +39,8 @@ describe('path', function() {
   });
 
   it('takes a path that contains negative indices into arrays', function() {
-    eq(R.path(['x', -2], {x: ['a', 'b', 'c', 'd']}), 'c');
-    eq(R.path([-1, 'y'], [{x: 1, y: 99}, {x: 2, y: 98}, {x: 3, y: 97}]), 97);
+    eq(R.path(['x', -2], {x: ['a', 'b', 'c', 'd']}), undefined);
+    eq(R.path([-1, 'y'], [{x: 1, y: 99}, {x: 2, y: 98}, {x: 3, y: 97}]), undefined);
   });
 
   it("gets a deep property's value from objects", function() {

--- a/test/paths.js
+++ b/test/paths.js
@@ -26,8 +26,8 @@ describe('paths', function() {
   });
 
   it('takes a path that contains negative indices into arrays', function() {
-    eq(R.paths([['p', -2, 'q'], ['p', -1]], obj), [3, 'Hi']);
-    eq(R.paths([['p', -4, 'q'], ['x', 'z', -1, 0]], obj), [undefined, {}]);
+    eq(R.paths([['p', -2, 'q'], ['p', -1]], obj), [undefined, undefined]);
+    eq(R.paths([['p', -4, 'q'], ['x', 'z', -1, 0]], obj), [undefined, undefined]);
   });
 
   it("gets a deep property's value from objects", function() {

--- a/test/prop.js
+++ b/test/prop.js
@@ -16,7 +16,7 @@ describe('prop', function() {
     eq(R.prop(0, deities), 'Cthulhu');
     eq(R.prop(1, deities), 'Dagon');
     eq(R.prop(2, deities), 'Yog-Sothoth');
-    eq(R.prop(-1, deities), 'Yog-Sothoth');
+    eq(R.prop(-1, deities), undefined);
   });
 
   it('shows the same behaviour as path for a nonexistent property', function() {

--- a/test/propEq.js
+++ b/test/propEq.js
@@ -17,7 +17,7 @@ describe('propEq', function() {
     eq(R.propEq(0, 'Cthulhu', deities), true);
     eq(R.propEq(1, 'Dagon', deities), true);
     eq(R.propEq(2, 'Yog-Sothoth', deities), true);
-    eq(R.propEq(-1, 'Yog-Sothoth', deities), true);
+    eq(R.propEq(-1, 'Yog-Sothoth', deities), false);
     eq(R.propEq(3, undefined, deities), true);
   });
 

--- a/test/propIs.js
+++ b/test/propIs.js
@@ -18,7 +18,7 @@ describe('propIs', function() {
     eq(R.propIs(String, 0, deities), true);
     eq(R.propIs(String, 1, deities), true);
     eq(R.propIs(String, 2, deities), true);
-    eq(R.propIs(String, -1, deities), true);
+    eq(R.propIs(String, -1, deities), false);
     eq(R.propIs(String, 3, deities), false);
   });
 

--- a/test/propOr.js
+++ b/test/propOr.js
@@ -32,7 +32,7 @@ describe('propOr', function() {
     eq(R.propOr('Unknown', 0, deities), 'Cthulhu');
     eq(R.propOr('Unknown', 1, deities), 'Dagon');
     eq(R.propOr('Unknown', 2, deities), 'Yog-Sothoth');
-    eq(R.propOr('Unknown', -1, deities), 'Yog-Sothoth');
+    eq(R.propOr('Unknown', -1, deities), 'Unknown');
     eq(R.propOr('Unknown', 3, deities), 'Unknown');
   });
 


### PR DESCRIPTION
This PR removes support of negative indices in functions: lensIndex, prop, path, paths, pathEq, pathOr, propEq, propIs, propOr.

The first PR in which this logic was added: https://github.com/ramda/ramda/pull/2670

API inconsistency that was reported as an bug: https://github.com/ramda/ramda/issues/2974

An example that shows why this logic is not compatible with the rest of the functions in Ramda (and JS itself):
```javascript
const ar = ['a', 'b']
const idxOfC = findIndex(equals('c'))(ar)
console.log( prop(idxOfC, ar) ) // => 'b'
```

Interest: @2beaucoup @CrossEye @Bradcomp @Andrey-Bazhanov