### PR TITLE
fix: clone typed arrays

### DIFF
--- a/source/internal/_clone.js
+++ b/source/internal/_clone.js
@@ -35,7 +35,19 @@ export default function _clone(value, refFrom, refTo, deep) {
     case 'Object':  return copy(Object.create(Object.getPrototypeOf(value)));
     case 'Array':   return copy([]);
     case 'Date':    return new Date(value.valueOf());
-    case 'RegExp':  return _cloneRegExp(value);
+    case 'RegExp': return _cloneRegExp(value);
+    case 'Int8Array':
+    case 'Uint8Array':
+    case 'Uint8ClampedArray':
+    case 'Int16Array':
+    case 'Uint16Array':
+    case 'Int32Array':
+    case 'Uint32Array':
+    case 'Float32Array':
+    case 'Float64Array':
+    case 'BigInt64Array':
+    case 'BigUint64Array':
+      return value.slice();
     default:        return value;
   }
 }

--- a/test/clone.js
+++ b/test/clone.js
@@ -135,6 +135,81 @@ describe('deep clone arrays', function() {
 
 });
 
+describe('deep clone typed arrays', function() {
+  it('clones Uint16Array', function() {
+    var array = new Uint16Array([1, 2, 3]);
+    var clone = R.clone(array);
+
+    assert.notStrictEqual(array, clone);
+    eq(clone, new Uint16Array([1, 2, 3]));
+  });
+
+  it('clones Int8Array', function() {
+    var array = new Int8Array([1,2,3]);
+    var clone = R.clone(array);
+
+    assert.notStrictEqual(array, clone);
+    eq(clone, new Int8Array([1,2,3]));
+  });
+  it('clones Uint8Array', function() {
+    var array = new Uint8Array([1,2,3]);
+    var clone = R.clone(array);
+
+    assert.notStrictEqual(array, clone);
+    eq(clone, new Uint8Array([1,2,3]));
+  });
+  it('clones Uint8ClampedArray', function() {
+    var array = new Uint8ClampedArray([1,2,3]);
+    var clone = R.clone(array);
+
+    assert.notStrictEqual(array, clone);
+    eq(clone, new Uint8ClampedArray([1,2,3]));
+  });
+  it('clones Int16Array', function() {
+    var array = new Int16Array([1,2,3]);
+    var clone = R.clone(array);
+
+    assert.notStrictEqual(array, clone);
+    eq(clone, new Int16Array([1,2,3]));
+  });
+  it('clones Uint16Array', function() {
+    var array = new Uint16Array([1,2,3]);
+    var clone = R.clone(array);
+
+    assert.notStrictEqual(array, clone);
+    eq(clone, new Uint16Array([1,2,3]));
+  });
+  it('clones Int32Array', function() {
+    var array = new Int32Array([1,2,3]);
+    var clone = R.clone(array);
+
+    assert.notStrictEqual(array, clone);
+    eq(clone, new Int32Array([1,2,3]));
+  });
+  it('clones Uint32Array', function() {
+    var array = new Uint32Array([1,2,3]);
+    var clone = R.clone(array);
+
+    assert.notStrictEqual(array, clone);
+    eq(clone, new Uint32Array([1,2,3]));
+  });
+  it('clones Float32Array', function() {
+    var array = new Float32Array([1,2,3]);
+    var clone = R.clone(array);
+
+    assert.notStrictEqual(array, clone);
+    eq(clone, new Float32Array([1,2,3]));
+  });
+  it('clones Float64Array', function() {
+    var array = new Float64Array([1,2,3]);
+    var clone = R.clone(array);
+
+    assert.notStrictEqual(array, clone);
+    eq(clone, new Float64Array([1,2,3]));
+  });
+
+});
+
 describe('deep clone functions', function() {
   it('keep reference to function', function() {
     var fn = function(x) { return x + x;};


### PR DESCRIPTION
When cloning a typed array, the value is a reference to the original value.
This can be fixed by cloning the array using `.slice()`


An example to see how clone is currently behaving
```js
import * as R from "ramda";

const a = new Int8Array([1]);
const b = R.clone(a);

b[0] = 100;

console.log(a[0]); // 100
console.log(b[0]); // 100
```