### PR TITLE
chore: return val will be more precise

### DIFF
--- a/source/paths.js
+++ b/source/paths.js
@@ -14,7 +14,7 @@ import nth from './nth.js';
  * @param {Array} pathsArray The array of paths to be fetched.
  * @param {Object} obj The object to retrieve the nested properties from.
  * @return {Array} A list consisting of values at paths specified by "pathsArray".
- * @see R.path
+ * @see R.path, R.props
  * @example
  *
  *      R.paths([['a', 'b'], ['p', 0, 'q']], {a: {b: 2}, p: [{q: 3}]}); //=> [2, 3]
@@ -27,7 +27,7 @@ var paths = _curry2(function paths(pathsArray, obj) {
     var p;
     while (idx < paths.length) {
       if (val == null) {
-        return;
+        return val;
       }
       p = paths[idx];
       val = _isInteger(p) ? nth(p, val) : val[p];

--- a/source/props.js
+++ b/source/props.js
@@ -14,7 +14,7 @@ import path from './path.js';
  * @param {Array} ps The property names to fetch
  * @param {Object} obj The object to query
  * @return {Array} The corresponding values or partially applied function.
- * @see R.prop, R.pluck, R.project
+ * @see R.prop, R.pluck, R.project, R.paths
  * @example
  *
  *      R.props(['x', 'y'], {x: 1, y: 2}); //=> [1, 2]


### PR DESCRIPTION
In the [current `paths` implementation](https://github.com/ramda/ramda/blob/v0.27.0/source/paths.js#L29), current iterating path of `paths` will always return `undefined` if the intermediate path value is nil (`val == null`) . Return the actual nil value may be more precise?