### PR TITLE
Move detailed spec to description section

### DIFF
--- a/source/and.js
+++ b/source/and.js
@@ -2,7 +2,7 @@ import _curry2 from './internal/_curry2.js';
 
 
 /**
- * Returns `true` if both arguments are `true`; `false` otherwise.
+ * Returns the first argument if it is falsy, otherwise the second argument.
  *
  * @func
  * @memberOf R
@@ -11,7 +11,7 @@ import _curry2 from './internal/_curry2.js';
  * @sig a -> b -> a | b
  * @param {Any} a
  * @param {Any} b
- * @return {Any} the first argument if it is falsy, otherwise the second argument.
+ * @return {Any}
  * @see R.both, R.or
  * @example
  *

--- a/source/and.js
+++ b/source/and.js
@@ -3,6 +3,7 @@ import _curry2 from './internal/_curry2.js';
 
 /**
  * Returns the first argument if it is falsy, otherwise the second argument.
+ * Acts as the boolean `and` statement if both inputs are `Boolean`s.
  *
  * @func
  * @memberOf R

--- a/source/or.js
+++ b/source/or.js
@@ -1,8 +1,9 @@
 import _curry2 from './internal/_curry2.js';
 
+
 /**
- * Returns `true` if one or both of its arguments are `true`. Returns `false`
- * if both arguments are `false`.
+ * Returns the first argument if it is truthy, otherwise the second argument.
+ * Acts as the boolean `or` statement if both inputs are `Boolean`s.
  *
  * @func
  * @memberOf R
@@ -11,7 +12,7 @@ import _curry2 from './internal/_curry2.js';
  * @sig a -> b -> a | b
  * @param {Any} a
  * @param {Any} b
- * @return {Any} the first argument if truthy, otherwise the second argument.
+ * @return {Any}
  * @see R.either, R.and
  * @example
  *


### PR DESCRIPTION
The current description is quite confusing, I think it's better to use the comment from the `@return` section as a header because it's clear and complete.