### PR TITLE
Update cond.js

### DIFF
--- a/source/cond.js
+++ b/source/cond.js
@@ -55,7 +55,7 @@ var cond = _curry1(function cond(pairs) {
         let predicate = pair[0].apply(this, arguments)
         if (predicate) {
           let args = Array.from(arguments)
-          args.push(predicate) // transformer(...arguments, predicate)
+          args.push(predicate) // transformer(...arguments, predicate(...arguments))
           return pair[1].apply(this, args);
         }
       }

--- a/source/cond.js
+++ b/source/cond.js
@@ -40,16 +40,24 @@ var cond = _curry1(function cond(pairs) {
   var arity = reduce(
     max,
     0,
-    map(function(pair) { return pair[0].length; }, pairs)
+    map(function (pair) { return pair[0].length; }, pairs)
   );
-  return _arity(arity, function() {
+  return _arity(arity, function () {
     var idx = 0;
     while (idx < pairs.length) {
-      let predicate = pairs[idx][0].apply(this, arguments)
-      if (predicate) {
-        let args = Array.from(arguments)
-        args.push(predicate) // transformer(...arguments, predicate)
-        return pairs[idx][1].apply(this, args);
+      let pair = pairs[idx]
+      if (typeof pair === 'function') {
+        let transformer = pair.apply(this, arguments)
+        if (transformer) {
+          return transformer;
+        }
+      } else if (Array.isArray(pair)) {
+        let predicate = pair[0].apply(this, arguments)
+        if (predicate) {
+          let args = Array.from(arguments)
+          args.push(predicate) // transformer(...arguments, predicate)
+          return pair[1].apply(this, args);
+        }
       }
       idx += 1;
     }

--- a/source/cond.js
+++ b/source/cond.js
@@ -45,8 +45,11 @@ var cond = _curry1(function cond(pairs) {
   return _arity(arity, function() {
     var idx = 0;
     while (idx < pairs.length) {
-      if (pairs[idx][0].apply(this, arguments)) {
-        return pairs[idx][1].apply(this, arguments);
+      let predicate = pairs[idx][0].apply(this, arguments)
+      if (predicate) {
+        let args = Array.from(arguments)
+        args.push(predicate) // transformer(...arguments, predicate)
+        return pairs[idx][1].apply(this, args);
       }
       idx += 1;
     }

--- a/source/cond.js
+++ b/source/cond.js
@@ -40,7 +40,7 @@ var cond = _curry1(function cond(pairs) {
   var arity = reduce(
     max,
     0,
-    map(function (pair) { return pair[0].length; }, pairs)
+    map(function (pair) { return typeof pair === 'function' ? pair.length : pair[0].length; }, pairs)
   );
   return _arity(arity, function () {
     var idx = 0;

--- a/test/cond.js
+++ b/test/cond.js
@@ -39,7 +39,7 @@ describe('cond', function() {
     var fn = R.cond([
       [function(_, x) { return x === 42; }, function() { return arguments.length; }]
     ]);
-    eq(fn(21, 42, 84), 3);
+    eq(fn(21, 42, 84), 4);  // transformer.arguments = ( 21, 42, 84, true )
   });
 
   it('retains highest predicate arity', function() {
@@ -49,6 +49,42 @@ describe('cond', function() {
       [R.nAry(1, R.T), R.T]
     ]);
     eq(fn.length, 3);
+  });
+
+});
+
+import {  equals, trim, identity } from 'ramda';
+
+describe('cond new featrues', function () {
+
+  it('storage predicate result', function () {
+    let sS = cond([
+      [trim, (_, res) => res],
+    ]);
+    let y = sS("  x  ")
+    expect(y).toEqual("x")
+    let z = sS("")
+    expect(z).toEqual(undefined)
+    let x = sS(" ")
+    expect(x).toEqual(undefined)
+  });
+
+  it('just transformer', function () {
+    let token = cond([
+      input => {
+        let mtch = /^\d+/.exec(input)
+        if (mtch && mtch.length > 0) { 
+          let lexeme = mtch[0]
+          let restInput = input.slice(lexeme.length)
+          return { token: { number: parseInt(lexeme) }, restInput }
+        } else {
+          return null
+        }
+      },
+      [equals(""), identity],
+    ]);
+    let y = token("123+234")
+    expect(y).toEqual({ "restInput": "+234", "token": { "number": 123 } })
   });
 
 });

--- a/test/cond.js
+++ b/test/cond.js
@@ -53,13 +53,11 @@ describe('cond', function() {
 
 });
 
-import {  equals, trim, identity } from 'ramda';
-
 describe('cond new featrues', function () {
 
   it('storage predicate result', function () {
     let sS = cond([
-      [trim, (_, res) => res],
+      [R.trim, (_, res) => res],
     ]);
     let y = sS("  x  ")
     expect(y).toEqual("x")
@@ -80,8 +78,7 @@ describe('cond new featrues', function () {
         } else {
           return null
         }
-      },
-      [equals(""), identity],
+      }
     ]);
     let y = token("123+234")
     expect(y).toEqual({ "restInput": "+234", "token": { "number": 123 } })

--- a/test/cond.js
+++ b/test/cond.js
@@ -55,23 +55,33 @@ describe('cond', function() {
 
 describe('cond new featrues', function () {
 
-  it('storage predicate result', function () {
-    let sS = cond([
-      [R.trim, (_, res) => res],
-    ]);
-    let y = sS("  x  ")
+  it('just predicate and return result', function () {
+    let fmt = cond([trim]);
+    let x = fmt(" ")
+    expect(x).toEqual(undefined)
+    let y = fmt("  x  ")
     expect(y).toEqual("x")
-    let z = sS("")
+    let z = fmt("")
     expect(z).toEqual(undefined)
-    let x = sS(" ")
+  });
+
+  it('cache predicate result', function () {
+    let fmt = cond([
+      [trim, (_, res) => ({ res })],
+    ]);
+    let y = fmt("  x  ")
+    expect(y).toEqual({ res: "x" })
+    let z = fmt("")
+    expect(z).toEqual(undefined)
+    let x = fmt(" ")
     expect(x).toEqual(undefined)
   });
 
-  it('just transformer', function () {
+  it('an example in world', function () {
     let token = cond([
       input => {
         let mtch = /^\d+/.exec(input)
-        if (mtch && mtch.length > 0) { 
+        if (mtch && mtch.length > 0) {
           let lexeme = mtch[0]
           let restInput = input.slice(lexeme.length)
           return { token: { number: parseInt(lexeme) }, restInput }


### PR DESCRIPTION
Attach an argument to the transformer function to pass the result value of the predicate. 
```js
transformer(...arguments, predicate(...arguments))
```

provide a special case:
```js
transformer = (..., predicateResult) => predicateResult
```
so the pair `[predicate,transformer]` array reduce to `predicate` function.