### PR TITLE
doc: memoizeWith type requires a string

### DIFF
--- a/source/memoizeWith.js
+++ b/source/memoizeWith.js
@@ -24,7 +24,7 @@ import _has from './internal/_has.js';
  * @example
  *
  *      let count = 0;
- *      const factorial = R.memoizeWith(Number, n => {
+ *      const factorial = R.memoizeWith(R.toString, n => {
  *        count += 1;
  *        return R.product(R.range(1, n + 1));
  *      });


### PR DESCRIPTION
The typing for memoizeWith requires the identity function to return a string.  This updates the example with the correct method