### PR TITLE
Add ntheq

### DIFF
--- a/source/index.js
+++ b/source/index.js
@@ -148,6 +148,7 @@ export { default as none } from './none.js';
 export { default as not } from './not.js';
 export { default as nth } from './nth.js';
 export { default as nthArg } from './nthArg.js';
+export { default as nthEq } from './nthEq.js';
 export { default as o } from './o.js';
 export { default as objOf } from './objOf.js';
 export { default as of } from './of.js';

--- a/source/nthEq.js
+++ b/source/nthEq.js
@@ -12,7 +12,8 @@ import equals from './equals.js';
  * @memberOf R
  * @since v2.7.2
  * @category Relation
- * @sig Number -> a -> Object -> Boolean
+ * @sig Number -> a -> [a] -> Boolean
+ * @sig Number -> String -> String -> Boolean
  * @param {Number} offset
  * @param {*} val
  * @param {*} list
@@ -28,16 +29,16 @@ import equals from './equals.js';
  *      const examinees = {
  *        bobby: ['apple', '1A', 'math'],
  *        claire: ['apple', '1B', 'economics'],
- *        fred: ['PB & J', '2a', 'math'],
+ *        fred: ['PB & J', '2A', 'math'],
  *        jess: ['brisket', '2B', 'english'],
  *      };
  *      const takingMathExam = R.nthEq(labels.exam, 'math');
  *      const seatsForMathExam = R.pipe(
- *        R.filter(takingMathExam), //=> {"bobby": ["apple", "1A", "math"], "fred": ["PB & J", "2a", "math"]}
- *        R.values, //=>[["apple", "1A", "math"], ["PB & J", "2a", "math"]]
- *        R.map(R.nth(labels.seat)) //=>["1A", "2a"]
+ *        R.filter(takingMathExam), //=> {"bobby": ["apple", "1A", "math"], "fred": ["PB & J", "2A", "math"]}
+ *        R.values, //=>[["apple", "1A", "math"], ["PB & J", "2A", "math"]]
+ *        R.map(R.nth(labels.seat)) //=>["1A", "2A"]
  *      );
- *      seatsForMathExam(examinees) //=>["1A", "2a"]
+ *      seatsForMathExam(examinees) //=>["1A", "2A"]
  */
 var nthEq = _curry3(function nthEq(offset, val, list) {
   return equals(val, nth(offset, list));

--- a/source/nthEq.js
+++ b/source/nthEq.js
@@ -20,19 +20,24 @@ import equals from './equals.js';
  * @see R.equals
  * @example
  *
- *      const labels = ['snack', 'seat', 'exam'];
- *      const bobby = ['apple', '1A', 'math'];
- *      const claire = ['apple', '1B', 'economics'];
- *      const fred = ['PB & J', '2a', 'math'];
- *      const jess = ['brisket', '2B', 'english'];
- *      const examinees = {
- *        bobby,
- *        claire,
- *        fred,
- *        jess,
+ *      const labels = {
+ *        snack: 0,
+ *        seat: 1,
+ *        exam: 2,
  *      };
- *      const takingMathExam = R.nth(2, 'math');
- *      R.filter(takingMathExamm, examinees); //=> [fred, rusty]
+ *      const examinees = {
+ *        bobby: ['apple', '1A', 'math'],
+ *        claire: ['apple', '1B', 'economics'],
+ *        fred: ['PB & J', '2a', 'math'],
+ *        jess: ['brisket', '2B', 'english'],
+ *      };
+ *      const takingMathExam = R.nthEq(labels.exam, 'math');
+ *      const seatsForMathExam = R.pipe(
+ *        R.filter(takingMathExam), //=> {"bobby": ["apple", "1A", "math"], "fred": ["PB & J", "2a", "math"]}
+ *        R.values, //=>[["apple", "1A", "math"], ["PB & J", "2a", "math"]]
+ *        R.map(R.nth(labels.seat)) //=>["1A", "2a"]
+ *      );
+ *      seatsForMathExam(examinees) //=>["1A", "2a"]
  */
 var nthEq = _curry3(function nthEq(offset, val, list) {
   return equals(val, nth(offset, list));

--- a/source/nthEq.js
+++ b/source/nthEq.js
@@ -18,7 +18,7 @@ import equals from './equals.js';
  * @param {*} val
  * @param {*} list
  * @return {Boolean}
- * @see R.equals
+ * @see R.nth, R.equals
  * @example
  *
  *      const labels = {

--- a/source/nthEq.js
+++ b/source/nthEq.js
@@ -1,0 +1,40 @@
+import _curry3 from './internal/_curry3.js';
+import nth from './nth.js';
+import equals from './equals.js';
+
+
+/**
+ * Returns `true` if the nth element (or if n is negative the element
+ * at index length + n) of the given list or string is equal, in
+ * [`R.equals`](#equals) terms, to the given value; `false` otherwise.
+ *
+ * @func
+ * @memberOf R
+ * @since v2.7.2
+ * @category Relation
+ * @sig Number -> a -> Object -> Boolean
+ * @param {Number} offset
+ * @param {*} val
+ * @param {*} list
+ * @return {Boolean}
+ * @see R.equals
+ * @example
+ *
+ *      const labels = ['snack', 'seat', 'exam'];
+ *      const bobby = ['apple', '1A', 'math'];
+ *      const claire = ['apple', '1B', 'economics'];
+ *      const fred = ['PB & J', '2a', 'math'];
+ *      const jess = ['brisket', '2B', 'english'];
+ *      const examinees = {
+ *        bobby,
+ *        claire,
+ *        fred,
+ *        jess,
+ *      };
+ *      const takingMathExam = R.nth(2, 'math');
+ *      R.filter(takingMathExamm, examinees); //=> [fred, rusty]
+ */
+var nthEq = _curry3(function nthEq(offset, val, list) {
+  return equals(val, nth(offset, list));
+});
+export default nthEq;

--- a/test/nthEq.js
+++ b/test/nthEq.js
@@ -10,8 +10,13 @@ describe('nthEq', function() {
 
   it('determines whether a particular offset matches a given value for a specific list', function() {
     eq(R.nthEq(0, 'apples', list1), true);
+    eq(R.nthEq(-3, 'apples', list1), true);
+
     eq(R.nthEq(1, 'oranges', list1), true);
-    eq(R.nthEq(1, 'paper', list2), false);
+    eq(R.nthEq(-2, 'oranges', list1), true);
+
+    eq(R.nthEq(2, 'paper', list2), false);
+    eq(R.nthEq(-1, 'paper', list2), false);
   });
 
   it('has R.equals semantics', function() {

--- a/test/nthEq.js
+++ b/test/nthEq.js
@@ -5,7 +5,7 @@ var eq = require('./shared/eq');
 
 
 describe('nthEq', function() {
-  var list1 = ['apple', 'oranges', 'pears'];
+  var list1 = ['apples', 'oranges', 'pears'];
   var list2 = ['books', 'pens', 'rulers'];
 
   it('determines whether a particular offset matches a given value for a specific list', function() {
@@ -14,17 +14,17 @@ describe('nthEq', function() {
     eq(R.nthEq(1, 'paper', list2), false);
   });
 
-  // it('has R.equals semantics', function() {
-  //   function Just(x) { this.value = x; }
-  //   Just.prototype.equals = function(x) {
-  //     return x instanceof Just && R.equals(x.value, this.value);
-  //   };
+  it('has R.equals semantics', function() {
+    function Just(x) { this.value = x; }
+    Just.prototype.equals = function(x) {
+      return x instanceof Just && R.equals(x.value, this.value);
+    };
 
-  //   eq(R.propEq('value', 0, {value: -0}), false);
-  //   eq(R.propEq('value', -0, {value: 0}), false);
-  //   eq(R.propEq('value', NaN, {value: NaN}), true);
-  //   eq(R.propEq('value', new Just([42]), {value: new Just([42])}), true);
-  // });
+    eq(R.nthEq(0, 0, [-0]), false);
+    eq(R.nthEq(0, -0, [0]), false);
+    eq(R.nthEq(0, NaN, [NaN]), true);
+    eq(R.nthEq(0, new Just([42]), [new Just([42])]), true);
+  });
 
   it('it has the same behavior as nth for null or undefined', function() {
     assert.throws(function() { R.nthEq(0, '', null); }, TypeError);

--- a/test/nthEq.js
+++ b/test/nthEq.js
@@ -1,0 +1,34 @@
+var assert = require('assert');
+
+var R = require('../source');
+var eq = require('./shared/eq');
+
+
+describe('nthEq', function() {
+  var list1 = ['apple', 'oranges', 'pears'];
+  var list2 = ['books', 'pens', 'rulers'];
+
+  it('determines whether a particular offset matches a given value for a specific list', function() {
+    eq(R.nthEq(0, 'apples', list1), true);
+    eq(R.nthEq(1, 'oranges', list1), true);
+    eq(R.nthEq(1, 'paper', list2), false);
+  });
+
+  // it('has R.equals semantics', function() {
+  //   function Just(x) { this.value = x; }
+  //   Just.prototype.equals = function(x) {
+  //     return x instanceof Just && R.equals(x.value, this.value);
+  //   };
+
+  //   eq(R.propEq('value', 0, {value: -0}), false);
+  //   eq(R.propEq('value', -0, {value: 0}), false);
+  //   eq(R.propEq('value', NaN, {value: NaN}), true);
+  //   eq(R.propEq('value', new Just([42]), {value: new Just([42])}), true);
+  // });
+
+  it('it has the same behavior as nth for null or undefined', function() {
+    assert.throws(function() { R.nthEq(0, '', null); }, TypeError);
+    assert.throws(function() { R.nthEq(0, '', undefined); }, TypeError);
+  });
+
+});


### PR DESCRIPTION
## Proposed
```js
const ar = ['apple', '1A', 'math'];

R.nthEq(2, 'math', ar); //=> true
R.nthEq(-1, 'math', ar); //=> true
```
- All indexing semantics would be the same as `R.nth`
- All equals semantics would be the same as `R.equals`
## Reasoning
Sometimes users of `ramda` maybe have their data shaped in unusual ways due to constraints out of their control. They may then need to check if the `nth` item in a list equals a given value. Currently, this can be achieved using `R.propEq(idx, val, list)`. However, this is less legible than `R.nthEq`. In addition, by the pure presence of `R.nth` when `R.prop` can handle indices and offsets (i.e. numbers) then `R.nthEq` should also be present.

Finally, offset semantics are weirdly inconsistent in `R.propEq` when compared to `R.prop`. For example:
```js
const ar = ['apple', '1A', 'math'];

R.propEq(2, 'math', ar); //=> true
R.propEq(-1, 'math', ar); //=> false

R.prop(2, ar); //=> math
R.prop(-1, ar); //=> math
```
