### PR TITLE
fix: prototype poisoning (CWE-915)

### DIFF
--- a/source/mapObjIndexed.js
+++ b/source/mapObjIndexed.js
@@ -26,7 +26,10 @@ import keys from './keys.js';
  */
 var mapObjIndexed = _curry2(function mapObjIndexed(fn, obj) {
   return _reduce(function(acc, key) {
-    acc[key] = fn(obj[key], key, obj);
+    // Prevention of prototype poisoning
+    if (key !== "__proto__" && key !== "prototype" && key !== "constructor") {
+      acc[key] = fn(obj[key], key, obj);
+    }
     return acc;
   }, {}, keys(obj));
 });


### PR DESCRIPTION
Added protection from prototype poisoning to mapObjIndexed().
For Proof of Concept exploit of the vulnerability visit https://jsfiddle.net/3pomzw5g/2/ 