### PR TITLE
chore: no need to restrict whenTrue and whenFalse's return type as input type

### DIFF
--- a/source/unless.js
+++ b/source/unless.js
@@ -11,7 +11,7 @@ import _curry3 from './internal/_curry3.js';
  * @memberOf R
  * @since v0.18.0
  * @category Logic
- * @sig (a -> Boolean) -> (a -> a) -> a -> a
+ * @sig (a -> Boolean) -> (a -> b) -> a -> a | b
  * @param {Function} pred        A predicate function
  * @param {Function} whenFalseFn A function to invoke when the `pred` evaluates
  *                               to a falsy value.

--- a/source/when.js
+++ b/source/when.js
@@ -11,7 +11,7 @@ import _curry3 from './internal/_curry3.js';
  * @memberOf R
  * @since v0.18.0
  * @category Logic
- * @sig (a -> Boolean) -> (a -> a) -> a -> a
+ * @sig (a -> Boolean) -> (a -> b) -> a -> a | b
  * @param {Function} pred       A predicate function
  * @param {Function} whenTrueFn A function to invoke when the `condition`
  *                              evaluates to a truthy value.


### PR DESCRIPTION
There's no need to restrict `whenTrueFn`'s return type to be consistent to `R.when`'s input type.