### PR TITLE
feat: add transducer support for uniqBy/uniqWith

### DIFF
--- a/source/internal/_xuniqBy.js
+++ b/source/internal/_xuniqBy.js
@@ -1,0 +1,18 @@
+import _curry2 from './_curry2.js';
+import _Set from './_Set.js';
+import _xfBase from './_xfBase.js';
+
+
+function XUniqBy(f, xf) {
+  this.xf = xf;
+  this.f = f;
+  this.set = new _Set();
+}
+XUniqBy.prototype['@@transducer/init'] = _xfBase.init;
+XUniqBy.prototype['@@transducer/result'] = _xfBase.result;
+XUniqBy.prototype['@@transducer/step'] = function(result, input) {
+  return this.set.add(this.f(input)) ? this.xf['@@transducer/step'](result, input) : result;
+};
+
+var _xuniqBy = _curry2(function _xuniqBy(f, xf) { return new XUniqBy(f, xf); });
+export default _xuniqBy;

--- a/source/internal/_xuniqWith.js
+++ b/source/internal/_xuniqWith.js
@@ -1,0 +1,24 @@
+import _Set from './_Set.js';
+import _curry2 from './_curry2.js';
+import _includesWith from './_includesWith.js';
+import _xfBase from './_xfBase.js';
+
+
+function XUniqWith(pred, xf) {
+  this.xf = xf;
+  this.pred = pred;
+  this.items = [];
+}
+XUniqWith.prototype['@@transducer/init'] = _xfBase.init;
+XUniqWith.prototype['@@transducer/result'] = _xfBase.result;
+XUniqWith.prototype['@@transducer/step'] = function(result, input) {
+  if (_includesWith(this.pred, input, this.items)) {
+    return result;
+  } else {
+    this.items.push(input);
+    return this.xf['@@transducer/step'](result, input);
+  }
+};
+
+var _xuniqWith = _curry2(function _xuniqWith(pred, xf) { return new XUniqWith(pred, xf); });
+export default _xuniqWith;

--- a/source/uniqBy.js
+++ b/source/uniqBy.js
@@ -1,5 +1,7 @@
 import _Set from './internal/_Set.js';
 import _curry2 from './internal/_curry2.js';
+import _dispatchable from './internal/_dispatchable.js';
+import _xuniqBy from './internal/_xuniqBy.js';
 
 
 /**
@@ -7,6 +9,8 @@ import _curry2 from './internal/_curry2.js';
  * list, based upon the value returned by applying the supplied function to
  * each list element. Prefers the first item if the supplied function produces
  * the same value on two items. [`R.equals`](#equals) is used for comparison.
+ *
+ * Acts as a transducer if a transformer is given in list position.
  *
  * @func
  * @memberOf R
@@ -20,7 +24,7 @@ import _curry2 from './internal/_curry2.js';
  *
  *      R.uniqBy(Math.abs, [-1, -5, 2, 10, 1, 2]); //=> [-1, -5, 2, 10]
  */
-var uniqBy = _curry2(function uniqBy(fn, list) {
+var uniqBy = _curry2(_dispatchable([], _xuniqBy, function(fn, list) {
   var set = new _Set();
   var result = [];
   var idx = 0;
@@ -35,5 +39,5 @@ var uniqBy = _curry2(function uniqBy(fn, list) {
     idx += 1;
   }
   return result;
-});
+}));
 export default uniqBy;

--- a/source/uniqWith.js
+++ b/source/uniqWith.js
@@ -1,5 +1,7 @@
-import _includesWith from './internal/_includesWith.js';
 import _curry2 from './internal/_curry2.js';
+import _dispatchable from './internal/_dispatchable.js';
+import _includesWith from './internal/_includesWith.js';
+import _xuniqWith from './internal/_xuniqWith.js';
 
 
 /**
@@ -7,6 +9,8 @@ import _curry2 from './internal/_curry2.js';
  * list, based upon the value returned by applying the supplied predicate to
  * two list elements. Prefers the first item if two items compare equal based
  * on the predicate.
+ *
+ * Acts as a transducer if a transformer is given in list position.
  *
  * @func
  * @memberOf R
@@ -24,7 +28,7 @@ import _curry2 from './internal/_curry2.js';
  *      R.uniqWith(strEq)([1, '1', 1]);    //=> [1]
  *      R.uniqWith(strEq)(['1', 1, 1]);    //=> ['1']
  */
-var uniqWith = _curry2(function uniqWith(pred, list) {
+var uniqWith = _curry2(_dispatchable([], _xuniqWith, function(pred, list) {
   var idx = 0;
   var len = list.length;
   var result = [];
@@ -37,5 +41,5 @@ var uniqWith = _curry2(function uniqWith(pred, list) {
     idx += 1;
   }
   return result;
-});
+}));
 export default uniqWith;

--- a/test/transduce.js
+++ b/test/transduce.js
@@ -5,7 +5,9 @@ describe('transduce', function() {
   var add = R.add;
   var mult = function(a, b) {return a * b;};
   var isOdd = function(b) { return b % 2 !== 0; };
+  var isEven = function(b) { return b % 2 === 0; };
   var square = function(a) {return a * a;};
+  var negate = function(a) {return -1 * a;};
   var addxf = {
     '@@transducer/step': function(acc, x) { return acc + x; },
     '@@transducer/init': function() { return 0; },
@@ -40,6 +42,10 @@ describe('transduce', function() {
     eq(R.transduce(R.filter(isOdd), R.flip(R.append), [],  [1, 2, 3, 4]), [1, 3]);
     eq(R.transduce(R.compose(R.map(add(1)), R.take(2)), R.flip(R.append), [],  [1, 2, 3, 4]), [2, 3]);
     eq(R.transduce(R.compose(R.filter(isOdd), R.take(1)), R.flip(R.append), [],  [1, 2, 3, 4]), [1]);
+    eq(R.transduce(R.compose(R.uniq, R.map(square), R.take(3)), R.flip(R.append), [],  [1, 1, 2, 2, 3, 3, 4, 4]), [1, 4, 9]);
+    eq(R.transduce(R.compose(R.filter(isEven), R.uniq), R.flip(R.append), [],  [1, 1, 2, 2, 3, 3, 4, 4]), [2, 4]);
+    eq(R.transduce(R.compose(R.map(negate), R.uniqBy(Math.abs), R.map(square)), R.flip(R.append), [],  [-1, -5, 2, 10, 1, 2]), [1, 25, 4, 100]);
+    eq(R.transduce(R.compose(R.uniqWith(R.eqBy(String)), R.map(square), R.take(3)), R.flip(R.append), [],  [1, '1', '2', 2, 3, '3', '4', 4]), [1, 4, 9]);
   });
 
   it('transduces into strings', function() {


### PR DESCRIPTION
As the title implies, this PR adds transducer support for uniq/uniqBy/uniqWith.
Unit test is updated to cover this change.

Related issue #1683