### PR TITLE
chore: remove dependencies badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ A practical functional library for JavaScript programmers.
 [![npm module](https://badge.fury.io/js/ramda.svg)](https://www.npmjs.org/package/ramda)
 [![deno land](http://img.shields.io/badge/available%20on-deno.land/x-lightgrey.svg?logo=deno&labelColor=black)](https://deno.land/x/ramda@v0.27.2)
 [![nest badge](https://nest.land/badge.svg)](https://nest.land/package/ramda)
-[![dependencies](https://david-dm.org/ramda/ramda.svg)](https://david-dm.org/ramda/ramda)
 [![Gitter](https://badges.gitter.im/Join_Chat.svg)](https://gitter.im/ramda/ramda?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 


### PR DESCRIPTION
As of time of writing the service https://david-dm.org/ seems to be down
and/or unreliable. As Ramda is a no-dependency library I'm not seeing
much value in this badge.

![Screenshot 2021-12-26 at 18 29 23](https://user-images.githubusercontent.com/681975/147417021-ff42a5e2-da41-41ea-a6cb-40b0c2a2b666.png)

---

I know we have _way_ more important things to do but the broken link didn't look great and this is a very quick fix. If you prefer to keep the dependencies status here's a shields.io alternative:

![Libraries.io dependency status for latest release](https://img.shields.io/librariesio/release/npm/ramda)


