### PR TITLE
Remove placeholder check from `identical`

### DIFF
--- a/source/identical.js
+++ b/source/identical.js
@@ -42,7 +42,7 @@ var identical = function(a, b) {
           }
         };
       }());
-    case 2:
+    default:
       return _objectIs(a, b);
   }
 };

--- a/source/identical.js
+++ b/source/identical.js
@@ -1,5 +1,4 @@
 import _objectIs from './internal/_objectIs.js';
-import _curry2 from './internal/_curry2.js';
 
 
 /**
@@ -46,4 +45,10 @@ var identical = function(a, b) {
       return _objectIs(a, b);
   }
 };
+
+// In order to support Cross-origin Window objects as arguments to identical,
+// it cannot be implemented as _curry2(_objectIs). 
+// The reason is that _curry2 checks if a function argument is the placeholder __ 
+// by accessing a paritcular property. However, across URL origins access 
+// to most properties of Window is forbidden. 
 export default identical;

--- a/source/identical.js
+++ b/source/identical.js
@@ -31,9 +31,9 @@ import _objectIs from './internal/_objectIs.js';
 var identical = function(a, b) {
   switch (arguments.length) {
     case 0:
-      return identical; 
+      return identical;
     case 1:
-      return (function(){
+      return (function() {
         return function unaryIdentical(_b) {
           switch (arguments.length) {
             case 0:
@@ -49,8 +49,8 @@ var identical = function(a, b) {
 };
 
 // In order to support Cross-origin Window objects as arguments to identical,
-// it cannot be implemented as _curry2(_objectIs). 
-// The reason is that _curry2 checks if a function argument is the placeholder __ 
-// by accessing a paritcular property. However, across URL origins access 
-// to most properties of Window is forbidden. 
+// it cannot be implemented as _curry2(_objectIs).
+// The reason is that _curry2 checks if a function argument is the placeholder __
+// by accessing a paritcular property. However, across URL origins access
+// to most properties of Window is forbidden.
 export default identical;

--- a/source/identical.js
+++ b/source/identical.js
@@ -8,6 +8,8 @@ import _objectIs from './internal/_objectIs.js';
  *
  * Note this is merely a curried version of ES6 `Object.is`.
  *
+ * `identical` does not support the `__` placeholder.
+ *
  * @func
  * @memberOf R
  * @since v0.15.0

--- a/source/identical.js
+++ b/source/identical.js
@@ -27,5 +27,23 @@ import _curry2 from './internal/_curry2.js';
  *      R.identical(0, -0); //=> false
  *      R.identical(NaN, NaN); //=> true
  */
-var identical = _curry2(_objectIs);
+var identical = function(a, b) {
+  switch (arguments.length) {
+    case 0:
+      return identical; 
+    case 1:
+      return (function(){
+        return function unaryIdentical(_b) {
+          switch (arguments.length) {
+            case 0:
+              return unaryIdentical;
+            default:
+              return _objectIs(a, _b);
+          }
+        };
+      }());
+    case 2:
+      return _objectIs(a, b);
+  }
+};
 export default identical;

--- a/test/identical.js
+++ b/test/identical.js
@@ -1,5 +1,6 @@
 var R = require('../source');
 var eq = require('./shared/eq');
+var assert = require('assert');
 
 
 describe('identical', function() {
@@ -24,6 +25,38 @@ describe('identical', function() {
     eq(R.identical(0, new Number(0)), false);
     eq(R.identical(new Number(0), 0), false);
     eq(R.identical(new Number(0), new Number(0)), false);
+  });
+  
+  it('is auto-curried', function() {
+    assert.strictEqual(R.identical.length, 2);
+    var unaryFn = R.identical("foo");
+    assert.strictEqual(unaryFn.length, 1);
+    eq(unaryFn("bar"), false);
+    eq(unaryFn("foo"), true);
+    
+    eq(R.identical()("foo")()("foo"), true);
+  });
+  
+  it("does not access the placeholder property of it's arguments which is forbidden for cross-origin browser windows", function() {
+    var forbiddenPropertyAccessObject = {};
+    Object.defineProperty(
+      forbiddenPropertyAccessObject, 
+      '@@functional/placeholder', 
+      { get: function(){ throw new Error("Not allowed!"); } }
+    );
+    
+    assert.doesNotThrow(
+      () => R.identical(forbiddenPropertyAccessObject, {}),
+      Error
+    );
+    
+    assert.doesNotThrow(
+      () => R.identical({}, forbiddenPropertyAccessObject),
+      Error
+    );
+    
+    eq(R.identical(forbiddenPropertyAccessObject, forbiddenPropertyAccessObject), true);
+    eq(R.identical(forbiddenPropertyAccessObject, {}), false);
   });
 
 });

--- a/test/identical.js
+++ b/test/identical.js
@@ -3,7 +3,7 @@ var eq = require('./shared/eq');
 var assert = require('assert');
 
 // see https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy#cross-origin_script_api_access
-const allowedCrossOriginProperties = ["blur", "close", "focus", "postMessage", "closed", "frames", "length", "location", "opener", "parent", "top", "window"];
+const allowedCrossOriginProperties = ['blur', 'close', 'focus', 'postMessage', 'closed', 'frames', 'length', 'location', 'opener', 'parent', 'top', 'window'];
 
 
 describe('identical', function() {
@@ -29,29 +29,29 @@ describe('identical', function() {
     eq(R.identical(new Number(0), 0), false);
     eq(R.identical(new Number(0), new Number(0)), false);
   });
-  
+
   it('is auto-curried', function() {
     assert.strictEqual(R.identical.length, 2);
-    var unaryFn = R.identical("foo");
+    var unaryFn = R.identical('foo');
     assert.strictEqual(unaryFn.length, 1);
-    eq(unaryFn("bar"), false);
-    eq(unaryFn("foo"), true);
+    eq(unaryFn('bar'), false);
+    eq(unaryFn('foo'), true);
   });
-  
-  it("does not access the placeholder property of it's arguments which is forbidden for cross-origin browser windows", function() {
+
+  it('does not access the placeholder property of its arguments which is forbidden for cross-origin browser windows', function() {
     // mock cross origin window object
     // Access is just to a few properties allowed
     // See https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy#cross-origin_script_api_access
-    
-    function CrossOriginWindow() {};
+
+    function CrossOriginWindow() {}
 
     // disallow instanceof
     Object.defineProperty(
       CrossOriginWindow,
       Symbol.hasInstance,
-      { value: function() { throw new Error("Not allowed instanceof!"); } }
+      { value: function() { throw new Error('Not allowed instanceof!'); } }
     );
-    
+
     const crossOriginWindowObject = new Proxy(
       new CrossOriginWindow(),
       {
@@ -63,17 +63,17 @@ describe('identical', function() {
         }
       }
     );
-    
+
     assert.doesNotThrow(
       () => R.identical(crossOriginWindowObject, {}),
       Error
     );
-    
+
     assert.doesNotThrow(
       () => R.identical({}, crossOriginWindowObject),
       Error
     );
-    
+
     eq(R.identical(crossOriginWindowObject, crossOriginWindowObject), true);
     eq(R.identical(crossOriginWindowObject, {}), false);
   });

--- a/test/invariants.js
+++ b/test/invariants.js
@@ -15,8 +15,9 @@ describe('invariants', function() {
   });
 
   it('-- applying function f with length n (where n > 0) to R.__ gives function with length n', function() {
+    var unsupportedFunctionNames = ["identical"];
     for (var prop in R) {
-      if (typeof R[prop] === 'function' && R[prop].length > 0) {
+      if (typeof R[prop] === 'function' && R[prop].length > 0 && unsupportedFunctionNames.indexOf(prop) === -1) {
         var result = R[prop](R.__);
         eq(typeof result, 'function');
         eq(result.length, R[prop].length);

--- a/test/invariants.js
+++ b/test/invariants.js
@@ -15,7 +15,7 @@ describe('invariants', function() {
   });
 
   it('-- applying function f with length n (where n > 0) to R.__ gives function with length n', function() {
-    var unsupportedFunctionNames = ["identical"];
+    var unsupportedFunctionNames = ['identical'];
     for (var prop in R) {
       if (typeof R[prop] === 'function' && R[prop].length > 0 && unsupportedFunctionNames.indexOf(prop) === -1) {
         var result = R[prop](R.__);


### PR DESCRIPTION
This fixes #2533, where calling `identical` with cross-origin browser window objects throws a DOMException.

The reason for the exception is the checking for the placeholder property in the `curry*` functions.

Since placeholder support makes no sense for commutative functions it can be removed from `identical`. This is done here by wrapping `isObject` with a `curry2` wrapper without placeholder property checks.