### PR TITLE
Update partialObject definition to make it more JSDoc friendly

### DIFF
--- a/source/partialObject.js
+++ b/source/partialObject.js
@@ -29,5 +29,5 @@ import _curry2 from './internal/_curry2.js';
  *      sayHelloToMs({ firstName: 'Jane', lastName: 'Jones' }); //=> 'Hello, Ms. Jane Jones!'
  * @symb R.partialObject(f, { a, b })({ c, d }) = f({ a, b, c, d })
  */
-
-export default _curry2((f, o) => (props) => f.call(this, mergeDeepRight(o, props)));
+var partialObject = _curry2((f, o) => (props) => f.call(this, mergeDeepRight(o, props)));
+export default partialObject;


### PR DESCRIPTION
**Before**

JSDoc cannot infer the name of the function and so default to `module.exports`

```javascript
export default () => 42
```

**After**

JSDoc can infer the name of the function as it has been assigned to the `answer` variable.

```javascript
var answer  = () => 42;
export default answer;
```

