### PR TITLE
Fix merge with nil objects

### DIFF
--- a/source/mergeWithKey.js
+++ b/source/mergeWithKey.js
@@ -30,6 +30,8 @@ import _has from './internal/_has.js';
 var mergeWithKey = _curry3(function mergeWithKey(fn, l, r) {
   var result = {};
   var k;
+  l = l || {};
+  r = r || {};
 
   for (k in l) {
     if (_has(k, l)) {

--- a/test/mergeAll.js
+++ b/test/mergeAll.js
@@ -19,4 +19,16 @@ describe('mergeAll', function() {
     eq(res, {fizz: 'buzz'});
   });
 
+  describe('acts as if nil values are simply empty objects', function() {
+    it('... if the first object is nil', function() {
+      eq(R.mergeAll([null, {foo:1}, {foo:2}, {bar:2}]), {foo:2, bar:2});
+    });
+    it('... if the last object is nil', function() {
+      eq(R.mergeAll([{foo:1}, {foo:2}, {bar:2}, undefined]), {foo:2, bar:2});
+    });
+    it('... if an intermediate object is nil', function() {
+      eq(R.mergeAll([{foo:1}, {foo:2}, null, {bar:2}]), {foo:2, bar:2});
+    });
+  });
+
 });

--- a/test/mergeLeft.js
+++ b/test/mergeLeft.js
@@ -40,4 +40,21 @@ describe('mergeLeft', function() {
     eq(res, { x: { u: 1, v: 2 }, y: 0, z: 0 });
   });
 
+  describe('acts as if nil values are simply empty objects', function() {
+    var a = {w: 1, x: 2};
+    var b = {w: 100, y: 3, z: 4};
+
+    it('... if the first object is nil', function() {
+      eq(R.mergeLeft(null, b), b);
+    });
+
+    it('... if the second object is nil', function() {
+      eq(R.mergeLeft(a, undefined), a);
+    });
+
+    it('... if both objects are nil', function() {
+      eq(R.mergeLeft(null, undefined), {});
+    });
+  });
+
 });

--- a/test/mergeRight.js
+++ b/test/mergeRight.js
@@ -40,4 +40,22 @@ describe('mergeRight', function() {
     eq(res, { x: { u: 3, w: 4 }, y: 0, z: 0 });
   });
 
+  describe('acts as if nil values are simply empty objects', function() {
+    var a = {w: 1, x: 2};
+    var b = {w: 100, y: 3, z: 4};
+
+    it('... if the first object is nil', function() {
+      eq(R.mergeRight(null, b), b);
+    });
+
+    it('... if the second object is nil', function() {
+      eq(R.mergeRight(a, undefined), a);
+    });
+
+    it('... if both objects are nil', function() {
+      eq(R.mergeRight(null, undefined), {});
+    });
+
+  });
+
 });

--- a/test/mergeWith.js
+++ b/test/mergeWith.js
@@ -37,4 +37,26 @@ describe('mergeWith', function() {
     eq(R.mergeWith(last, new Cla(), {w: 1}), {w: 1});
   });
 
+  describe('acts as if nil values are simply empty objects', function() {
+    it('... if the first object is nil and the second empty', function() {
+      eq(R.mergeWith(R.concat, undefined, {}), {});
+    });
+
+    it('... if the first object is empty and the second nil', function() {
+      eq(R.mergeWith(R.concat, {}, null), {});
+    });
+
+    it('... if both objects are nil', function() {
+      eq(R.mergeWith(R.concat, undefined, null), {});
+    });
+
+    it('... if the first object is not empty and the second is nil', function() {
+      eq(R.mergeWith(R.concat, {a: 'a'}, null), {a: 'a'});
+    });
+
+    it('... if the first object is nil and the second is not empty', function() {
+      eq(R.mergeWith(R.concat, undefined, {a: 'a'}), {a: 'a'});
+    });
+  });
+
 });

--- a/test/mergeWithKey.js
+++ b/test/mergeWithKey.js
@@ -37,4 +37,25 @@ describe('mergeWithKey', function() {
     eq(R.mergeWithKey(last, a, new Cla()), {w: 1, x: 2});
   });
 
+  describe('acts as if nil values are simply empty objects', function() {
+    var a = {a: 'b', x: 'd'};
+    var b = {a: 'c', y: 'e'};
+    const combine = function(k, a, b) { return k + a + b; };
+
+    eq(R.mergeWithKey(combine, a, b), {a: 'abc', x: 'd', y: 'e'});
+
+    it('... if the first object is nil', function() {
+      eq(R.mergeWithKey(combine, null, b), b);
+
+    });
+
+    it('... if the second object is nil', function() {
+      eq(R.mergeWithKey(combine, a, undefined), a);
+    });
+
+    it('... if both objects are nil', function() {
+      eq(R.mergeWithKey(combine, null, undefined), {});
+    });
+  });
+
 });


### PR DESCRIPTION
Question: Is there a great reason to write even more tests for the `mergeDeep*` functions?  I feel this is already testing overkill, and the same fix should apply to them.

Fixes #2586