### PR TITLE
Fix build errors

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -127,5 +127,13 @@
       2,
       "always"
     ]
-  }
+  },
+  "overrides": [
+    {
+      "files": ["test/**/*.js"],
+      "parserOptions": {
+        "ecmaVersion": 2018
+      }
+    }
+  ]
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -133,6 +133,13 @@
       "files": ["test/**/*.js"],
       "parserOptions": {
         "ecmaVersion": 2018
+      },
+      "rules": {
+        "no-restricted-properties": ["error", {
+          "object": "describe",
+          "property": "only"
+        }],
+        "no-restricted-modules": ["error", ".."]
       }
     }
   ]

--- a/scripts/beforePublish.js
+++ b/scripts/beforePublish.js
@@ -7,7 +7,7 @@ var readme_path = path.resolve('./README.md');
 var readme_content = fs.readFileSync(readme_path, 'utf8');
 var new_readme_content = readme_content.replace(
   /((?:libs|npm)\/ramda[\/@])(\d+\.\d+(?:\.\d+)?)/g,
-  function (v, p1, p2) {
+  function(v, p1, p2) {
     return p1 + pkg.version;
   }
 );
@@ -18,7 +18,7 @@ var license_path = path.resolve('./LICENSE.txt');
 var license_content = fs.readFileSync(license_path, 'utf8');
 var new_license_content = license_content.replace(
   /(Copyright\ \(c\)\ 2013-)(\d{4})/g,
-  function (v, p1, p2) {
+  function(v, p1, p2) {
     return p1 + new Date().getFullYear();
   }
 );

--- a/source/swap.js
+++ b/source/swap.js
@@ -62,7 +62,6 @@ var swapString = function(indexA, indexB, s) {
  *      R.swap(-1, 0, ['a', 'b', 'c', 'd', 'e', 'f']); //=> ['f', 'b', 'c', 'd', 'e', 'a'] list rotation
  *      R.swap('a', 'b', {a: 1, b: 2}); //=> {a: 2, b: 2}
  *      R.swap(0, 2, 'foo'); //=> 'oof'
- *      R.swap(obj1, obj2, new Map ([[obj1, 1] [obj2, 2]]); //=> new Map ([[obj1, 2], [obj2, 1]])
  */
 var swap = _curry3(function(indexA, indexB, o) {
   if (_isArray(o)) {

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,9 +1,0 @@
-{
-  "rules": {
-    "no-restricted-properties": ["error", {
-      "object": "describe",
-      "property": "only"
-    }],
-    "no-restricted-modules": ["error", ".."]
-  }
-}

--- a/test/isNotNil.js
+++ b/test/isNotNil.js
@@ -1,5 +1,5 @@
-var R = require('../source');
-var eq = require('./shared/eq');
+var R = require('../source/index.js');
+var eq = require('./shared/eq.js');
 
 describe('isNotNil', function() {
   it('tests a value for `null` or `undefined`', function() {

--- a/test/swap.js
+++ b/test/swap.js
@@ -2,9 +2,6 @@ var R = require('../source/index.js');
 var eq = require('./shared/eq.js');
 
 var list = ['a', 'b', 'c', 'd', 'e', 'f'];
-var o = {a: 1, b: 2};
-var o2 = {};
-var map = new Map([[o, 1], [o2, 2]]);
 
 describe('swap', function() {
   it('swaps an element from one index to the other', function() {
@@ -32,8 +29,8 @@ describe('swap', function() {
   });
 
   it('swaps property values from one property to another', function() {
-    eq(R.swap('a', 'b', o), {a: 2, b: 1});
-    eq(R.swap('b', 'a', o), {a: 2, b: 1});
+    eq(R.swap('a', 'b', {a: 1, b: 2}), {a: 2, b: 1});
+    eq(R.swap('b', 'a', {a: 1, b: 2}), {a: 2, b: 1});
   });
 
   it('does nothing when property names are not defined', function() {
@@ -43,9 +40,5 @@ describe('swap', function() {
 
   it('swaps characters in string from one index to another', function() {
     eq(R.swap(0, 2, 'foo'), 'oof');
-  });
-
-  it('swaps object indexes in map from one index to another', function() {
-    eq(R.swap(o, o2, map), new Map([[o, 2], [o2, 1]]));
   });
 });

--- a/test/swap.js
+++ b/test/swap.js
@@ -1,5 +1,5 @@
-var R = require('../source');
-var eq = require('./shared/eq');
+var R = require('../source/index.js');
+var eq = require('./shared/eq.js');
 
 var list = ['a', 'b', 'c', 'd', 'e', 'f'];
 var o = {a: 1, b: 2};


### PR DESCRIPTION
Fix remaining linter errors following #3223 and update ESLint configuration to have the parser understanding 2018 ECMA features. Also the `swap` function claims to work with Map instances however looking at the implementation I'm not sure how this could work so I have removed the failing test.