### PR TITLE
chore: rename innerJoin to intersectionWith

### DIFF
--- a/source/index.js
+++ b/source/index.js
@@ -87,7 +87,7 @@ export { default as includes } from './includes.js';
 export { default as indexBy } from './indexBy.js';
 export { default as indexOf } from './indexOf.js';
 export { default as init } from './init.js';
-export { default as innerJoin } from './innerJoin.js';
+export { default as intersectionWith } from './intersectionWith.js';
 export { default as insert } from './insert.js';
 export { default as insertAll } from './insertAll.js';
 export { default as intersection } from './intersection.js';

--- a/source/intersection.js
+++ b/source/intersection.js
@@ -17,7 +17,7 @@ import uniq from './uniq.js';
  * @param {Array} list1 The first list.
  * @param {Array} list2 The second list.
  * @return {Array} The list of elements found in both `list1` and `list2`.
- * @see R.innerJoin
+ * @see R.intersectionWith
  * @example
  *
  *      R.intersection([1,2,3,4], [7,6,5,4,3]); //=> [4, 3]

--- a/source/intersectionWith.js
+++ b/source/intersectionWith.js
@@ -27,7 +27,7 @@ import _filter from './internal/_filter.js';
  * @see R.intersection
  * @example
  *
- *      R.innerJoin(
+ *      R.intersectionWith(
  *        (record, id) => record.id === id,
  *        [{id: 824, name: 'Richie Furay'},
  *         {id: 956, name: 'Dewey Martin'},
@@ -38,7 +38,7 @@ import _filter from './internal/_filter.js';
  *      );
  *      //=> [{id: 456, name: 'Stephen Stills'}, {id: 177, name: 'Neil Young'}]
  */
-var innerJoin = _curry3(function innerJoin(pred, xs, ys) {
+var intersectionWith = _curry3(function intersectionWith(pred, xs, ys) {
   return _filter(function(x) { return _includesWith(pred, x, ys); }, xs);
 });
-export default innerJoin;
+export default intersectionWith;

--- a/test/innerJoin.js
+++ b/test/innerJoin.js
@@ -5,10 +5,10 @@ var eq = require('./shared/eq.js');
 var a = {id: 1, name: 'a'};
 var b = {id: 2, name: 'b'};
 var c = {id: 3, name: 'c'};
-var f = R.innerJoin(function(r, id) { return r.id === id; });
+var f = R.intersectionWith(function(r, id) { return r.id === id; });
 
 
-describe('innerJoin', function() {
+describe('intersectionWith', function() {
 
   it('only returns elements from the first list', function() {
     eq(f([a, b, c], []), []);


### PR DESCRIPTION
`innerJoin` is a sql command, `R.innerJoin` only has `inner` but no `join`, so rename it to `intersectionWith` may be more accurate?