### PR TITLE
refactor(3230): remove curryX dependency for internal transducer creator functions

### DIFF
--- a/source/dropRepeats.js
+++ b/source/dropRepeats.js
@@ -24,6 +24,8 @@ import equals from './equals.js';
  *     R.dropRepeats([1, 1, 1, 2, 3, 4, 4, 2, 2]); //=> [1, 2, 3, 4, 2]
  */
 var dropRepeats = _curry1(
-  _dispatchable([], _xdropRepeatsWith(equals), dropRepeatsWith(equals))
+  _dispatchable([], function() {
+    return _xdropRepeatsWith(equals);
+  }, dropRepeatsWith(equals))
 );
 export default dropRepeats;

--- a/source/internal/_xall.js
+++ b/source/internal/_xall.js
@@ -1,4 +1,3 @@
-import _curry2 from './_curry2.js';
 import _reduced from './_reduced.js';
 import _xfBase from './_xfBase.js';
 
@@ -23,5 +22,6 @@ XAll.prototype['@@transducer/step'] = function(result, input) {
   return result;
 };
 
-var _xall = _curry2(function _xall(f, xf) { return new XAll(f, xf); });
-export default _xall;
+export default function _xall(f) {
+  return function(xf) { return new XAll(f, xf); };
+}

--- a/source/internal/_xany.js
+++ b/source/internal/_xany.js
@@ -1,4 +1,3 @@
-import _curry2 from './_curry2.js';
 import _reduced from './_reduced.js';
 import _xfBase from './_xfBase.js';
 
@@ -23,5 +22,6 @@ XAny.prototype['@@transducer/step'] = function(result, input) {
   return result;
 };
 
-var _xany = _curry2(function _xany(f, xf) { return new XAny(f, xf); });
-export default _xany;
+export default function _xany(f) {
+  return function(xf) { return new XAny(f, xf); };
+}

--- a/source/internal/_xaperture.js
+++ b/source/internal/_xaperture.js
@@ -1,5 +1,4 @@
 import _concat from './_concat.js';
-import _curry2 from './_curry2.js';
 import _xfBase from './_xfBase.js';
 
 
@@ -32,5 +31,6 @@ XAperture.prototype.getCopy = function() {
   );
 };
 
-var _xaperture = _curry2(function _xaperture(n, xf) { return new XAperture(n, xf); });
-export default _xaperture;
+export default function _xaperture(n) {
+  return function(xf) { return new XAperture(n, xf); };
+}

--- a/source/internal/_xchain.js
+++ b/source/internal/_xchain.js
@@ -1,9 +1,7 @@
-import _curry2 from './_curry2.js';
 import _flatCat from './_flatCat.js';
-import map from '../map.js';
+import _xmap from './_xmap.js';
 
 
-var _xchain = _curry2(function _xchain(f, xf) {
-  return map(f, _flatCat(xf));
-});
-export default _xchain;
+export default function _xchain(f) {
+  return function(xf) { return _xmap(f)(_flatCat(xf)); };
+}

--- a/source/internal/_xdrop.js
+++ b/source/internal/_xdrop.js
@@ -1,4 +1,3 @@
-import _curry2 from './_curry2.js';
 import _xfBase from './_xfBase.js';
 
 
@@ -16,5 +15,6 @@ XDrop.prototype['@@transducer/step'] = function(result, input) {
   return this.xf['@@transducer/step'](result, input);
 };
 
-var _xdrop = _curry2(function _xdrop(n, xf) { return new XDrop(n, xf); });
-export default _xdrop;
+export default function _xdrop(n) {
+  return function(xf) { return new XDrop(n, xf); };
+}

--- a/source/internal/_xdropLast.js
+++ b/source/internal/_xdropLast.js
@@ -1,4 +1,3 @@
-import _curry2 from './_curry2.js';
 import _xfBase from './_xfBase.js';
 
 
@@ -29,5 +28,6 @@ XDropLast.prototype.store = function(input) {
   }
 };
 
-var _xdropLast = _curry2(function _xdropLast(n, xf) { return new XDropLast(n, xf); });
-export default _xdropLast;
+export default function _xdropLast(n) {
+  return function(xf) { return new XDropLast(n, xf); };
+}

--- a/source/internal/_xdropLastWhile.js
+++ b/source/internal/_xdropLastWhile.js
@@ -1,4 +1,3 @@
-import _curry2 from './_curry2.js';
 import _reduce from './_reduce.js';
 import _xfBase from './_xfBase.js';
 
@@ -32,5 +31,6 @@ XDropLastWhile.prototype.retain = function(result, input) {
   return result;
 };
 
-var _xdropLastWhile = _curry2(function _xdropLastWhile(fn, xf) { return new XDropLastWhile(fn, xf); });
-export default _xdropLastWhile;
+export default function _xdropLastWhile(fn) {
+  return function(xf) { return new XDropLastWhile(fn, xf); };
+}

--- a/source/internal/_xdropRepeatsWith.js
+++ b/source/internal/_xdropRepeatsWith.js
@@ -1,4 +1,3 @@
-import _curry2 from './_curry2.js';
 import _xfBase from './_xfBase.js';
 
 
@@ -22,5 +21,6 @@ XDropRepeatsWith.prototype['@@transducer/step'] = function(result, input) {
   return sameAsLast ? result : this.xf['@@transducer/step'](result, input);
 };
 
-var _xdropRepeatsWith = _curry2(function _xdropRepeatsWith(pred, xf) { return new XDropRepeatsWith(pred, xf); });
-export default _xdropRepeatsWith;
+export default function _xdropRepeatsWith(pred) {
+  return function(xf) { return new XDropRepeatsWith(pred, xf); };
+}

--- a/source/internal/_xdropWhile.js
+++ b/source/internal/_xdropWhile.js
@@ -1,4 +1,3 @@
-import _curry2 from './_curry2.js';
 import _xfBase from './_xfBase.js';
 
 
@@ -18,5 +17,6 @@ XDropWhile.prototype['@@transducer/step'] = function(result, input) {
   return this.xf['@@transducer/step'](result, input);
 };
 
-var _xdropWhile = _curry2(function _xdropWhile(f, xf) { return new XDropWhile(f, xf); });
-export default _xdropWhile;
+export default function _xdropWhile(f) {
+  return function(xf) { return new XDropWhile(f, xf); };
+}

--- a/source/internal/_xfilter.js
+++ b/source/internal/_xfilter.js
@@ -1,4 +1,3 @@
-import _curry2 from './_curry2.js';
 import _xfBase from './_xfBase.js';
 
 
@@ -12,5 +11,6 @@ XFilter.prototype['@@transducer/step'] = function(result, input) {
   return this.f(input) ? this.xf['@@transducer/step'](result, input) : result;
 };
 
-var _xfilter = _curry2(function _xfilter(f, xf) { return new XFilter(f, xf); });
-export default _xfilter;
+export default function _xfilter(f) {
+  return function(xf) { return new XFilter(f, xf); };
+}

--- a/source/internal/_xfind.js
+++ b/source/internal/_xfind.js
@@ -1,4 +1,3 @@
-import _curry2 from './_curry2.js';
 import _reduced from './_reduced.js';
 import _xfBase from './_xfBase.js';
 
@@ -23,5 +22,6 @@ XFind.prototype['@@transducer/step'] = function(result, input) {
   return result;
 };
 
-var _xfind = _curry2(function _xfind(f, xf) { return new XFind(f, xf); });
-export default _xfind;
+export default function _xfind(f) {
+  return function(xf) { return new XFind(f, xf); };
+}

--- a/source/internal/_xfindIndex.js
+++ b/source/internal/_xfindIndex.js
@@ -1,4 +1,3 @@
-import _curry2 from './_curry2.js';
 import _reduced from './_reduced.js';
 import _xfBase from './_xfBase.js';
 
@@ -25,5 +24,6 @@ XFindIndex.prototype['@@transducer/step'] = function(result, input) {
   return result;
 };
 
-var _xfindIndex = _curry2(function _xfindIndex(f, xf) { return new XFindIndex(f, xf); });
-export default _xfindIndex;
+export default function _xfindIndex(f) {
+  return function(xf) { return new XFindIndex(f, xf); };
+}

--- a/source/internal/_xfindLast.js
+++ b/source/internal/_xfindLast.js
@@ -1,4 +1,3 @@
-import _curry2 from './_curry2.js';
 import _xfBase from './_xfBase.js';
 
 
@@ -17,5 +16,6 @@ XFindLast.prototype['@@transducer/step'] = function(result, input) {
   return result;
 };
 
-var _xfindLast = _curry2(function _xfindLast(f, xf) { return new XFindLast(f, xf); });
-export default _xfindLast;
+export default function _xfindLast(f) {
+  return function(xf) { return new XFindLast(f, xf); };
+}

--- a/source/internal/_xfindLastIndex.js
+++ b/source/internal/_xfindLastIndex.js
@@ -1,4 +1,3 @@
-import _curry2 from './_curry2.js';
 import _xfBase from './_xfBase.js';
 
 
@@ -20,5 +19,6 @@ XFindLastIndex.prototype['@@transducer/step'] = function(result, input) {
   return result;
 };
 
-var _xfindLastIndex = _curry2(function _xfindLastIndex(f, xf) { return new XFindLastIndex(f, xf); });
-export default _xfindLastIndex;
+export default function _xfindLastIndex(f) {
+  return function(xf) { return new XFindLastIndex(f, xf); };
+}

--- a/source/internal/_xmap.js
+++ b/source/internal/_xmap.js
@@ -1,4 +1,3 @@
-import _curry2 from './_curry2.js';
 import _xfBase from './_xfBase.js';
 
 
@@ -12,5 +11,7 @@ XMap.prototype['@@transducer/step'] = function(result, input) {
   return this.xf['@@transducer/step'](result, this.f(input));
 };
 
-var _xmap = _curry2(function _xmap(f, xf) { return new XMap(f, xf); });
+var _xmap = function _xmap(f) {
+  return function(xf) { return new XMap(f, xf); };
+};
 export default _xmap;

--- a/source/internal/_xpromap.js
+++ b/source/internal/_xpromap.js
@@ -1,4 +1,3 @@
-import _curry3 from './_curry3.js';
 import _xfBase from './_xfBase.js';
 import _promap from './_promap.js';
 
@@ -14,5 +13,6 @@ XPromap.prototype['@@transducer/step'] = function(result, input) {
   return this.xf['@@transducer/step'](result, _promap(this.f, this.g, input));
 };
 
-var _xpromap = _curry3(function _xpromap(f, g, xf) { return new XPromap(f, g, xf); });
-export default _xpromap;
+export default function _xpromap(f, g) {
+  return function(xf) { return new XPromap(f, g, xf); };
+}

--- a/source/internal/_xreduceBy.js
+++ b/source/internal/_xreduceBy.js
@@ -1,4 +1,3 @@
-import _curryN from './_curryN.js';
 import _has from './_has.js';
 import _xfBase from './_xfBase.js';
 
@@ -32,9 +31,8 @@ XReduceBy.prototype['@@transducer/step'] = function(result, input) {
   return result;
 };
 
-var _xreduceBy = _curryN(4, [],
-  function _xreduceBy(valueFn, valueAcc, keyFn, xf) {
+export default function _xreduceBy(valueFn, valueAcc, keyFn) {
+  return function(xf) {
     return new XReduceBy(valueFn, valueAcc, keyFn, xf);
-  }
-);
-export default _xreduceBy;
+  };
+}

--- a/source/internal/_xtake.js
+++ b/source/internal/_xtake.js
@@ -1,4 +1,3 @@
-import _curry2 from './_curry2.js';
 import _reduced from './_reduced.js';
 import _xfBase from './_xfBase.js';
 
@@ -16,5 +15,6 @@ XTake.prototype['@@transducer/step'] = function(result, input) {
   return this.n >= 0 && this.i >= this.n ? _reduced(ret) : ret;
 };
 
-var _xtake = _curry2(function _xtake(n, xf) { return new XTake(n, xf); });
-export default _xtake;
+export default function _xtake(n) {
+  return function(xf) {return new XTake(n, xf); };
+}

--- a/source/internal/_xtakeWhile.js
+++ b/source/internal/_xtakeWhile.js
@@ -1,4 +1,3 @@
-import _curry2 from './_curry2.js';
 import _reduced from './_reduced.js';
 import _xfBase from './_xfBase.js';
 
@@ -13,5 +12,6 @@ XTakeWhile.prototype['@@transducer/step'] = function(result, input) {
   return this.f(input) ? this.xf['@@transducer/step'](result, input) : _reduced(result);
 };
 
-var _xtakeWhile = _curry2(function _xtakeWhile(f, xf) { return new XTakeWhile(f, xf); });
-export default _xtakeWhile;
+export default function _xtakeWhile(f) {
+  return function(xf) { return new XTakeWhile(f, xf); };
+}

--- a/source/internal/_xtap.js
+++ b/source/internal/_xtap.js
@@ -1,4 +1,3 @@
-import _curry2 from './_curry2.js';
 import _xfBase from './_xfBase.js';
 
 
@@ -13,5 +12,6 @@ XTap.prototype['@@transducer/step'] = function(result, input) {
   return this.xf['@@transducer/step'](result, input);
 };
 
-var _xtap = _curry2(function _xtap(f, xf) { return new XTap(f, xf); });
-export default _xtap;
+export default function _xtap(f) {
+  return function(xf) { return new XTap(f, xf); };
+}

--- a/source/internal/_xuniqBy.js
+++ b/source/internal/_xuniqBy.js
@@ -1,4 +1,3 @@
-import _curry2 from './_curry2.js';
 import _Set from './_Set.js';
 import _xfBase from './_xfBase.js';
 
@@ -14,5 +13,6 @@ XUniqBy.prototype['@@transducer/step'] = function(result, input) {
   return this.set.add(this.f(input)) ? this.xf['@@transducer/step'](result, input) : result;
 };
 
-var _xuniqBy = _curry2(function _xuniqBy(f, xf) { return new XUniqBy(f, xf); });
-export default _xuniqBy;
+export default function _xuniqBy(f) {
+  return function(xf) { return new XUniqBy(f, xf); };
+}

--- a/source/internal/_xuniqWith.js
+++ b/source/internal/_xuniqWith.js
@@ -1,4 +1,3 @@
-import _curry2 from './_curry2.js';
 import _includesWith from './_includesWith.js';
 import _xfBase from './_xfBase.js';
 
@@ -19,5 +18,6 @@ XUniqWith.prototype['@@transducer/step'] = function(result, input) {
   }
 };
 
-var _xuniqWith = _curry2(function _xuniqWith(pred, xf) { return new XUniqWith(pred, xf); });
-export default _xuniqWith;
+export default function _xuniqWith(pred) {
+  return function(xf) { return new XUniqWith(pred, xf); };
+}


### PR DESCRIPTION
From issue #3230 

Notice that now transducer creator functions just depend on  themselves after removing curryX functions. This could facilitate ramda modularity because now it's easier to create a library that works just with transducers without rely in other parts of the library.