### PR TITLE
bugfix: groupBy transducer functionality

### DIFF
--- a/source/groupBy.js
+++ b/source/groupBy.js
@@ -44,7 +44,10 @@ import reduceBy from './reduceBy.js';
  *      // }
  */
 var groupBy = _curry2(_checkForMethod('groupBy', reduceBy(function(acc, item) {
+  if (acc == null) {
+    acc = [];
+  }
   acc.push(item);
   return acc;
-}, [])));
+}, null)));
 export default groupBy;

--- a/test/groupBy.js
+++ b/test/groupBy.js
@@ -44,4 +44,12 @@ describe('groupBy', function() {
     eq(_isTransformer(R.groupBy(byType, xf)), true);
   });
 
+  it('works as a transducer without polluting state', function() {
+    eq(R.into([], R.groupBy(x => x.length), ['a', 'xyz', 'ab', 'xy', 'abc', 'x']), [
+      [1, ['a', 'x']],
+      [2, ['ab', 'xy']],
+      [3, ['xyz', 'abc']]
+    ]);
+    eq(R.groupBy(x => x.length, ['a', 'xyz', 'ab', 'xy', 'abc', 'x']), {1: ['a', 'x'], 2: ['ab', 'xy'], 3: ['xyz', 'abc']});
+  });
 });


### PR DESCRIPTION
Fixes #3232
Reverts code change in #9b5d8925

Setting an absent absent/nullish accumulator, rather than passing an empty on to `reduceBy,` appears to correct the cached copy behavior causing pollution in the accumulators on subsequent invocations, as well as the "passthrough" behavior dumping every value in every group; I believe this is due due the cached shallow-copying combined with the currying of `reduceBy`.

It may be more desirable to correct the copy caching to prevent the error while still deterministically setting the accumulator, but for what it's worth, it's at least in line with traditional transducer behavior to get the initial value from the transformer, albeit not *quite* this way!