### PR TITLE
fix(3245): fix R.dropLast with negative and zero param when used as transducer

### DIFF
--- a/source/internal/_xdropLast.js
+++ b/source/internal/_xdropLast.js
@@ -3,6 +3,9 @@ import _xfBase from './_xfBase.js';
 
 
 function XDropLast(n, xf) {
+  if (n <= 0) {
+    return xf;
+  }
   this.xf = xf;
   this.pos = 0;
   this.full = false;

--- a/test/dropLast.js
+++ b/test/dropLast.js
@@ -32,8 +32,10 @@ describe('dropLast', function() {
 
   it('can act as a transducer', function() {
     var dropLast2 = R.dropLast(2);
-    assert.deepEqual(R.into([], dropLast2, [1, 3, 5, 7, 9, 1, 2]), [1, 3, 5, 7, 9]);
-    assert.deepEqual(R.into([], dropLast2, [1]), []);
+    eq(R.into([], dropLast2, [1, 3, 5, 7, 9, 1, 2]), [1, 3, 5, 7, 9]);
+    eq(R.into([], dropLast2, [1]), []);
+    eq(R.into([], R.dropLast(0), [1, 3, 5]), [1, 3, 5]);
+    eq(R.into([], R.dropLast(-1), [1, 3, 5]), [1, 3, 5]);
   });
 
 });


### PR DESCRIPTION
It fixes #3245 