### PR TITLE
split _reduce to _xReduce(for transformers) & _reduce(for reducers)

### DIFF
--- a/source/filter.js
+++ b/source/filter.js
@@ -1,8 +1,8 @@
+import _arrayReduce from './internal/_arrayReduce.js';
 import _curry2 from './internal/_curry2.js';
 import _dispatchable from './internal/_dispatchable.js';
 import _filter from './internal/_filter.js';
 import _isObject from './internal/_isObject.js';
-import _reduce from './internal/_reduce.js';
 import _xfilter from './internal/_xfilter.js';
 import keys from './keys.js';
 
@@ -38,7 +38,7 @@ import keys from './keys.js';
 var filter = _curry2(_dispatchable(['fantasy-land/filter', 'filter'], _xfilter, function(pred, filterable) {
   return (
     _isObject(filterable) ?
-      _reduce(function(acc, key) {
+      _arrayReduce(function(acc, key) {
         if (pred(filterable[key])) {
           acc[key] = filterable[key];
         }

--- a/source/internal/_arrayReduce.js
+++ b/source/internal/_arrayReduce.js
@@ -1,0 +1,9 @@
+export default function _arrayReduce(reducer, acc, list) {
+  var index = 0;
+  var length = list.length;
+  while (index < length) {
+    acc = reducer(acc, list[index]);
+    index += 1;
+  }
+  return acc;
+}

--- a/source/internal/_createReduce.js
+++ b/source/internal/_createReduce.js
@@ -1,0 +1,29 @@
+import _isArrayLike from './_isArrayLike.js';
+
+
+var symIterator = (typeof Symbol !== 'undefined') ? Symbol.iterator : '@@iterator';
+
+export default function _createReduce(arrayReduce, methodReduce, iterableReduce) {
+  return function _reduce(xf, acc, list) {
+    if (_isArrayLike(list)) {
+      return arrayReduce(xf, acc, list);
+    }
+    if (list == null) {
+      return acc;
+    }
+    if (typeof list['fantasy-land/reduce'] === 'function') {
+      return methodReduce(xf, acc, list, 'fantasy-land/reduce');
+    }
+    if (list[symIterator] != null) {
+      return iterableReduce(xf, acc, list[symIterator]());
+    }
+    if (typeof list.next === 'function') {
+      return iterableReduce(xf, acc, list);
+    }
+    if (typeof list.reduce === 'function') {
+      return methodReduce(xf, acc, list, 'reduce');
+    }
+
+    throw new TypeError('reduce: list must be array or iterable');
+  };
+}

--- a/source/internal/_flatCat.js
+++ b/source/internal/_flatCat.js
@@ -1,6 +1,7 @@
 import _forceReduced from './_forceReduced.js';
 import _isArrayLike from './_isArrayLike.js';
-import _reduce from './_reduce.js';
+import _xArrayReduce from './_xArrayReduce.js';
+import _xReduce from './_xReduce.js';
 import _xfBase from './_xfBase.js';
 
 var preservingReduced = function(xf) {
@@ -24,7 +25,7 @@ var _flatCat = function _xcat(xf) {
       return rxf['@@transducer/result'](result);
     },
     '@@transducer/step': function(result, input) {
-      return !_isArrayLike(input) ? _reduce(rxf, result, [input]) : _reduce(rxf, result, input);
+      return !_isArrayLike(input) ? _xArrayReduce(rxf, result, [input]) : _xReduce(rxf, result, input);
     }
   };
 };

--- a/source/internal/_reduce.js
+++ b/source/internal/_reduce.js
@@ -1,63 +1,19 @@
-import _isArrayLike from './_isArrayLike.js';
-import _xwrap from './_xwrap.js';
-import bind from '../bind.js';
+import _arrayReduce from './_arrayReduce.js';
+import _createReduce from './_createReduce.js';
 
 
-function _arrayReduce(xf, acc, list) {
-  var idx = 0;
-  var len = list.length;
-  while (idx < len) {
-    acc = xf['@@transducer/step'](acc, list[idx]);
-    if (acc && acc['@@transducer/reduced']) {
-      acc = acc['@@transducer/value'];
-      break;
-    }
-    idx += 1;
-  }
-  return xf['@@transducer/result'](acc);
-}
-
-function _iterableReduce(xf, acc, iter) {
+function _iterableReduce(reducer, acc, iter) {
   var step = iter.next();
   while (!step.done) {
-    acc = xf['@@transducer/step'](acc, step.value);
-    if (acc && acc['@@transducer/reduced']) {
-      acc = acc['@@transducer/value'];
-      break;
-    }
+    acc = reducer(acc, step.value);
     step = iter.next();
   }
-  return xf['@@transducer/result'](acc);
+  return acc;
 }
 
-function _methodReduce(xf, acc, obj, methodName) {
-  return xf['@@transducer/result'](obj[methodName](bind(xf['@@transducer/step'], xf), acc));
+function _methodReduce(reducer, acc, obj, methodName) {
+  return obj[methodName](reducer, acc);
 }
 
-var symIterator = (typeof Symbol !== 'undefined') ? Symbol.iterator : '@@iterator';
-
-export default function _reduce(fn, acc, list) {
-  if (typeof fn === 'function') {
-    fn = _xwrap(fn);
-  }
-  if (_isArrayLike(list)) {
-    return _arrayReduce(fn, acc, list);
-  }
-  if (list == null) {
-    return acc;
-  }
-  if (typeof list['fantasy-land/reduce'] === 'function') {
-    return _methodReduce(fn, acc, list, 'fantasy-land/reduce');
-  }
-  if (list[symIterator] != null) {
-    return _iterableReduce(fn, acc, list[symIterator]());
-  }
-  if (typeof list.next === 'function') {
-    return _iterableReduce(fn, acc, list);
-  }
-  if (typeof list.reduce === 'function') {
-    return _methodReduce(fn, acc, list, 'reduce');
-  }
-
-  throw new TypeError('reduce: list must be array or iterable');
-}
+var _reduce = _createReduce(_arrayReduce, _methodReduce, _iterableReduce);
+export default _reduce;

--- a/source/internal/_xArrayReduce.js
+++ b/source/internal/_xArrayReduce.js
@@ -1,0 +1,13 @@
+export default function _xArrayReduce(xf, acc, list) {
+  var idx = 0;
+  var len = list.length;
+  while (idx < len) {
+    acc = xf['@@transducer/step'](acc, list[idx]);
+    if (acc && acc['@@transducer/reduced']) {
+      acc = acc['@@transducer/value'];
+      break;
+    }
+    idx += 1;
+  }
+  return xf['@@transducer/result'](acc);
+}

--- a/source/internal/_xReduce.js
+++ b/source/internal/_xReduce.js
@@ -1,0 +1,24 @@
+import _createReduce from './_createReduce.js';
+import _xArrayReduce from './_xArrayReduce.js';
+import bind from '../bind.js';
+
+
+function _xIterableReduce(xf, acc, iter) {
+  var step = iter.next();
+  while (!step.done) {
+    acc = xf['@@transducer/step'](acc, step.value);
+    if (acc && acc['@@transducer/reduced']) {
+      acc = acc['@@transducer/value'];
+      break;
+    }
+    step = iter.next();
+  }
+  return xf['@@transducer/result'](acc);
+}
+
+function _xMethodReduce(xf, acc, obj, methodName) {
+  return xf['@@transducer/result'](obj[methodName](bind(xf['@@transducer/step'], xf), acc));
+}
+
+var _xReduce = _createReduce(_xArrayReduce, _xMethodReduce, _xIterableReduce);
+export default _xReduce;

--- a/source/internal/_xdropLastWhile.js
+++ b/source/internal/_xdropLastWhile.js
@@ -1,6 +1,6 @@
 import _curry2 from './_curry2.js';
-import _reduce from './_reduce.js';
 import _xfBase from './_xfBase.js';
+import _xReduce from './_xReduce.js';
 
 
 function XDropLastWhile(fn, xf) {
@@ -19,8 +19,8 @@ XDropLastWhile.prototype['@@transducer/step'] = function(result, input) {
     : this.flush(result, input);
 };
 XDropLastWhile.prototype.flush = function(result, input) {
-  result = _reduce(
-    this.xf['@@transducer/step'],
+  result = _xReduce(
+    this.xf,
     result,
     this.retained
   );

--- a/source/into.js
+++ b/source/into.js
@@ -1,7 +1,7 @@
 import _clone from './internal/_clone.js';
 import _curry3 from './internal/_curry3.js';
 import _isTransformer from './internal/_isTransformer.js';
-import _reduce from './internal/_reduce.js';
+import _xReduce from './internal/_xReduce.js';
 import _stepCat from './internal/_stepCat.js';
 
 
@@ -46,7 +46,7 @@ import _stepCat from './internal/_stepCat.js';
  */
 var into = _curry3(function into(acc, xf, list) {
   return _isTransformer(acc)
-    ? _reduce(xf(acc), acc['@@transducer/init'](), list)
-    : _reduce(xf(_stepCat(acc)), _clone(acc, false), list);
+    ? _xReduce(xf(acc), acc['@@transducer/init'](), list)
+    : _xReduce(xf(_stepCat(acc)), _clone(acc, false), list);
 });
 export default into;

--- a/source/liftN.js
+++ b/source/liftN.js
@@ -1,5 +1,5 @@
 import _curry2 from './internal/_curry2.js';
-import _reduce from './internal/_reduce.js';
+import _arrayReduce from './internal/_arrayReduce.js';
 import ap from './ap.js';
 import curryN from './curryN.js';
 import map from './map.js';
@@ -25,7 +25,7 @@ import map from './map.js';
 var liftN = _curry2(function liftN(arity, fn) {
   var lifted = curryN(arity, fn);
   return curryN(arity, function() {
-    return _reduce(ap, map(lifted, arguments[0]), Array.prototype.slice.call(arguments, 1));
+    return _arrayReduce(ap, map(lifted, arguments[0]), Array.prototype.slice.call(arguments, 1));
   });
 });
 export default liftN;

--- a/source/map.js
+++ b/source/map.js
@@ -1,7 +1,7 @@
+import _arrayReduce from './internal/_arrayReduce.js';
 import _curry2 from './internal/_curry2.js';
 import _dispatchable from './internal/_dispatchable.js';
 import _map from './internal/_map.js';
-import _reduce from './internal/_reduce.js';
 import _xmap from './internal/_xmap.js';
 import curryN from './curryN.js';
 import keys from './keys.js';
@@ -49,7 +49,7 @@ var map = _curry2(_dispatchable(['fantasy-land/map', 'map'], _xmap, function map
         return fn.call(this, functor.apply(this, arguments));
       });
     case '[object Object]':
-      return _reduce(function(acc, key) {
+      return _arrayReduce(function(acc, key) {
         acc[key] = fn(functor[key]);
         return acc;
       }, {}, keys(functor));

--- a/source/mapObjIndexed.js
+++ b/source/mapObjIndexed.js
@@ -1,5 +1,5 @@
+import _arrayReduce from './internal/_arrayReduce.js';
 import _curry2 from './internal/_curry2.js';
-import _reduce from './internal/_reduce.js';
 import keys from './keys.js';
 
 
@@ -25,7 +25,7 @@ import keys from './keys.js';
  *      R.mapObjIndexed(prependKeyAndDouble, xyz); //=> { x: 'x2', y: 'y4', z: 'z6' }
  */
 var mapObjIndexed = _curry2(function mapObjIndexed(fn, obj) {
-  return _reduce(function(acc, key) {
+  return _arrayReduce(function(acc, key) {
     acc[key] = fn(obj[key], key, obj);
     return acc;
   }, {}, keys(obj));

--- a/source/reduce.js
+++ b/source/reduce.js
@@ -1,5 +1,6 @@
 import _curry3 from './internal/_curry3.js';
-import _reduce from './internal/_reduce.js';
+import _xReduce from './internal/_xReduce.js';
+import _xwrap from './internal/_xwrap.js';
 
 
 /**
@@ -54,5 +55,7 @@ import _reduce from './internal/_reduce.js';
  *
  * @symb R.reduce(f, a, [b, c, d]) = f(f(f(a, b), c), d)
  */
-var reduce = _curry3(_reduce);
+var reduce = _curry3(function(xf, acc, list) {
+  return _xReduce(typeof xf === 'function' ? _xwrap(xf) : xf, acc, list);
+});
 export default reduce;

--- a/source/reduceBy.js
+++ b/source/reduceBy.js
@@ -2,9 +2,10 @@ import _clone from './internal/_clone.js';
 import _curryN from './internal/_curryN.js';
 import _dispatchable from './internal/_dispatchable.js';
 import _has from './internal/_has.js';
-import _reduce from './internal/_reduce.js';
 import _reduced from './internal/_reduced.js';
+import _xReduce from './internal/_xReduce.js';
 import _xreduceBy from './internal/_xreduceBy.js';
+import _xwrap from './internal/_xwrap.js';
 
 
 /**
@@ -53,7 +54,7 @@ import _xreduceBy from './internal/_xreduceBy.js';
  */
 var reduceBy = _curryN(4, [], _dispatchable([], _xreduceBy,
   function reduceBy(valueFn, valueAcc, keyFn, list) {
-    return _reduce(function(acc, elt) {
+    var xf = _xwrap(function(acc, elt) {
       var key = keyFn(elt);
       var value = valueFn(_has(key, acc) ? acc[key] : _clone(valueAcc, false), elt);
 
@@ -63,6 +64,7 @@ var reduceBy = _curryN(4, [], _dispatchable([], _xreduceBy,
 
       acc[key] = value;
       return acc;
-    }, {}, list);
+    });
+    return _xReduce(xf, {}, list);
   }));
 export default reduceBy;

--- a/source/reduceWhile.js
+++ b/source/reduceWhile.js
@@ -1,5 +1,6 @@
 import _curryN from './internal/_curryN.js';
-import _reduce from './internal/_reduce.js';
+import _xReduce from './internal/_xReduce.js';
+import _xwrap from './internal/_xwrap.js';
 import _reduced from './internal/_reduced.js';
 
 
@@ -34,8 +35,9 @@ import _reduced from './internal/_reduced.js';
  *      R.reduceWhile(isOdd, R.add, 111, ys); //=> 111
  */
 var reduceWhile = _curryN(4, [], function _reduceWhile(pred, fn, a, list) {
-  return _reduce(function(acc, x) {
+  var xf = _xwrap(function(acc, x) {
     return pred(acc, x) ? fn(acc, x) : _reduced(acc);
-  }, a, list);
+  });
+  return _xReduce(xf, a, list);
 });
 export default reduceWhile;

--- a/source/transduce.js
+++ b/source/transduce.js
@@ -1,4 +1,4 @@
-import _reduce from './internal/_reduce.js';
+import _xReduce from './internal/_xReduce.js';
 import _xwrap from './internal/_xwrap.js';
 import curryN from './curryN.js';
 
@@ -51,6 +51,6 @@ import curryN from './curryN.js';
  *      R.transduce(firstOddTransducer, R.flip(R.append), [], R.range(0, 100)); //=> [1]
  */
 var transduce = curryN(4, function transduce(xf, fn, acc, list) {
-  return _reduce(xf(typeof fn === 'function' ? _xwrap(fn) : fn), acc, list);
+  return _xReduce(xf(typeof fn === 'function' ? _xwrap(fn) : fn), acc, list);
 });
 export default transduce;


### PR DESCRIPTION
Following the approach about what I said in #3247, I also extracted _arrayReduce and _xArrayReduce to be used in places where function are only working with array lists. In this way, we are not executing additional type checks in cases are not needed.
