### PR TITLE
feat(propIncludes): introduce propIncludes

### DIFF
--- a/source/index.js
+++ b/source/index.js
@@ -181,6 +181,7 @@ export { default as project } from './project.js';
 export { default as promap } from './promap.js';
 export { default as prop } from './prop.js';
 export { default as propEq } from './propEq.js';
+export { default as propIncludes } from './propIncludes.js';
 export { default as propIs } from './propIs.js';
 export { default as propOr } from './propOr.js';
 export { default as propSatisfies } from './propSatisfies.js';

--- a/source/propIncludes.js
+++ b/source/propIncludes.js
@@ -1,0 +1,33 @@
+import _curry3 from './internal/_curry3.js';
+import prop from './prop.js';
+import includes from './includes.js';
+
+
+/**
+ * Returns `true` if the specified object property is found in the list supplied,
+ * in [`R.includes`](#includes) terms; `false` otherwise.
+ *
+ * @func
+ * @memberOf R
+ * @category Relation
+ * @sig String -> [a] -> Object -> Boolean
+ * @param {String} name
+ * @param {Array} list
+ * @param {*} obj
+ * @return {Boolean}
+ * @see R.propEq, R.propSatisfies, R.includes
+ * @example
+ *
+ *      const kwabena = {name: 'Kwabena', country: "ghana"};
+ *      const naadei = {name: 'Naadei', country: "ghana"};
+ *      const bogdan = {name: 'Bogdan', country: "romania"};
+ *      const contributors = [kwabena, naadei, bogdan]
+ *
+ *      const africanCountries = ["ghana", "nigeria"];
+ *      const isFromAfrica = R.includes('country', africanCountries);
+ *      R.filter(isFromAfrica, contributors); //=> [kwabena, naadei]
+ */
+var propIncludes = _curry3(function propIncludes(name, list, obj) {
+  return includes(prop(name, obj), list);
+});
+export default propIncludes;

--- a/test/propIncludes.js
+++ b/test/propIncludes.js
@@ -1,0 +1,36 @@
+var R = require('../source/index.js');
+var eq = require('./shared/eq.js');
+
+
+describe('propIncludes', function() {
+
+  var kwabena = {name: 'Kwabena', country: 'ghana'};
+  var naadei = {name: 'Naadei', country: 'ghana'};
+  var bogdan = {name: 'Bogdan', country: 'romania'};
+
+  var africanCountries = ['ghana', 'nigeria'];
+  var europeanCountries = ['romania', 'ukraine'];
+
+  it('returns false if supplied name is falsy/invalid', function() {
+    eq(R.propIncludes(null, africanCountries, kwabena), false);
+    eq(R.propIncludes(undefined, africanCountries, kwabena), false);
+    eq(R.propIncludes('', africanCountries, kwabena), false);
+    eq(R.propIncludes('eyeColor', africanCountries, kwabena), false);
+  });
+
+  it('returns false if supplied list is empty', function() {
+    eq(R.propIncludes('country', [], kwabena), false);
+  });
+
+  it('determines whether a particular property is included in the supplied list for a specific object', function() {
+    eq(R.propIncludes('country')(africanCountries)(kwabena), true);
+    eq(R.propIncludes('country', africanCountries)(kwabena), true);
+    eq(R.propIncludes('country', africanCountries, kwabena), true);
+
+    eq(R.propIncludes('country', africanCountries, naadei), true);
+    eq(R.propIncludes('country', africanCountries, bogdan), false);
+
+    eq(R.propIncludes('country', europeanCountries, bogdan), true);
+    eq(R.propIncludes('country', europeanCountries, kwabena), false);
+  });
+});


### PR DESCRIPTION
Add a relation function `(propIncludes)` that can be used to determine whether an object has a property which is found in a list.

This is the `includes` version of [propEq](https://ramdajs.com/docs/#propEq)

```
// Before
pipe(filter(  (product) => includes(product?.id, productIds))  )



// After
pipe(filter(  propIncludes("id", productIds ))  )
```