### PR TITLE
update package.json exports section to support node version 10 to 17

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,9 @@
       "import": "./es/index.js",
       "default": "./src/index.js"
     },
+    "./es/*": "./es/*.js",
+    "./src/*": "./src/*.js",
+    "./dist/*": "./dist/*.js",
     "./es/": "./es/",
     "./src/": "./src/",
     "./dist/": "./dist/"


### PR DESCRIPTION
- npm test passes using node 17 as well as node 10
- no error thrown on importing files using node 17

Fixes (#3236)