### PR TITLE
extract Just related duplicated code

### DIFF
--- a/test/difference.js
+++ b/test/difference.js
@@ -1,6 +1,6 @@
 var R = require('../source/index.js');
 var eq = require('./shared/eq.js');
-var Maybe = require('./shared/Maybe.js');
+var {Just} = require('./shared/Maybe.js');
 
 
 describe('difference', function() {
@@ -22,7 +22,7 @@ describe('difference', function() {
     eq(R.difference([0], [-0]).length, 1);
     eq(R.difference([-0], [0]).length, 1);
     eq(R.difference([NaN], [NaN]).length, 0);
-    eq(R.difference([new Maybe.Just([42])], [new Maybe.Just([42])]).length, 0);
+    eq(R.difference([new Just([42])], [new Just([42])]).length, 0);
   });
 
   it('works for arrays of different lengths', function() {

--- a/test/difference.js
+++ b/test/difference.js
@@ -1,5 +1,6 @@
 var R = require('../source/index.js');
 var eq = require('./shared/eq.js');
+var Maybe = require('./shared/Maybe.js');
 
 
 describe('difference', function() {
@@ -18,15 +19,10 @@ describe('difference', function() {
   });
 
   it('has R.equals semantics', function() {
-    function Just(x) { this.value = x; }
-    Just.prototype.equals = function(x) {
-      return x instanceof Just && R.equals(x.value, this.value);
-    };
-
     eq(R.difference([0], [-0]).length, 1);
     eq(R.difference([-0], [0]).length, 1);
     eq(R.difference([NaN], [NaN]).length, 0);
-    eq(R.difference([new Just([42])], [new Just([42])]).length, 0);
+    eq(R.difference([new Maybe.Just([42])], [new Maybe.Just([42])]).length, 0);
   });
 
   it('works for arrays of different lengths', function() {

--- a/test/dropRepeats.js
+++ b/test/dropRepeats.js
@@ -1,5 +1,6 @@
 var R = require('../source/index.js');
 var eq = require('./shared/eq.js');
+var Maybe = require('./shared/Maybe.js');
 
 
 describe('dropRepeats', function() {
@@ -21,15 +22,10 @@ describe('dropRepeats', function() {
   });
 
   it('has R.equals semantics', function() {
-    function Just(x) { this.value = x; }
-    Just.prototype.equals = function(x) {
-      return x instanceof Just && R.equals(x.value, this.value);
-    };
-
     eq(R.dropRepeats([0, -0]).length, 2);
     eq(R.dropRepeats([-0, 0]).length, 2);
     eq(R.dropRepeats([NaN, NaN]).length, 1);
-    eq(R.dropRepeats([new Just([42]), new Just([42])]).length, 1);
+    eq(R.dropRepeats([new Maybe.Just([42]), new Maybe.Just([42])]).length, 1);
   });
 
 });

--- a/test/dropRepeats.js
+++ b/test/dropRepeats.js
@@ -1,6 +1,6 @@
 var R = require('../source/index.js');
 var eq = require('./shared/eq.js');
-var Maybe = require('./shared/Maybe.js');
+var {Just} = require('./shared/Maybe.js');
 
 
 describe('dropRepeats', function() {
@@ -25,7 +25,7 @@ describe('dropRepeats', function() {
     eq(R.dropRepeats([0, -0]).length, 2);
     eq(R.dropRepeats([-0, 0]).length, 2);
     eq(R.dropRepeats([NaN, NaN]).length, 1);
-    eq(R.dropRepeats([new Maybe.Just([42]), new Maybe.Just([42])]).length, 1);
+    eq(R.dropRepeats([new Just([42]), new Just([42])]).length, 1);
   });
 
 });

--- a/test/eqBy.js
+++ b/test/eqBy.js
@@ -1,6 +1,6 @@
 var R = require('../source/index.js');
 var eq = require('./shared/eq.js');
-var Maybe = require('./shared/Maybe.js');
+var {Just} = require('./shared/Maybe.js');
 
 
 describe('eqBy', function() {
@@ -17,7 +17,7 @@ describe('eqBy', function() {
     eq(R.eqBy(R.identity, 0, -0), false);
     eq(R.eqBy(R.identity, -0, 0), false);
     eq(R.eqBy(R.identity, NaN, NaN), true);
-    eq(R.eqBy(R.identity, new Maybe.Just([42]), new Maybe.Just([42])), true);
+    eq(R.eqBy(R.identity, new Just([42]), new Just([42])), true);
   });
 
 });

--- a/test/eqBy.js
+++ b/test/eqBy.js
@@ -1,5 +1,6 @@
 var R = require('../source/index.js');
 var eq = require('./shared/eq.js');
+var Maybe = require('./shared/Maybe.js');
 
 
 describe('eqBy', function() {
@@ -13,15 +14,10 @@ describe('eqBy', function() {
   });
 
   it('has R.equals semantics', function() {
-    function Just(x) { this.value = x; }
-    Just.prototype.equals = function(x) {
-      return x instanceof Just && R.equals(x.value, this.value);
-    };
-
     eq(R.eqBy(R.identity, 0, -0), false);
     eq(R.eqBy(R.identity, -0, 0), false);
     eq(R.eqBy(R.identity, NaN, NaN), true);
-    eq(R.eqBy(R.identity, new Just([42]), new Just([42])), true);
+    eq(R.eqBy(R.identity, new Maybe.Just([42]), new Maybe.Just([42])), true);
   });
 
 });

--- a/test/eqProps.js
+++ b/test/eqProps.js
@@ -1,6 +1,6 @@
 var R = require('../source/index.js');
 var eq = require('./shared/eq.js');
-var Maybe = require('./shared/Maybe.js');
+var {Just} = require('./shared/Maybe.js');
 
 
 describe('eqProps', function() {
@@ -13,7 +13,7 @@ describe('eqProps', function() {
     eq(R.eqProps('value', {value: 0}, {value: -0}), false);
     eq(R.eqProps('value', {value: -0}, {value: 0}), false);
     eq(R.eqProps('value', {value: NaN}, {value: NaN}), true);
-    eq(R.eqProps('value', {value: new Maybe.Just([42])}, {value: new Maybe.Just([42])}), true);
+    eq(R.eqProps('value', {value: new Just([42])}, {value: new Just([42])}), true);
   });
 
 });

--- a/test/eqProps.js
+++ b/test/eqProps.js
@@ -1,5 +1,6 @@
 var R = require('../source/index.js');
 var eq = require('./shared/eq.js');
+var Maybe = require('./shared/Maybe.js');
 
 
 describe('eqProps', function() {
@@ -9,15 +10,10 @@ describe('eqProps', function() {
   });
 
   it('has R.equals semantics', function() {
-    function Just(x) { this.value = x; }
-    Just.prototype.equals = function(x) {
-      return x instanceof Just && R.equals(x.value, this.value);
-    };
-
     eq(R.eqProps('value', {value: 0}, {value: -0}), false);
     eq(R.eqProps('value', {value: -0}, {value: 0}), false);
     eq(R.eqProps('value', {value: NaN}, {value: NaN}), true);
-    eq(R.eqProps('value', {value: new Just([42])}, {value: new Just([42])}), true);
+    eq(R.eqProps('value', {value: new Maybe.Just([42])}, {value: new Maybe.Just([42])}), true);
   });
 
 });

--- a/test/filter.js
+++ b/test/filter.js
@@ -1,6 +1,6 @@
 var R = require('../source/index.js');
 var eq = require('./shared/eq.js');
-var Maybe = require('./shared/Maybe.js');
+var {Just} = require('./shared/Maybe.js');
 
 
 describe('filter', function() {
@@ -33,7 +33,7 @@ describe('filter', function() {
   });
 
   it('correctly uses fantasy-land implementations', function() {
-    var m1 = Maybe.Just(-1);
+    var m1 = Just(-1);
     var m2 = R.filter(function(x) { return x > 0; } , m1);
 
     eq(m2.isNothing, true);

--- a/test/includes.js
+++ b/test/includes.js
@@ -1,5 +1,6 @@
 var R = require('../source/index.js');
 var eq = require('./shared/eq.js');
+var Maybe = require('./shared/Maybe.js');
 
 
 describe('includes', function() {
@@ -16,15 +17,10 @@ describe('includes', function() {
   });
 
   it('has R.equals semantics', function() {
-    function Just(x) { this.value = x; }
-    Just.prototype.equals = function(x) {
-      return x instanceof Just && R.equals(x.value, this.value);
-    };
-
     eq(R.includes(0, [-0]), false);
     eq(R.includes(-0, [0]), false);
     eq(R.includes(NaN, [NaN]), true);
-    eq(R.includes(new Just([42]), [new Just([42])]), true);
+    eq(R.includes(new Maybe.Just([42]), [new Maybe.Just([42])]), true);
   });
 
   it('returns true if substring is part of string', function() {

--- a/test/includes.js
+++ b/test/includes.js
@@ -1,6 +1,6 @@
 var R = require('../source/index.js');
 var eq = require('./shared/eq.js');
-var Maybe = require('./shared/Maybe.js');
+var {Just} = require('./shared/Maybe.js');
 
 
 describe('includes', function() {
@@ -20,7 +20,7 @@ describe('includes', function() {
     eq(R.includes(0, [-0]), false);
     eq(R.includes(-0, [0]), false);
     eq(R.includes(NaN, [NaN]), true);
-    eq(R.includes(new Maybe.Just([42]), [new Maybe.Just([42])]), true);
+    eq(R.includes(new Just([42]), [new Just([42])]), true);
   });
 
   it('returns true if substring is part of string', function() {

--- a/test/indexOf.js
+++ b/test/indexOf.js
@@ -1,6 +1,6 @@
 var R = require('../source/index.js');
 var eq = require('./shared/eq.js');
-var Maybe = require('./shared/Maybe.js');
+var {Just} = require('./shared/Maybe.js');
 
 
 describe('indexOf', function() {
@@ -50,7 +50,7 @@ describe('indexOf', function() {
     eq(R.indexOf(0, [-0]), -1);
     eq(R.indexOf(-0, [0]), -1);
     eq(R.indexOf(NaN, [NaN]), 0);
-    eq(R.indexOf(new Maybe.Just([42]), [new Maybe.Just([42])]), 0);
+    eq(R.indexOf(new Just([42]), [new Just([42])]), 0);
   });
 
   it('dispatches to `indexOf` method', function() {

--- a/test/indexOf.js
+++ b/test/indexOf.js
@@ -1,5 +1,6 @@
 var R = require('../source/index.js');
 var eq = require('./shared/eq.js');
+var Maybe = require('./shared/Maybe.js');
 
 
 describe('indexOf', function() {
@@ -46,15 +47,10 @@ describe('indexOf', function() {
   });
 
   it('has R.equals semantics', function() {
-    function Just(x) { this.value = x; }
-    Just.prototype.equals = function(x) {
-      return x instanceof Just && R.equals(x.value, this.value);
-    };
-
     eq(R.indexOf(0, [-0]), -1);
     eq(R.indexOf(-0, [0]), -1);
     eq(R.indexOf(NaN, [NaN]), 0);
-    eq(R.indexOf(new Just([42]), [new Just([42])]), 0);
+    eq(R.indexOf(new Maybe.Just([42]), [new Maybe.Just([42])]), 0);
   });
 
   it('dispatches to `indexOf` method', function() {

--- a/test/intersection.js
+++ b/test/intersection.js
@@ -1,6 +1,6 @@
 var R = require('../source/index.js');
 var eq = require('./shared/eq.js');
-var Maybe = require('./shared/Maybe.js');
+var {Just} = require('./shared/Maybe.js');
 
 
 describe('intersection', function() {
@@ -28,7 +28,7 @@ describe('intersection', function() {
     eq(R.intersection([0], [-0]).length, 0);
     eq(R.intersection([-0], [0]).length, 0);
     eq(R.intersection([NaN], [NaN]).length, 1);
-    eq(R.intersection([new Maybe.Just([42])], [new Maybe.Just([42])]).length, 1);
+    eq(R.intersection([new Just([42])], [new Just([42])]).length, 1);
   });
 
 });

--- a/test/intersection.js
+++ b/test/intersection.js
@@ -1,5 +1,6 @@
 var R = require('../source/index.js');
 var eq = require('./shared/eq.js');
+var Maybe = require('./shared/Maybe.js');
 
 
 describe('intersection', function() {
@@ -24,15 +25,10 @@ describe('intersection', function() {
   });
 
   it('has R.equals semantics', function() {
-    function Just(x) { this.value = x; }
-    Just.prototype.equals = function(x) {
-      return x instanceof Just && R.equals(x.value, this.value);
-    };
-
     eq(R.intersection([0], [-0]).length, 0);
     eq(R.intersection([-0], [0]).length, 0);
     eq(R.intersection([NaN], [NaN]).length, 1);
-    eq(R.intersection([new Just([42])], [new Just([42])]).length, 1);
+    eq(R.intersection([new Maybe.Just([42])], [new Maybe.Just([42])]).length, 1);
   });
 
 });

--- a/test/lastIndexOf.js
+++ b/test/lastIndexOf.js
@@ -1,5 +1,6 @@
 var R = require('../source/index.js');
 var eq = require('./shared/eq.js');
+var Maybe = require('./shared/Maybe.js');
 
 
 describe('lastIndexOf', function() {
@@ -37,15 +38,10 @@ describe('lastIndexOf', function() {
   });
 
   it('has R.equals semantics', function() {
-    function Just(x) { this.value = x; }
-    Just.prototype.equals = function(x) {
-      return x instanceof Just && R.equals(x.value, this.value);
-    };
-
     eq(R.lastIndexOf(0, [-0]), -1);
     eq(R.lastIndexOf(-0, [0]), -1);
     eq(R.lastIndexOf(NaN, [NaN]), 0);
-    eq(R.lastIndexOf(new Just([42]), [new Just([42])]), 0);
+    eq(R.lastIndexOf(new Maybe.Just([42]), [new Maybe.Just([42])]), 0);
   });
 
   it('dispatches to `lastIndexOf` method', function() {

--- a/test/lastIndexOf.js
+++ b/test/lastIndexOf.js
@@ -1,6 +1,6 @@
 var R = require('../source/index.js');
 var eq = require('./shared/eq.js');
-var Maybe = require('./shared/Maybe.js');
+var {Just} = require('./shared/Maybe.js');
 
 
 describe('lastIndexOf', function() {
@@ -41,7 +41,7 @@ describe('lastIndexOf', function() {
     eq(R.lastIndexOf(0, [-0]), -1);
     eq(R.lastIndexOf(-0, [0]), -1);
     eq(R.lastIndexOf(NaN, [NaN]), 0);
-    eq(R.lastIndexOf(new Maybe.Just([42]), [new Maybe.Just([42])]), 0);
+    eq(R.lastIndexOf(new Just([42]), [new Just([42])]), 0);
   });
 
   it('dispatches to `lastIndexOf` method', function() {

--- a/test/lift.js
+++ b/test/lift.js
@@ -1,7 +1,7 @@
 
 var R = require('../source/index.js');
 var eq = require('./shared/eq.js');
-var Maybe = require('./shared/Maybe.js');
+var {Just} = require('./shared/Maybe.js');
 
 var not = function(x) { return !x; };
 var add3 = R.curry(function add3(a, b, c) {
@@ -40,7 +40,7 @@ describe('lift', function() {
 
   it('works with other functors such as "Maybe"', function() {
     var addM = R.lift(R.add);
-    eq(addM(Maybe.Just(3), Maybe.Just(5)), Maybe.Just(8));
+    eq(addM(Just(3), Just(5)), Just(8));
   });
 
 });

--- a/test/liftN.js
+++ b/test/liftN.js
@@ -1,7 +1,7 @@
 
 var R = require('../source/index.js');
 var eq = require('./shared/eq.js');
-var Maybe = require('./shared/Maybe.js');
+var {Just} = require('./shared/Maybe.js');
 
 
 var addN = function() {
@@ -34,7 +34,7 @@ describe('liftN', function() {
 
   it('works with other functors such as "Maybe"', function() {
     var addM = R.liftN(2, R.add);
-    eq(addM(Maybe.Just(3), Maybe.Just(5)), Maybe.Just(8));
+    eq(addM(Just(3), Just(5)), Just(8));
   });
 
   it('interprets [a] as a functor', function() {

--- a/test/pathEq.js
+++ b/test/pathEq.js
@@ -1,5 +1,6 @@
 var R = require('../source/index.js');
 var eq = require('./shared/eq.js');
+var Maybe = require('./shared/Maybe.js');
 
 
 describe('pathEq', function() {
@@ -34,15 +35,10 @@ describe('pathEq', function() {
   });
 
   it('has R.equals semantics', function() {
-    function Just(x) { this.value = x; }
-    Just.prototype.equals = function(x) {
-      return x instanceof Just && R.equals(x.value, this.value);
-    };
-
     eq(R.pathEq(0, ['value'], {value: -0}), false);
     eq(R.pathEq(-0, ['value'], {value: 0}), false);
     eq(R.pathEq(NaN, ['value'], {value: NaN}), true);
-    eq(R.pathEq(new Just([42]), ['value'], {value: new Just([42])}), true);
+    eq(R.pathEq(new Maybe.Just([42]), ['value'], {value: new Maybe.Just([42])}), true);
   });
 
 });

--- a/test/pathEq.js
+++ b/test/pathEq.js
@@ -1,6 +1,6 @@
 var R = require('../source/index.js');
 var eq = require('./shared/eq.js');
-var Maybe = require('./shared/Maybe.js');
+var {Just} = require('./shared/Maybe.js');
 
 
 describe('pathEq', function() {
@@ -38,7 +38,7 @@ describe('pathEq', function() {
     eq(R.pathEq(0, ['value'], {value: -0}), false);
     eq(R.pathEq(-0, ['value'], {value: 0}), false);
     eq(R.pathEq(NaN, ['value'], {value: NaN}), true);
-    eq(R.pathEq(new Maybe.Just([42]), ['value'], {value: new Maybe.Just([42])}), true);
+    eq(R.pathEq(new Just([42]), ['value'], {value: new Just([42])}), true);
   });
 
 });

--- a/test/propEq.js
+++ b/test/propEq.js
@@ -1,5 +1,6 @@
 var R = require('../source/index.js');
 var eq = require('./shared/eq.js');
+var Maybe = require('./shared/Maybe.js');
 
 
 describe('propEq', function() {
@@ -22,15 +23,10 @@ describe('propEq', function() {
   });
 
   it('has R.equals semantics', function() {
-    function Just(x) { this.value = x; }
-    Just.prototype.equals = function(x) {
-      return x instanceof Just && R.equals(x.value, this.value);
-    };
-
     eq(R.propEq(0, 'value', {value: -0}), false);
     eq(R.propEq(-0, 'value', {value: 0}), false);
     eq(R.propEq(NaN, 'value', {value: NaN}), true);
-    eq(R.propEq(new Just([42]), 'value', {value: new Just([42])}), true);
+    eq(R.propEq(new Maybe.Just([42]), 'value', {value: new Maybe.Just([42])}), true);
   });
 
   it('returns false if called with a null or undefined object', function() {

--- a/test/propEq.js
+++ b/test/propEq.js
@@ -1,6 +1,6 @@
 var R = require('../source/index.js');
 var eq = require('./shared/eq.js');
-var Maybe = require('./shared/Maybe.js');
+var {Just} = require('./shared/Maybe.js');
 
 
 describe('propEq', function() {
@@ -26,7 +26,7 @@ describe('propEq', function() {
     eq(R.propEq(0, 'value', {value: -0}), false);
     eq(R.propEq(-0, 'value', {value: 0}), false);
     eq(R.propEq(NaN, 'value', {value: NaN}), true);
-    eq(R.propEq(new Maybe.Just([42]), 'value', {value: new Maybe.Just([42])}), true);
+    eq(R.propEq(new Just([42]), 'value', {value: new Just([42])}), true);
   });
 
   it('returns false if called with a null or undefined object', function() {

--- a/test/reject.js
+++ b/test/reject.js
@@ -1,5 +1,6 @@
 var R = require('../source/index.js');
 var eq = require('./shared/eq.js');
+var Maybe = require('./shared/Maybe.js');
 
 
 describe('reject', function() {
@@ -26,21 +27,10 @@ describe('reject', function() {
   });
 
   it('dispatches to `filter` method', function() {
-    function Nothing() {}
-    Nothing.value = new Nothing();
-    Nothing.prototype.filter = function() {
-      return this;
-    };
-
-    function Just(x) { this.value = x; }
-    Just.prototype.filter = function(pred) {
-      return pred(this.value) ? this : Nothing.value;
-    };
-
-    var m = new Just(42);
+    var m = new Maybe.Just(42);
     eq(R.filter(R.T, m), m);
-    eq(R.filter(R.F, m), Nothing.value);
-    eq(R.reject(R.T, m), Nothing.value);
+    eq(R.filter(R.F, m), Maybe.Nothing);
+    eq(R.reject(R.T, m), Maybe.Nothing);
     eq(R.reject(R.F, m), m);
   });
 

--- a/test/reject.js
+++ b/test/reject.js
@@ -1,6 +1,6 @@
 var R = require('../source/index.js');
 var eq = require('./shared/eq.js');
-var Maybe = require('./shared/Maybe.js');
+var {Just, Nothing} = require('./shared/Maybe.js');
 
 
 describe('reject', function() {
@@ -27,10 +27,10 @@ describe('reject', function() {
   });
 
   it('dispatches to `filter` method', function() {
-    var m = new Maybe.Just(42);
+    var m = new Just(42);
     eq(R.filter(R.T, m), m);
-    eq(R.filter(R.F, m), Maybe.Nothing);
-    eq(R.reject(R.T, m), Maybe.Nothing);
+    eq(R.filter(R.F, m), Nothing);
+    eq(R.reject(R.T, m), Nothing);
     eq(R.reject(R.F, m), m);
   });
 

--- a/test/symmetricDifference.js
+++ b/test/symmetricDifference.js
@@ -1,6 +1,7 @@
 var R = require('../source/index.js');
 var eq = require('./shared/eq.js');
 var fc = require('fast-check');
+var Maybe = require('./shared/Maybe.js');
 
 
 describe('symmetricDifference', function() {
@@ -20,15 +21,10 @@ describe('symmetricDifference', function() {
   });
 
   it('has R.equals semantics', function() {
-    function Just(x) { this.value = x; }
-    Just.prototype.equals = function(x) {
-      return x instanceof Just && R.equals(x.value, this.value);
-    };
-
     eq(R.symmetricDifference([0], [-0]).length, 2);
     eq(R.symmetricDifference([-0], [0]).length, 2);
     eq(R.symmetricDifference([NaN], [NaN]).length, 0);
-    eq(R.symmetricDifference([new Just([42])], [new Just([42])]).length, 0);
+    eq(R.symmetricDifference([new Maybe.Just([42])], [new Maybe.Just([42])]).length, 0);
   });
 
   it('works for arrays of different lengths', function() {

--- a/test/symmetricDifference.js
+++ b/test/symmetricDifference.js
@@ -1,7 +1,7 @@
 var R = require('../source/index.js');
 var eq = require('./shared/eq.js');
 var fc = require('fast-check');
-var Maybe = require('./shared/Maybe.js');
+var {Just} = require('./shared/Maybe.js');
 
 
 describe('symmetricDifference', function() {
@@ -24,7 +24,7 @@ describe('symmetricDifference', function() {
     eq(R.symmetricDifference([0], [-0]).length, 2);
     eq(R.symmetricDifference([-0], [0]).length, 2);
     eq(R.symmetricDifference([NaN], [NaN]).length, 0);
-    eq(R.symmetricDifference([new Maybe.Just([42])], [new Maybe.Just([42])]).length, 0);
+    eq(R.symmetricDifference([new Just([42])], [new Just([42])]).length, 0);
   });
 
   it('works for arrays of different lengths', function() {

--- a/test/toString.js
+++ b/test/toString.js
@@ -1,7 +1,7 @@
 var assert = require('assert');
 
 var R = require('../source/index.js');
-var Maybe = require('./shared/Maybe.js');
+var {Just} = require('./shared/Maybe.js');
 
 
 describe('toString', function() {
@@ -149,9 +149,9 @@ describe('toString', function() {
     };
     assert.strictEqual(R.toString(new Point(1, 2)), 'new Point(1, 2)');
 
-    assert.strictEqual(R.toString(Maybe.Just(42)), 'Just(42)');
-    assert.strictEqual(R.toString(Maybe.Just([1, 2, 3])), 'Just([1, 2, 3])');
-    assert.strictEqual(R.toString(Maybe.Just(Maybe.Just(Maybe.Just('')))), 'Just(Just(Just("")))');
+    assert.strictEqual(R.toString(Just(42)), 'Just(42)');
+    assert.strictEqual(R.toString(Just([1, 2, 3])), 'Just([1, 2, 3])');
+    assert.strictEqual(R.toString(Just(Just(Just('')))), 'Just(Just(Just("")))');
 
     assert.strictEqual(R.toString({toString: R.always('x')}), 'x');
   });

--- a/test/toString.js
+++ b/test/toString.js
@@ -1,6 +1,7 @@
 var assert = require('assert');
 
 var R = require('../source/index.js');
+var Maybe = require('./shared/Maybe.js');
 
 
 describe('toString', function() {
@@ -148,18 +149,9 @@ describe('toString', function() {
     };
     assert.strictEqual(R.toString(new Point(1, 2)), 'new Point(1, 2)');
 
-    function Just(x) {
-      if (!(this instanceof Just)) {
-        return new Just(x);
-      }
-      this.value = x;
-    }
-    Just.prototype.toString = function() {
-      return 'Just(' + R.toString(this.value) + ')';
-    };
-    assert.strictEqual(R.toString(Just(42)), 'Just(42)');
-    assert.strictEqual(R.toString(Just([1, 2, 3])), 'Just([1, 2, 3])');
-    assert.strictEqual(R.toString(Just(Just(Just('')))), 'Just(Just(Just("")))');
+    assert.strictEqual(R.toString(Maybe.Just(42)), 'Just(42)');
+    assert.strictEqual(R.toString(Maybe.Just([1, 2, 3])), 'Just([1, 2, 3])');
+    assert.strictEqual(R.toString(Maybe.Just(Maybe.Just(Maybe.Just('')))), 'Just(Just(Just("")))');
 
     assert.strictEqual(R.toString({toString: R.always('x')}), 'x');
   });

--- a/test/union.js
+++ b/test/union.js
@@ -1,5 +1,6 @@
 var R = require('../source/index.js');
 var eq = require('./shared/eq.js');
+var Maybe = require('./shared/Maybe.js');
 
 
 describe('union', function() {
@@ -10,15 +11,10 @@ describe('union', function() {
   });
 
   it('has R.equals semantics', function() {
-    function Just(x) { this.value = x; }
-    Just.prototype.equals = function(x) {
-      return x instanceof Just && R.equals(x.value, this.value);
-    };
-
     eq(R.union([0], [-0]).length, 2);
     eq(R.union([-0], [0]).length, 2);
     eq(R.union([NaN], [NaN]).length, 1);
-    eq(R.union([new Just([42])], [new Just([42])]).length, 1);
+    eq(R.union([new Maybe.Just([42])], [new Maybe.Just([42])]).length, 1);
   });
 
 });

--- a/test/union.js
+++ b/test/union.js
@@ -1,6 +1,6 @@
 var R = require('../source/index.js');
 var eq = require('./shared/eq.js');
-var Maybe = require('./shared/Maybe.js');
+var {Just} = require('./shared/Maybe.js');
 
 
 describe('union', function() {
@@ -14,7 +14,7 @@ describe('union', function() {
     eq(R.union([0], [-0]).length, 2);
     eq(R.union([-0], [0]).length, 2);
     eq(R.union([NaN], [NaN]).length, 1);
-    eq(R.union([new Maybe.Just([42])], [new Maybe.Just([42])]).length, 1);
+    eq(R.union([new Just([42])], [new Just([42])]).length, 1);
   });
 
 });

--- a/test/uniq.js
+++ b/test/uniq.js
@@ -1,6 +1,6 @@
 var R = require('../source/index.js');
 var eq = require('./shared/eq.js');
-var Maybe = require('./shared/Maybe.js');
+var {Just} = require('./shared/Maybe.js');
 
 
 describe('uniq', function() {
@@ -22,7 +22,7 @@ describe('uniq', function() {
     eq(R.uniq([0, -0]).length, 2);
     eq(R.uniq([NaN, NaN]).length, 1);
     eq(R.uniq([[1], [1]]).length, 1);
-    eq(R.uniq([new Maybe.Just([42]), new Maybe.Just([42])]).length, 1);
+    eq(R.uniq([new Just([42]), new Just([42])]).length, 1);
   });
 
   it('handles null and undefined elements', function() {

--- a/test/uniq.js
+++ b/test/uniq.js
@@ -1,5 +1,6 @@
 var R = require('../source/index.js');
 var eq = require('./shared/eq.js');
+var Maybe = require('./shared/Maybe.js');
 
 
 describe('uniq', function() {
@@ -17,16 +18,11 @@ describe('uniq', function() {
   });
 
   it('has R.equals semantics', function() {
-    function Just(x) { this.value = x; }
-    Just.prototype.equals = function(x) {
-      return x instanceof Just && R.equals(x.value, this.value);
-    };
-
     eq(R.uniq([-0, -0]).length, 1);
     eq(R.uniq([0, -0]).length, 2);
     eq(R.uniq([NaN, NaN]).length, 1);
     eq(R.uniq([[1], [1]]).length, 1);
-    eq(R.uniq([new Just([42]), new Just([42])]).length, 1);
+    eq(R.uniq([new Maybe.Just([42]), new Maybe.Just([42])]).length, 1);
   });
 
   it('handles null and undefined elements', function() {

--- a/test/uniqBy.js
+++ b/test/uniqBy.js
@@ -1,5 +1,6 @@
 var R = require('../source/index.js');
 var eq = require('./shared/eq.js');
+var Maybe = require('./shared/Maybe.js');
 
 
 describe('uniqBy', function() {
@@ -17,15 +18,9 @@ describe('uniqBy', function() {
   });
 
   it('has R.equals semantics', function() {
-    function Just(x) {
-      this.value = x;
-    }
-    Just.prototype.equals = function(x) {
-      return x instanceof Just && R.equals(x.value, this.value);
-    };
     eq(R.uniqBy(R.identity, [-0, 0]).length, 2);
     eq(R.uniqBy(R.identity, [NaN, NaN]).length, 1);
-    eq(R.uniqBy(R.identity, [new Just([1, 2, 3]), new Just([1, 2, 3])]).length, 1);
+    eq(R.uniqBy(R.identity, [new  Maybe.Just([1, 2, 3]), new Maybe.Just([1, 2, 3])]).length, 1);
   });
 
   it('can act as a transducer', function() {

--- a/test/uniqBy.js
+++ b/test/uniqBy.js
@@ -1,6 +1,6 @@
 var R = require('../source/index.js');
 var eq = require('./shared/eq.js');
-var Maybe = require('./shared/Maybe.js');
+var {Just} = require('./shared/Maybe.js');
 
 
 describe('uniqBy', function() {
@@ -20,7 +20,7 @@ describe('uniqBy', function() {
   it('has R.equals semantics', function() {
     eq(R.uniqBy(R.identity, [-0, 0]).length, 2);
     eq(R.uniqBy(R.identity, [NaN, NaN]).length, 1);
-    eq(R.uniqBy(R.identity, [new  Maybe.Just([1, 2, 3]), new Maybe.Just([1, 2, 3])]).length, 1);
+    eq(R.uniqBy(R.identity, [new Just([1, 2, 3]), new Just([1, 2, 3])]).length, 1);
   });
 
   it('can act as a transducer', function() {

--- a/test/unnest.js
+++ b/test/unnest.js
@@ -2,7 +2,7 @@ var assert = require('assert');
 
 var R = require('../source/index.js');
 var eq = require('./shared/eq.js');
-var Maybe = require('./shared/Maybe.js');
+var {Just, Nothing} = require('./shared/Maybe.js');
 
 
 describe('unnest', function() {
@@ -31,9 +31,6 @@ describe('unnest', function() {
   });
 
   it('is equivalent to R.chain(R.identity)', function() {
-    var Nothing = Maybe.Nothing;
-    var Just = Maybe.Just;
-
     eq(R.unnest(Nothing), Nothing);
     eq(R.unnest(Just(Nothing)), Nothing);
     eq(R.unnest(Just(Just(Nothing))), Just(Nothing));

--- a/test/without.js
+++ b/test/without.js
@@ -1,5 +1,6 @@
 var R = require('../source/index.js');
 var eq = require('./shared/eq.js');
+var Maybe = require('./shared/Maybe.js');
 
 
 describe('without', function() {
@@ -13,15 +14,10 @@ describe('without', function() {
   });
 
   it('has R.equals semantics', function() {
-    function Just(x) { this.value = x; }
-    Just.prototype.equals = function(x) {
-      return x instanceof Just && R.equals(x.value, this.value);
-    };
-
     eq(R.without([0], [-0]).length, 1);
     eq(R.without([-0], [0]).length, 1);
     eq(R.without([NaN], [NaN]).length, 0);
     eq(R.without([[1]], [[1]]).length, 0);
-    eq(R.without([new Just([42])], [new Just([42])]).length, 0);
+    eq(R.without([new Maybe.Just([42])], [new Maybe.Just([42])]).length, 0);
   });
 });

--- a/test/without.js
+++ b/test/without.js
@@ -1,6 +1,6 @@
 var R = require('../source/index.js');
 var eq = require('./shared/eq.js');
-var Maybe = require('./shared/Maybe.js');
+var {Just} = require('./shared/Maybe.js');
 
 
 describe('without', function() {
@@ -18,6 +18,6 @@ describe('without', function() {
     eq(R.without([-0], [0]).length, 1);
     eq(R.without([NaN], [NaN]).length, 0);
     eq(R.without([[1]], [[1]]).length, 0);
-    eq(R.without([new Maybe.Just([42])], [new Maybe.Just([42])]).length, 0);
+    eq(R.without([new Just([42])], [new Just([42])]).length, 0);
   });
 });


### PR DESCRIPTION
I found there are many places using the same code like below.

```js
function Just(x) { this.value = x; }
Just.prototype.equals = function(x) {
  return x instanceof Just && R.equals(x.value, this.value);
};
```

I think we can extract the common part and create a Just | Nothing in shared folder just like `Maybe`.

Tell me your opinion.
Thanks!