### PR TITLE
Fix of @since for splitWhenever jsdoc

### DIFF
--- a/source/splitWhenever.js
+++ b/source/splitWhenever.js
@@ -4,7 +4,7 @@ import _curryN from './internal/_curryN.js';
  *
  * @func
  * @memberOf R
- * @since v0.26.1
+ * @since v0.28.0
  * @category List
  * @sig (a -> Boolean) -> [a] -> [[a]]
  * @param {Function} pred The predicate that determines where the array is split.


### PR DESCRIPTION
The original jsdoc is misleading because splitWhenever was added in 0.28.0 see https://github.com/ramda/ramda/issues/2881