### PR TITLE
chore: Bump fast-check to version 3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ramda",
-  "version": "0.29.1",
+  "version": "0.30.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ramda",
-      "version": "0.29.1",
+      "version": "0.30.0",
       "license": "MIT",
       "devDependencies": {
         "@babel/cli": "^7.23.0",
@@ -26,7 +26,7 @@
         "envvar": "^2.0.0",
         "eslint": "^8.53.0",
         "eslint-plugin-import": "^2.29.0",
-        "fast-check": "^2.12.0",
+        "fast-check": "^3.18.0",
         "handlebars": "^4.7.8",
         "js-yaml": "^4.1.0",
         "mocha": "^10.2.0",
@@ -5393,19 +5393,25 @@
       ]
     },
     "node_modules/fast-check": {
-      "version": "2.25.0",
-      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-2.25.0.tgz",
-      "integrity": "sha512-wRUT2KD2lAmT75WNIJIHECawoUUMHM0I5jrlLXGtGeqmPL8jl/EldUDjY1VCp6fDY8yflyfUeIOsOBrIbIiArg==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.18.0.tgz",
+      "integrity": "sha512-/951xaT0kA40w0GXRsZXEwSTE7LugjZtSA/8vPgFkiPQ8wNp8tRvqWuNDHBgLxJYXtsK11e/7Q4ObkKW5BdTFQ==",
       "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
       "dependencies": {
-        "pure-rand": "^5.0.1"
+        "pure-rand": "^6.1.0"
       },
       "engines": {
         "node": ">=8.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/fast-check"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -9125,9 +9131,9 @@
       ]
     },
     "node_modules/pure-rand": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-5.0.5.tgz",
-      "integrity": "sha512-BwQpbqxSCBJVpamI6ydzcKqyFmnd5msMWUGvzXLm1aXvusbbgkbOto/EUPM00hjveJEaJtdbhUjKSzWRhQVkaw==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
+      "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
       "dev": true,
       "funding": [
         {
@@ -15572,12 +15578,12 @@
       }
     },
     "fast-check": {
-      "version": "2.25.0",
-      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-2.25.0.tgz",
-      "integrity": "sha512-wRUT2KD2lAmT75WNIJIHECawoUUMHM0I5jrlLXGtGeqmPL8jl/EldUDjY1VCp6fDY8yflyfUeIOsOBrIbIiArg==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.18.0.tgz",
+      "integrity": "sha512-/951xaT0kA40w0GXRsZXEwSTE7LugjZtSA/8vPgFkiPQ8wNp8tRvqWuNDHBgLxJYXtsK11e/7Q4ObkKW5BdTFQ==",
       "dev": true,
       "requires": {
-        "pure-rand": "^5.0.1"
+        "pure-rand": "^6.1.0"
       }
     },
     "fast-deep-equal": {
@@ -18428,9 +18434,9 @@
       "dev": true
     },
     "pure-rand": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-5.0.5.tgz",
-      "integrity": "sha512-BwQpbqxSCBJVpamI6ydzcKqyFmnd5msMWUGvzXLm1aXvusbbgkbOto/EUPM00hjveJEaJtdbhUjKSzWRhQVkaw==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
+      "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
       "dev": true
     },
     "qs": {

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "envvar": "^2.0.0",
     "eslint": "^8.53.0",
     "eslint-plugin-import": "^2.29.0",
-    "fast-check": "^2.12.0",
+    "fast-check": "^3.18.0",
     "handlebars": "^4.7.8",
     "js-yaml": "^4.1.0",
     "mocha": "^10.2.0",

--- a/test/symmetricDifference.js
+++ b/test/symmetricDifference.js
@@ -59,7 +59,7 @@ describe('symmetricDifference', function() {
 
   it('returns empty arrays when receiving an array and a permutation of it', function() {
     fc.assert(fc.property(fc.clone(compatibleREquals, 2).chain(function(arrays) {
-      return fc.tuple(fc.constant(arrays[0]), fc.shuffledSubarray(arrays[1], arrays[1].length, arrays[1].length));
+      return fc.tuple(fc.constant(arrays[0]), fc.shuffledSubarray(arrays[1], {minLength: arrays[1].length, maxLength: arrays[1].length}));
     }), function(arrays) {
       var A1 = arrays[0];
       var A2 = arrays[1];


### PR DESCRIPTION
The version 3 of fast-check added something very interesting for libraries such as ramda: it can more likely produce values such as `__proto__` or `toString` which are known sources for CVE.

On fast-check's side, I also worked on some tooling making poisoning related issues even simpler to detect with an automatic detection for poisoning on globals. I successfully found back several past CVEs of lodash thanks to it.