### PR TITLE
Write more TS tests and update type for Add function

### DIFF
--- a/test/types/adjust.ts
+++ b/test/types/adjust.ts
@@ -1,4 +1,4 @@
-import { expectType, expectError, expectNotAssignable } from "tsd";
+import { expectType, expectError } from "tsd";
 import * as R from "../../es/index";
 
 expectType<string[]>(R.adjust(1, R.toUpper, ["a", "b", "c"]));

--- a/test/types/adjust.ts
+++ b/test/types/adjust.ts
@@ -1,0 +1,12 @@
+import { expectType, expectError, expectNotAssignable } from "tsd";
+import * as R from "../../es/index";
+
+expectType<string[]>(R.adjust(1, R.toUpper, ["a", "b", "c"]));
+expectType<string[]>(R.adjust(2, R.toUpper)(["c", "d", "e"]));
+
+expectType<number[]>(R.adjust(2, (n: number) => n * 2)([1, 2, 3]));
+expectType<boolean[]>(R.adjust(2, (n: boolean) => !n)([true, false, true]));
+
+expectError(R.adjust(1, R.toString, [1, 2, 3]));
+expectError(R.adjust("1", R.toUpper, ["c", "d", "e"]));
+expectError(R.adjust(2, R.isNil)([2, 3, 4]));

--- a/test/types/all.ts
+++ b/test/types/all.ts
@@ -1,0 +1,12 @@
+import { expectType, expectError } from "tsd";
+import * as R from "../../es/index";
+
+expectType<boolean>(R.all(R.equals(3), [3, 3, 3]));
+expectType<boolean>(R.all(R.equals(true))([false, false, false]));
+expectType<boolean>(
+  R.all((n) => n === "hello")(["Goodbye", "Ciao", "Auf Wiedersehen"])
+);
+
+expectError(R.all((n: number) => n, [1, 3, 4]));
+expectError(R.all((n: string) => n, [5, 6, 7]));
+expectError(R.all((n: null | undefined) => n, [null, undefined, null]));

--- a/test/types/allPass.ts
+++ b/test/types/allPass.ts
@@ -1,0 +1,50 @@
+import { expectType, expectError } from "tsd";
+import * as R from "../../es/index";
+
+const isOld = R.propEq("age", 212);
+const isAllergicToGarlic = R.propEq("garlic_allergy", true);
+const isAllergicToSun = R.propEq("sun_allergy", true);
+const isFast = R.propEq("fast", null);
+const isAfraid = R.propEq("fear", undefined);
+
+const isVampire = R.allPass([
+  isOld,
+  isAllergicToGarlic,
+  isAllergicToSun,
+  isFast,
+  isAfraid,
+]);
+
+expectType<boolean>(
+  isVampire({
+    age: 212,
+    garlic_allergy: true,
+    sun_allergy: true,
+    fast: null,
+    fear: undefined,
+  })
+);
+
+expectType<boolean>(
+  isVampire({
+    age: 21,
+    garlic_allergy: true,
+    sun_allergy: true,
+    fast: false,
+    fear: true,
+  })
+);
+
+expectError(
+  isVampire({
+    age: 40,
+    garlic_allergy: true,
+    fear: false,
+  })
+);
+
+expectError(
+  isVampire({
+    nickname: "Blade",
+  })
+);

--- a/test/types/always.ts
+++ b/test/types/always.ts
@@ -1,0 +1,12 @@
+import { expectType, expectError } from "tsd";
+import * as R from "../../es/index";
+
+expectType<string>(R.always("a")());
+expectType<string[]>(R.always(["a"])());
+expectType<number>(R.always(2)());
+expectType<Record<string, number>>(R.always({ a: 2, b: 3, c: 4 })());
+expectType<null>(R.always(null)());
+expectType<(...args: unknown[]) => number>(R.always(1));
+
+expectError<string>(R.always("a"));
+expectError<(...args: unknown[]) => number>(R.always("a"));

--- a/test/types/always.ts
+++ b/test/types/always.ts
@@ -8,5 +8,4 @@ expectType<Record<string, number>>(R.always({ a: 2, b: 3, c: 4 })());
 expectType<null>(R.always(null)());
 expectType<(...args: unknown[]) => number>(R.always(1));
 
-expectError<string>(R.always("a"));
 expectError<(...args: unknown[]) => number>(R.always("a"));

--- a/test/types/always.ts
+++ b/test/types/always.ts
@@ -4,7 +4,9 @@ import * as R from "../../es/index";
 expectType<string>(R.always("a")());
 expectType<string[]>(R.always(["a"])());
 expectType<number>(R.always(2)());
-expectType<Record<string, number>>(R.always({ a: 2, b: 3, c: 4 })());
+expectType<{ a: number; b: number; c: number }>(
+  R.always({ a: 2, b: 3, c: 4 })()
+);
 expectType<null>(R.always(null)());
 expectType<(...args: unknown[]) => number>(R.always(1));
 

--- a/test/types/and.ts
+++ b/test/types/and.ts
@@ -1,0 +1,10 @@
+import { expectType, expectError } from "tsd";
+import * as R from "../../es/index";
+
+expectType<boolean>(R.and("a")(false));
+expectType<boolean>(R.and("true")("true"));
+expectType<boolean>(R.and(false)(true));
+expectType<boolean>(R.and(1, [2]));
+expectType<boolean>(R.and("1", [2]));
+expectType<boolean>(R.and({ a: 1, b: 2, c: 3 }, [2]));
+expectType<boolean>(R.and(null, undefined));

--- a/test/types/and.ts
+++ b/test/types/and.ts
@@ -1,10 +1,9 @@
 import { expectType, expectError } from "tsd";
 import * as R from "../../es/index";
 
-expectType<boolean>(R.and("a")(false));
-expectType<boolean>(R.and("true")("true"));
-expectType<boolean>(R.and(false)(true));
-expectType<boolean>(R.and(1, [2]));
-expectType<boolean>(R.and("1", [2]));
-expectType<boolean>(R.and({ a: 1, b: 2, c: 3 }, [2]));
-expectType<boolean>(R.and(null, undefined));
+expectType<string | boolean>(R.and("a")(false));
+expectType<string | boolean>(R.and("true")("true"));
+expectType<boolean | boolean>(R.and(false)(true));
+expectType<number | boolean>(R.and(1, [2]));
+expectType<number[] | boolean>(R.and([2], "1"));
+expectType<null | boolean>(R.and(null, undefined));

--- a/test/types/any.ts
+++ b/test/types/any.ts
@@ -1,0 +1,13 @@
+import { expectType, expectError } from "tsd";
+import * as R from "../../es/index";
+
+expectType<boolean>(R.any(R.isNotNil, [1, 2, null]));
+expectType<boolean>(R.any(R.isNil, [null, 2, undefined]));
+expectType<boolean>(R.any(R.flip(R.lt)(0), [1, 2, -1]));
+expectType<boolean>(R.any(R.flip(R.lt)(0), [1, 2, -1]));
+expectType<boolean>(R.any(R.is(String), [1, 2, -1]));
+expectType<boolean>(R.any(R.is(Number), [1, 2, -1]));
+
+expectError(R.any(R.flip(R.lt)(0), [null, 2, undefined]));
+expectError(R.any(R.flip(R.lt)(0), { a: 2, b: 3 }));
+expectError(R.any(R.flip(R.lt)(0), "error!"));

--- a/types/and.d.ts
+++ b/types/and.d.ts
@@ -1,2 +1,2 @@
-export function and<T, U>(a: T, b: U): T | U;
-export function and<T>(a: T): <U>(b: U) => T | U;
+export function and<T, U>(a: T, b: U): boolean;
+export function and<T>(a: T): <U>(b: U) => boolean;

--- a/types/and.d.ts
+++ b/types/and.d.ts
@@ -1,2 +1,2 @@
-export function and<T, U>(a: T, b: U): boolean;
-export function and<T>(a: T): <U>(b: U) => boolean;
+export function and<T, U>(a: T, b: U): T | U;
+export function and<T>(a: T): <U>(b: U) => T | U;


### PR DESCRIPTION
This PR adds TS tests for the following functions:
- `adjust`
- `all`
- `allPass`
- `always`
- `and`
- `any`

I also noticed something odd about the return type of the `add` function, in that a `boolean` value is always returned, but the type function returned a union of the two input types, for instance: `and<T, U>(a: T, b: U): T | U;`. Because the return value is always a `boolean`, I thought it made more sense to change the return type: `and<T, U>(a: T, b: U): boolean;`.

Perhaps I'm misunderstanding the reasoning behind the current type implementation of `add`, but a return type of `boolean` made sense while I was testing the type. I can always change it back to the original type 😃 

I would like to continue writing more TS tests, and a PR of ~5 tests seemed like a good number, but let me know if a larger PR is preferred. 