### PR TITLE
Complete typings for R.all

### DIFF
--- a/test/types/all.ts
+++ b/test/types/all.ts
@@ -9,18 +9,35 @@ class TestType {
   }
 }
 
+// all(fn, list)
 expectType<boolean>(R.all(R.equals(3), [3, 3, 3]));
+expectType<boolean>(R.all(R.equals(true), [false, false, false]));
+expectType<boolean>(
+  R.all((n) => n === "hello", ["Goodbye", "Ciao", "Auf Wiedersehen"])
+);
+
+// all({ all }, list)
+expectType<boolean>(R.all(R.equals(3), new TestType([3, 3, 3])));
+
+// all(__, list)
+expectType<(fn: (a: number) => boolean) => boolean>(R.all(R.__, [3, 3, 3]));
+// all(__, list)(fn)
+expectType<boolean>(R.all(R.__, [3, 3, 3])(R.equals(3)));
+
+// all(__, { all })
+expectType<(fn: (a: number) => boolean) => boolean>(R.all(R.__, new TestType([3, 3, 3])));
+// all(__, { all })(fn)
+expectType<boolean>(R.all(R.__, new TestType([3, 3, 3]))(R.equals(3)));
+
+// all(fn)(list)
+expectType<boolean>(R.all(R.equals(3))([3, 3, 3]));
 expectType<boolean>(R.all(R.equals(true))([false, false, false]));
 expectType<boolean>(
   R.all((n) => n === "hello")(["Goodbye", "Ciao", "Auf Wiedersehen"])
 );
-expectType<(fn: (a: number) => boolean) => boolean>(R.all(R.__, [3, 3, 3]));
-expectType<boolean>(R.all(R.__, [3, 3, 3])(R.equals(3)));
 
-expectType<boolean>(R.all(R.equals(3), new TestType([3, 3, 3])));
+// all (fn)({ all })
 expectType<boolean>(R.all(R.equals(3))(new TestType([3, 3, 3])));
-expectType<(fn: (a: number) => boolean) => boolean>(R.all(R.__, new TestType([3, 3, 3])));
-expectType<boolean>(R.all(R.__, new TestType([3, 3, 3]))(R.equals(3)));
 
 expectError(R.all((n: number) => n, [1, 3, 4]));
 expectError(R.all((n: string) => n, [5, 6, 7]));

--- a/test/types/all.ts
+++ b/test/types/all.ts
@@ -17,6 +17,11 @@ expectType<boolean>(
 expectType<(fn: (a: number) => boolean) => boolean>(R.all(R.__, [3, 3, 3]));
 expectType<boolean>(R.all(R.__, [3, 3, 3])(R.equals(3)));
 
+expectType<boolean>(R.all(R.equals(3), new TestType([3, 3, 3])));
+expectType<boolean>(R.all(R.equals(3))(new TestType([3, 3, 3])));
+expectType<(fn: (a: number) => boolean) => boolean>(R.all(R.__, new TestType([3, 3, 3])));
+expectType<boolean>(R.all(R.__, new TestType([3, 3, 3]))(R.equals(3)));
+
 expectError(R.all((n: number) => n, [1, 3, 4]));
 expectError(R.all((n: string) => n, [5, 6, 7]));
 expectError(R.all((n: null | undefined) => n, [null, undefined, null]));

--- a/test/types/all.ts
+++ b/test/types/all.ts
@@ -1,12 +1,23 @@
 import { expectType, expectError } from "tsd";
 import * as R from "../../es/index";
 
+class TestType {
+  constructor(public value: number[]) {}
+
+  all(fn: (a: number) => boolean): boolean {
+    return this.value.every(fn);
+  }
+}
+
 expectType<boolean>(R.all(R.equals(3), [3, 3, 3]));
 expectType<boolean>(R.all(R.equals(true))([false, false, false]));
 expectType<boolean>(
   R.all((n) => n === "hello")(["Goodbye", "Ciao", "Auf Wiedersehen"])
 );
+expectType<(fn: (a: number) => boolean) => boolean>(R.all(R.__, [3, 3, 3]));
+expectType<boolean>(R.all(R.__, [3, 3, 3])(R.equals(3)));
 
 expectError(R.all((n: number) => n, [1, 3, 4]));
 expectError(R.all((n: string) => n, [5, 6, 7]));
 expectError(R.all((n: null | undefined) => n, [null, undefined, null]));
+

--- a/types/all.d.ts
+++ b/types/all.d.ts
@@ -1,12 +1,19 @@
 import { InferAllAType, Placeholder } from './util/tools';
 
+// all(fn, list)
 export function all<T>(fn: (a: T) => boolean, list: readonly T[]): boolean;
+// all({ all }, list)
 export function all<T, U extends { all: (fn: (a: T) => boolean) => boolean }>(fn: (a: T) => boolean, obj: U): boolean;
 
+// all(__, list)(fn)
 export function all<T>(__: Placeholder, list: readonly T[]): (fn: (a: T) => boolean) => boolean;
+// all(__, { all })(fn)
 export function all<U extends { all: (fn: (a: any) => boolean) => boolean }>(__: Placeholder, obj: U): (fn: (a: InferAllAType<U>) => boolean) => boolean;
 
+// all (fn)
 export function all<T>(fn: (a: T) => boolean): {
+  // all (fn)(list)
   (list: readonly T[]): boolean;
+  // all (fn)({ all })
   <U extends { all: (fn: (a: T) => boolean) => boolean }>(obj: U): boolean;
 };

--- a/types/all.d.ts
+++ b/types/all.d.ts
@@ -2,7 +2,7 @@ import { InferAllAType, Placeholder } from './util/tools';
 
 // all(fn, list)
 export function all<T>(fn: (a: T) => boolean, list: readonly T[]): boolean;
-// all({ all }, list)
+// all(fn, { all })
 export function all<T, U extends { all: (fn: (a: T) => boolean) => boolean }>(fn: (a: T) => boolean, obj: U): boolean;
 
 // all(__, list)(fn)

--- a/types/all.d.ts
+++ b/types/all.d.ts
@@ -1,2 +1,12 @@
+import { InferAllAType, Placeholder } from './util/tools';
+
 export function all<T>(fn: (a: T) => boolean, list: readonly T[]): boolean;
-export function all<T>(fn: (a: T) => boolean): (list: readonly T[]) => boolean;
+export function all<T, U extends { all: (fn: (a: T) => boolean) => boolean }>(fn: (a: T) => boolean, obj: U): boolean;
+
+export function all<T>(__: Placeholder, list: readonly T[]): (fn: (a: T) => boolean) => boolean;
+export function all<U extends { all: (fn: (a: any) => boolean) => boolean }>(__: Placeholder, obj: U): (fn: (a: InferAllAType<U>) => boolean) => boolean;
+
+export function all<T>(fn: (a: T) => boolean): {
+  (list: readonly T[]): boolean;
+  <U extends { all: (fn: (a: T) => boolean) => boolean }>(obj: U): boolean;
+};

--- a/types/util/tools.d.ts
+++ b/types/util/tools.d.ts
@@ -198,6 +198,12 @@ type Arr1LessThanOrEqual<
     : never;
 
 /**
+ * R.all dispatches to `.all` of the second argument, if present.
+ * This type infers the type of the first argument of that method and returns it
+ */
+export type InferAllAType<T> = T extends { all: (fn: (a: infer A) => boolean) => boolean } ? A : never;
+
+/**
  * Return true if types T1 and T2 can intersect, e.g. both are primitives or both are objects.
  * Taking into account branded types too.
  *


### PR DESCRIPTION
Corrected the typings to handle placeholders and the "Dispatches to the all method of the second argument, if present." case