### PR TITLE
Added curried version for R.and and fixed tests

### DIFF
--- a/test/types/and.ts
+++ b/test/types/and.ts
@@ -1,9 +1,26 @@
-import { expectType, expectError } from "tsd";
-import * as R from "../../es/index";
+import { expectAssignable, expectType, expectError } from 'tsd';
+import { __, and } from '../../es/index';
 
-expectType<string | boolean>(R.and("a")(false));
-expectType<string | boolean>(R.and("true")("true"));
-expectType<boolean | boolean>(R.and(false)(true));
-expectType<number | boolean>(R.and(1, [2]));
-expectType<number[] | boolean>(R.and([2], "1"));
-expectType<null | boolean>(R.and(null, undefined));
+// literal types will return their literal types
+// eg function identity<T>(v: T) => v;
+// identity('a') // type 'a'
+// the type definition for `and` is (a: A, b: B) => A | B
+// this means `and('a', 'b')` returns `'a' | 'b'
+// however, `'a' | 'b'` is assignable to `string
+// just as `and('a', 1)` returns `'a' | 1`, but is assignable to `string | number`
+// so it makes more sense to test this function is `expectAssignable` versus `expectType`
+
+// and(string, boolean) => `string | boolean`
+expectAssignable<string | boolean>(and('a', false));
+expectAssignable<<A>(a: A) => A | boolean>(and(__, false));
+expectAssignable<string | boolean>(and(__, false)('a'));
+
+// and(string, string) => `string | string` which is just `string`
+expectAssignable<string>(and('true', 'false'));
+expectAssignable<<A>(a: A) => A | string>(and(__, 'false'));
+expectAssignable<string>(and(__, 'false')('true'));
+
+// and(number, string) => `number | string`
+expectAssignable<number | string>(and(1, 'a'));
+expectAssignable<<A>(a: A) => A | string>(and(__, 'a'));
+expectAssignable<number | string>(and(1)('a'));

--- a/types/and.d.ts
+++ b/types/and.d.ts
@@ -1,2 +1,5 @@
-export function and<T, U>(a: T, b: U): T | U;
-export function and<T>(a: T): <U>(b: U) => T | U;
+import { Placeholder } from './util/tools';
+
+export function and<B>(__: Placeholder, b: B): <A>(a: A) => A | B;
+export function and<A, B>(a: A, b: B): A | B;
+export function and<A>(a: A): <B>(b: B) => A | B;


### PR DESCRIPTION
I added typings for `and(__, b)(a)` variety

Also redid the tests for it. They were failing. Let me know if you want to be more exhaustive with the tests for this one and I'll add more (probably not needed TBH, the typing for this function is very simple)