### PR TITLE
do not enforce js extension omission in imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,9 +56,9 @@
       "import": "./es/index.js",
       "default": "./src/index.js"
     },
-    "./es/*": "./es/*.js",
-    "./src/*": "./src/*.js",
-    "./dist/*": "./dist/*.js",
+    "./es/*": "./es/*",
+    "./src/*": "./src/*",
+    "./dist/*": "./dist/*",
     "./es/": "./es/",
     "./src/": "./src/",
     "./dist/": "./dist/"


### PR DESCRIPTION
Hello and thank you for this excellent package.

I'm struggling with imports because nodejs don't let me import a source file with the ".js" extension.

But first, it seems that the package.json of version 0.28.0 (on npm) has no exports that allows per-module imports:
```json
 "exports": {
    ".": {
      "require": "./src/index.js",
      "import": "./es/index.js",
      "default": "./src/index.js"
    },
    "./es/": "./es/",
    "./src/": "./src/",
    "./dist/": "./dist/"
  },
```

So when importing `ramda/src/pipe` it throws an error:
```
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './src/pipe' is not defined by "exports" in
```

On the other hand, the master branch has differents `exports`, which seems to accept imports like `ramda/src/pipe`:

```json
  "exports": {
    ".": {
      "require": "./src/index.js",
      "import": "./es/index.js",
      "default": "./src/index.js"
    },
    "./es/*": "./es/*.js",
    "./src/*": "./src/*.js",
    "./dist/*": "./dist/*.js",
    "./es/": "./es/",
    "./src/": "./src/",
    "./dist/": "./dist/"
  },
```
Importing `ramda/src/pipe` works great but it's necessary to install the master branch version of the package.

But it don't let me import modules with js extension (ie.  `ramda/src/pipe.js`)
I get an error:
```
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './src/pipe.js' is not defined by "exports" in
```

I need to import es modules in two ways:
- in a browser (via a CDN that looks at `exports` to determine which file to serve)
- in a node server (which refuse to import the modules because there is no match in `exports` for the specifier `ramda/src/pipe.js`  )

So I propose this change to let users decide if they import files with or without the `.js` extension:
```json
"exports": {
    ".": {
      "require": "./src/index.js",
      "import": "./es/index.js",
      "default": "./src/index.js"
    },
    "./es/*": "./es/*",
    "./src/*": "./src/*",
    "./dist/*": "./dist/*",
    "./es/": "./es/",
    "./src/": "./src/",
    "./dist/": "./dist/"
  },
```

