### PR TITLE
Update: Known array lengths

### DIFF
--- a/source/internal/_clone.js
+++ b/source/internal/_clone.js
@@ -39,9 +39,9 @@ export default function _clone(value, deep, map) {
 
   switch (type(value)) {
     case 'Object':  return copy(Object.create(Object.getPrototypeOf(value)));
-    case 'Array':   return copy([]);
+    case 'Array':   return copy(Array(value.length));
     case 'Date':    return new Date(value.valueOf());
-    case 'RegExp': return _cloneRegExp(value);
+    case 'RegExp':  return _cloneRegExp(value);
     case 'Int8Array':
     case 'Uint8Array':
     case 'Uint8ClampedArray':

--- a/source/internal/_concat.js
+++ b/source/internal/_concat.js
@@ -15,16 +15,16 @@ export default function _concat(set1, set2) {
   var idx;
   var len1 = set1.length;
   var len2 = set2.length;
-  var result = Array(len1 + len2);
+  var result = [];
 
   idx = 0;
   while (idx < len1) {
-    result[idx] = set1[idx];
+    result[result.length] = set1[idx];
     idx += 1;
   }
   idx = 0;
   while (idx < len2) {
-    result[len1 + idx] = set2[idx];
+    result[result.length] = set2[idx];
     idx += 1;
   }
   return result;

--- a/source/internal/_concat.js
+++ b/source/internal/_concat.js
@@ -15,16 +15,16 @@ export default function _concat(set1, set2) {
   var idx;
   var len1 = set1.length;
   var len2 = set2.length;
-  var result = [];
+  var result = Array(len1 + len2);
 
   idx = 0;
   while (idx < len1) {
-    result[result.length] = set1[idx];
+    result[idx] = set1[idx];
     idx += 1;
   }
   idx = 0;
   while (idx < len2) {
-    result[result.length] = set2[idx];
+    result[len1 + idx] = set2[idx];
     idx += 1;
   }
   return result;

--- a/source/intersperse.js
+++ b/source/intersperse.js
@@ -21,6 +21,7 @@ import _curry2 from './internal/_curry2.js';
  */
 var intersperse = _curry2(_checkForMethod('intersperse', function _intersperse(separator, list) {
   var length = list.length;
+  if (length === 0) { return []; }
   var out = Array(length * 2 - 1);
   var idx = 0;
   while (idx < length) {

--- a/source/intersperse.js
+++ b/source/intersperse.js
@@ -19,15 +19,17 @@ import _curry2 from './internal/_curry2.js';
  *
  *      R.intersperse('a', ['b', 'n', 'n', 's']); //=> ['b', 'a', 'n', 'a', 'n', 'a', 's']
  */
-var intersperse = _curry2(_checkForMethod('intersperse', function intersperse(separator, list) {
-  var out = [];
-  var idx = 0;
+var intersperse = _curry2(_checkForMethod('intersperse', function _intersperse(separator, list) {
   var length = list.length;
+  var out = Array(length * 2 - 1);
+  var idx = 0;
   while (idx < length) {
+    var i = idx * 2;
     if (idx === length - 1) {
-      out.push(list[idx]);
+      out[i] = list[idx];
     } else {
-      out.push(list[idx], separator);
+      out[i] = list[idx];
+      out[i + 1] = separator;
     }
     idx += 1;
   }

--- a/source/mapAccum.js
+++ b/source/mapAccum.js
@@ -38,7 +38,7 @@ import _curry3 from './internal/_curry3.js';
 var mapAccum = _curry3(function mapAccum(fn, acc, list) {
   var idx = 0;
   var len = list.length;
-  var result = [];
+  var result = Array(len);
   var tuple = [acc];
   while (idx < len) {
     tuple = fn(tuple[0], list[idx]);

--- a/source/mapAccumRight.js
+++ b/source/mapAccumRight.js
@@ -40,7 +40,7 @@ import _curry3 from './internal/_curry3.js';
  */
 var mapAccumRight = _curry3(function mapAccumRight(fn, acc, list) {
   var idx = list.length - 1;
-  var result = [];
+  var result = Array(list.length);
   var tuple = [acc];
   while (idx >= 0) {
     tuple = fn(tuple[0], list[idx]);

--- a/source/range.js
+++ b/source/range.js
@@ -22,7 +22,7 @@ var range = _curry2(function range(from, to) {
   if (!(_isNumber(from) && _isNumber(to))) {
     throw new TypeError('Both arguments to range must be numbers');
   }
-  var result = [];
+  var result = Array(n < to ? to - n : 0);
   var n = from;
   while (n < to) {
     result.push(n);

--- a/source/range.js
+++ b/source/range.js
@@ -22,11 +22,12 @@ var range = _curry2(function range(from, to) {
   if (!(_isNumber(from) && _isNumber(to))) {
     throw new TypeError('Both arguments to range must be numbers');
   }
-  var result = Array(n < to ? to - n : 0);
-  var n = from;
-  while (n < to) {
-    result.push(n);
-    n += 1;
+  var result = Array(from < to ? to - from : 0);
+  var finish = from < 0 ? to + Math.abs(from) : to - from;
+  var idx = 0;
+  while (idx < finish) {
+    result[idx] = idx + from;
+    idx += 1;
   }
   return result;
 });

--- a/source/scan.js
+++ b/source/scan.js
@@ -29,7 +29,8 @@ import _xscan from './internal/_xscan.js';
 var scan = _curry3(_dispatchable([], _xscan, function scan(fn, acc, list) {
   var idx = 0;
   var len = list.length;
-  var result = [acc];
+  var result = Array(len + 1);
+  result[0] = acc;
   while (idx < len) {
     acc = fn(acc, list[idx]);
     result[idx + 1] = acc;

--- a/source/times.js
+++ b/source/times.js
@@ -26,15 +26,15 @@ import _curry2 from './internal/_curry2.js';
  */
 var times = _curry2(function times(fn, n) {
   var len = Number(n);
-  var idx = 0;
-  var list;
 
   if (len < 0 || isNaN(len)) {
     throw new RangeError('n must be a non-negative number');
   }
-  list = [];
+
+  var idx = 0;
+  var list = Array(len);
   while (idx < len) {
-    list.push(fn(idx));
+    list[idx] = fn(idx);
     idx += 1;
   }
   return list;

--- a/source/xprod.js
+++ b/source/xprod.js
@@ -24,7 +24,7 @@ var xprod = _curry2(function xprod(a, b) { // = xprodWith(prepend); (takes about
   var ilen = a.length;
   var j;
   var jlen = b.length;
-  var result = Array(ilen + jlen);
+  var result = Array(ilen * jlen);
   while (idx < ilen) {
     j = 0;
     while (j < jlen) {

--- a/source/xprod.js
+++ b/source/xprod.js
@@ -20,18 +20,18 @@ import _curry2 from './internal/_curry2.js';
  * @symb R.xprod([a, b], [c, d]) = [[a, c], [a, d], [b, c], [b, d]]
  */
 var xprod = _curry2(function xprod(a, b) { // = xprodWith(prepend); (takes about 3 times as long...)
-  var idx = 0;
+  var i = 0;
   var ilen = a.length;
   var j;
   var jlen = b.length;
   var result = Array(ilen * jlen);
-  while (idx < ilen) {
+  while (i < ilen) {
     j = 0;
     while (j < jlen) {
-      result[idx + j] = [a[idx], b[j]];
+      result[(i * jlen) + j] = [a[i], b[j]];
       j += 1;
     }
-    idx += 1;
+    i += 1;
   }
   return result;
 });

--- a/source/xprod.js
+++ b/source/xprod.js
@@ -24,11 +24,11 @@ var xprod = _curry2(function xprod(a, b) { // = xprodWith(prepend); (takes about
   var ilen = a.length;
   var j;
   var jlen = b.length;
-  var result = [];
+  var result = Array(ilen + jlen);
   while (idx < ilen) {
     j = 0;
     while (j < jlen) {
-      result[result.length] = [a[idx], b[j]];
+      result[idx + j] = [a[idx], b[j]];
       j += 1;
     }
     idx += 1;

--- a/source/zip.js
+++ b/source/zip.js
@@ -21,9 +21,9 @@ import _curry2 from './internal/_curry2.js';
  * @symb R.zip([a, b, c], [d, e, f]) = [[a, d], [b, e], [c, f]]
  */
 var zip = _curry2(function zip(a, b) {
-  var rv = [];
-  var idx = 0;
   var len = Math.min(a.length, b.length);
+  var rv = Array(len);
+  var idx = 0;
   while (idx < len) {
     rv[idx] = [a[idx], b[idx]];
     idx += 1;

--- a/source/zipWith.js
+++ b/source/zipWith.js
@@ -26,9 +26,9 @@ import _curry3 from './internal/_curry3.js';
  * @symb R.zipWith(fn, [a, b, c], [d, e, f]) = [fn(a, d), fn(b, e), fn(c, f)]
  */
 var zipWith = _curry3(function zipWith(fn, a, b) {
-  var rv = [];
-  var idx = 0;
   var len = Math.min(a.length, b.length);
+  var rv = Array(len);
+  var idx = 0;
   while (idx < len) {
     rv[idx] = fn(a[idx], b[idx]);
     idx += 1;


### PR DESCRIPTION
As pointed out in https://github.com/ramda/ramda/issues/3364, V8 cares if you instantiate an Array with a known length is far faster to fill than to start with an empty array

This MR updates the following areas of `ramda` to do exactly that

* _clone :: https://jsperf.app/jopaqu - seeing a ~10% gain
* intersperse :: https://jsperf.app/dibehu - ~40%
* mapAccum :: https://jsperf.app/gozalu - 2% (small)
* mapAccumRight, same as ^^
* range :: https://jsperf.app/yaxihu - ~45%
* scan :: https://jsperf.app/tokefo - ~50%
* times :: https://jsperf.app/matoqu - ~50% gain!
* xprod :: https://jsperf.app/cezeko - ~75%
* zip :: https://jsperf.app/foxowi - seeing a ~15% gain
* zipWith :: https://jsperf.app/yasibi - ~ 20%