### PR TITLE
Add version to es distribution

### DIFF
--- a/scripts/addModulePackageScope.js
+++ b/scripts/addModulePackageScope.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const path = require('path');
+const { version } = require('../package.json');
 
 const PACKAGE_SCOPE_PATH = path.join(__dirname, '..', 'es', 'package.json');
 
-fs.writeFileSync(PACKAGE_SCOPE_PATH, JSON.stringify({ type: 'module' }));
+fs.writeFileSync(PACKAGE_SCOPE_PATH, JSON.stringify({ type: 'module', version }));


### PR DESCRIPTION
Fixes `ModuleFederationPlugin` versioning for shared packages, as discussed here:
https://github.com/webpack/webpack/issues/17188