### PR TITLE
Documentation: add 'AsyncFunction' example for `R.type`

### DIFF
--- a/source/type.js
+++ b/source/type.js
@@ -24,6 +24,7 @@ import _curry1 from './internal/_curry1.js';
  *      R.type([]); //=> "Array"
  *      R.type(/[A-z]/); //=> "RegExp"
  *      R.type(() => {}); //=> "Function"
+ *      R.type(async () => {}); //=> "AsyncFunction"
  *      R.type(undefined); //=> "Undefined"
  */
 var type = _curry1(function type(val) {


### PR DESCRIPTION
@Patriksafar [pointed out](https://github.com/ramda/types/issues/57) that `R.type(async () => {})` returns `'AsyncFunction'`. This MR simply adds this as one of the examples in the block comments for `R.type`. An [MR](https://github.com/ramda/types/pull/58) for the function type adding this as a possible return value has also been made