### PR TITLE
fix: add sideEffects flag for es package.json

### DIFF
--- a/scripts/addModulePackageScope.js
+++ b/scripts/addModulePackageScope.js
@@ -4,4 +4,4 @@ const { version } = require('../package.json');
 
 const PACKAGE_SCOPE_PATH = path.join(__dirname, '..', 'es', 'package.json');
 
-fs.writeFileSync(PACKAGE_SCOPE_PATH, JSON.stringify({ type: 'module', version }));
+fs.writeFileSync(PACKAGE_SCOPE_PATH, JSON.stringify({ type: 'module', sideEffects: false, version }));


### PR DESCRIPTION
Currently tree shaking doesn't work, because es/package.json doesn't have "sideEffects" flag in it

This PR fixes the problem


**Before 👎:**
![image](https://github.com/ramda/ramda/assets/69215292/38d71aea-a3bd-4175-ac1c-fc580a931f70)


**After 👍:**
![image](https://github.com/ramda/ramda/assets/69215292/f9e12c83-e080-43bc-9fa0-df79a4711aef)
