### PR TITLE
doc: fix broken link to Bit in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ This requires having Node/io.js installed and ramda's dependencies installed (ju
 
 ### Install specific functions
 
-[Install individual functions](https://bitsrc.io/ramda/ramda) with bit, npm and yarn without installing the whole library.
+[Install individual functions](https://bit.cloud/ramda/ramda) with bit, npm and yarn without installing the whole library.
 
 Documentation
 -------------


### PR DESCRIPTION
Close #3400 

In the README, there is a description for "Bit" that includes a link to bit.src. However, this link is currently broken and unable to resolve the URL. It should be updated to point to bit.cloud.

## Related links
- https://twitter.com/bitdev_/status/1504155770362945540