### PR TITLE
remove broken link to bitsrc in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,10 +154,6 @@ It is possible to build Ramda with a subset of the functionality to reduce its f
 
 This requires having Node/io.js installed and ramda's dependencies installed (just use `npm install` before running partial build). 
 
-### Install specific functions
-
-[Install individual functions](https://bitsrc.io/ramda/ramda) with bit, npm and yarn without installing the whole library.
-
 Documentation
 -------------
 


### PR DESCRIPTION
Closes https://github.com/ramda/ramda/issues/3400

This was a strange thing to have in the README in the first place and had become link rot. Can add to the wiki as needed.