### PR TITLE
Optimize R.path and dependents

### DIFF
--- a/source/head.js
+++ b/source/head.js
@@ -1,4 +1,5 @@
-import nth from './nth.js';
+import _curry1 from './internal/_curry1.js';
+import _nth from './internal/_nth.js';
 
 
 /**
@@ -22,5 +23,7 @@ import nth from './nth.js';
  *      R.head('abc'); //=> 'a'
  *      R.head(''); //=> ''
  */
-var head = nth(0);
+var head = _curry1(function(list) {
+  return _nth(0, list);
+});
 export default head;

--- a/source/internal/_nth.js
+++ b/source/internal/_nth.js
@@ -1,28 +1,5 @@
 import _isString from './_isString.js';
 
-/**
- * Returns the nth element of the given list or string. If n is negative the
- * element at index length + n is returned.
- *
- * @func
- * @sig (Number, [a]) -> a | Undefined
- * @sig (Number, String) -> String
- * @param {Number} offset
- * @param {*} list
- * @return {*}
- * @example
- *
- *      const list = ['foo', 'bar', 'baz', 'quux'];
- *      nth(1, list); //=> 'bar'
- *      nth(-1, list); //=> 'quux'
- *      nth(-99, list); //=> undefined
- *
- *      nth(2, 'abc'); //=> 'c'
- *      nth(3, 'abc'); //=> ''
- * @symb nth(-1, [a, b, c]) = c
- * @symb nth(0, [a, b, c]) = a
- * @symb nth(1, [a, b, c]) = b
- */
 function nth(offset, list) {
   var idx = offset < 0 ? list.length + offset : offset;
   return _isString(list) ? list.charAt(idx) : list[idx];

--- a/source/internal/_nth.js
+++ b/source/internal/_nth.js
@@ -1,7 +1,6 @@
 import _isString from './_isString.js';
 
-function nth(offset, list) {
+export default function _nth(offset, list) {
   var idx = offset < 0 ? list.length + offset : offset;
   return _isString(list) ? list.charAt(idx) : list[idx];
 }
-export default nth;

--- a/source/internal/_nth.js
+++ b/source/internal/_nth.js
@@ -1,0 +1,30 @@
+import _isString from './_isString.js';
+
+/**
+ * Returns the nth element of the given list or string. If n is negative the
+ * element at index length + n is returned.
+ *
+ * @func
+ * @sig (Number, [a]) -> a | Undefined
+ * @sig (Number, String) -> String
+ * @param {Number} offset
+ * @param {*} list
+ * @return {*}
+ * @example
+ *
+ *      const list = ['foo', 'bar', 'baz', 'quux'];
+ *      nth(1, list); //=> 'bar'
+ *      nth(-1, list); //=> 'quux'
+ *      nth(-99, list); //=> undefined
+ *
+ *      nth(2, 'abc'); //=> 'c'
+ *      nth(3, 'abc'); //=> ''
+ * @symb nth(-1, [a, b, c]) = c
+ * @symb nth(0, [a, b, c]) = a
+ * @symb nth(1, [a, b, c]) = b
+ */
+function nth(offset, list) {
+  var idx = offset < 0 ? list.length + offset : offset;
+  return _isString(list) ? list.charAt(idx) : list[idx];
+}
+export default nth;

--- a/source/internal/_path.js
+++ b/source/internal/_path.js
@@ -1,7 +1,7 @@
 import _isInteger from './_isInteger.js';
 import _nth from './_nth.js';
 
-function path(pathAr, obj) {
+export default function _path(pathAr, obj) {
   var val = obj;
   for (var i = 0; i < pathAr.length; i += 1) {
     if (val == null) {
@@ -17,5 +17,3 @@ function path(pathAr, obj) {
   }
   return val;
 }
-
-export default path;

--- a/source/internal/_path.js
+++ b/source/internal/_path.js
@@ -1,0 +1,43 @@
+import _isInteger from './_isInteger.js';
+import _nth from './_nth.js';
+
+/**
+ * Retrieves the value at a given path. The nodes of the path can be arbitrary strings or non-negative integers.
+ * For anything else, the value is unspecified. Integer paths are meant to index arrays, strings are meant for objects.
+ *
+ * @func
+ * @category Object
+ * @typedefn Idx = String | Int | Symbol
+ * @sig ([Idx], {a}) -> a | Undefined
+ * @sig Idx = String | NonNegativeInt
+ * @param {Array} path The path to use.
+ * @param {Object} obj The object or array to retrieve the nested property from.
+ * @return {*} The data at `path`.
+ * @example
+ *
+ *      path(['a', 'b'], {a: {b: 2}}); //=> 2
+ *      path(['a', 'b'], {c: {b: 2}}); //=> undefined
+ *      path(['a', 'b', 0], {a: {b: [1, 2, 3]}}); //=> 1
+ *      path(['a', 'b', -2], {a: {b: [1, 2, 3]}}); //=> 2
+ *      path([2], {'2': 2}); //=> 2
+ *      path([-2], {'-2': 'a'}); //=> undefined
+ */
+
+function path(pathAr, obj) {
+  let val = obj;
+  for (let i = 0; i < pathAr.length; i += 1) {
+    if (val == null) {
+      return undefined;
+    }
+
+    const p = pathAr[i];
+    if (_isInteger(p)) {
+      val = _nth(p, val);
+    } else {
+      val = val[p];
+    }
+  }
+  return val;
+}
+
+export default path;

--- a/source/internal/_path.js
+++ b/source/internal/_path.js
@@ -1,28 +1,6 @@
 import _isInteger from './_isInteger.js';
 import _nth from './_nth.js';
 
-/**
- * Retrieves the value at a given path. The nodes of the path can be arbitrary strings or non-negative integers.
- * For anything else, the value is unspecified. Integer paths are meant to index arrays, strings are meant for objects.
- *
- * @func
- * @category Object
- * @typedefn Idx = String | Int | Symbol
- * @sig ([Idx], {a}) -> a | Undefined
- * @sig Idx = String | NonNegativeInt
- * @param {Array} path The path to use.
- * @param {Object} obj The object or array to retrieve the nested property from.
- * @return {*} The data at `path`.
- * @example
- *
- *      path(['a', 'b'], {a: {b: 2}}); //=> 2
- *      path(['a', 'b'], {c: {b: 2}}); //=> undefined
- *      path(['a', 'b', 0], {a: {b: [1, 2, 3]}}); //=> 1
- *      path(['a', 'b', -2], {a: {b: [1, 2, 3]}}); //=> 2
- *      path([2], {'2': 2}); //=> 2
- *      path([-2], {'-2': 'a'}); //=> undefined
- */
-
 function path(pathAr, obj) {
   let val = obj;
   for (let i = 0; i < pathAr.length; i += 1) {

--- a/source/internal/_path.js
+++ b/source/internal/_path.js
@@ -2,8 +2,8 @@ import _isInteger from './_isInteger.js';
 import _nth from './_nth.js';
 
 function path(pathAr, obj) {
-  let val = obj;
-  for (let i = 0; i < pathAr.length; i += 1) {
+  var val = obj;
+  for (var i = 0; i < pathAr.length; i += 1) {
     if (val == null) {
       return undefined;
     }

--- a/source/last.js
+++ b/source/last.js
@@ -1,4 +1,5 @@
-import nth from './nth.js';
+import _curry1 from './internal/_curry1.js';
+import _nth from './internal/_nth.js';
 
 
 /**
@@ -21,5 +22,7 @@ import nth from './nth.js';
  *      R.last('abc'); //=> 'c'
  *      R.last(''); //=> ''
  */
-var last = nth(-1);
+var last = _curry1(function(list) {
+  return _nth(-1, list);
+});
 export default last;

--- a/source/lensIndex.js
+++ b/source/lensIndex.js
@@ -26,7 +26,7 @@ import update from './update.js';
  */
 var lensIndex = _curry1(function lensIndex(n) {
   return lens(
-    val => _nth(n, val),
+    function(val) { return _nth(n, val);},
     update(n)
   );
 });

--- a/source/lensIndex.js
+++ b/source/lensIndex.js
@@ -1,6 +1,6 @@
 import _curry1 from './internal/_curry1.js';
+import _nth from './internal/_nth.js';
 import lens from './lens.js';
-import nth from './nth.js';
 import update from './update.js';
 
 
@@ -25,6 +25,9 @@ import update from './update.js';
  *      R.over(headLens, R.toUpper, ['a', 'b', 'c']); //=> ['A', 'b', 'c']
  */
 var lensIndex = _curry1(function lensIndex(n) {
-  return lens(nth(n), update(n));
+  return lens(
+    val => _nth(n, val),
+    update(n)
+  );
 });
 export default lensIndex;

--- a/source/lensPath.js
+++ b/source/lensPath.js
@@ -1,7 +1,7 @@
 import _curry1 from './internal/_curry1.js';
 import assocPath from './assocPath.js';
 import lens from './lens.js';
-import path from './path.js';
+import _path from './internal/_path.js';
 
 
 /**
@@ -28,7 +28,11 @@ import path from './path.js';
  *      R.over(xHeadYLens, R.negate, {x: [{y: 2, z: 3}, {y: 4, z: 5}]});
  *      //=> {x: [{y: -2, z: 3}, {y: 4, z: 5}]}
  */
+
 var lensPath = _curry1(function lensPath(p) {
-  return lens(path(p), assocPath(p));
+  return lens(
+    (val) => _path(p, val),
+    assocPath(p)
+  );
 });
 export default lensPath;

--- a/source/lensPath.js
+++ b/source/lensPath.js
@@ -31,7 +31,7 @@ import _path from './internal/_path.js';
 
 var lensPath = _curry1(function lensPath(p) {
   return lens(
-    (val) => _path(p, val),
+    function(val) { return _path(p, val);},
     assocPath(p)
   );
 });

--- a/source/nth.js
+++ b/source/nth.js
@@ -1,6 +1,5 @@
 import _curry2 from './internal/_curry2.js';
-import _isString from './internal/_isString.js';
-
+import _nth from './internal/_nth.js';
 
 /**
  * Returns the nth element of the given list or string. If n is negative the
@@ -28,8 +27,5 @@ import _isString from './internal/_isString.js';
  * @symb R.nth(0, [a, b, c]) = a
  * @symb R.nth(1, [a, b, c]) = b
  */
-var nth = _curry2(function nth(offset, list) {
-  var idx = offset < 0 ? list.length + offset : offset;
-  return _isString(list) ? list.charAt(idx) : list[idx];
-});
+var nth = _curry2(_nth);
 export default nth;

--- a/source/nthArg.js
+++ b/source/nthArg.js
@@ -1,6 +1,6 @@
 import _curry1 from './internal/_curry1.js';
+import _nth from './internal/_nth.js';
 import curryN from './curryN.js';
-import nth from './nth.js';
 
 
 /**
@@ -24,7 +24,7 @@ import nth from './nth.js';
 var nthArg = _curry1(function nthArg(n) {
   var arity = n < 0 ? 1 : n + 1;
   return curryN(arity, function() {
-    return nth(n, arguments);
+    return _nth(n, arguments);
   });
 });
 export default nthArg;

--- a/source/path.js
+++ b/source/path.js
@@ -1,5 +1,5 @@
 import _curry2 from './internal/_curry2.js';
-import paths from './paths.js';
+import _path from './internal/_path.js';
 
 /**
  * Retrieves the value at a given path. The nodes of the path can be arbitrary strings or non-negative integers.
@@ -26,7 +26,5 @@ import paths from './paths.js';
  *      R.path([-2], {'-2': 'a'}); //=> undefined
  */
 
-var path = _curry2(function path(pathAr, obj) {
-  return paths([pathAr], obj)[0];
-});
+var path = _curry2(_path);
 export default path;

--- a/source/pathEq.js
+++ b/source/pathEq.js
@@ -1,6 +1,6 @@
 import _curry3 from './internal/_curry3.js';
+import _path from './internal/_path.js';
 import equals from './equals.js';
-import path from './path.js';
 
 
 /**
@@ -14,7 +14,7 @@ import path from './path.js';
  * @typedefn Idx = String | Int | Symbol
  * @sig a -> [Idx] -> {a} -> Boolean
  * @param {*} val The value to compare the nested property with
- * @param {Array} path The path of the nested property to use
+ * @param {Array} pathAr The path of the nested property to use
  * @param {Object} obj The object to check the nested property in
  * @return {Boolean} `true` if the value equals the nested object property,
  *         `false` otherwise.
@@ -28,7 +28,7 @@ import path from './path.js';
  *      const isFamous = R.pathEq(90210, ['address', 'zipCode']);
  *      R.filter(isFamous, users); //=> [ user1 ]
  */
-var pathEq = _curry3(function pathEq(val, _path, obj) {
-  return equals(path(_path, obj), val);
+var pathEq = _curry3(function pathEq(val, pathAr, obj) {
+  return equals(_path(pathAr, obj), val);
 });
 export default pathEq;

--- a/source/pathEq.js
+++ b/source/pathEq.js
@@ -14,7 +14,7 @@ import equals from './equals.js';
  * @typedefn Idx = String | Int | Symbol
  * @sig a -> [Idx] -> {a} -> Boolean
  * @param {*} val The value to compare the nested property with
- * @param {Array} pathAr The path of the nested property to use
+ * @param {Array} path The path of the nested property to use
  * @param {Object} obj The object to check the nested property in
  * @return {Boolean} `true` if the value equals the nested object property,
  *         `false` otherwise.

--- a/source/pathOr.js
+++ b/source/pathOr.js
@@ -1,6 +1,6 @@
 import _curry3 from './internal/_curry3.js';
+import _path from './internal/_path.js';
 import defaultTo from './defaultTo.js';
-import path from './path.js';
 
 
 /**
@@ -23,6 +23,6 @@ import path from './path.js';
  *      R.pathOr('N/A', ['a', 'b'], {c: {b: 2}}); //=> "N/A"
  */
 var pathOr = _curry3(function pathOr(d, p, obj) {
-  return defaultTo(d, path(p, obj));
+  return defaultTo(d, _path(p, obj));
 });
 export default pathOr;

--- a/source/pathSatisfies.js
+++ b/source/pathSatisfies.js
@@ -1,5 +1,5 @@
 import _curry3 from './internal/_curry3.js';
-import path from './path.js';
+import _path from './internal/_path.js';
 
 
 /**
@@ -23,6 +23,6 @@ import path from './path.js';
  *      R.pathSatisfies(R.is(Object), [], {x: {y: 2}}); //=> true
  */
 var pathSatisfies = _curry3(function pathSatisfies(pred, propPath, obj) {
-  return pred(path(propPath, obj));
+  return pred(_path(propPath, obj));
 });
 export default pathSatisfies;

--- a/source/paths.js
+++ b/source/paths.js
@@ -1,6 +1,6 @@
 import _curry2 from './internal/_curry2.js';
 import _isInteger from './internal/_isInteger.js';
-import nth from './nth.js';
+import _nth from './internal/_nth.js';
 
 /**
  * Retrieves the values at given paths of an object.
@@ -30,7 +30,7 @@ var paths = _curry2(function paths(pathsArray, obj) {
         return;
       }
       p = paths[idx];
-      val = _isInteger(p) ? nth(p, val) : val[p];
+      val = _isInteger(p) ? _nth(p, val) : val[p];
       idx += 1;
     }
     return val;

--- a/source/prop.js
+++ b/source/prop.js
@@ -1,6 +1,6 @@
 import _curry2 from './internal/_curry2.js';
 import _isInteger from './internal/_isInteger.js';
-import nth from './nth.js';
+import _nth from './internal/_nth.js';
 
 
 /**
@@ -29,6 +29,6 @@ var prop = _curry2(function prop(p, obj) {
   if (obj == null) {
     return;
   }
-  return _isInteger(p) ? nth(p, obj) : obj[p];
+  return _isInteger(p) ? _nth(p, obj) : obj[p];
 });
 export default prop;

--- a/source/props.js
+++ b/source/props.js
@@ -1,5 +1,5 @@
 import _curry2 from './internal/_curry2.js';
-import path from './path.js';
+import prop from './prop.js';
 
 
 /**
@@ -25,7 +25,7 @@ import path from './path.js';
  */
 var props = _curry2(function props(ps, obj) {
   return  ps.map(function(p) {
-    return path([p], obj);
+    return prop(p, obj);
   });
 });
 export default props;


### PR DESCRIPTION
My attempt at solving functions like path running slow due to using currying when not necessary and depending on functions that do more work than required.

## Results
```
path old x 2,060,753 ops/sec ±3.83% (22 runs sampled)
path new x 4,981,880 ops/sec ±0.92% (24 runs sampled)
```

## Optimization steps
- Own code for path function to avoid curry call and extra array when using paths
- moved nth functionality to internal to have access to an non curried version
- moved path functionality to internal to have access to an non curried version
- replacing calls of nth and path with non curried versions will also improve performance of dependent functions

## Curry vs no curry
In the future all functions should probably call an internal non curried version of the functionality. Not creating a new function on the fly and then calling it was a major part of these performance optimizations. Being able to use these non curried versions from the library would be amazing, although this would probably go against ramda's "everything is curried" policy.

```
path curried  x 4,981,880 ops/sec ±0.92% (24 runs sampled)
path internal x 8,866,690 ops/sec ±4.40% (23 runs sampled)
```

see [here](https://github.com/Berndy/ramda/blob/benchmark-path/benchmarkPath.md) for my benchmark experiment

