### PR TITLE
replaced let with var in _clone.js for consistency

### DIFF
--- a/source/internal/_clone.js
+++ b/source/internal/_clone.js
@@ -69,7 +69,7 @@ function _ObjectMap() {
 }
 
 _ObjectMap.prototype.set = function(key, value) {
-  const hashedKey = this.hash(key);
+  var hashedKey = this.hash(key);
 
   var bucket = this.map[hashedKey];
   if (!bucket) {
@@ -96,11 +96,11 @@ _ObjectMap.prototype.get = function(key) {
    */
   if (this.length <= 180) {
 
-    for (const p in this.map) {
-      const bucket = this.map[p];
+    for (var p in this.map) {
+      var bucket = this.map[p];
 
       for (var i = 0; i < bucket.length; i += 1) {
-        const element = bucket[i];
+        var element = bucket[i];
         if (element[0] === key) {return element[1];}
       }
 
@@ -108,13 +108,13 @@ _ObjectMap.prototype.get = function(key) {
     return;
   }
 
-  const hashedKey = this.hash(key);
-  const bucket = this.map[hashedKey];
+  var hashedKey = this.hash(key);
+  var bucket = this.map[hashedKey];
 
   if (!bucket) {return;}
 
   for (var i = 0; i < bucket.length; i += 1) {
-    const element = bucket[i];
+    var element = bucket[i];
     if (element[0] === key) {return element[1];}
   }
 

--- a/source/internal/_path.js
+++ b/source/internal/_path.js
@@ -8,7 +8,7 @@ export default function _path(pathAr, obj) {
       return undefined;
     }
 
-    const p = pathAr[i];
+    var p = pathAr[i];
     if (_isInteger(p)) {
       val = _nth(p, val);
     } else {


### PR DESCRIPTION
We try to refrain from using `const` and `let` in favor of `var`, so I replaced some leftover `let` in _clone.js