### PR TITLE
adds flow serial function application

### DIFF
--- a/source/flow.js
+++ b/source/flow.js
@@ -1,11 +1,18 @@
 import applyTo from './applyTo.js';
-import tail from './tail.js';
+import _curry2 from './internal/_curry2.js';
 
 /**
- * Pipe the value of an expression into a pipeline of functions by performing
- * left-to-right serial function composition.
- * The first argument is the seed value;
- * the remaining arguments must be unary functions.
+ * Takes the value of an expression and applies it to a function
+ * which is the left-to-right serial composition of the functions
+ * given in the second argument.
+ *
+ * The functions in the pipeline should be unary functions.
+ *
+ * `flow` is helps to avoid introducing named functions with named arguments
+ * for computing the result of a function pipeline which depends on given initial values.
+ * Rather than composing a custom pipeline function `p = (_x, _y) => R.pipe(g(x), h(y), …)`
+ * which is only later needed once `z = p(x, y)`,
+ * the introduction of `p`, `_x` and `_y` can be avoided: `z = flow(x, [g, h(y),…]`
  *
  * In some libraries this function is named `pipe`.
  *
@@ -13,21 +20,18 @@ import tail from './tail.js';
  * @memberOf R
  * @since v0.30.0
  * @category Function
- * @sig (a, (a → b), …, (y → z)) → z
+ * @sig (a, [(a → b), …, (y → z)]) → z
  * @param {*} a The seed value
- * @param {...Function} functions
- * @return {*} z The result of the function pipeline
+ * @param {Array<Function>} pipeline functions composing the pipeline
+ * @return {*} z The result of applying the seed value to the function pipeline
  * @see R.pipe
  * @example
- *
- *      const m2 = R.flow(9, Math.sqrt, R.negate, R.inc); //=> -2
+ *      const defaultName = 'Jane Doe';
+ *      const savedName = R.flow(localStorage.get('name'), [R.when(R.isNil(defaultName)), R.match(/(.+)\s/), R.nth(0)]);
+ *      const givenName = R.flow($givenName.value, [R.trim, R.when(R.isEmpty, R.always(savedName))])
  */
-export default function flow() {
-  if (arguments.length === 0) {
-    throw new Error('flow requires at least one argument');
-  }
-  return tail(arguments).reduce(
-    applyTo,
-    arguments[0]
-  );
-}
+var flow = _curry2(function flow(seed, pipeline) {
+  return pipeline.reduce(applyTo, seed);
+});
+
+export default flow;

--- a/source/flow.js
+++ b/source/flow.js
@@ -1,5 +1,6 @@
 import applyTo from './applyTo.js';
 import _curry2 from './internal/_curry2.js';
+import _reduce from './internal/_reduce.js';
 
 /**
  * Takes the value of an expression and applies it to a function
@@ -8,11 +9,11 @@ import _curry2 from './internal/_curry2.js';
  *
  * The functions in the pipeline should be unary functions.
  *
- * `flow` is helps to avoid introducing named functions with named arguments
+ * `flow` is helps to avoid introducing an extra function with named arguments
  * for computing the result of a function pipeline which depends on given initial values.
- * Rather than composing a custom pipeline function `p = (_x, _y) => R.pipe(g(x), h(y), …)`
- * which is only later needed once `z = p(x, y)`,
- * the introduction of `p`, `_x` and `_y` can be avoided: `z = flow(x, [g, h(y),…]`
+ * Rather than defining a referential transparent function `f = (_x, _y) => R.pipe(g(_x), h(_y), …)`
+ * which is only later needed once `z = f(x, y)`,
+ * the introduction of `f`, `_x` and `_y` can be avoided: `z = flow(x, [g, h(y),…]`
  *
  * In some libraries this function is named `pipe`.
  *
@@ -28,10 +29,10 @@ import _curry2 from './internal/_curry2.js';
  * @example
  *      const defaultName = 'Jane Doe';
  *      const savedName = R.flow(localStorage.get('name'), [R.when(R.isNil(defaultName)), R.match(/(.+)\s/), R.nth(0)]);
- *      const givenName = R.flow($givenName.value, [R.trim, R.when(R.isEmpty, R.always(savedName))])
+ *      const givenName = R.flow($givenNameInput.value, [R.trim, R.when(R.isEmpty, R.always(savedName))])
  */
 var flow = _curry2(function flow(seed, pipeline) {
-  return pipeline.reduce(applyTo, seed);
+  return _reduce(applyTo, seed, pipeline);
 });
 
 export default flow;

--- a/source/flow.js
+++ b/source/flow.js
@@ -20,7 +20,7 @@ import _curry2 from './internal/_curry2.js';
  * @memberOf R
  * @since v0.30.0
  * @category Function
- * @sig (a, [(a → b), …, (y → z)]) → z
+ * @sig a → [(a → b), …, (y → z)] → z
  * @param {*} a The seed value
  * @param {Array<Function>} pipeline functions composing the pipeline
  * @return {*} z The result of applying the seed value to the function pipeline

--- a/source/flow.js
+++ b/source/flow.js
@@ -1,0 +1,31 @@
+import applyTo from './applyTo.js';
+import tail from './tail.js';
+
+/**
+ * Performs left-to-right serial function application. The first argument is the seed value;
+ * the remaining arguments must be unary functions.
+ *
+ * In some libraries this function is named `pipe`.
+ *
+ * @func
+ * @memberOf R
+ * @since v0.30.0
+ * @category Function
+ * @sig (a → (a → b), …, (y → z)) → z
+ * @param {*} a The seed value
+ * @param {...Function} functions
+ * @return {*} z The result of the function pipeline
+ * @see R.pipe
+ * @example
+ *
+ *      const m2 = R.pipe(9, Math.sqrt, R.negate, R.inc); //=> -2
+ */
+export default function flow() {
+  if (arguments.length <= 1) {
+    throw new Error('flow requires at least two arguments');
+  }
+  return tail(arguments).reduce(
+    applyTo,
+    arguments[0]
+  );
+}

--- a/source/flow.js
+++ b/source/flow.js
@@ -27,6 +27,8 @@ import _reduce from './internal/_reduce.js';
  * @return {*} z The result of applying the seed value to the function pipeline
  * @see R.pipe
  * @example
+ *      R.flow(9, [Math.sqrt, R.negate, R.inc]), //=> -2
+ *
  *      const defaultName = 'Jane Doe';
  *      const savedName = R.flow(localStorage.get('name'), [R.when(R.isNil(defaultName)), R.match(/(.+)\s/), R.nth(0)]);
  *      const givenName = R.flow($givenNameInput.value, [R.trim, R.when(R.isEmpty, R.always(savedName))])

--- a/source/flow.js
+++ b/source/flow.js
@@ -2,7 +2,9 @@ import applyTo from './applyTo.js';
 import tail from './tail.js';
 
 /**
- * Performs left-to-right serial function application. The first argument is the seed value;
+ * Pipe the value of an expression into a pipeline of functions by performing
+ * left-to-right serial function composition.
+ * The first argument is the seed value;
  * the remaining arguments must be unary functions.
  *
  * In some libraries this function is named `pipe`.
@@ -11,7 +13,7 @@ import tail from './tail.js';
  * @memberOf R
  * @since v0.30.0
  * @category Function
- * @sig (a → (a → b), …, (y → z)) → z
+ * @sig (a, (a → b), …, (y → z)) → z
  * @param {*} a The seed value
  * @param {...Function} functions
  * @return {*} z The result of the function pipeline

--- a/source/flow.js
+++ b/source/flow.js
@@ -18,11 +18,11 @@ import tail from './tail.js';
  * @see R.pipe
  * @example
  *
- *      const m2 = R.pipe(9, Math.sqrt, R.negate, R.inc); //=> -2
+ *      const m2 = R.flow(9, Math.sqrt, R.negate, R.inc); //=> -2
  */
 export default function flow() {
-  if (arguments.length <= 1) {
-    throw new Error('flow requires at least two arguments');
+  if (arguments.length === 0) {
+    throw new Error('flow requires at least one argument');
   }
   return tail(arguments).reduce(
     applyTo,

--- a/source/index.js
+++ b/source/index.js
@@ -70,6 +70,7 @@ export { default as findLast } from './findLast.js';
 export { default as findLastIndex } from './findLastIndex.js';
 export { default as flatten } from './flatten.js';
 export { default as flip } from './flip.js';
+export { default as flow } from './flow.js';
 export { default as forEach } from './forEach.js';
 export { default as forEachObjIndexed } from './forEachObjIndexed.js';
 export { default as fromPairs } from  './fromPairs.js';

--- a/test/flow.js
+++ b/test/flow.js
@@ -8,7 +8,7 @@ describe('flow', function() {
     eq(R.flow.length, 2);
   });
 
-  it('performs left-to-right function composition', function() {
+  it('applies the first argument to a left-to-right composed function', function() {
     //  f :: [Number] -> [Number]
     var f2 = R.flow(4, [Math.sqrt, R.multiply, R.map]);
     var f3 = R.flow(9, [Math.sqrt, R.multiply, R.map]);

--- a/test/flow.js
+++ b/test/flow.js
@@ -1,0 +1,35 @@
+var assert = require('assert');
+
+var R = require('../source/index.js');
+var eq = require('./shared/eq.js');
+
+describe('flow', function() {
+
+  it('is a variadic function', function() {
+    eq(typeof R.flow, 'function');
+    eq(R.flow.length, 0);
+  });
+
+  it('performs left-to-right function composition', function() {
+    //  f10 :: [Number] -> [Number]
+    var f2 = R.flow(4, Math.sqrt, R.multiply, R.map);
+    var f3 = R.flow(9, Math.sqrt, R.multiply, R.map);
+
+    eq(f2([1, 2, 3]), [2, 4, 6]);
+    eq(f3([1, 2, 3]), [3, 6, 9]);
+  });
+
+  it('throws if given no arguments', function() {
+    assert.throws(
+      function() { R.flow(); },
+      function(err) {
+        return err.constructor === Error &&
+               err.message === 'flow requires at least two arguments';
+      }
+    );
+  });
+
+  it('can be applied to one argument', function() {
+    eq(R.flow(16, Math.sqrt), 4);
+  });
+});

--- a/test/flow.js
+++ b/test/flow.js
@@ -24,12 +24,13 @@ describe('flow', function() {
       function() { R.flow(); },
       function(err) {
         return err.constructor === Error &&
-               err.message === 'flow requires at least two arguments';
+               err.message === 'flow requires at least one argument';
       }
     );
   });
 
-  it('can be applied to one argument', function() {
-    eq(R.flow(16, Math.sqrt), 4);
+  it('returns the seed argument when the only one given', function() {
+    var sentinel = { foo: 'bar' };
+    eq(R.flow(sentinel), sentinel);
   });
 });

--- a/test/flow.js
+++ b/test/flow.js
@@ -1,5 +1,3 @@
-var assert = require('assert');
-
 var R = require('../source/index.js');
 var eq = require('./shared/eq.js');
 

--- a/test/flow.js
+++ b/test/flow.js
@@ -5,32 +5,19 @@ var eq = require('./shared/eq.js');
 
 describe('flow', function() {
 
-  it('is a variadic function', function() {
+  it('is a binary function', function() {
     eq(typeof R.flow, 'function');
-    eq(R.flow.length, 0);
+    eq(R.flow.length, 2);
   });
 
   it('performs left-to-right function composition', function() {
-    //  f10 :: [Number] -> [Number]
-    var f2 = R.flow(4, Math.sqrt, R.multiply, R.map);
-    var f3 = R.flow(9, Math.sqrt, R.multiply, R.map);
+    //  f :: [Number] -> [Number]
+    var f2 = R.flow(4, [Math.sqrt, R.multiply, R.map]);
+    var f3 = R.flow(9, [Math.sqrt, R.multiply, R.map]);
 
     eq(f2([1, 2, 3]), [2, 4, 6]);
     eq(f3([1, 2, 3]), [3, 6, 9]);
-  });
 
-  it('throws if given no arguments', function() {
-    assert.throws(
-      function() { R.flow(); },
-      function(err) {
-        return err.constructor === Error &&
-               err.message === 'flow requires at least one argument';
-      }
-    );
-  });
-
-  it('returns the seed argument when the only one given', function() {
-    var sentinel = { foo: 'bar' };
-    eq(R.flow(sentinel), sentinel);
+    eq(R.flow(9, [Math.sqrt, R.negate, R.inc]), -2);
   });
 });


### PR DESCRIPTION
I find myself frequently using function pipelines for immediate values `h(g(f(x)))`:
```javascript
const val = pipe(
  () => x, f, g, h)()
```
It's tedious to write and the many parentheses are easy to mess up. 
Also I don't want to put the seed `x` in the end `pipe(f, g, h)(x)`, because `x` is far away from `f` and thus your eyes have to jump up and down reading the code.

Therefore I propose to include `flow` for serial function application, i.e. the same spirit as above
```javascript
const val = flow(x, g, h)
```
Such a function is provided elsewhere. E.g. in [fp-ts](https://gcanti.github.io/fp-ts/modules/function.ts.html#pipe) named `pipe`. There was even a [proposal to TC39](https://github.com/tc39/proposal-function-pipe-flow) for including it in JavaScript.

#### Naming:
Ramda's `R.pipe` is mostly named `flow` everywhere else (e.g. lodash), and the proposed `R.flow` is mostly named `pipe`. [See the post about function composition](https://jrsinclair.com/articles/2022/javascript-function-composition-whats-the-big-deal/#flow) by James Sinclair to maximise your confusion.

#### Details: 
For generality — if omitting all functions — one could provide `flow(x) ≡ x` as fp-ts does. Is that reasonable?