### PR TITLE
fix: splitWhenever jsdoc

### DIFF
--- a/source/splitWhenever.js
+++ b/source/splitWhenever.js
@@ -4,7 +4,7 @@ import _curryN from './internal/_curryN.js';
  *
  * @func
  * @memberOf R
- * @since v0.26.1
+ * @since v0.28.0
  * @category List
  * @sig (a -> Boolean) -> [a] -> [[a]]
  * @param {Function} pred The predicate that determines where the array is split.


### PR DESCRIPTION
Despite this existing [PR](https://github.com/ramda/ramda/pull/3288), it seems that the merge has not taken place and that the correction is still necessary.