### PR TITLE
JSDoc: `type()` can return `BigInt`

### DIFF
--- a/source/type.js
+++ b/source/type.js
@@ -26,6 +26,7 @@ import _curry1 from './internal/_curry1.js';
  *      R.type(() => {}); //=> "Function"
  *      R.type(async () => {}); //=> "AsyncFunction"
  *      R.type(undefined); //=> "Undefined"
+ *      R.type(BigInt(123)); //=> "BigInt"
  */
 var type = _curry1(function type(val) {
   return val === null


### PR DESCRIPTION
Due to https://github.com/ramda/types/pull/116#issuecomment-2030996327