### PR TITLE
Support Objects aka dictionaries as Traversables

### DIFF
--- a/source/traverse.js
+++ b/source/traverse.js
@@ -11,6 +11,8 @@ import sequence from './sequence.js';
  *
  * Dispatches to the `traverse` method of the third argument, if present.
  *
+ * Also accepts `Object` as the Traversable to aid working with [dictionaries](https://github.com/ramda/ramda/wiki/Type-Signatures#simple-objects) (Objects of like-typed values).
+ *
  * @func
  * @memberOf R
  * @since v0.19.0
@@ -30,6 +32,8 @@ import sequence from './sequence.js';
  *
  *      R.traverse(Maybe.of, safeDiv(10), [2, 4, 5]); //=> Maybe.Just([5, 2.5, 2])
  *      R.traverse(Maybe.of, safeDiv(10), [2, 0, 5]); //=> Maybe.Nothing
+ *
+ *      R.traverse(Maybe.of, safeDiv(10), {a: 2, b: 4}); //=> Maybe.Just({a: 5, b: 2.5})
  *
  *      // Using a Type Representative
  *      R.traverse(Maybe, safeDiv(10), Right(4)); //=> Just(Right(2.5))

--- a/test/sequence.js
+++ b/test/sequence.js
@@ -24,6 +24,11 @@ describe('sequence', function() {
     eq(R.sequence(ofMaybe, [Just(3), Nothing, Just(5)]), Nothing);
   });
 
+  it('operates on a dictionary of applicatives', function() {
+    eq(R.sequence(ofMaybe, {a: Just(3), b: Just(4), c: Just(5)}), Just({a: 3, b: 4, c: 5}));
+    eq(R.sequence(ofMaybe, {a: Just(3), b: Nothing, c: Just(5)}), Nothing);
+  });
+
   it('traverses left to right', function() {
     eq(R.sequence(ofEither, [Right(1), Right(2)]), Right([1, 2]));
     eq(R.sequence(ofEither, [Right(1), Left('XXX')]), Left('XXX'));

--- a/test/traverse.js
+++ b/test/traverse.js
@@ -25,6 +25,11 @@ describe('traverse', function() {
     eq(R.traverse(ofMaybe, R.map(R.add(10)), [Just(3), Nothing, Just(5)]), Nothing);
   });
 
+  it('operates on a dictionary of applicatives', function() {
+    eq(R.traverse(ofMaybe, R.map(R.add(10)), {a: Just(3), b: Just(4), c: Just(5)}), Just({a: 13, b: 14, c: 15}));
+    eq(R.traverse(ofMaybe, R.map(R.add(10)), {a: Just(3), b: Nothing, c: Just(5)}), Nothing);
+  });
+
   it('operates on a list of FL-applicatives', function() {
     eq(R.traverse(Maybe, R.map(R.add(10)), [Just(3), Just(4), Just(5)]), Just([13, 14, 15]));
     eq(R.traverse(Maybe, R.map(R.add(10)), [Just(3), Nothing, Just(5)]), Nothing);


### PR DESCRIPTION
As implemented elsewhere:

- in the [`Map` type](https://mostly-adequate.gitbook.io/mostly-adequate-guide/appendix_b#map) of Prof. Frisby's FP Guide 
- in the [`Record` type](https://gcanti.github.io/fp-ts/modules/Record.ts.html#traverse) of [fp-ts](https://gcanti.github.io/fp-ts/)