### PR TITLE
support Reader monad in R.of(Function)

### DIFF
--- a/source/chain.js
+++ b/source/chain.js
@@ -13,6 +13,7 @@ import map from './map.js';
  * according to the [FantasyLand Chain spec](https://github.com/fantasyland/fantasy-land#chain).
  *
  * If second argument is a function, `chain(f, g)(x)` is equivalent to `f(g(x), x)`.
+ * This can be used in a Reader monad pipeline, to pass the environment value as second argument into that function.
  *
  * Acts as a transducer if a transformer is given in list position.
  *
@@ -30,6 +31,15 @@ import map from './map.js';
  *      R.chain(duplicate, [1, 2, 3]); //=> [1, 1, 2, 2, 3, 3]
  *
  *      R.chain(R.append, R.head)([1, 2, 3]); //=> [1, 2, 3, 1]
+ *
+ *      // withSumInKey :: string → {number} → {number}
+ *      withSumInKey = key => R.flow(
+ *        R.of(Function, key),    // :: Reader {number} string
+ *        [R.chain(R.dissoc),
+ *        R.map(R.o(R.sum, R.values)),
+ *        R.chain(R.assoc(key))]
+ *      );
+ *      withSumInKey('baz')({foo: 10, bar: 20, baz: 50}); //=>{"foo":10,"bar":20,"baz":30}
  */
 var chain = _curry2(_dispatchable(['fantasy-land/chain', 'chain'], _xchain, function chain(fn, monad) {
   if (typeof monad === 'function') {

--- a/test/of.js
+++ b/test/of.js
@@ -16,4 +16,8 @@ describe('of', function() {
   it('dispatches to an available of method', function() {
     eq(R.of(Maybe, 100), Just(100));
   });
+
+  it('returns a Reader monad', function() {
+    eq(R.of(Function, {foo: 'bar'})(12), {foo: 'bar'});
+  });
 });


### PR DESCRIPTION
Ramda already supports binary curried functions as [Reader monad][FunctionFunctors-TH]:
- `map` composes the mapping function and the Reader function
- `chain` composes the chaining function in its first (value) argument with the Reader function and forwards the environment to the second argument.
- `ap` is implemented so that `lift` ≅ `R.converge`

Still missing is the factory function `of`.

Although users can easily write their own,
```javascript
const ofReader = a => x => a;
// or
const ofReader = a => always(a);
```
for convenience Ramda ought provide it as `of(Function)`.

To illustrate a simple Reader function pipeline, I added some detailed examples to the documentation of `R.of` and `R.chain`. 

If those examples are misleading I can remove or change them. 
Furthermore, the `R.of` example is copied from @i-am-tom 's ["Fantas, Eel, and Specification"][FES-TH] article series which — sadly — seems to be offline now. I hope, we have his permission to use it here.

[FunctionFunctors-TH]: https://web.archive.org/web/20231206133938/http://tomharding.me/2017/04/15/functions-as-functors/
[FES-TH]: https://web.archive.org/web/20231206133938/http://tomharding.me/fantasy-land