### PR TITLE
JSDoc:  update `head()`, `last()`, and `nth()` to reflect actual behavior

### DIFF
--- a/dist/ramda.js
+++ b/dist/ramda.js
@@ -2979,7 +2979,7 @@
    * @since v0.1.0
    * @category List
    * @sig [a] -> a | Undefined
-   * @sig String -> String
+   * @sig String -> String | Undefined
    * @param {Array|String} list
    * @return {*}
    * @see R.tail, R.init, R.last
@@ -2989,7 +2989,7 @@
    *      R.head([]); //=> undefined
    *
    *      R.head('abc'); //=> 'a'
-   *      R.head(''); //=> ''
+   *      R.head(''); //=> undefined
    */
   var head = _curry1(function (list) {
     return _nth(0, list);

--- a/dist/ramda.js
+++ b/dist/ramda.js
@@ -4259,7 +4259,7 @@
    * @since v0.1.4
    * @category List
    * @sig [a] -> a | Undefined
-   * @sig String -> String
+   * @sig String -> String | Undefined
    * @param {*} list
    * @return {*}
    * @see R.init, R.head, R.tail
@@ -7396,7 +7396,7 @@
    * @since v0.1.0
    * @category List
    * @sig Number -> [a] -> a | Undefined
-   * @sig Number -> String -> String
+   * @sig Number -> String -> String | Undefined
    * @param {Number} offset
    * @param {*} list
    * @return {*}
@@ -7408,7 +7408,7 @@
    *      R.nth(-99, list); //=> undefined
    *
    *      R.nth(2, 'abc'); //=> 'c'
-   *      R.nth(3, 'abc'); //=> ''
+   *      R.nth(3, 'abc'); //=> undefined
    * @symb R.nth(-1, [a, b, c]) = c
    * @symb R.nth(0, [a, b, c]) = a
    * @symb R.nth(1, [a, b, c]) = b

--- a/dist/ramda.js
+++ b/dist/ramda.js
@@ -4269,7 +4269,7 @@
    *      R.last([]); //=> undefined
    *
    *      R.last('abc'); //=> 'c'
-   *      R.last(''); //=> ''
+   *      R.last(''); //=> undefined
    */
   var last = _curry1(function (list) {
     return _nth(-1, list);

--- a/dist/ramda.js
+++ b/dist/ramda.js
@@ -2979,7 +2979,7 @@
    * @since v0.1.0
    * @category List
    * @sig [a] -> a | Undefined
-   * @sig String -> String | Undefined
+   * @sig String -> String
    * @param {Array|String} list
    * @return {*}
    * @see R.tail, R.init, R.last
@@ -2989,7 +2989,7 @@
    *      R.head([]); //=> undefined
    *
    *      R.head('abc'); //=> 'a'
-   *      R.head(''); //=> undefined
+   *      R.head(''); //=> ''
    */
   var head = _curry1(function (list) {
     return _nth(0, list);
@@ -4259,7 +4259,7 @@
    * @since v0.1.4
    * @category List
    * @sig [a] -> a | Undefined
-   * @sig String -> String | Undefined
+   * @sig String -> String
    * @param {*} list
    * @return {*}
    * @see R.init, R.head, R.tail
@@ -4269,7 +4269,7 @@
    *      R.last([]); //=> undefined
    *
    *      R.last('abc'); //=> 'c'
-   *      R.last(''); //=> undefined
+   *      R.last(''); //=> ''
    */
   var last = _curry1(function (list) {
     return _nth(-1, list);
@@ -7396,7 +7396,7 @@
    * @since v0.1.0
    * @category List
    * @sig Number -> [a] -> a | Undefined
-   * @sig Number -> String -> String | Undefined
+   * @sig Number -> String -> String
    * @param {Number} offset
    * @param {*} list
    * @return {*}
@@ -7408,7 +7408,7 @@
    *      R.nth(-99, list); //=> undefined
    *
    *      R.nth(2, 'abc'); //=> 'c'
-   *      R.nth(3, 'abc'); //=> undefined
+   *      R.nth(3, 'abc'); //=> ''
    * @symb R.nth(-1, [a, b, c]) = c
    * @symb R.nth(0, [a, b, c]) = a
    * @symb R.nth(1, [a, b, c]) = b

--- a/source/head.js
+++ b/source/head.js
@@ -11,7 +11,7 @@ import _nth from './internal/_nth.js';
  * @since v0.1.0
  * @category List
  * @sig [a] -> a | Undefined
- * @sig String -> String
+ * @sig String -> String | Undefined
  * @param {Array|String} list
  * @return {*}
  * @see R.tail, R.init, R.last
@@ -21,7 +21,7 @@ import _nth from './internal/_nth.js';
  *      R.head([]); //=> undefined
  *
  *      R.head('abc'); //=> 'a'
- *      R.head(''); //=> ''
+ *      R.head(''); //=> undefined
  */
 var head = _curry1(function(list) {
   return _nth(0, list);

--- a/source/last.js
+++ b/source/last.js
@@ -20,7 +20,7 @@ import _nth from './internal/_nth.js';
  *      R.last([]); //=> undefined
  *
  *      R.last('abc'); //=> 'c'
- *      R.last(''); //=> ''
+ *      R.last(''); //=> undefined
  */
 var last = _curry1(function(list) {
   return _nth(-1, list);

--- a/source/last.js
+++ b/source/last.js
@@ -10,7 +10,7 @@ import _nth from './internal/_nth.js';
  * @since v0.1.4
  * @category List
  * @sig [a] -> a | Undefined
- * @sig String -> String
+ * @sig String -> String | Undefined
  * @param {*} list
  * @return {*}
  * @see R.init, R.head, R.tail

--- a/source/nth.js
+++ b/source/nth.js
@@ -10,7 +10,7 @@ import _nth from './internal/_nth.js';
  * @since v0.1.0
  * @category List
  * @sig Number -> [a] -> a | Undefined
- * @sig Number -> String -> String
+ * @sig Number -> String -> String | Undefined
  * @param {Number} offset
  * @param {*} list
  * @return {*}
@@ -22,7 +22,7 @@ import _nth from './internal/_nth.js';
  *      R.nth(-99, list); //=> undefined
  *
  *      R.nth(2, 'abc'); //=> 'c'
- *      R.nth(3, 'abc'); //=> ''
+ *      R.nth(3, 'abc'); //=> undefined
  * @symb R.nth(-1, [a, b, c]) = c
  * @symb R.nth(0, [a, b, c]) = a
  * @symb R.nth(1, [a, b, c]) = b


### PR DESCRIPTION
I noticed this while testing https://github.com/ramda/types/pull/101 which effects the typings for `last()`

`R.last(''); //=> ''` is not true, `R.last(''); //=> undefined` is

Looking at the git-history of `head.js`, `last.js` and `nth.js`. This has always been the behavior, the documentation was incorrect from the get-go. I think it was a bad copy/paste assumption in that `init()` and `tail()` both return `''` when given `''`

See in [repl](https://ramdajs.com/repl/?v=0.30.0#?R.head%28%27%27%29%3B%20%2F%2F%3D%3E%20undefined%2C%20not%20%27%27%0AR.last%28%27%27%29%3B%20%2F%2F%3D%3E%20undefined%2C%20not%20%27%27%0AR.nth%283%2C%20%27abc%27%29%3B%20%2F%2F%3D%3E%20undefined%2C%20not%20%27%27%0A)