### PR TITLE
Chore: set package-lock.json version to 0.30.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ramda",
-  "version": "0.29.1",
+  "version": "0.30.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ramda",
-      "version": "0.29.1",
+      "version": "0.30.0",
       "license": "MIT",
       "devDependencies": {
         "@babel/cli": "^7.23.0",


### PR DESCRIPTION
`package-lock.json` was still `0.29.1`. Running `npm i` updates it to `0.30.0`