### PR TITLE
Chore: make Flow jsdoc example runnable in the repl

### DIFF
--- a/dist/ramda.js
+++ b/dist/ramda.js
@@ -4970,11 +4970,11 @@
    * @return {*} z The result of applying the seed value to the function pipeline
    * @see R.pipe
    * @example
-   *      R.flow(9, [Math.sqrt, R.negate, R.inc]), //=> -2
+   *      R.flow(9, [Math.sqrt, R.negate, R.inc]); //=> -2
    *
-   *      const defaultName = 'Jane Doe';
-   *      const savedName = R.flow(localStorage.get('name'), [R.when(R.isNil(defaultName)), R.match(/(.+)\s/), R.nth(0)]);
-   *      const givenName = R.flow($givenNameInput.value, [R.trim, R.when(R.isEmpty, R.always(savedName))])
+   *      const personObj = { first: 'Jane', last: 'Doe' };
+   *      const fullName = R.flow(personObj, [R.values, R.join(' ')]); //=> "Jane Doe"
+   *      const givenName = R.flow('    ', [R.trim, R.when(R.isEmpty, R.always(fullName))]); //=> "Jane Doe"
    */
   var flow = _curry2(function flow(seed, pipeline) {
     return _reduce(applyTo, seed, pipeline);

--- a/dist/ramda.js
+++ b/dist/ramda.js
@@ -4970,11 +4970,11 @@
    * @return {*} z The result of applying the seed value to the function pipeline
    * @see R.pipe
    * @example
-   *      R.flow(9, [Math.sqrt, R.negate, R.inc]); //=> -2
+   *      R.flow(9, [Math.sqrt, R.negate, R.inc]), //=> -2
    *
-   *      const personObj = { first: 'Jane', last: 'Doe' };
-   *      const fullName = R.flow(personObj, [R.values, R.join(' ')]); //=> "Jane Doe"
-   *      const givenName = R.flow('    ', [R.trim, R.when(R.isEmpty, R.always(fullName))]); //=> "Jane Doe"
+   *      const defaultName = 'Jane Doe';
+   *      const savedName = R.flow(localStorage.get('name'), [R.when(R.isNil(defaultName)), R.match(/(.+)\s/), R.nth(0)]);
+   *      const givenName = R.flow($givenNameInput.value, [R.trim, R.when(R.isEmpty, R.always(savedName))])
    */
   var flow = _curry2(function flow(seed, pipeline) {
     return _reduce(applyTo, seed, pipeline);

--- a/source/flow.js
+++ b/source/flow.js
@@ -27,11 +27,11 @@ import _reduce from './internal/_reduce.js';
  * @return {*} z The result of applying the seed value to the function pipeline
  * @see R.pipe
  * @example
- *      R.flow(9, [Math.sqrt, R.negate, R.inc]), //=> -2
+ *      R.flow(9, [Math.sqrt, R.negate, R.inc]); //=> -2
  *
- *      const defaultName = 'Jane Doe';
- *      const savedName = R.flow(localStorage.get('name'), [R.when(R.isNil(defaultName)), R.match(/(.+)\s/), R.nth(0)]);
- *      const givenName = R.flow($givenNameInput.value, [R.trim, R.when(R.isEmpty, R.always(savedName))])
+ *      const personObj = { first: 'Jane', last: 'Doe' };
+ *      const savedName = R.flow(personObj, [R.values, R.join(' ')]); //=> "Jane Doe"
+ *      const givenName = R.flow('    ', [R.trim, R.when(R.isEmpty, R.always(savedName))]); //=> "Jane Doe"
  */
 var flow = _curry2(function flow(seed, pipeline) {
   return _reduce(applyTo, seed, pipeline);

--- a/source/flow.js
+++ b/source/flow.js
@@ -30,8 +30,8 @@ import _reduce from './internal/_reduce.js';
  *      R.flow(9, [Math.sqrt, R.negate, R.inc]); //=> -2
  *
  *      const personObj = { first: 'Jane', last: 'Doe' };
- *      const savedName = R.flow(personObj, [R.values, R.join(' ')]); //=> "Jane Doe"
- *      const givenName = R.flow('    ', [R.trim, R.when(R.isEmpty, R.always(savedName))]); //=> "Jane Doe"
+ *      const fullName = R.flow(personObj, [R.values, R.join(' ')]); //=> "Jane Doe"
+ *      const givenName = R.flow('    ', [R.trim, R.when(R.isEmpty, R.always(fullName))]); //=> "Jane Doe"
  */
 var flow = _curry2(function flow(seed, pipeline) {
   return _reduce(applyTo, seed, pipeline);


### PR DESCRIPTION
```typescript
R.flow(9, [Math.sqrt, R.negate, R.inc]), //=> -2

const defaultName = 'Jane Doe';
const savedName = R.flow(localStorage.get('name'), [R.when(R.isNil(defaultName)), R.match(/(.+)\s/), R.nth(0)]);
const givenName = R.flow($givenNameInput.value, [R.trim, R.when(R.isEmpty, R.always(savedName))])
```
First line ends with `,` not `;` causing a parsing errors
`localStorage.get` is not available in the repl's environment
`$givenNameInput` is an undeclared variable

Updated to a similar example that demonstrates the same behavior that has no errors
```typescript
R.flow(9, [Math.sqrt, R.negate, R.inc]); //=> -2

const personObj = { first: 'Jane', last: 'Doe' };
const fullName = R.flow(personObj, [R.values, R.join(' ')]); //=> "Jane Doe"
const givenName = R.flow('    ', [R.trim, R.when(R.isEmpty, R.always(fullName))]); //=> "Jane Doe"
```