### PR TITLE
Fix: cross-version placeholder support

### DIFF
--- a/source/__.js
+++ b/source/__.js
@@ -1,4 +1,3 @@
-import _placeholder from './internal/_placeholder.js';
 /**
  * A special placeholder value used to specify "gaps" within curried functions,
  * allowing partial application of any combination of arguments, regardless of
@@ -26,4 +25,5 @@ import _placeholder from './internal/_placeholder.js';
  *      const greet = R.replace('{name}', R.__, 'Hello, {name}!');
  *      greet('Alice'); //=> 'Hello, Alice!'
  */
-export default _placeholder;
+export default {'@@functional/placeholder': true};
+

--- a/source/internal/_isPlaceholder.js
+++ b/source/internal/_isPlaceholder.js
@@ -1,5 +1,5 @@
-import _placeholder from './_placeholder.js';
-
 export default function _isPlaceholder(a) {
-  return a === _placeholder;
+  return a != null &&
+         typeof a === 'object' &&
+         a['@@functional/placeholder'] === true;
 }

--- a/source/internal/_placeholder.js
+++ b/source/internal/_placeholder.js
@@ -1,1 +1,0 @@
-export default {'@@functional/placeholder': true};


### PR DESCRIPTION
Closes https://github.com/ramda/ramda/issues/3458

The strict equality operator means that `_isPlacerholder` works for only the `R.__` from _that_ specific install. If your project has multiple versions of ramda (which can easily happen due to npm semver resolution and `^` versus `~` versus exact in `package.json`), you'll have problems.

https://github.com/ramda/ramda/pull/3388/files#diff-cfb81eb9592aa5597e5aa32c6e449214f5b7eabeb172ad2447e2e537232454d2L2-R4

Reverting the logic back to what it was before is a looser check that will work cross-version