### PR TITLE
Chore: update `isNotEmpty` @since value in documentation

### DIFF
--- a/source/isNotEmpty.js
+++ b/source/isNotEmpty.js
@@ -8,7 +8,7 @@ import isEmpty from './isEmpty.js';
  *
  * @func
  * @memberOf R
- * @since v0.29.2
+ * @since v0.30.0
  * @category Logic
  * @sig a -> Boolean
  * @param {*} x


### PR DESCRIPTION
In my original MR I set it to `0.29.2`. Updates to `0.30.0`, the actual version of release