### PR TITLE
Update docs for ascendNaturally and descendNaturally

### DIFF
--- a/source/ascendNatural.js
+++ b/source/ascendNatural.js
@@ -9,9 +9,9 @@ import curry from './curry.js';
  * @memberOf R
  * @since v0.30.1
  * @category Function
- * @sig Ord b => s -> (a -> b) -> a -> a -> Number
+ * @sig s -> (a -> String) -> a -> a -> Number
  * @param {String|Array} locales A string with a BCP 47 language tag, or an array of such strings. Corresponds to the locales parameter of the Intl.Collator() constructor.
- * @param {Function} fn A function of arity one that returns a value that can be compared
+ * @param {Function} fn A function of arity one that returns a string that can be compared
  * @param {*} a The first item to be compared.
  * @param {*} b The second item to be compared.
  * @return {Number} `-1` if a occurs before b, `1` if a occurs after b, otherwise `0`

--- a/source/descendNatural.js
+++ b/source/descendNatural.js
@@ -9,9 +9,9 @@ import curry from './curry.js';
  * @memberOf R
  * @since v0.30.1
  * @category Function
- * @sig Ord b => s -> (a -> b) -> a -> a -> Number
+ * @sig s -> (a -> String) -> a -> a -> Number
  * @param {String|Array} locales A string with a BCP 47 language tag, or an array of such strings. Corresponds to the locales parameter of the Intl.Collator() constructor.
- * @param {Function} fn A function of arity one that returns a value that can be compared
+ * @param {Function} fn A function of arity one that returns a string that can be compared
  * @param {*} a The first item to be compared.
  * @param {*} b The second item to be compared.
  * @return {Number} `-1` if a occurs after b, `1` if a occurs before b, otherwise `0`


### PR DESCRIPTION
While working on https://github.com/ramda/types/pull/127 I noticed that the block comment docs are a bit off because of how these are implemented

https://github.com/ramda/ramda/pull/3442/files#diff-2f0444491e08d72d422c4e936a1e621a9a3fdb85d20da37118526f4df5bb5ddaR35

`.localeCompare` only exists on the prototype of `string`. This means that the compare function for `ascendNaturally` and `descendNaturally` need to return `String`, and not `Ord`. `Ord` is defined as `number | string | boolean | Date`, which are the only types in javascript you can use `<`, `>`, `<=`, and `>=` on. This makes since for `ascend` and `descend` of course, but trying those with `ascendNaturally` and `descendNaturally` will give you a runtime error