### PR TITLE
Aline `nth` `head` `last` behavior with documentation 

### DIFF
--- a/source/internal/_nth.js
+++ b/source/internal/_nth.js
@@ -1,6 +1,4 @@
-import _isString from './_isString.js';
-
 export default function _nth(offset, list) {
   var idx = offset < 0 ? list.length + offset : offset;
-  return _isString(list) ? list.charAt(idx) : list[idx];
+  return list[idx];
 }

--- a/test/head.js
+++ b/test/head.js
@@ -15,7 +15,7 @@ describe('head', function() {
     eq(R.head('abc'), 'a');
     eq(R.head('bc'), 'b');
     eq(R.head('c'), 'c');
-    eq(R.head(''), '');
+    eq(R.head(''), undefined);
   });
 
   it('throws if applied to null or undefined', function() {

--- a/test/last.js
+++ b/test/last.js
@@ -15,7 +15,7 @@ describe('last', function() {
     eq(R.last('abc'), 'c');
     eq(R.last('ab'), 'b');
     eq(R.last('a'), 'a');
-    eq(R.last(''), '');
+    eq(R.last(''), undefined);
   });
 
   it('throws if applied to null or undefined', function() {

--- a/test/nth.js
+++ b/test/nth.js
@@ -18,7 +18,7 @@ describe('nth', function() {
     eq(R.nth(0, 'abc'), 'a');
     eq(R.nth(1, 'abc'), 'b');
     eq(R.nth(2, 'abc'), 'c');
-    eq(R.nth(3, 'abc'), '');
+    eq(R.nth(3, 'abc'), undefined);
   });
 
   it('accepts negative offsets', function() {
@@ -31,7 +31,7 @@ describe('nth', function() {
     eq(R.nth(-1, 'abc'), 'c');
     eq(R.nth(-2, 'abc'), 'b');
     eq(R.nth(-3, 'abc'), 'a');
-    eq(R.nth(-4, 'abc'), '');
+    eq(R.nth(-4, 'abc'), undefined);
   });
 
   it('throws if applied to null or undefined', function() {


### PR DESCRIPTION
Align `nth`, `head` and `last` functions with docs. They should return undefined in case of empty string