### PR TITLE
move dist build from npm build to publish script

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,8 +77,6 @@
     "bookmarklet": "node scripts/bookmarklet",
     "build:es": "cross-env BABEL_ENV=es babel source --out-dir es && node ./scripts/addModulePackageScope.js",
     "build:cjs": "cross-env BABEL_ENV=cjs babel source --out-dir src",
-    "build:umd": "cross-env NODE_ENV=development rollup -c -o dist/ramda.js",
-    "build:umd:min": "cross-env NODE_ENV=production rollup -c -o dist/ramda.min.js",
     "build": "npm-run-all --parallel build:**",
     "partial-build": "node ./scripts/partialBuild",
     "clean": "rimraf es/* src/* dist/* coverage/*",

--- a/scripts/prepublish
+++ b/scripts/prepublish
@@ -13,6 +13,8 @@ done
 
 npm run clean
 npm run build
+./node_modules/.bin/cross-env NODE_ENV=development rollup -c -o dist/ramda.js
+./node_modules/.bin/cross-env NODE_ENV=production rollup -c -o dist/ramda.min.js
 
 # build reads version from package.json, which isn't updated until after this script is run by xyz
 distpath=dist/ramda.js


### PR DESCRIPTION
We've long had the confusing situation where build creates the `dist` artifacts but we don't actually want those in PRs. This moves them from npm build to the publish script which is when we actually want them built