### PR TITLE
R.empty() support for Map and Set

### DIFF
--- a/source/empty.js
+++ b/source/empty.js
@@ -41,17 +41,21 @@ var empty = _curry1(function empty(x) {
           ? x.empty()
           : (x != null && x.constructor != null && typeof x.constructor.empty === 'function')
             ? x.constructor.empty()
-            : _isArray(x)
-              ? []
-              : _isString(x)
-                ? ''
-                : _isObject(x)
-                  ? {}
-                  : _isArguments(x)
-                    ? (function() { return arguments; }())
-                    : _isTypedArray(x)
-                      ? x.constructor.from('')
-                      : void 0  // else
+            : (x instanceof Set)
+              ? new Set()
+              : (x instanceof Map)
+                ? new Map()
+                : _isArray(x)
+                  ? []
+                  : _isString(x)
+                    ? ''
+                    : _isObject(x)
+                      ? {}
+                      : _isArguments(x)
+                        ? (function() { return arguments; }())
+                        : _isTypedArray(x)
+                          ? x.constructor.from('')
+                          : void 0  // else
   );
 });
 export default empty;

--- a/source/empty.js
+++ b/source/empty.js
@@ -41,9 +41,9 @@ var empty = _curry1(function empty(x) {
           ? x.empty()
           : (x != null && x.constructor != null && typeof x.constructor.empty === 'function')
             ? x.constructor.empty()
-            : (x instanceof Set)
+            : (x == Set || x instanceof Set)
               ? new Set()
-              : (x instanceof Map)
+              : (x == Map || x instanceof Map)
                 ? new Map()
                 : _isArray(x)
                   ? []

--- a/source/empty.js
+++ b/source/empty.js
@@ -8,7 +8,7 @@ import _isTypedArray from './internal/_isTypedArray.js';
 
 /**
  * Returns the empty value of its argument's type. Ramda defines the empty
- * value of Array (`[]`), Object (`{}`), String (`''`),
+ * value of Array (`[]`), Object (`{}`), String (`''`), Map (`new Map()`), Set (`new Set()`),
  * TypedArray (`Uint8Array []`, `Float32Array []`, etc), and Arguments. Other
  * types are supported if they define `<Type>.empty`,
  * `<Type>.prototype.empty` or implement the
@@ -30,6 +30,7 @@ import _isTypedArray from './internal/_isTypedArray.js';
  *      R.empty('unicorns');             //=> ''
  *      R.empty({x: 1, y: 2});           //=> {}
  *      R.empty(Uint8Array.from('123')); //=> Uint8Array []
+ *      R.empty(Set);                    //=> Set()
  */
 var empty = _curry1(function empty(x) {
   return (

--- a/source/isEmpty.js
+++ b/source/isEmpty.js
@@ -24,6 +24,8 @@ import equals from './equals.js';
  *      R.isEmpty({});                  //=> true
  *      R.isEmpty({length: 0});         //=> false
  *      R.isEmpty(Uint8Array.from('')); //=> true
+ *      R.isEmpty(new Set())            //=> true
+ *      R.isEmpty(new Map())            //=> true
  */
 var isEmpty = _curry1(function isEmpty(x) {
   return x != null && equals(x, empty(x));

--- a/test/empty.js
+++ b/test/empty.js
@@ -51,4 +51,11 @@ describe('empty', function() {
     eq(R.empty(x), (function() { return arguments; }()));
   });
 
+  it('returns empty Set given an instance of Set', function() {
+    eq(R.empty(new Set([1, 2, 3])), new Set());
+  });
+
+  it('returns empty Map given an instance of Map', function() {
+    eq(R.empty(new Map([['a', 1], ['b', 2], ['c', 3]])), new Map());
+  });
 });

--- a/test/empty.js
+++ b/test/empty.js
@@ -51,11 +51,13 @@ describe('empty', function() {
     eq(R.empty(x), (function() { return arguments; }()));
   });
 
-  it('returns empty Set given an instance of Set', function() {
+  it('returns empty Set', function() {
+    eq(R.empty(Set), new Set());
     eq(R.empty(new Set([1, 2, 3])), new Set());
   });
 
-  it('returns empty Map given an instance of Map', function() {
+  it('returns empty Map', function() {
+    eq(R.empty(Map), new Map());
     eq(R.empty(new Map([['a', 1], ['b', 2], ['c', 3]])), new Map());
   });
 });

--- a/test/isEmpty.js
+++ b/test/isEmpty.js
@@ -47,4 +47,13 @@ describe('isEmpty', function() {
     eq(R.isEmpty(['']), false);
   });
 
+  it('returns correctly for Set', function() {
+    eq(R.isEmpty(new Set()), true);
+    eq(R.isEmpty(new Set([1])), false);
+  });
+
+  it('returns correctly for Map', function() {
+    eq(R.isEmpty(new Map()), true);
+    eq(R.isEmpty(new Map([['a', 1]])), false);
+  });
 });


### PR DESCRIPTION
Stemming from https://github.com/ramda/ramda/pull/3475#issuecomment-2175437701

> `isEmpty` returns false for empty Map and Set

To Fix this, `empty()` should return `new Map()`/`new Set()` respectively. `isEmpty()` then naturally works due to it's implementation

```typescript
var s1 = new Set([1, 2, 3]);
var s2 = s1.union(new Set());
R.equals(s1, s2); // => true
```

My implementation works when passed either an instance or the constructor

```typescript
R.empty(Set) // => empty Set
R.empty(new Set([1, 2, 3])) empty Set

R.empty(Map) // => empty Map
R.empty(new Map([1, 2, 3])) // => empty Map
```