### PR TITLE
3438 (docs details), 3472 (minor version)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ramda",
-  "version": "0.30.0",
+  "version": "0.30.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ramda",
-      "version": "0.30.0",
+      "version": "0.30.1",
       "license": "MIT",
       "devDependencies": {
         "@babel/cli": "^7.23.0",

--- a/source/andThen.js
+++ b/source/andThen.js
@@ -16,19 +16,27 @@ import _assertPromise from './internal/_assertPromise.js';
  * @param {Function} onSuccess The function to apply. Can return a value or a promise of a value.
  * @param {Promise} p
  * @return {Promise} The result of calling `p.then(onSuccess)`
- * @see R.otherwise
+ * @see R.otherwise, R.pipeWith
  * @example
  *
  *      const makeQuery = email => ({ query: { email }});
  *      const fetchMember = request =>
  *        Promise.resolve({ firstName: 'Bob', lastName: 'Loblaw', id: 42 });
+ *      const pickName = R.pick(['firstName', 'lastName'])
  *
  *      //getMemberName :: String -> Promise ({ firstName, lastName })
  *      const getMemberName = R.pipe(
  *        makeQuery,
  *        fetchMember,
- *        R.andThen(R.pick(['firstName', 'lastName']))
+ *        R.andThen(pickName),
  *      );
+ *
+ *      Alternately
+ *      const getMemberName = R.pipe(
+ *        makeQuery,
+ *        fetchMember,
+ *      )
+ *      R.pipeWith(R.andThen(pickName))(getMemberName)
  *
  *      getMemberName('bob@gmail.com').then(console.log);
  */

--- a/source/andThen.js
+++ b/source/andThen.js
@@ -31,7 +31,7 @@ import _assertPromise from './internal/_assertPromise.js';
  *        R.andThen(pickName),
  *      );
  *
- *      Alternately
+ *      // Alternately
  *      const getMemberName = R.pipe(
  *        makeQuery,
  *        fetchMember,

--- a/source/andThen.js
+++ b/source/andThen.js
@@ -36,7 +36,9 @@ import _assertPromise from './internal/_assertPromise.js';
  *        makeQuery,
  *        fetchMember,
  *      )
- *      R.pipeWith(R.andThen(pickName))(getMemberName)
+ *
+ *      R.pipeWith(R.andThen, [getMemberName, pickName])('bob@gmail.com').then(console.log)
+ *      // logs {"firstName":"Bob","lastName":"Loblaw"}
  *
  *      getMemberName('bob@gmail.com').then(console.log);
  */

--- a/source/pipeWith.js
+++ b/source/pipeWith.js
@@ -25,10 +25,8 @@ import identity from './identity.js';
  * @examples
  *
  *      const doubleFn = (req) => Promise.resolve(req * 2)
- *      const x = R.pipeWith(
- *        doubleFn,
- *        R.andThen
- *      )(8) // 16
+ *      R.pipeWith(R.andThen, [doubleFn, R.inc])(8).then(console.log)
+ *      // logs 17
  *
  *      const pipeWhileNotNil = R.pipeWith((f, res) => R.isNil(res) ? res : f(res));
  *      const f = pipeWhileNotNil([Math.pow, R.negate, R.inc])

--- a/source/pipeWith.js
+++ b/source/pipeWith.js
@@ -21,8 +21,14 @@ import identity from './identity.js';
  * @param {Function} transformer The transforming function
  * @param {Array} functions The functions to pipe
  * @return {Function}
- * @see R.composeWith, R.pipe
- * @example
+ * @see R.andThen, R.composeWith, R.pipe
+ * @examples
+ *
+ *      const doubleFn = (req) => Promise.resolve(req * 2)
+ *      const x = R.pipeWith(
+ *        doubleFn,
+ *        R.andThen
+ *      )(8) // 16
  *
  *      const pipeWhileNotNil = R.pipeWith((f, res) => R.isNil(res) ? res : f(res));
  *      const f = pipeWhileNotNil([Math.pow, R.negate, R.inc])


### PR DESCRIPTION
Fixes #3438 

### refer to pipeWith from andThen docs with egs
* with examples to show the usage, two examples, one shows that a fn can easily be added to pipe, using  and the second shows the  being used independently, in both cases, the successful Promise resultis handled

### improve pipeWith example
* the example hadn't thought through, the edit should make it more sensible

Fixes #3472 

### actually did the upgrade, my master was only one minor version off

Wouldn't normally mix two