### PR TITLE
Add rebuild, mapKeys, ,and renameKeys

### DIFF
--- a/source/chain.js
+++ b/source/chain.js
@@ -1,8 +1,5 @@
 import _curry2 from './internal/_curry2.js';
-import _dispatchable from './internal/_dispatchable.js';
-import _makeFlat from './internal/_makeFlat.js';
-import _xchain from './internal/_xchain.js';
-import map from './map.js';
+import _chain from './internal/_chain.js';
 
 
 /**
@@ -31,10 +28,5 @@ import map from './map.js';
  *
  *      R.chain(R.append, R.head)([1, 2, 3]); //=> [1, 2, 3, 1]
  */
-var chain = _curry2(_dispatchable(['fantasy-land/chain', 'chain'], _xchain, function chain(fn, monad) {
-  if (typeof monad === 'function') {
-    return function(x) { return fn(monad(x))(x); };
-  }
-  return _makeFlat(false)(map(fn, monad));
-}));
+var chain = _curry2(_chain);
 export default chain;

--- a/source/fromPairs.js
+++ b/source/fromPairs.js
@@ -1,5 +1,5 @@
 import _curry1 from './internal/_curry1.js';
-
+import _fromPairs from './internal/_fromPairs.js';
 
 /**
  * Creates a new object from a list key-value pairs. If a key appears in
@@ -17,13 +17,5 @@ import _curry1 from './internal/_curry1.js';
  *
  *      R.fromPairs([['a', 1], ['b', 2], ['c', 3]]); //=> {a: 1, b: 2, c: 3}
  */
-var fromPairs = _curry1(function fromPairs(pairs) {
-  var result = {};
-  var idx = 0;
-  while (idx < pairs.length) {
-    result[pairs[idx][0]] = pairs[idx][1];
-    idx += 1;
-  }
-  return result;
-});
+var fromPairs = _curry1(_fromPairs);
 export default fromPairs;

--- a/source/index.js
+++ b/source/index.js
@@ -124,6 +124,7 @@ export { default as lte } from './lte.js';
 export { default as map } from './map.js';
 export { default as mapAccum } from './mapAccum.js';
 export { default as mapAccumRight } from './mapAccumRight.js';
+export { default as mapKeys } from './mapKeys.js';
 export { default as mapObjIndexed } from './mapObjIndexed.js';
 export { default as match } from './match.js';
 export { default as mathMod } from './mathMod.js';

--- a/source/index.js
+++ b/source/index.js
@@ -190,6 +190,7 @@ export { default as propOr } from './propOr.js';
 export { default as propSatisfies } from './propSatisfies.js';
 export { default as props } from './props.js';
 export { default as range } from './range.js';
+export { default as rebuild } from './rebuild.js';
 export { default as reduce } from './reduce.js';
 export { default as reduceBy } from './reduceBy.js';
 export { default as reduceRight } from './reduceRight.js';

--- a/source/index.js
+++ b/source/index.js
@@ -199,6 +199,7 @@ export { default as reduceWhile } from './reduceWhile.js';
 export { default as reduced } from './reduced.js';
 export { default as reject } from './reject.js';
 export { default as remove } from './remove.js';
+export { default as renameKeys } from './renameKeys.js';
 export { default as repeat } from './repeat.js';
 export { default as replace } from './replace.js';
 export { default as reverse } from './reverse.js';

--- a/source/internal/_chain.js
+++ b/source/internal/_chain.js
@@ -1,0 +1,12 @@
+import _dispatchable from './_dispatchable.js';
+import _makeFlat from './_makeFlat.js';
+import _xchain from './_xchain.js';
+import map from '../map.js';
+
+
+export default _dispatchable(['fantasy-land/chain', 'chain'], _xchain, function chain(fn, monad) {
+  if (typeof monad === 'function') {
+    return function(x) { return fn(monad(x))(x); };
+  }
+  return _makeFlat(false)(map(fn, monad));
+});

--- a/source/internal/_fromPairs.js
+++ b/source/internal/_fromPairs.js
@@ -1,0 +1,10 @@
+
+export default function fromPairs(pairs) {
+  var result = {};
+  var idx = 0;
+  while (idx < pairs.length) {
+    result[pairs[idx][0]] = pairs[idx][1];
+    idx += 1;
+  }
+  return result;
+}

--- a/source/internal/_mapKeys.js
+++ b/source/internal/_mapKeys.js
@@ -1,0 +1,7 @@
+import _rebuild from './_rebuild.js';
+
+var mapKeys = function mapKeys(fn, obj) {
+  return _rebuild(function(k, v) {return [[fn(k), v]];}, obj);
+};
+
+export default mapKeys;

--- a/source/internal/_rebuild.js
+++ b/source/internal/_rebuild.js
@@ -1,0 +1,11 @@
+import _fromPairs from './_fromPairs.js';
+import _toPairs from './_toPairs.js';
+import _chain from './_chain.js';
+
+var rebuild = function(convert, obj) {
+  return _fromPairs(_chain(
+    function(pair) {return convert(pair[0], pair[1]);},
+    _toPairs(obj)
+  ));
+};
+export default rebuild;

--- a/source/internal/_toPairs.js
+++ b/source/internal/_toPairs.js
@@ -1,0 +1,12 @@
+import _has from './_has.js';
+
+
+export default function _toPairs(obj) {
+  var pairs = [];
+  for (var prop in obj) {
+    if (_has(prop, obj)) {
+      pairs[pairs.length] = [prop, obj[prop]];
+    }
+  }
+  return pairs;
+}

--- a/source/mapKeys.js
+++ b/source/mapKeys.js
@@ -13,7 +13,7 @@ import _mapKeys from './internal/_mapKeys.js';
  * @param {Function} fn
  * @param {Object} obj
  * @return {Object}
- * @see R.map
+ * @see R.map, R.rebuild, R.renameKeys
  * @example
  *
  *      R.mapKeys(toUpper, {foo: 1, bar: 2, baz: 3}) //=> {FOO: 1, BAR: 2, BAZ: 3}

--- a/source/mapKeys.js
+++ b/source/mapKeys.js
@@ -1,5 +1,5 @@
 import _curry2 from './internal/_curry2.js';
-import _rebuild from './internal/_rebuild.js';
+import _mapKeys from './internal/_mapKeys.js';
 
 /**
  * Transforms an object by converting the keys to new values.
@@ -8,7 +8,6 @@ import _rebuild from './internal/_rebuild.js';
  *
  * @func
  * @memberOf R
- * @since v0.9.0
  * @category Object
  * @sig (String -> String) -> Object -> Object
  * @param {Function} fn
@@ -19,8 +18,6 @@ import _rebuild from './internal/_rebuild.js';
  *
  *      R.mapKeys(toUpper, {foo: 1, bar: 2, baz: 3}) //=> {FOO: 1, BAR: 2, BAZ: 3}
  */
-var mapKeys = _curry2(function mapKeys(fn, obj) {
-  return _rebuild(function(k, v) {return [[fn(k), v]];}, obj);
-});
+var mapKeys = _curry2(_mapKeys);
 
 export default mapKeys;

--- a/source/mapKeys.js
+++ b/source/mapKeys.js
@@ -1,0 +1,26 @@
+import _curry2 from './internal/_curry2.js';
+import _rebuild from './internal/_rebuild.js';
+
+/**
+ * Transforms an object by converting the keys to new values.
+ *
+ * **Note** that if multiple keys map to the same new key, the last one processed will dominate.
+ *
+ * @func
+ * @memberOf R
+ * @since v0.9.0
+ * @category Object
+ * @sig (String -> String) -> Object -> Object
+ * @param {Function} fn
+ * @param {Object} obj
+ * @return {Object}
+ * @see R.map
+ * @example
+ *
+ *      R.mapKeys(toUpper, {foo: 1, bar: 2, baz: 3}) //=> {FOO: 1, BAR: 2, BAZ: 3}
+ */
+var mapKeys = _curry2(function mapKeys(fn, obj) {
+  return _rebuild(function(k, v) {return [[fn(k), v]];}, obj);
+});
+
+export default mapKeys;

--- a/source/rebuild.js
+++ b/source/rebuild.js
@@ -9,11 +9,12 @@ import _rebuild from './internal/_rebuild.js';
  * @func
  * @memberOf R
  * @category List
- * @sig ([String, a] -> [[String, b]]) -> Object<a> -> Object<b>
+ * @sig ([String, a] -> [[String, b]]) -> {k: a} -> {k: b}
  * @param {Function} convert A function that converts a key and a value to an array of key-value arrays.
  * @param {Object} obj The structure to convert
  * @return {Array} A new object whose key-value pairs are the result of applying the `convert` function
  *         to every key-value pair in `obj`.
+ * @see R.map, R.mapKeys, R.renameKeys
  * @example
  *
  *      R.rebuild((k, v) => [[k.toUpperCase(), v * v]], {a: 1, b: 2, c: 3}) //=> {A: 1, B: 4, C: 9}

--- a/source/rebuild.js
+++ b/source/rebuild.js
@@ -1,0 +1,29 @@
+import _curry2 from './internal/_curry2.js';
+import _fromPairs from './internal/_fromPairs.js';
+import _toPairs from './internal/_toPairs.js';
+import chain from './chain.js';
+
+/**
+ * Transforms an object into a new one, applying to every key-value pair a
+ * function creating zero, one, or many new key-value pairs, and combining
+ * the resulst into a single object.
+ *
+ * @func
+ * @memberOf R
+ * @category List
+ * @sig ([String, a] -> [[String, b]]) -> Object<a> -> Object<b>
+ * @param {Function} convert A function that converts a key and a value to an array of key-value arrays.
+ * @param {Object} obj The structure to convert
+ * @return {Array} A new object whose key-value pairs are the result of applying the `convert` function
+ *         to every key-value pair in `obj`.
+ * @example
+ *
+ *      R.rebuild((k, v) => [[k.toUpperCase(), v * v]], {a: 1, b: 2, c: 3}) //=> {A: 1, B: 4, C: 9}
+ */
+var rebuild = _curry2(function rebuild(convert, obj) {
+  return _fromPairs(chain(
+    function(pair) {return convert(pair[0], pair[1]);},
+    _toPairs(obj)
+  ));
+});
+export default rebuild;

--- a/source/rebuild.js
+++ b/source/rebuild.js
@@ -1,7 +1,5 @@
 import _curry2 from './internal/_curry2.js';
-import _fromPairs from './internal/_fromPairs.js';
-import _toPairs from './internal/_toPairs.js';
-import chain from './chain.js';
+import _rebuild from './internal/_rebuild.js';
 
 /**
  * Transforms an object into a new one, applying to every key-value pair a
@@ -20,10 +18,5 @@ import chain from './chain.js';
  *
  *      R.rebuild((k, v) => [[k.toUpperCase(), v * v]], {a: 1, b: 2, c: 3}) //=> {A: 1, B: 4, C: 9}
  */
-var rebuild = _curry2(function rebuild(convert, obj) {
-  return _fromPairs(chain(
-    function(pair) {return convert(pair[0], pair[1]);},
-    _toPairs(obj)
-  ));
-});
+var rebuild = _curry2(_rebuild);
 export default rebuild;

--- a/source/renameKeys.js
+++ b/source/renameKeys.js
@@ -14,11 +14,11 @@ import _mapKeys from './internal/_mapKeys.js';
  * @param {Function} mapping An object pairing existing keys with new ones
  * @param {Object} obj A target object to convert
  * @return {Object} The result of replacing existing keys with their mapping counterparts when such exist
- * @see R.map
+ * @see R.mapKeys, R.rebuild
  * @example
  *
  *      var mapping = { name: 'firstName', address: 'street' };
-*       var obj = { name: 'John', city: 'Paris' };
+ *      var obj = { name: 'John', city: 'Paris' };
  *
  *      R.renameKeys(mapping, obj) //=>  { firstName: 'John', city: 'Paris' }
  */

--- a/source/renameKeys.js
+++ b/source/renameKeys.js
@@ -1,0 +1,33 @@
+import _curry2 from './internal/_curry2.js';
+import _has from './internal/_has.js';
+import _mapKeys from './internal/_mapKeys.js';
+
+
+/**
+ * Converts an object to a new one by changing all keys that are also found as keys in a mapping
+ * object to their corresponding values from that object.
+ *
+ * @func
+ * @memberOf R
+ * @category Object
+ * @sig Object -> Object -> Object
+ * @param {Function} mapping An object pairing existing keys with new ones
+ * @param {Object} obj A target object to convert
+ * @return {Object} The result of replacing existing keys with their mapping counterparts when such exist
+ * @see R.map
+ * @example
+ *
+ *      var mapping = { name: 'firstName', address: 'street' };
+*       var obj = { name: 'John', city: 'Paris' };
+ *
+ *      R.renameKeys(mapping, obj) //=>  { firstName: 'John', city: 'Paris' }
+ */
+var renameKeys = _curry2(function renameKeys(mapping, obj) {
+  return _mapKeys(
+    function(key) {
+      return _has(key, mapping) ? mapping[key] : key;
+    },
+    obj
+  );
+});
+export default renameKeys;

--- a/source/toPairs.js
+++ b/source/toPairs.js
@@ -1,5 +1,5 @@
 import _curry1 from './internal/_curry1.js';
-import _has from './internal/_has.js';
+import _toPairs from './internal/_toPairs.js';
 
 
 /**
@@ -20,13 +20,5 @@ import _has from './internal/_has.js';
  *
  *      R.toPairs({a: 1, b: 2, c: 3}); //=> [['a', 1], ['b', 2], ['c', 3]]
  */
-var toPairs = _curry1(function toPairs(obj) {
-  var pairs = [];
-  for (var prop in obj) {
-    if (_has(prop, obj)) {
-      pairs[pairs.length] = [prop, obj[prop]];
-    }
-  }
-  return pairs;
-});
+var toPairs = _curry1(_toPairs);
 export default toPairs;

--- a/test/mapKeys.js
+++ b/test/mapKeys.js
@@ -1,0 +1,14 @@
+var R = require('../source/index.js');
+var eq = require('./shared/eq.js');
+
+
+describe('mapKeys', function() {
+
+  it('converts the keys of an object via the supplied function', function() {
+    eq(R.mapKeys(R.toUpper, {a: 1, b: 2, c: 3, d: 4}), {A: 1, B: 2, C: 3, D: 4});
+  });
+
+  it('keeps the last key-value pair processed if multiple invocations return the same key', function() {
+    eq(R.mapKeys(function(k) {return 'foo';}, {a: 1, b: 2, c: 3}), {foo: 3});
+  });
+});

--- a/test/rebuild.js
+++ b/test/rebuild.js
@@ -1,0 +1,36 @@
+var R = require('../source/index.js');
+var eq = require('./shared/eq.js');
+var isOdd = function(n) {return n % 2 == 1;};
+
+describe('rebuild', function() {
+  it('changes keys and values', function() {
+    eq(
+      R.rebuild(
+        function(k, v) {return [[k.toUpperCase(), v * v]];},
+        {a: 1, b: 2, c: 3}
+      ),
+      {A: 1, B: 4, C: 9}
+    );
+  });
+
+  it('can skip particular entries', function() {
+    eq(
+      R.rebuild(
+        function(k, v) {return isOdd(v) ? [[k.toUpperCase(), v * v]] : [];},
+        {a: 1, b: 2, c: 3}
+      ),
+      {A: 1, C: 9}
+    );
+  });
+
+  it('can include multiple entries for a single input', function() {
+    eq(
+      R.rebuild(
+        function(k, v) {return isOdd(v) ? [[k.toUpperCase(), v * v]] : [[k + '1', v * v], [k + '2', v * v]];},
+        {a: 1, b: 2, c: 3}
+      ),
+      {A: 1, b1: 4, b2: 4, C: 9}
+    );
+  });
+
+});

--- a/test/renameKeys.js
+++ b/test/renameKeys.js
@@ -1,0 +1,27 @@
+var R = require('../source/index.js');
+var eq = require('./shared/eq.js');
+
+
+describe('renameKeys', function() {
+
+  it('converts found keys to new ones', function() {
+    eq(
+      R.renameKeys(
+        {a: 'alpha', b: 'bravo', c: 'charlie'},
+        {a: 1, b: 2, c: 3}
+      ),
+      {alpha: 1, bravo: 2, charlie: 3}
+    );
+  });
+
+  it('ignores keys not found in the mapping', function() {
+    eq(
+      R.renameKeys(
+        {a: 'alpha', b: 'bravo', c: 'charlie', d: 'delta'},
+        {a: 1, b: 2, c: 3, foo: 4}
+      ),
+      {alpha: 1, bravo: 2, charlie: 3, foo: 4}
+    );
+  });
+
+});


### PR DESCRIPTION
Fixes #3491 
Fixes #1361 

This adds three new functions:

  * **`rebuild`** allows you to reconstruct objects -- thought of as collections of key-value pairs -- into new objects by mapping each key-value into an array of key-value pairs.  It unpacks the object, calls the function supplied on each one, and takes the resulting values and folds them into an object.

  * **`mapKeys`** is built atop `rebuild`, and allows you to transform an object using a function that maps each key to a new value.

  * **`renameKeys`** is built atop `mapKeys` and uses a mapping object to form the basis for its key transformation.  Any key of the object to be transformed that is found in the mapping object, will take the corresponding value.  Others will be left as is.

In an [earlier discussion][ed] on this idea, I also floated the function `remap`, which is similar to `rebuild`, but is simpler, and would be used when our transformation is a one-to-one mapping between key-value pairs.  I wasn't sure whether to include it here or not.  What do people think?

Although it was the driving function of the issue that inspired this change, I'm still not really convinced that `renameKeys` is appropriate for Ramda.  Do  you use this functionality often?

----------

On a side note, to keep with our model, this involved moving `fromPairs` and `toPairs` to `_internal` function, and to make the new `rebuild` and `mapKeys` `_internal` functions, all with public glosses that add currying.

I'm thinking that this could be refactored.  I haven't tried yet, but could we remove the `_internal` functions altogether and add the currying inside `sources/index.js` when we're exporting?  It seems to me that it would be a significant cleanup in all sorts of ways.  I haven't looked at all the builds, but it does feel as though this could be quite useful.  What do you think?


  [ed]: https://github.com/ramda/ramda/issues/1361#issuecomment-780716313