### PR TITLE
Add missing list parameter to count function documentation and ensure consistency.

### DIFF
--- a/source/count.js
+++ b/source/count.js
@@ -10,8 +10,9 @@ import curry from './curry.js';
  * @since v0.28.0
  * @category List
  * @sig (a -> Boolean) -> [a] -> Number
- * @param {Function} predicate to match items against
- * @return {Number} the count of items matching the predicate
+ * @param {Function} predicate The function to match items against.
+ * @param {Array} list The list to count elements from.
+ * @return {Number} The count of items matching the predicate.
  * @example
  *
  *      const even = x => x % 2 == 0;


### PR DESCRIPTION
This PR updates the documentation of the count function to include the previously missing list parameter and align the comment style with the rest of the library for consistency.

related issue: #3495 
related commit : #3496
