### PR TITLE
Remove references to R.merge in documentation for other merge functions.

### DIFF
--- a/source/mergeDeepLeft.js
+++ b/source/mergeDeepLeft.js
@@ -16,7 +16,7 @@ import mergeDeepWithKey from './mergeDeepWithKey.js';
  * @param {Object} lObj
  * @param {Object} rObj
  * @return {Object}
- * @see R.merge, R.mergeDeepRight, R.mergeDeepWith, R.mergeDeepWithKey
+ * @see R.mergeDeepRight, R.mergeDeepWith, R.mergeDeepWithKey
  * @example
  *
  *      R.mergeDeepLeft({ name: 'fred', age: 10, contact: { email: 'moo@example.com' }},

--- a/source/mergeDeepRight.js
+++ b/source/mergeDeepRight.js
@@ -16,7 +16,7 @@ import mergeDeepWithKey from './mergeDeepWithKey.js';
  * @param {Object} lObj
  * @param {Object} rObj
  * @return {Object}
- * @see R.merge, R.mergeDeepLeft, R.mergeDeepWith, R.mergeDeepWithKey
+ * @see R.mergeDeepLeft, R.mergeDeepWith, R.mergeDeepWithKey
  * @example
  *
  *      R.mergeDeepRight({ name: 'fred', age: 10, contact: { email: 'moo@example.com' }},

--- a/source/mergeWith.js
+++ b/source/mergeWith.js
@@ -17,7 +17,7 @@ import mergeWithKey from './mergeWithKey.js';
  * @param {Object} l
  * @param {Object} r
  * @return {Object}
- * @see R.mergeDeepWith, R.merge, R.mergeWithKey
+ * @see R.mergeDeepWith, R.mergeWithKey
  * @example
  *
  *      R.mergeWith(R.concat,

--- a/source/mergeWithKey.js
+++ b/source/mergeWithKey.js
@@ -17,7 +17,7 @@ import _has from './internal/_has.js';
  * @param {Object} l
  * @param {Object} r
  * @return {Object}
- * @see R.mergeDeepWithKey, R.merge, R.mergeWith
+ * @see R.mergeDeepWithKey, R.mergeWith
  * @example
  *
  *      let concatValues = (k, l, r) => k == 'values' ? R.concat(l, r) : r


### PR DESCRIPTION
On the [ramda.js docs site](https://ramdajs.com/docs/) I came across references to the `R.merge` function which doesn't seem to be part of the library anymore. I took the liberty of removing those references in the relevant places.