### PR TITLE
docs: update outdate link

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,13 +117,13 @@ or the minified version:
 or from a CDN, either cdnjs:
 
 ```html
-<script src="//cdnjs.cloudflare.com/ajax/libs/ramda/0.31.2/ramda.min.js"></script>
+<script src="//cdnjs.cloudflare.com/ajax/libs/ramda/0.31.3/ramda.min.js"></script>
 ```
 
 or one of the below links from [jsDelivr](http://jsdelivr.com):
 
 ```html
-<script src="//cdn.jsdelivr.net/npm/ramda@0.31.2/dist/ramda.min.js"></script>
+<script src="//cdn.jsdelivr.net/npm/ramda@0.31.3/dist/ramda.min.js"></script>
 <script src="//cdn.jsdelivr.net/npm/ramda@latest/dist/ramda.min.js"></script>
 ```
 


### PR DESCRIPTION
https://cdn.jsdelivr.net/npm/ramda@0.31.2/dist/ramda.min.js cant work