### PR TITLE
docs(pipeWith): add usage example

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ramda",
-  "version": "0.31.2",
+  "version": "0.31.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ramda",
-      "version": "0.31.2",
+      "version": "0.31.3",
       "license": "MIT",
       "devDependencies": {
         "@babel/cli": "^7.23.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ramda",
-  "version": "0.31.3",
+  "version": "0.31.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ramda",
-      "version": "0.31.3",
+      "version": "0.31.2",
       "license": "MIT",
       "devDependencies": {
         "@babel/cli": "^7.23.0",

--- a/source/pipeWith.js
+++ b/source/pipeWith.js
@@ -24,10 +24,10 @@ import identity from './identity.js';
  * @see R.andThen, R.composeWith, R.pipe
  * @examples
  *
- *    const pipeWhileNotNil = R.pipeWith((f, res) => R.isNil(res) ? res : f(res));
+ *      const pipeWhileNotNil = R.pipeWith((f, res) => R.isNil(res) ? res : f(res));
  *
- *    pipeWhileNotNil([R.prop('age'), R.inc ])({age: 1}) //=> 2
- *    pipeWhileNotNil([R.prop('age'), R.inc ])({}) //=> undefined
+ *      pipeWhileNotNil([R.prop('age'), R.inc ])({age: 1}) //=> 2
+ *      pipeWhileNotNil([R.prop('age'), R.inc ])({}) //=> undefined
  * @symb R.pipeWith(f)([g, h, i])(...args) = f(i, f(h, g(...args)))
  */
 var pipeWith = _curry2(function pipeWith(xf, list) {

--- a/source/pipeWith.js
+++ b/source/pipeWith.js
@@ -24,14 +24,10 @@ import identity from './identity.js';
  * @see R.andThen, R.composeWith, R.pipe
  * @examples
  *
- *      const doubleFn = (req) => Promise.resolve(req * 2)
- *      R.pipeWith(R.andThen, [doubleFn, R.inc])(8).then(console.log)
- *      // logs 17
+ *    const pipeWhileNotNil = R.pipeWith((f, res) => R.isNil(res) ? res : f(res));
  *
- *      const pipeWhileNotNil = R.pipeWith((f, res) => R.isNil(res) ? res : f(res));
- *      const f = pipeWhileNotNil([Math.pow, R.negate, R.inc])
- *
- *      f(3, 4); // -(3^4) + 1
+ *    pipeWhileNotNil([R.prop('age'), R.inc ])({age: 1}) //=> 2
+ *    pipeWhileNotNil([R.prop('age'), R.inc ])({}) //=> undefined
  * @symb R.pipeWith(f)([g, h, i])(...args) = f(i, f(h, g(...args)))
  */
 var pipeWith = _curry2(function pipeWith(xf, list) {


### PR DESCRIPTION
I noticed the code example for the pipeWith function is not showing on the documentation page. I felt like the same example for composeWith would serve as a reasonable example. This is the first PR I have done, so my apologies if I have done anything incorrectly. 