### PR TITLE
docs(rebuild): fix typo

### DIFF
--- a/source/rebuild.js
+++ b/source/rebuild.js
@@ -4,7 +4,7 @@ import _rebuild from './internal/_rebuild.js';
 /**
  * Transforms an object into a new one, applying to every key-value pair a
  * function creating zero, one, or many new key-value pairs, and combining
- * the resulst into a single object.
+ * the results into a single object.
  *
  * @func
  * @memberOf R


### PR DESCRIPTION
Fixes transposed letters in the documentation of `rebuild`.

`resulst` -> `results`