### PR TITLE
fix: package.json exports fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,9 +59,9 @@
     "./es/*": "./es/*.js",
     "./src/*": "./src/*.js",
     "./dist/*": "./dist/*.js",
-    "./es/": "./es/",
-    "./src/": "./src/",
-    "./dist/": "./dist/"
+    "./es": "./es/index.js",
+    "./src": "./src/index.js",
+    "./dist": "./dist/index.js"
   },
   "module": "./es/index.js",
   "unpkg": "dist/ramda.min.js",


### PR DESCRIPTION
Figured this out from this PR: https://github.com/DefinitelyTyped/DefinitelyTyped/pull/73646

What I updated was invalid. Left side can't have trailing slashes, right side needs to resolve to a file, not a folder